### PR TITLE
Update exp57 scaling plots with viridis colors and Mendelian-v2 prefixes

### DIFF
--- a/snakemake/analysis/evals_v1/config/config.yaml
+++ b/snakemake/analysis/evals_v1/config/config.yaml
@@ -1122,10 +1122,13 @@ custom_plots:
     models:
       - model: exp57-balanced-mixture-qwen3_0_6b-r01-bbdeea
         title: "0.6B"
+        color: "#440154"  # viridis(0.0)
       - model: exp57-balanced-mixture-qwen3_1_7b-r01-75adbc
         title: "1.7B"
+        color: "#21918C"  # viridis(0.5)
       - model: exp57-balanced-mixture-qwen3_4b-r01-05747c
         title: "4B"
+        color: "#FDE725"  # viridis(1.0)
     n_cols: 3
     dataset_subsets:
       - dataset: traitgym_mendelian
@@ -1162,45 +1165,48 @@ custom_plots:
       - dataset: traitgym_mendelian_v2
         subset: tss_proximal
         score_type: minus_llr
-        title: "Promoter"
+        title: "Mendelian-v2 Promoter"
       - dataset: traitgym_mendelian_v2
         subset: 5_prime_UTR_variant
         score_type: minus_llr
-        title: "5' UTR"
+        title: "Mendelian-v2 5' UTR"
       - dataset: traitgym_mendelian_v2
         subset: distal
         score_type: minus_llr
-        title: "Distal"
+        title: "Mendelian-v2 Distal"
       - dataset: traitgym_mendelian_v2
         subset: missense_variant
         score_type: minus_llr
-        title: "Missense"
+        title: "Mendelian-v2 Missense"
       - dataset: traitgym_mendelian_v2
         subset: splicing
         score_type: minus_llr
-        title: "Splicing"
+        title: "Mendelian-v2 Splicing"
       - dataset: traitgym_mendelian_v2
         subset: synonymous_variant
         score_type: minus_llr
-        title: "Synonymous"
+        title: "Mendelian-v2 Synonymous"
       - dataset: traitgym_mendelian_v2
         subset: non_coding_transcript_exon_variant
         score_type: minus_llr
-        title: "ncRNA"
+        title: "Mendelian-v2 ncRNA"
       - dataset: traitgym_mendelian_v2
         subset: 3_prime_UTR_variant
         score_type: minus_llr
-        title: "3' UTR"
+        title: "Mendelian-v2 3' UTR"
 
   - name: exp57_balanced_mixture_scaling_r02
     title: "Exp57 Balanced Mixture - Model Scaling (r02)"
     models:
       - model: exp57-balanced-mixture-qwen3_0_6b-r02-4aeb57
         title: "0.6B"
+        color: "#440154"  # viridis(0.0)
       - model: exp57-balanced-mixture-qwen3_1_7b-r02-f451e5
         title: "1.7B"
+        color: "#21918C"  # viridis(0.5)
       - model: exp57-balanced-mixture-qwen3_4b-r02-5f6b01
         title: "4B"
+        color: "#FDE725"  # viridis(1.0)
     n_cols: 3
     dataset_subsets:
       - dataset: traitgym_mendelian
@@ -1237,35 +1243,35 @@ custom_plots:
       - dataset: traitgym_mendelian_v2
         subset: tss_proximal
         score_type: minus_llr
-        title: "Promoter"
+        title: "Mendelian-v2 Promoter"
       - dataset: traitgym_mendelian_v2
         subset: 5_prime_UTR_variant
         score_type: minus_llr
-        title: "5' UTR"
+        title: "Mendelian-v2 5' UTR"
       - dataset: traitgym_mendelian_v2
         subset: distal
         score_type: minus_llr
-        title: "Distal"
+        title: "Mendelian-v2 Distal"
       - dataset: traitgym_mendelian_v2
         subset: missense_variant
         score_type: minus_llr
-        title: "Missense"
+        title: "Mendelian-v2 Missense"
       - dataset: traitgym_mendelian_v2
         subset: splicing
         score_type: minus_llr
-        title: "Splicing"
+        title: "Mendelian-v2 Splicing"
       - dataset: traitgym_mendelian_v2
         subset: synonymous_variant
         score_type: minus_llr
-        title: "Synonymous"
+        title: "Mendelian-v2 Synonymous"
       - dataset: traitgym_mendelian_v2
         subset: non_coding_transcript_exon_variant
         score_type: minus_llr
-        title: "ncRNA"
+        title: "Mendelian-v2 ncRNA"
       - dataset: traitgym_mendelian_v2
         subset: 3_prime_UTR_variant
         score_type: minus_llr
-        title: "3' UTR"
+        title: "Mendelian-v2 3' UTR"
 
   - name: exp64_kmer_tokenization
     title: "Exp64 K-mer Tokenization - promoters, Qwen 0.6B"


### PR DESCRIPTION
## Summary
- Add viridis color scale to exp57 balanced mixture scaling plots (r01 and r02) to represent model size continuously (0.6B → dark, 1.7B → mid, 4B → bright)
- Prefix all `traitgym_mendelian_v2` subplot titles with "Mendelian-v2" for clarity

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)