### PR TITLE
Simplify conservation statistics

### DIFF
--- a/snakemake/training_dataset/dataset_creation/config/config.yaml
+++ b/snakemake/training_dataset/dataset_creation/config/config.yaml
@@ -96,7 +96,7 @@ functional_regions:
   - cds
   - 5_prime_utr
   - 3_prime_utr
-  - promoters
+  - promoters_mRNA/256/256
   - ncrna_exons
 
 # Color palette for functional regions (consistent across all plots)
@@ -105,6 +105,7 @@ region_colors:
   5_prime_utr: "#fc8d62"
   3_prime_utr: "#8da0cb"
   promoters: "#e78ac3"
+  promoters_mRNA/256/256: "#e78ac3"
   ncrna_exons: "#a6d854"
 
 # Display labels for functional regions
@@ -113,6 +114,7 @@ region_labels:
   5_prime_utr: "5' UTR"
   3_prime_utr: "3' UTR"
   promoters: "Promoter"
+  promoters_mRNA/256/256: "Promoter"
   ncrna_exons: "ncRNA"
 
 # Conservation analysis settings
@@ -120,6 +122,13 @@ region_labels:
 # innovation across hundreds of placental mammals." Science 380.6643 (2023): eabn3943.
 conservation:
   phylop_cutoff: 2.27  # bases with phyloP >= this value are considered conserved
+
+# Promoter variants for comparison plot
+promoter_comparison_regions:
+  - promoters_mRNA/256/256
+  - promoters_mRNA/2048/2048
+  - promoters/256/256
+  - promoters/2048/2048
 
 # Priority genomes for BED export (for visualization in genome browsers)
 genome_subset_bed:

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/common.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/common.smk
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import pyBigWig
+import matplotlib.pyplot as plt
 from tqdm import tqdm
 
 # Bolinas module imports

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/intervals.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/intervals.smk
@@ -190,6 +190,28 @@ rule extract_promoters:
         promoters.write_parquet(output[0])
 
 
+rule extract_promoters_mRNA:
+    input:
+        "results/annotation/{g}.gtf.gz",
+        "results/intervals/all/{g}.bed.gz",
+    output:
+        "results/intervals/promoters_mRNA/{upstream}/{downstream}/{g}.parquet",
+    run:
+        ann = load_annotation(input[0])
+        bounds = GenomicSet.read_bed(input[1])
+        promoters = get_promoters(
+            ann,
+            n_upstream=int(wildcards.upstream),
+            n_downstream=int(wildcards.downstream),
+            mRNA_only=True,
+            within_bounds=bounds,
+        )
+        assert (
+            promoters.n_intervals() > 0
+        ), f"No mRNA promoter regions found for {wildcards.g}"
+        promoters.write_parquet(output[0])
+
+
 rule extract_ncrna_exons:
     input:
         "results/annotation/{g}.gtf.gz",


### PR DESCRIPTION
## Summary
- Simplify conservation analysis to output % conserved per functional region
- Use phyloP cutoff of 2.27 (from Zoonomia/Christmas et al. 2023)
- Replace histogram with bar charts showing % conserved and total conserved bases
- Add consistent color palette and display labels across all plots

## Test plan
- [x] Dry run verifies only conservation rules recompute
- [x] Generated `results/conservation/summary.parquet` with correct schema
- [x] Generated `results/plots/conservation_summary.svg` and `conservation_total_bases.svg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)