### PR TITLE
Support odd window sizes in eval harness materialization

### DIFF
--- a/snakemake/evals/README.md
+++ b/snakemake/evals/README.md
@@ -94,4 +94,4 @@ Datasets materialized with `_harness_{window_size}` contain additional columns:
 | `alt_completion` | Alternate allele + right flank sequence |
 | `target` | Binary label (renamed from `label`) |
 
-The window is centered on the variant: `context` has length `window_size // 2` and `ref_completion` / `alt_completion` each have length `window_size // 2`.
+The window is centered on the variant: `context` has length `window_size // 2` and `ref_completion` / `alt_completion` each have length `window_size - window_size // 2`. For odd window sizes, the extra base goes to the completion (right side).

--- a/src/bolinas/evals/materialize.py
+++ b/src/bolinas/evals/materialize.py
@@ -32,7 +32,7 @@ def _add_eval_harness_fields(
 
     center = pos - 1  # 0-based
     start = center - window_size // 2
-    end = center + window_size // 2
+    end = start + window_size
 
     context = genome(chrom, start, center).upper()
     right_flank = genome(chrom, center + 1, end).upper()
@@ -57,7 +57,7 @@ def materialize_sequences(
     Args:
         dataset: HF Dataset with columns [chrom, pos, ref, alt, label].
         genome: Loaded Genome instance.
-        window_size: Total window size centered on the variant (must be even).
+        window_size: Total window size centered on the variant.
 
     Returns:
         Dataset with added columns [context, ref_completion, alt_completion, target].

--- a/tests/evals/test_materialize.py
+++ b/tests/evals/test_materialize.py
@@ -50,6 +50,21 @@ def test_window_centering(mini_genome):
     assert len(result["alt_completion"]) == 10
 
 
+def test_odd_window_size(mini_genome):
+    """Odd window sizes should work, with the extra base going to the completion."""
+    example = {"chrom": "1", "pos": 25, "ref": "A", "alt": "T", "label": 0}
+    result = _add_eval_harness_fields(example, genome=mini_genome, window_size=11)
+
+    assert len(result["context"]) == 5  # 11 // 2
+    assert len(result["ref_completion"]) == 6  # 11 - 11 // 2
+    assert len(result["context"]) + len(result["ref_completion"]) == 11
+
+    full_ref_window = result["context"] + result["ref_completion"]
+    # pos=25 (1-based) => center=24, start=24-5=19, end=24+6=30
+    expected = mini_genome("1", 19, 30).upper()
+    assert full_ref_window == expected
+
+
 def test_context_plus_ref_completion_matches_genome(mini_genome):
     """context + ref_completion should reconstruct the reference window."""
     example = {"chrom": "1", "pos": 25, "ref": "A", "alt": "T", "label": 0}


### PR DESCRIPTION
## Summary
- Fix eval harness materialization to work with odd `window_size` values (e.g. 255)
- Previously required even window sizes due to symmetric `window_size // 2` split
- Now computes `end = start + window_size`, so odd sizes naturally give the extra base to the completion (right side)

## Test plan
- [x] Existing tests pass (even window sizes unchanged)
- [x] New test for odd window size (window_size=11)
- [x] Pipeline tested end-to-end: `traitgym_mendelian_v2_harness_255` materialized and uploaded to HF

🤖 Generated with [Claude Code](https://claude.com/claude-code)