### PR TITLE
Add exon overlap filter for enhancer classification

### DIFF
--- a/snakemake/enhancer_classification/config/config.yaml
+++ b/snakemake/enhancer_classification/config/config.yaml
@@ -17,6 +17,10 @@ genome_urls:
     gallus_gallus: "https://ftp.ensembl.org/pub/release-104/fasta/gallus_gallus/dna/Gallus_gallus.GRCg6a.dna_sm.toplevel.fa.gz"
     drosophila_melanogaster: "https://ftp.ensembl.org/pub/release-104/fasta/drosophila_melanogaster/dna/Drosophila_melanogaster.BDGP6.32.dna_sm.toplevel.fa.gz"
 
+annotation_urls:
+    homo_sapiens: "https://ftp.ensembl.org/pub/release-113/gtf/homo_sapiens/Homo_sapiens.GRCh38.113.gtf.gz"
+    mus_musculus: "https://ftp.ensembl.org/pub/release-102/gtf/mus_musculus/Mus_musculus.GRCm38.102.gtf.gz"
+
 standard_chroms:
     homo_sapiens:
         [
@@ -164,10 +168,13 @@ datasets:
         intervals: ELS
     v3:
         split: v2
-        intervals: ELS_conserved/phyloP_241m/20
+        intervals: conserved/phyloP_241m/20/ELS
     v4:
         split: v2
-        intervals: ELS_conserved/phastCons_43p/20
+        intervals: conserved/phastCons_43p/20/ELS
+    v5:
+        split: v2
+        intervals: noexon/conserved/phastCons_43p/20/ELS
 
 # Thresholds from: Sullivan, Patrick F., et al. "Leveraging base-pair mammalian
 # constraint to understand genetic variation and human disease."

--- a/snakemake/enhancer_classification/config/config.yaml
+++ b/snakemake/enhancer_classification/config/config.yaml
@@ -216,13 +216,13 @@ models:
         mlp_hidden_dim: 256
 
 experiments:
-    - { model: finetune, dataset: v4 }
+    - { model: finetune, dataset: v5 }
 
 visualization:
     window_size: 255
     step_size: 32
     checkpoints:
-        - { model: finetune, dataset: v4 }
+        - { model: finetune, dataset: v5 }
     regions:
         - genome: homo_sapiens
           chrom: "7"

--- a/snakemake/enhancer_classification/workflow/Snakefile
+++ b/snakemake/enhancer_classification/workflow/Snakefile
@@ -11,6 +11,12 @@ MODEL_NAMES = [k for k in config.get("models", {}) if k != "default"]
 EXPERIMENTS = config.get("experiments", [])
 
 
+ruleorder: filter_no_exon_overlap > process_cre
+ruleorder: cre_filter_conserved > filter_enhancers
+ruleorder: filter_no_exon_overlap > filter_enhancers
+ruleorder: filter_no_exon_overlap > cre_filter_conserved
+
+
 wildcard_constraints:
     species="|".join(SPECIES),
     dataset="|".join(DATASET_NAMES),

--- a/snakemake/enhancer_classification/workflow/rules/common.smk
+++ b/snakemake/enhancer_classification/workflow/rules/common.smk
@@ -10,7 +10,7 @@ import pyBigWig
 from huggingface_hub import hf_hub_download
 
 from bolinas.data.intervals import GenomicSet
-from bolinas.data.utils import ENHANCER_CRE_CLASSES, add_rc, load_fasta
+from bolinas.data.utils import ENHANCER_CRE_CLASSES, add_rc, get_exons, load_annotation, load_fasta
 
 
 SPECIES = list(config["genome_urls"].keys())

--- a/snakemake/enhancer_classification/workflow/rules/data.smk
+++ b/snakemake/enhancer_classification/workflow/rules/data.smk
@@ -203,7 +203,7 @@ rule cre_filter_conserved:
     input:
         "results/cre/{species}/ELS_conservation/{conservation}.parquet",
     output:
-        "results/cre/{species}/ELS_conserved/{conservation}/{n}.parquet",
+        "results/cre/{species}/conserved/{conservation}/{n}/ELS.parquet",
     run:
         min_conserved = int(wildcards.n)
         (
@@ -212,6 +212,39 @@ rule cre_filter_conserved:
             .select(["chrom", "start", "end"])
             .write_parquet(output[0])
         )
+
+
+rule download_annotation:
+    output:
+        "results/annotation/{species}.gtf.gz",
+    params:
+        url=lambda wildcards: config["annotation_urls"][wildcards.species],
+    shell:
+        "wget -O {output} {params.url}"
+
+
+rule extract_exons:
+    input:
+        "results/annotation/{species}.gtf.gz",
+    output:
+        "results/annotation/{species}/exons.parquet",
+    run:
+        ann = load_annotation(input[0])
+        exons = get_exons(ann)
+        exons.write_parquet(output[0])
+
+
+rule filter_no_exon_overlap:
+    input:
+        intervals="results/cre/{species}/{base}.parquet",
+        exons="results/annotation/{species}/exons.parquet",
+    output:
+        "results/cre/{species}/noexon/{base}.parquet",
+    run:
+        intervals = GenomicSet.read_parquet(input.intervals)
+        exons = GenomicSet.read_parquet(input.exons)
+        filtered = intervals.filter_not_overlapping(exons)
+        filtered.to_polars().write_parquet(output[0])
 
 
 rule make_positives:

--- a/snakemake/enhancer_classification/workflow/rules/data.smk
+++ b/snakemake/enhancer_classification/workflow/rules/data.smk
@@ -244,7 +244,7 @@ rule filter_no_exon_overlap:
         intervals = GenomicSet.read_parquet(input.intervals)
         exons = GenomicSet.read_parquet(input.exons)
         filtered = intervals.filter_not_overlapping(exons)
-        filtered.to_polars().write_parquet(output[0])
+        filtered.write_parquet(output[0])
 
 
 rule make_positives:

--- a/src/bolinas/data/intervals.py
+++ b/src/bolinas/data/intervals.py
@@ -96,6 +96,24 @@ class GenomicSet:
             return GenomicSet(self._data.copy())
         return GenomicSet(bf.subtract(self._data, other._data))
 
+    def filter_not_overlapping(self, other: "GenomicSet") -> "GenomicSet":
+        """Remove intervals that overlap any interval in the other set.
+
+        Unlike subtraction (which splits intervals at overlap boundaries),
+        this removes entire intervals from self that have any overlap with other.
+
+        Args:
+            other: A GenomicSet whose intervals define regions to exclude.
+
+        Returns:
+            A new GenomicSet containing only intervals from self that do not
+            overlap any interval in other.
+        """
+        if len(self._data) == 0 or len(other._data) == 0:
+            return GenomicSet(self._data.copy())
+        result = bf.count_overlaps(self._data, other._data)
+        return GenomicSet(result.loc[result["count"] == 0, INTERVAL_COORDS])
+
     def __eq__(self, other: object) -> bool:
         """Equality comparison based on underlying DataFrame equality.
 
@@ -294,24 +312,6 @@ class GenomicSet:
             path: Path to the output BED file.
         """
         self._data.to_csv(path, sep="\t", header=False, index=False)
-
-    def filter_not_overlapping(self, other: "GenomicSet") -> "GenomicSet":
-        """Remove intervals that overlap any interval in the other set.
-
-        Unlike subtraction (which splits intervals at overlap boundaries),
-        this removes entire intervals from self that have any overlap with other.
-
-        Args:
-            other: A GenomicSet whose intervals define regions to exclude.
-
-        Returns:
-            A new GenomicSet containing only intervals from self that do not
-            overlap any interval in other.
-        """
-        if len(self._data) == 0 or len(other._data) == 0:
-            return GenomicSet(self._data.copy())
-        result = bf.count_overlaps(self._data, other._data)
-        return GenomicSet(result.loc[result["count"] == 0, INTERVAL_COORDS])
 
     def write_parquet(self, path: str) -> None:
         """Write intervals to a parquet file.

--- a/src/bolinas/data/intervals.py
+++ b/src/bolinas/data/intervals.py
@@ -295,6 +295,24 @@ class GenomicSet:
         """
         self._data.to_csv(path, sep="\t", header=False, index=False)
 
+    def filter_not_overlapping(self, other: "GenomicSet") -> "GenomicSet":
+        """Remove intervals that overlap any interval in the other set.
+
+        Unlike subtraction (which splits intervals at overlap boundaries),
+        this removes entire intervals from self that have any overlap with other.
+
+        Args:
+            other: A GenomicSet whose intervals define regions to exclude.
+
+        Returns:
+            A new GenomicSet containing only intervals from self that do not
+            overlap any interval in other.
+        """
+        if len(self._data) == 0 or len(other._data) == 0:
+            return GenomicSet(self._data.copy())
+        result = bf.count_overlaps(self._data, other._data)
+        return GenomicSet(result.loc[result["count"] == 0, INTERVAL_COORDS])
+
     def write_parquet(self, path: str) -> None:
         """Write intervals to a parquet file.
 

--- a/src/bolinas/data/utils.py
+++ b/src/bolinas/data/utils.py
@@ -87,6 +87,7 @@ def load_annotation(path: str) -> pl.DataFrame:
                 "frame",
                 "attribute",
             ],
+            schema_overrides={"chrom": pl.Utf8},
         )
         .with_columns(pl.col("start") - 1)  # gtf to bed conversion
         .filter(pl.col("strand").is_in(["+", "-"]))
@@ -221,6 +222,18 @@ def _get_functional_transcript_exons(ann: pl.DataFrame) -> pl.DataFrame:
         ["chrom", "start", "end", "strand", "transcript_id"]
     )
     return pl.concat([mrna_exons, ncrna_exons])
+
+
+def get_exons(ann: pl.DataFrame) -> GenomicSet:
+    """Extract all exon regions from an annotation DataFrame.
+
+    Args:
+        ann: Annotation DataFrame from load_annotation().
+
+    Returns:
+        GenomicSet containing merged exon regions.
+    """
+    return GenomicSet(ann.filter(pl.col("feature") == "exon"))
 
 
 def get_cds(ann: pl.DataFrame) -> GenomicSet:

--- a/tests/test_intervals.py
+++ b/tests/test_intervals.py
@@ -2413,3 +2413,106 @@ def test_genomic_set_subtract_empty_from_empty():
         )
     )
     assert result == expected
+
+
+def test_filter_not_overlapping_removes_overlapping():
+    """Test that filter_not_overlapping removes intervals with any overlap.
+
+    Input set 1: chr1:0-100, chr1:200-300, chr1:400-500
+    Input set 2: chr1:50-60, chr1:450-600
+    Output: chr1:200-300 (only interval with no overlap kept)
+    """
+    data1 = pd.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr1"],
+            "start": [0, 200, 400],
+            "end": [100, 300, 500],
+        }
+    )
+    data2 = pd.DataFrame(
+        {
+            "chrom": ["chr1", "chr1"],
+            "start": [50, 450],
+            "end": [60, 600],
+        }
+    )
+
+    gs1 = GenomicSet(data1)
+    gs2 = GenomicSet(data2)
+    result = gs1.filter_not_overlapping(gs2)
+
+    expected = GenomicSet(
+        pd.DataFrame(
+            {
+                "chrom": ["chr1"],
+                "start": [200],
+                "end": [300],
+            }
+        )
+    )
+    assert result == expected
+
+
+def test_filter_not_overlapping_no_overlap():
+    """Test filter_not_overlapping when no intervals overlap.
+
+    Input set 1: chr1:0-100, chr1:200-300
+    Input set 2: chr2:0-100
+    Output: chr1:0-100, chr1:200-300 (all kept, different chroms)
+    """
+    data1 = pd.DataFrame(
+        {
+            "chrom": ["chr1", "chr1"],
+            "start": [0, 200],
+            "end": [100, 300],
+        }
+    )
+    data2 = pd.DataFrame(
+        {
+            "chrom": ["chr2"],
+            "start": [0],
+            "end": [100],
+        }
+    )
+
+    gs1 = GenomicSet(data1)
+    gs2 = GenomicSet(data2)
+    result = gs1.filter_not_overlapping(gs2)
+
+    assert result == gs1
+
+
+def test_filter_not_overlapping_empty_other():
+    """Test filter_not_overlapping with empty other set returns self unchanged."""
+    data1 = pd.DataFrame(
+        {
+            "chrom": ["chr1"],
+            "start": [0],
+            "end": [100],
+        }
+    )
+    empty = pd.DataFrame({"chrom": [], "start": [], "end": []})
+
+    gs1 = GenomicSet(data1)
+    gs2 = GenomicSet(empty)
+    result = gs1.filter_not_overlapping(gs2)
+
+    assert result == gs1
+
+
+def test_filter_not_overlapping_empty_self():
+    """Test filter_not_overlapping with empty self returns empty."""
+    empty = pd.DataFrame({"chrom": [], "start": [], "end": []})
+    data2 = pd.DataFrame(
+        {
+            "chrom": ["chr1"],
+            "start": [0],
+            "end": [100],
+        }
+    )
+
+    gs1 = GenomicSet(empty)
+    gs2 = GenomicSet(data2)
+    result = gs1.filter_not_overlapping(gs2)
+
+    assert result == gs1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from bolinas.data.utils import (
     get_array_split_pairs,
     get_cds,
     get_downstream_of_CDS,
+    get_exons,
     get_mrna_exons,
     get_ncrna_exons,
     get_promoters,
@@ -1967,3 +1968,35 @@ def test_get_downstream_of_CDS_chrY(chrY_annotation):
 
     df = result.to_polars()
     assert df["chrom"].unique().to_list() == ["NC_000024.10"]
+
+
+def test_get_exons():
+    """Test get_exons extracts all exon features regardless of transcript type.
+
+    Input: Annotation with exon, CDS, and gene features
+    Output: GenomicSet with only exon features (merged)
+    """
+    ann = pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr1", "chr1"],
+            "start": [100, 200, 300, 500],
+            "end": [150, 250, 350, 600],
+            "strand": ["+", "+", "+", "-"],
+            "feature": ["exon", "CDS", "exon", "exon"],
+            "attribute": [
+                'transcript_id "t1"; transcript_biotype "mRNA"',
+                'transcript_id "t1"; transcript_biotype "mRNA"',
+                'transcript_id "t2"; transcript_biotype "lnc_RNA"',
+                'transcript_id "t3"; transcript_biotype "miRNA"',
+            ],
+            "source": ["test"] * 4,
+            "score": ["."] * 4,
+            "frame": ["."] * 4,
+        }
+    )
+
+    result = get_exons(ann)
+
+    assert isinstance(result, GenomicSet)
+    assert result.n_intervals() == 3
+    assert result.total_size() == 50 + 50 + 100


### PR DESCRIPTION
## Summary
- Add `GenomicSet.filter_not_overlapping()` to remove entire intervals overlapping another set (uses `bioframe.count_overlaps`)
- Add `get_exons()` utility to extract all exon regions from GTF annotations
- Fix `load_annotation()` to handle Ensembl GTFs (numeric chromosome names)
- Add composable exon filter to enhancer pipeline using prefix-based path convention (`noexon/...`)
- Refactor conservation filter paths to same convention (`conserved/.../ELS`)
- Add dataset v5 and train finetune model

Filter impact (human): 1,718,669 → 310,674 (conservation) → 209,554 (exon removal, -32.4%)

Results posted in #96.

## Test plan
- [x] Unit tests for `filter_not_overlapping` (4 cases) and `get_exons`
- [x] `uv run pytest` — 175 tests pass
- [x] Snakemake dry-run for v5 dataset
- [x] Full pipeline run: dataset build, training, visualization

🤖 Generated with [Claude Code](https://claude.com/claude-code)