### PR TITLE
Add functional region plots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ The codebase has two main components:
    - See individual pipeline READMEs for details on what each pipeline does and how to configure them
    - Always do a dry-run first. Be extra careful whenever Snakemake is planning to rerun a very slow step (ask for my permission).
    - When working on a feature, do not try to run the whole pipeline, only the step relevant to the feature.
+   - Run with `uv run snakemake`
 
 ## Development Practices
 

--- a/snakemake/analysis/evals_v1/config/config.yaml
+++ b/snakemake/analysis/evals_v1/config/config.yaml
@@ -509,7 +509,9 @@ custom_plots:
         title: "Mendelian 5' UTR"
 
   - name: exp43_functional_regions
-    title: "Exp43 functional regions"
+    title: "Exp43 functional regions (TraitGym Mendelian v2)"
+    ylim: [0.1, 0.65]
+    scale: 0.6
     models:
       - model: exp43-cds-r01-976f2d
         title: "CDS"
@@ -520,71 +522,41 @@ custom_plots:
       - model: exp43-ncrna-r01-1cd7d3
         title: "ncRNA"
       - model: exp37-genomes-v4-genome_set-animals-intervals-v1_256_128-r02-4e2580
-        title: "Promoter (WIP)"
-    n_cols: 3
+        title: "Promoter"
+    n_cols: 4
     dataset_subsets:
-      - dataset: traitgym_mendelian
-        subset: nonexonic_AND_proximal
-        score_type: minus_llr
-        include_baselines: true
-        title: "Mendelian Promoter"
-      - dataset: traitgym_mendelian
-        subset: nonexonic_AND_distal
-        score_type: minus_llr
-        include_baselines: true
-        title: "Mendelian Distal"
-      - dataset: traitgym_mendelian
-        subset: 5_prime_UTR_variant
-        score_type: minus_llr
-        include_baselines: true
-        title: "Mendelian 5' UTR"
-      - dataset: traitgym_mendelian
-        subset: 3_prime_UTR_variant
-        score_type: minus_llr
-        include_baselines: true
-        title: "Mendelian 3' UTR"
-      - dataset: traitgym_mendelian
-        subset: non_coding_transcript_exon_variant
-        score_type: minus_llr
-        include_baselines: true
-        title: "Mendelian ncRNA"
-      - dataset: clinvar_missense
-        subset: global
-        score_type: minus_llr
-        include_baselines: true
-        title: "ClinVar missense"
       - dataset: traitgym_mendelian_v2
         subset: missense_variant
         score_type: minus_llr
-        title: "Mendelian-v2 missense"
-      - dataset: traitgym_mendelian_v2
-        subset: splicing
-        score_type: minus_llr
-        title: "Mendelian-v2 splicing"
+        title: "Missense"
       - dataset: traitgym_mendelian_v2
         subset: tss_proximal
         score_type: minus_llr
-        title: "Mendelian-v2 TSS proximal"
-      - dataset: traitgym_mendelian_v2
-        subset: synonymous_variant
-        score_type: minus_llr
-        title: "Mendelian-v2 synonymous"
-      - dataset: traitgym_mendelian_v2
-        subset: 5_prime_UTR_variant
-        score_type: minus_llr
-        title: "Mendelian-v2 5' UTR"
-      - dataset: traitgym_mendelian_v2
-        subset: non_coding_transcript_exon_variant
-        score_type: minus_llr
-        title: "Mendelian-v2 ncRNA"
+        title: "Promoter"
       - dataset: traitgym_mendelian_v2
         subset: distal
         score_type: minus_llr
-        title: "Mendelian-v2 distal"
+        title: "Distal"
+      - dataset: traitgym_mendelian_v2
+        subset: splicing
+        score_type: minus_llr
+        title: "Splicing"
+      - dataset: traitgym_mendelian_v2
+        subset: synonymous_variant
+        score_type: minus_llr
+        title: "Synonymous"
+      - dataset: traitgym_mendelian_v2
+        subset: 5_prime_UTR_variant
+        score_type: minus_llr
+        title: "5' UTR"
       - dataset: traitgym_mendelian_v2
         subset: 3_prime_UTR_variant
         score_type: minus_llr
-        title: "Mendelian-v2 3' UTR"
+        title: "3' UTR"
+      - dataset: traitgym_mendelian_v2
+        subset: non_coding_transcript_exon_variant
+        score_type: minus_llr
+        title: "ncRNA"
 
   - name: exp42_promoter_radius
     title: "Exp42 promoter radius"

--- a/snakemake/analysis/evals_v1/workflow/rules/plots.smk
+++ b/snakemake/analysis/evals_v1/workflow/rules/plots.smk
@@ -131,6 +131,10 @@ rule plot_custom_models_comparison:
             if not subplot_titles:
                 subplot_titles = None
 
+        ylim = plot_cfg.get("ylim")
+        if ylim is not None:
+            ylim = tuple(ylim)
+
         plot_models_comparison(
             metrics_df,
             output[0],
@@ -142,4 +146,6 @@ rule plot_custom_models_comparison:
             n_cols=plot_cfg.get("n_cols"),
             model_labels=model_labels,
             model_colors=model_colors,
+            ylim=ylim,
+            scale=plot_cfg.get("scale", 1.0),
         )

--- a/src/bolinas/evals/plotting.py
+++ b/src/bolinas/evals/plotting.py
@@ -142,6 +142,8 @@ def plot_models_comparison(
     n_cols: int | None = None,
     model_labels: dict[str, str] | None = None,
     model_colors: dict[str, str] | None = None,
+    ylim: tuple[float, float] | None = None,
+    scale: float = 1.0,
 ) -> None:
     """Plot metric values vs training step comparing models for a specific score type.
 
@@ -166,6 +168,9 @@ def plot_models_comparison(
         model_labels: Mapping of model name to display label for legend. If None, uses model name.
         model_colors: Mapping of model name to color (hex code or named color). If None, uses
             matplotlib's default color cycle.
+        ylim: Optional y-axis limits as (min, max) tuple. If None, uses auto-scaling.
+        scale: Scale factor for subplot size. Default 1.0 gives 4 inches per subplot.
+            Use >1.0 for larger plots, <1.0 for smaller.
     """
     output_path = Path(output_path)
 
@@ -238,7 +243,7 @@ def plot_models_comparison(
     if n_cols is None:
         n_cols = min(3, n_plots)
     n_rows = (n_plots + n_cols - 1) // n_cols
-    subplot_size = 4  # inches per subplot
+    subplot_size = 4 * scale  # inches per subplot
 
     if figsize is None:
         figsize = (subplot_size * n_cols, subplot_size * n_rows)
@@ -328,6 +333,10 @@ def plot_models_comparison(
         # Despine
         ax.spines["top"].set_visible(False)
         ax.spines["right"].set_visible(False)
+
+        # Apply y-axis limits if specified
+        if ylim is not None:
+            ax.set_ylim(ylim)
 
     # Hide x-axis labels for non-bottom rows (shared x-axis)
     for idx in range(n_plots):


### PR DESCRIPTION
## Summary
- Add `exp43_functional_regions` plot comparing models trained on different functional regions (CDS, UTRs, ncRNA, promoter) on TraitGym Mendelian v2 subsets
- Add `ylim` parameter to set y-axis limits on comparison plots
- Add `scale` parameter to proportionally resize figures

## Test plan
- [x] Ran snakemake to generate `exp43_functional_regions.svg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)