### PR TITLE
GC/repeat-matched negatives and improved exon filtering (#96)

### DIFF
--- a/snakemake/enhancer_classification/config/config.yaml
+++ b/snakemake/enhancer_classification/config/config.yaml
@@ -159,6 +159,12 @@ splits:
                 ]
             validation: ["19"]
 
+negative_sampling:
+    gc_repeat_matched:
+        oversampling_factor: 20
+        gc_bin_size: 0.02
+        repeat_bin_size: 0.05
+
 datasets:
     v1:
         split: v1
@@ -175,6 +181,10 @@ datasets:
     v5:
         split: v2
         intervals: noexon/conserved/phastCons_43p/20/ELS
+    v6:
+        split: v2
+        intervals: noexon/conserved/phastCons_43p/20/ELS
+        negative_sampling: gc_repeat_matched
 
 # Thresholds from: Sullivan, Patrick F., et al. "Leveraging base-pair mammalian
 # constraint to understand genetic variation and human disease."

--- a/snakemake/enhancer_classification/config/config.yaml
+++ b/snakemake/enhancer_classification/config/config.yaml
@@ -226,13 +226,13 @@ models:
         mlp_hidden_dim: 256
 
 experiments:
-    - { model: finetune, dataset: v5 }
+    - { model: finetune, dataset: v6 }
 
 visualization:
     window_size: 255
     step_size: 32
     checkpoints:
-        - { model: finetune, dataset: v5 }
+        - { model: finetune, dataset: v6 }
     regions:
         - genome: homo_sapiens
           chrom: "7"

--- a/snakemake/enhancer_classification/workflow/Snakefile
+++ b/snakemake/enhancer_classification/workflow/Snakefile
@@ -23,7 +23,8 @@ wildcard_constraints:
     intervals="|".join(ALL_INTERVALS),
     split_name="|".join(ALL_SPLIT_NAMES),
     conservation="|".join(ALL_CONSERVATIONS),
-    label_type="positives|negatives",
+    label_type="positives|negatives|negative_candidates|negatives_gc_repeat_matched",
+    neg_type="|".join(ALL_NEG_TYPES),
     n=r"\d+",
     model="|".join(MODEL_NAMES) if MODEL_NAMES else "NONE",
 

--- a/snakemake/enhancer_classification/workflow/rules/common.smk
+++ b/snakemake/enhancer_classification/workflow/rules/common.smk
@@ -13,7 +13,7 @@ import bioframe as bf
 
 from bolinas.data.intervals import GenomicList, GenomicSet
 from bolinas.data.negative_sampling import compute_gc_content, compute_repeat_fraction, match_by_gc_repeat
-from bolinas.data.utils import ENHANCER_CRE_CLASSES, add_rc, get_exons, get_ensembl_functional_exons, load_annotation, load_fasta
+from bolinas.data.utils import ENHANCER_CRE_CLASSES, add_rc, get_ensembl_functional_exons, load_annotation, load_fasta
 
 
 SPECIES = list(config["genome_urls"].keys())

--- a/snakemake/enhancer_classification/workflow/rules/common.smk
+++ b/snakemake/enhancer_classification/workflow/rules/common.smk
@@ -13,7 +13,7 @@ import bioframe as bf
 
 from bolinas.data.intervals import GenomicSet
 from bolinas.data.negative_sampling import compute_gc_content, compute_repeat_fraction, match_by_gc_repeat
-from bolinas.data.utils import ENHANCER_CRE_CLASSES, add_rc, get_exons, load_annotation, load_fasta
+from bolinas.data.utils import ENHANCER_CRE_CLASSES, add_rc, get_exons, get_ensembl_functional_exons, load_annotation, load_fasta
 
 
 SPECIES = list(config["genome_urls"].keys())

--- a/snakemake/enhancer_classification/workflow/rules/common.smk
+++ b/snakemake/enhancer_classification/workflow/rules/common.smk
@@ -9,6 +9,8 @@ import polars as pl
 import pyBigWig
 from huggingface_hub import hf_hub_download
 
+import bioframe as bf
+
 from bolinas.data.intervals import GenomicSet
 from bolinas.data.negative_sampling import compute_gc_content, compute_repeat_fraction, match_by_gc_repeat
 from bolinas.data.utils import ENHANCER_CRE_CLASSES, add_rc, get_exons, load_annotation, load_fasta

--- a/snakemake/enhancer_classification/workflow/rules/common.smk
+++ b/snakemake/enhancer_classification/workflow/rules/common.smk
@@ -11,7 +11,7 @@ from huggingface_hub import hf_hub_download
 
 import bioframe as bf
 
-from bolinas.data.intervals import GenomicSet
+from bolinas.data.intervals import GenomicList, GenomicSet
 from bolinas.data.negative_sampling import compute_gc_content, compute_repeat_fraction, match_by_gc_repeat
 from bolinas.data.utils import ENHANCER_CRE_CLASSES, add_rc, get_exons, get_ensembl_functional_exons, load_annotation, load_fasta
 

--- a/snakemake/enhancer_classification/workflow/rules/common.smk
+++ b/snakemake/enhancer_classification/workflow/rules/common.smk
@@ -10,6 +10,7 @@ import pyBigWig
 from huggingface_hub import hf_hub_download
 
 from bolinas.data.intervals import GenomicSet
+from bolinas.data.negative_sampling import compute_gc_content, compute_repeat_fraction, match_by_gc_repeat
 from bolinas.data.utils import ENHANCER_CRE_CLASSES, add_rc, get_exons, load_annotation, load_fasta
 
 
@@ -28,6 +29,15 @@ for _dataset_config in config["datasets"].values():
 ALL_CONSERVATIONS: set[str] = set()
 for _species_cons in config.get("conservation", {}).values():
     ALL_CONSERVATIONS.update(_species_cons.keys())
+
+NEGATIVES_FOR_SAMPLING: dict[str, str] = {
+    "random": "negatives",
+    "gc_repeat_matched": "negatives_gc_repeat_matched",
+}
+
+ALL_NEG_TYPES: set[str] = {"random"}
+for _dataset_config in config["datasets"].values():
+    ALL_NEG_TYPES.add(_dataset_config.get("negative_sampling", "random"))
 
 TRAIN_SPLIT = "train"
 

--- a/snakemake/enhancer_classification/workflow/rules/data.smk
+++ b/snakemake/enhancer_classification/workflow/rules/data.smk
@@ -230,7 +230,7 @@ rule extract_exons:
         "results/annotation/{species}/exons.parquet",
     run:
         ann = load_annotation(input[0])
-        exons = get_exons(ann)
+        exons = get_ensembl_functional_exons(ann)
         exons.write_parquet(output[0])
 
 

--- a/snakemake/enhancer_classification/workflow/rules/data.smk
+++ b/snakemake/enhancer_classification/workflow/rules/data.smk
@@ -305,6 +305,115 @@ rule sample_negatives:
         """
 
 
+rule generate_negative_candidates:
+    input:
+        positives="results/intervals/{intervals}/{species}/positives.bed",
+        exclusion="results/intervals/{intervals}/{species}/exclusion.bed",
+        chrom_sizes="results/genome/{species}.chrom.sizes.filtered",
+    output:
+        temp("results/intervals/{intervals}/{species}/negative_candidates.bed"),
+    params:
+        seed=config["seed"],
+        oversampling_factor=config["negative_sampling"]["gc_repeat_matched"][
+            "oversampling_factor"
+        ],
+    conda:
+        "../envs/bioinformatics.yaml"
+    shell:
+        """
+        for i in $(seq 1 {params.oversampling_factor}); do
+            bedtools shuffle \
+                -i {input.positives} \
+                -g {input.chrom_sizes} \
+                -excl {input.exclusion} \
+                -chrom \
+                -seed $(({params.seed} + i))
+        done | sort -k1,1 -k2,2n -u > {output}
+        """
+
+
+rule sample_gc_repeat_matched_negatives:
+    input:
+        pos_fa=local("results/sequences/{intervals}/{species}/positives.fa"),
+        cand_fa=local("results/sequences/{intervals}/{species}/negative_candidates.fa"),
+    output:
+        "results/intervals/{intervals}/{species}/negatives_gc_repeat_matched.bed",
+    params:
+        gc_bin_size=config["negative_sampling"]["gc_repeat_matched"]["gc_bin_size"],
+        repeat_bin_size=config["negative_sampling"]["gc_repeat_matched"][
+            "repeat_bin_size"
+        ],
+        seed=config["seed"],
+    run:
+        pos_seqs = load_fasta(input.pos_fa)
+        cand_seqs = load_fasta(input.cand_fa)
+
+        indices = match_by_gc_repeat(
+            pos_seqs,
+            cand_seqs,
+            gc_bin_size=params.gc_bin_size,
+            repeat_bin_size=params.repeat_bin_size,
+            seed=params.seed,
+        )
+
+        # Parse coordinates from FASTA headers (format: chrom:start-end)
+        matched_ids = cand_seqs.index[indices]
+        coords = matched_ids.str.split(":", expand=True)
+        start_end = coords.get_level_values(1).str.split("-", expand=True)
+        bed = pd.DataFrame(
+            {
+                "chrom": coords.get_level_values(0),
+                "start": start_end.get_level_values(0).astype(int),
+                "end": start_end.get_level_values(1).astype(int),
+            }
+        )
+        bed.to_csv(output[0], sep="\t", header=False, index=False)
+
+
+rule plot_negative_sampling:
+    input:
+        pos_fa=local("results/sequences/{intervals}/{species}/positives.fa"),
+        neg_random_fa=local("results/sequences/{intervals}/{species}/negatives.fa"),
+        neg_matched_fa=local(
+            "results/sequences/{intervals}/{species}/negatives_gc_repeat_matched.fa"
+        ),
+    output:
+        "results/plots/negative_sampling/{intervals}/{species}.svg",
+    run:
+        pos_seqs = load_fasta(input.pos_fa)
+        neg_random_seqs = load_fasta(input.neg_random_fa)
+        neg_matched_seqs = load_fasta(input.neg_matched_fa)
+
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+
+        bins_gc = np.linspace(0, 1, 81)
+        bins_rep = np.linspace(0, 1, 51)
+        hist_kw = dict(histtype="step", linewidth=1.5)
+
+        groups = [
+            (pos_seqs, "Enhancers"),
+            (neg_random_seqs, "Random negatives"),
+            (neg_matched_seqs, "GC/repeat matched"),
+        ]
+
+        for seqs, label in groups:
+            ax1.hist(compute_gc_content(seqs), bins=bins_gc, label=label, **hist_kw)
+        ax1.set_xlabel("GC content")
+        ax1.set_ylabel("Count")
+        ax1.legend()
+
+        for seqs, label in groups:
+            ax2.hist(compute_repeat_fraction(seqs), bins=bins_rep, label=label, **hist_kw)
+        ax2.set_xlabel("Repeat fraction")
+        ax2.set_ylabel("Count")
+        ax2.legend()
+
+        fig.suptitle(f"Negative sampling — {wildcards.species}")
+        fig.tight_layout()
+        fig.savefig(output[0])
+        plt.close(fig)
+
+
 rule prepare_bed_for_seq:
     input:
         "results/intervals/{intervals}/{species}/{label_type}.bed",
@@ -331,9 +440,12 @@ rule extract_sequences:
 rule make_species_parquet:
     input:
         pos=local("results/sequences/{intervals}/{species}/positives.fa"),
-        neg=local("results/sequences/{intervals}/{species}/negatives.fa"),
+        neg=lambda wc: local(
+            f"results/sequences/{wc.intervals}/{wc.species}/"
+            f"{NEGATIVES_FOR_SAMPLING[wc.neg_type]}.fa"
+        ),
     output:
-        "results/parquet/{intervals}/{species}.parquet",
+        "results/parquet/{intervals}/{neg_type}/{species}.parquet",
     run:
         window_size = config["window_size"]
 
@@ -350,7 +462,9 @@ rule build_dataset:
     input:
         lambda wc: [
             f"results/parquet/"
-            f"{config['datasets'][wc.dataset]['intervals']}/{species}.parquet"
+            f"{config['datasets'][wc.dataset]['intervals']}/"
+            f"{config['datasets'][wc.dataset].get('negative_sampling', 'random')}/"
+            f"{species}.parquet"
             for species, splits in (
                 config["splits"][config["datasets"][wc.dataset]["split"]].items()
             )

--- a/snakemake/enhancer_classification/workflow/rules/data.smk
+++ b/snakemake/enhancer_classification/workflow/rules/data.smk
@@ -247,18 +247,9 @@ rule filter_no_exon_overlap:
 
         # Check exon overlap on center conservation_window only,
         # consistent with how conservation is scored
-        size = df["end"] - df["start"]
-        center_adj = (size - conservation_window) // 2
-        center = pl.DataFrame(
-            {
-                "chrom": df["chrom"],
-                "start": df["start"] + center_adj,
-                "end": df["start"] + center_adj + conservation_window,
-            }
-        ).to_pandas()
-
-        overlaps = bf.count_overlaps(center, exons._data)
-        mask = (overlaps["count"] == 0).to_numpy()
+        center = GenomicList(df).resize(conservation_window)
+        no_overlap = bf.count_overlaps(center._data, exons._data)
+        mask = (no_overlap["count"] == 0).to_numpy()
 
         df.filter(pl.Series(mask)).write_parquet(output[0])
 
@@ -273,13 +264,13 @@ rule make_positives:
     run:
         window_size = config["window_size"]
 
-        intervals = GenomicSet(pl.read_parquet(input.intervals))
+        intervals = GenomicList(pl.read_parquet(input.intervals))
         intervals = intervals.resize(window_size)
 
         genome = GenomicSet.read_bed(input.genome)
         undefined = GenomicSet.read_bed(input.undefined)
         defined = genome - undefined
-        intervals = intervals & defined
+        intervals = intervals.filter_within(defined)
         intervals = intervals.filter_size(min_size=window_size, max_size=window_size)
 
         intervals.write_bed(output[0])

--- a/snakemake/enhancer_classification/workflow/rules/data.smk
+++ b/snakemake/enhancer_classification/workflow/rules/data.smk
@@ -241,10 +241,26 @@ rule filter_no_exon_overlap:
     output:
         "results/cre/{species}/noexon/{base}.parquet",
     run:
-        intervals = GenomicSet.read_parquet(input.intervals)
+        conservation_window = config["conservation_window"]
+        df = pl.read_parquet(input.intervals)
         exons = GenomicSet.read_parquet(input.exons)
-        filtered = intervals.filter_not_overlapping(exons)
-        filtered.write_parquet(output[0])
+
+        # Check exon overlap on center conservation_window only,
+        # consistent with how conservation is scored
+        size = df["end"] - df["start"]
+        center_adj = (size - conservation_window) // 2
+        center = pl.DataFrame(
+            {
+                "chrom": df["chrom"],
+                "start": df["start"] + center_adj,
+                "end": df["start"] + center_adj + conservation_window,
+            }
+        ).to_pandas()
+
+        overlaps = bf.count_overlaps(center, exons._data)
+        mask = (overlaps["count"] == 0).to_numpy()
+
+        df.filter(pl.Series(mask)).write_parquet(output[0])
 
 
 rule make_positives:

--- a/snakemake/enhancer_classification/workflow/rules/visualization.smk
+++ b/snakemake/enhancer_classification/workflow/rules/visualization.smk
@@ -34,5 +34,5 @@ rule predict_region:
             --window-size {params.window_size} \
             --step-size {params.step_size} \
             --output {output} \
-            --name "Enhancer probability"
+            --name "Enhancer probability ({wildcards.model}/{wildcards.dataset})"
         """

--- a/src/bolinas/data/intervals.py
+++ b/src/bolinas/data/intervals.py
@@ -320,3 +320,97 @@ class GenomicSet:
             path: Path to the output parquet file.
         """
         self._data.to_parquet(path, index=False)
+
+
+class GenomicList:
+    """An ordered list of genomic intervals that preserves each element's identity.
+
+    Unlike GenomicSet, intervals are never merged -- two overlapping intervals
+    remain as separate rows.  This is the right abstraction when each interval
+    represents an independent genomic element (e.g. enhancers resized to a
+    fixed window) and we need per-element filtering.
+
+    Coordinates follow Python semantics (0-based, half-open).
+
+    Args:
+        data: A pandas or polars DataFrame with at least columns
+            ['chrom', 'start', 'end'].  Only these columns are kept.
+    """
+
+    def __init__(self, data: pd.DataFrame | pl.DataFrame) -> None:
+        if isinstance(data, pl.DataFrame):
+            data = data.to_pandas()
+        self._data = data[INTERVAL_COORDS].reset_index(drop=True)
+
+    def __repr__(self) -> str:
+        return f"GenomicList ({len(self._data)} intervals)\n{self._data}"
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, GenomicList):
+            return False
+        return bool(self._data.equals(other._data))
+
+    # -- transforms --
+
+    def resize(self, target_size: int) -> "GenomicList":
+        """Resize every interval to exactly *target_size* bp, centred on
+        its midpoint.  Each element is handled independently."""
+        if target_size <= 0:
+            raise ValueError(f"target_size must be positive, got {target_size}")
+        res = self._data.copy()
+        size = res["end"] - res["start"]
+        diff = target_size - size
+        left_adj = diff // 2
+        right_adj = diff - left_adj
+        res["start"] = res["start"] - left_adj
+        res["end"] = res["end"] + right_adj
+        return GenomicList(res)
+
+    # -- filters --
+
+    def filter_size(
+        self, min_size: int = 0, max_size: int = np.iinfo(np.int64).max
+    ) -> "GenomicList":
+        """Keep only intervals whose size falls in [min_size, max_size]."""
+        size = self._data["end"] - self._data["start"]
+        return GenomicList(self._data.loc[size.between(min_size, max_size)])
+
+    def filter_not_overlapping(self, regions: GenomicSet) -> "GenomicList":
+        """Drop intervals that overlap any region in *regions*."""
+        if len(self._data) == 0 or len(regions._data) == 0:
+            return GenomicList(self._data.copy())
+        counts = bf.count_overlaps(self._data, regions._data)
+        return GenomicList(self._data.loc[counts["count"] == 0])
+
+    def filter_within(self, regions: GenomicSet) -> "GenomicList":
+        """Keep only intervals fully contained within *regions*.
+
+        An interval is kept when its coverage by *regions* equals its
+        full length (i.e. no part falls outside *regions*)."""
+        if len(self._data) == 0:
+            return GenomicList(self._data.copy())
+        if len(regions._data) == 0:
+            return GenomicList(self._data.iloc[:0].copy())
+        cov = bf.coverage(self._data, regions._data, return_input=False)
+        size = self._data["end"] - self._data["start"]
+        return GenomicList(self._data.loc[cov["coverage"] >= size])
+
+    # -- conversions --
+
+    def to_pandas(self) -> pd.DataFrame:
+        return self._data
+
+    def to_polars(self) -> pl.DataFrame:
+        return pl.from_pandas(self._data)
+
+    # -- I/O --
+
+    def write_bed(self, path: str) -> None:
+        self._data.to_csv(path, sep="\t", header=False, index=False)
+
+    @classmethod
+    def from_parquet(cls, path: str) -> "GenomicList":
+        return cls(pd.read_parquet(path))

--- a/src/bolinas/data/intervals.py
+++ b/src/bolinas/data/intervals.py
@@ -6,6 +6,18 @@ import polars as pl
 INTERVAL_COORDS = ["chrom", "start", "end"]
 
 
+def _resize_df(data: pd.DataFrame, target_size: int) -> pd.DataFrame:
+    """Resize intervals to *target_size* bp, centred on midpoints."""
+    res = data.copy()
+    size = res["end"] - res["start"]
+    diff = target_size - size
+    left_adj = diff // 2
+    right_adj = diff - left_adj
+    res["start"] = res["start"] - left_adj
+    res["end"] = res["end"] + right_adj
+    return res
+
+
 class GenomicSet:
     """A set of genomic intervals that are always non-overlapping.
 
@@ -227,14 +239,7 @@ class GenomicSet:
         """
         if target_size <= 0:
             raise ValueError(f"target_size must be positive, got {target_size}")
-        res = self._data.copy()
-        size = res["end"] - res["start"]
-        diff = target_size - size
-        left_adj = diff // 2
-        right_adj = diff - left_adj
-        res["start"] = res["start"] - left_adj
-        res["end"] = res["end"] + right_adj
-        return GenomicSet(res)
+        return GenomicSet(_resize_df(self._data, target_size))
 
     def add_flank(self, flank: int) -> "GenomicSet":
         """Expand intervals by adding flanking regions on both sides.
@@ -360,14 +365,7 @@ class GenomicList:
         its midpoint.  Each element is handled independently."""
         if target_size <= 0:
             raise ValueError(f"target_size must be positive, got {target_size}")
-        res = self._data.copy()
-        size = res["end"] - res["start"]
-        diff = target_size - size
-        left_adj = diff // 2
-        right_adj = diff - left_adj
-        res["start"] = res["start"] - left_adj
-        res["end"] = res["end"] + right_adj
-        return GenomicList(res)
+        return GenomicList(_resize_df(self._data, target_size))
 
     # -- filters --
 

--- a/src/bolinas/data/negative_sampling.py
+++ b/src/bolinas/data/negative_sampling.py
@@ -22,7 +22,7 @@ def compute_repeat_fraction(sequences: pd.Series) -> pd.Series:
     return lowercase_count / sequences.str.len()
 
 
-def _parse_chrom(index: pd.Index) -> pd.Series:
+def _parse_chrom(index: pd.Index) -> np.ndarray:
     """Extract chromosome from FASTA-style index (chrom:start-end)."""
     return index.to_series().str.split(":").str[0].to_numpy()
 
@@ -102,23 +102,19 @@ def _match_ungrouped(
     cand_gc = compute_gc_content(candidate_seqs).to_numpy()
     cand_repeat = compute_repeat_fraction(candidate_seqs).to_numpy()
 
-    # Assign bins
     pos_gc_bin = (pos_gc / gc_bin_size).astype(int)
     pos_rep_bin = (pos_repeat / repeat_bin_size).astype(int)
     cand_gc_bin = (cand_gc / gc_bin_size).astype(int)
     cand_rep_bin = (cand_repeat / repeat_bin_size).astype(int)
 
-    # Build bin → candidate index mapping
     bin_to_candidates: dict[tuple[int, int], list[int]] = {}
     for i in range(len(candidate_seqs)):
         key = (cand_gc_bin[i], cand_rep_bin[i])
         bin_to_candidates.setdefault(key, []).append(i)
 
-    # Shuffle candidates within each bin for random selection
     for indices in bin_to_candidates.values():
         rng.shuffle(indices)
 
-    # Track consumption position per bin
     bin_pos: dict[tuple[int, int], int] = {k: 0 for k in bin_to_candidates}
 
     matched_indices = np.full(len(positive_seqs), -1, dtype=int)

--- a/src/bolinas/data/negative_sampling.py
+++ b/src/bolinas/data/negative_sampling.py
@@ -22,6 +22,11 @@ def compute_repeat_fraction(sequences: pd.Series) -> pd.Series:
     return lowercase_count / sequences.str.len()
 
 
+def _parse_chrom(index: pd.Index) -> pd.Series:
+    """Extract chromosome from FASTA-style index (chrom:start-end)."""
+    return index.to_series().str.split(":").str[0].to_numpy()
+
+
 def match_by_gc_repeat(
     positive_seqs: pd.Series,
     candidate_seqs: pd.Series,
@@ -31,18 +36,22 @@ def match_by_gc_repeat(
 ) -> np.ndarray:
     """Match each positive to a candidate with similar GC and repeat content.
 
-    Uses bin-based matching: positives and candidates are assigned to 2D bins
-    defined by (GC%, repeat%). For each positive, a candidate from the same bin
-    is selected without replacement. Falls back to nearest-neighbor for
-    positives whose bin has no remaining candidates.
+    Matching is performed independently per chromosome (parsed from the Series
+    index, expected format ``chrom:start-end``) so that the chromosome
+    distribution of negatives mirrors that of positives.
+
+    Within each chromosome, uses bin-based matching on (GC%, repeat%) bins.
+    Falls back to nearest-neighbor for bins with no remaining candidates.
 
     Parameters
     ----------
     positive_seqs : pd.Series
         DNA sequences for positive (enhancer) regions, soft-masked.
+        Index must be ``chrom:start-end``.
     candidate_seqs : pd.Series
         DNA sequences for candidate negative regions, soft-masked.
         Should be oversampled (e.g. 20x) relative to positives.
+        Index must be ``chrom:start-end``.
     gc_bin_size : float
         Width of GC content bins (fraction, 0-1).
     repeat_bin_size : float
@@ -55,6 +64,37 @@ def match_by_gc_repeat(
     np.ndarray
         Indices into candidate_seqs, one per positive.
     """
+    pos_chroms = _parse_chrom(positive_seqs.index)
+    cand_chroms = _parse_chrom(candidate_seqs.index)
+
+    matched_indices = np.full(len(positive_seqs), -1, dtype=int)
+
+    for chrom in np.unique(pos_chroms):
+        pos_mask = pos_chroms == chrom
+        cand_mask = cand_chroms == chrom
+        pos_idx = np.where(pos_mask)[0]
+        cand_idx = np.where(cand_mask)[0]
+
+        group_matches = _match_ungrouped(
+            positive_seqs.iloc[pos_idx].reset_index(drop=True),
+            candidate_seqs.iloc[cand_idx].reset_index(drop=True),
+            gc_bin_size,
+            repeat_bin_size,
+            seed,
+        )
+        matched_indices[pos_idx] = cand_idx[group_matches]
+
+    return matched_indices
+
+
+def _match_ungrouped(
+    positive_seqs: pd.Series,
+    candidate_seqs: pd.Series,
+    gc_bin_size: float,
+    repeat_bin_size: float,
+    seed: int,
+) -> np.ndarray:
+    """Core bin-based matching logic for a single group."""
     rng = np.random.default_rng(seed)
 
     pos_gc = compute_gc_content(positive_seqs).to_numpy()

--- a/src/bolinas/data/negative_sampling.py
+++ b/src/bolinas/data/negative_sampling.py
@@ -1,0 +1,133 @@
+"""GC and repeat-content matched negative sampling for enhancer classification.
+
+Matches negative (non-enhancer) genomic regions to positive (enhancer) regions
+based on GC content and repeat fraction, removing compositional confounds that
+hinder cross-species generalization.
+"""
+
+import numpy as np
+import pandas as pd
+from scipy.spatial import KDTree
+
+
+def compute_gc_content(sequences: pd.Series) -> pd.Series:
+    """Fraction of G+C bases (case-insensitive) per sequence."""
+    gc_count = sequences.str.count("[GCgc]")
+    return gc_count / sequences.str.len()
+
+
+def compute_repeat_fraction(sequences: pd.Series) -> pd.Series:
+    """Fraction of lowercase (repeat-masked) bases in soft-masked sequences."""
+    lowercase_count = sequences.str.count("[acgt]")
+    return lowercase_count / sequences.str.len()
+
+
+def match_by_gc_repeat(
+    positive_seqs: pd.Series,
+    candidate_seqs: pd.Series,
+    gc_bin_size: float = 0.02,
+    repeat_bin_size: float = 0.05,
+    seed: int = 42,
+) -> np.ndarray:
+    """Match each positive to a candidate with similar GC and repeat content.
+
+    Uses bin-based matching: positives and candidates are assigned to 2D bins
+    defined by (GC%, repeat%). For each positive, a candidate from the same bin
+    is selected without replacement. Falls back to nearest-neighbor for
+    positives whose bin has no remaining candidates.
+
+    Parameters
+    ----------
+    positive_seqs : pd.Series
+        DNA sequences for positive (enhancer) regions, soft-masked.
+    candidate_seqs : pd.Series
+        DNA sequences for candidate negative regions, soft-masked.
+        Should be oversampled (e.g. 20x) relative to positives.
+    gc_bin_size : float
+        Width of GC content bins (fraction, 0-1).
+    repeat_bin_size : float
+        Width of repeat fraction bins (fraction, 0-1).
+    seed : int
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    np.ndarray
+        Indices into candidate_seqs, one per positive.
+    """
+    rng = np.random.default_rng(seed)
+
+    pos_gc = compute_gc_content(positive_seqs).to_numpy()
+    pos_repeat = compute_repeat_fraction(positive_seqs).to_numpy()
+    cand_gc = compute_gc_content(candidate_seqs).to_numpy()
+    cand_repeat = compute_repeat_fraction(candidate_seqs).to_numpy()
+
+    # Assign bins
+    pos_gc_bin = (pos_gc / gc_bin_size).astype(int)
+    pos_rep_bin = (pos_repeat / repeat_bin_size).astype(int)
+    cand_gc_bin = (cand_gc / gc_bin_size).astype(int)
+    cand_rep_bin = (cand_repeat / repeat_bin_size).astype(int)
+
+    # Build bin → candidate index mapping
+    bin_to_candidates: dict[tuple[int, int], list[int]] = {}
+    for i in range(len(candidate_seqs)):
+        key = (cand_gc_bin[i], cand_rep_bin[i])
+        bin_to_candidates.setdefault(key, []).append(i)
+
+    # Shuffle candidates within each bin for random selection
+    for indices in bin_to_candidates.values():
+        rng.shuffle(indices)
+
+    # Track consumption position per bin
+    bin_pos: dict[tuple[int, int], int] = {k: 0 for k in bin_to_candidates}
+
+    matched_indices = np.full(len(positive_seqs), -1, dtype=int)
+    unmatched_positives: list[int] = []
+
+    # Phase 1: bin-based matching
+    for i in range(len(positive_seqs)):
+        key = (pos_gc_bin[i], pos_rep_bin[i])
+        candidates = bin_to_candidates.get(key)
+        if candidates is not None and bin_pos[key] < len(candidates):
+            matched_indices[i] = candidates[bin_pos[key]]
+            bin_pos[key] += 1
+        else:
+            unmatched_positives.append(i)
+
+    # Phase 2: nearest-neighbor fallback for unmatched positives
+    if unmatched_positives:
+        used = set(matched_indices[matched_indices >= 0].tolist())
+        available_mask = np.ones(len(candidate_seqs), dtype=bool)
+        available_mask[list(used)] = False
+        available_indices = np.where(available_mask)[0]
+
+        if len(available_indices) < len(unmatched_positives):
+            msg = (
+                f"Not enough candidates ({len(candidate_seqs)}) to match "
+                f"all positives ({len(positive_seqs)})"
+            )
+            raise ValueError(msg)
+
+        cand_props = np.column_stack(
+            [cand_gc[available_indices], cand_repeat[available_indices]]
+        )
+        tree = KDTree(cand_props)
+
+        # Query enough neighbors to guarantee unique assignments
+        k = min(len(available_indices), len(unmatched_positives))
+        queries = np.column_stack(
+            [pos_gc[unmatched_positives], pos_repeat[unmatched_positives]]
+        )
+        _, all_nn_idx = tree.query(queries, k=k)
+
+        # Greedily assign nearest available neighbor
+        used_available: set[int] = set()
+        for row, i in enumerate(unmatched_positives):
+            nn_indices = all_nn_idx[row] if k > 1 else [all_nn_idx[row]]
+            for nn_idx in nn_indices:
+                if nn_idx not in used_available:
+                    matched_indices[i] = available_indices[nn_idx]
+                    used_available.add(nn_idx)
+                    break
+
+    return matched_indices

--- a/src/bolinas/data/utils.py
+++ b/src/bolinas/data/utils.py
@@ -224,6 +224,22 @@ def _get_functional_transcript_exons(ann: pl.DataFrame) -> pl.DataFrame:
     return pl.concat([mrna_exons, ncrna_exons])
 
 
+ENSEMBL_EXCLUDED_TRANSCRIPT_BIOTYPES = [
+    "retained_intron",
+    "nonsense_mediated_decay",
+    "protein_coding_CDS_not_defined",
+    "processed_pseudogene",
+    "transcribed_unprocessed_pseudogene",
+    "transcribed_processed_pseudogene",
+    "unprocessed_pseudogene",
+    "unitary_pseudogene",
+    "translated_processed_pseudogene",
+    "TEC",
+    "artifact",
+    "non_stop_decay",
+]
+
+
 def get_exons(ann: pl.DataFrame) -> GenomicSet:
     """Extract all exon regions from an annotation DataFrame.
 
@@ -234,6 +250,32 @@ def get_exons(ann: pl.DataFrame) -> GenomicSet:
         GenomicSet containing merged exon regions.
     """
     return GenomicSet(ann.filter(pl.col("feature") == "exon"))
+
+
+def get_ensembl_functional_exons(ann: pl.DataFrame) -> GenomicSet:
+    """Extract exon regions from well-supported transcripts only.
+
+    Excludes exons from transcript biotypes that represent annotation
+    artifacts or non-functional transcripts (retained introns, NMD,
+    pseudogenes, TEC, etc.). This avoids incorrectly marking enhancers
+    as exonic based on questionable transcript annotations.
+
+    Args:
+        ann: Annotation DataFrame from load_annotation().
+
+    Returns:
+        GenomicSet containing merged exon regions from well-supported
+        transcripts.
+    """
+    exons = ann.filter(pl.col("feature") == "exon")
+    biotype = exons.select(
+        pl.col("attribute")
+        .str.extract(r'transcript_biotype "([^"]+)"')
+        .alias("transcript_biotype")
+    )["transcript_biotype"]
+    return GenomicSet(
+        exons.filter(~biotype.is_in(ENSEMBL_EXCLUDED_TRANSCRIPT_BIOTYPES))
+    )
 
 
 def get_cds(ann: pl.DataFrame) -> GenomicSet:

--- a/src/bolinas/enhancer_classification/predict.py
+++ b/src/bolinas/enhancer_classification/predict.py
@@ -95,7 +95,7 @@ def write_bedgraph(
     ucsc_chrom = f"chr{chrom}"
     with open(path, "w") as f:
         f.write(
-            f'track type=bedGraph name="{track_name}" visibility=full autoScale=on\n'
+            f'track type=bedGraph name="{track_name}" visibility=full autoScale=on windowingFunction=mean\n'
         )
         for (start, end), score in zip(windows, scores):
             f.write(f"{ucsc_chrom}\t{start}\t{end}\t{score:.6f}\n")

--- a/tests/test_intervals.py
+++ b/tests/test_intervals.py
@@ -2,7 +2,7 @@ import pandas as pd
 import polars as pl
 import pytest
 
-from bolinas.data.intervals import GenomicSet
+from bolinas.data.intervals import GenomicList, GenomicSet
 
 
 # GenomicSet tests
@@ -2516,3 +2516,148 @@ def test_filter_not_overlapping_empty_self():
     result = gs1.filter_not_overlapping(gs2)
 
     assert result == gs1
+
+
+# GenomicList tests
+
+
+def test_genomic_list_preserves_overlapping_intervals():
+    """Overlapping intervals are NOT merged."""
+    data = pd.DataFrame(
+        {"chrom": ["chr1", "chr1"], "start": [0, 40], "end": [80, 120]}
+    )
+    gl = GenomicList(data)
+    assert len(gl) == 2
+    assert gl._data["start"].tolist() == [0, 40]
+
+
+def test_genomic_list_init_from_polars():
+    data = pl.DataFrame(
+        {"chrom": ["chr1", "chr1"], "start": [0, 40], "end": [80, 120]}
+    )
+    gl = GenomicList(data)
+    assert len(gl) == 2
+
+
+def test_genomic_list_resize_independent():
+    """Two adjacent elements resize independently without merging."""
+    data = pd.DataFrame(
+        {"chrom": ["chr1", "chr1"], "start": [100, 110], "end": [120, 130]}
+    )
+    gl = GenomicList(data).resize(50)
+    assert len(gl) == 2
+    assert gl._data["start"].tolist() == [85, 95]
+    assert gl._data["end"].tolist() == [135, 145]
+
+
+def test_genomic_list_drops_extra_columns():
+    data = pd.DataFrame(
+        {"chrom": ["chr1"], "start": [100], "end": [200], "name": ["enh1"]}
+    )
+    gl = GenomicList(data)
+    assert list(gl._data.columns) == ["chrom", "start", "end"]
+
+
+def test_genomic_list_resize_invalid():
+    gl = GenomicList(pd.DataFrame({"chrom": ["chr1"], "start": [0], "end": [10]}))
+    with pytest.raises(ValueError):
+        gl.resize(0)
+
+
+def test_genomic_list_filter_size():
+    data = pd.DataFrame(
+        {"chrom": ["chr1", "chr1", "chr1"], "start": [0, 0, 0], "end": [50, 100, 255]}
+    )
+    gl = GenomicList(data)
+    result = gl.filter_size(min_size=100, max_size=255)
+    assert len(result) == 2
+    assert result._data["end"].tolist() == [100, 255]
+
+
+def test_genomic_list_filter_not_overlapping():
+    """Intervals overlapping an exon set are dropped; others kept."""
+    intervals = pd.DataFrame(
+        {"chrom": ["chr1", "chr1", "chr1"], "start": [0, 100, 300], "end": [50, 200, 400]}
+    )
+    exons = GenomicSet(
+        pd.DataFrame({"chrom": ["chr1"], "start": [120], "end": [150]})
+    )
+    result = GenomicList(intervals).filter_not_overlapping(exons)
+    assert len(result) == 2
+    assert result._data["start"].tolist() == [0, 300]
+
+
+def test_genomic_list_filter_within():
+    """Only intervals fully inside defined regions are kept."""
+    intervals = pd.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr1"],
+            "start": [10, 50, 200],
+            "end": [30, 120, 250],
+        }
+    )
+    defined = GenomicSet(
+        pd.DataFrame({"chrom": ["chr1", "chr1"], "start": [0, 200], "end": [100, 300]})
+    )
+    result = GenomicList(intervals).filter_within(defined)
+    # 10-30 is within 0-100  ✓
+    # 50-120 extends past 100 ✗
+    # 200-250 is within 200-300 ✓
+    assert len(result) == 2
+    assert result._data["start"].tolist() == [10, 200]
+
+
+def test_genomic_list_filter_within_partial_coverage():
+    """Interval spanning a gap in defined regions is dropped."""
+    intervals = pd.DataFrame(
+        {"chrom": ["chr1"], "start": [50], "end": [250]}
+    )
+    defined = GenomicSet(
+        pd.DataFrame(
+            {"chrom": ["chr1", "chr1"], "start": [0, 200], "end": [100, 300]}
+        )
+    )
+    result = GenomicList(intervals).filter_within(defined)
+    # 50-250 spans the gap 100-200, coverage = 50 + 50 = 100 < 200
+    assert len(result) == 0
+
+
+def test_genomic_list_filter_within_empty():
+    intervals = pd.DataFrame(
+        {"chrom": ["chr1"], "start": [10], "end": [30]}
+    )
+    empty_regions = GenomicSet(pd.DataFrame({"chrom": [], "start": [], "end": []}))
+    result = GenomicList(intervals).filter_within(empty_regions)
+    assert len(result) == 0
+
+
+def test_genomic_list_write_bed(tmp_path):
+    data = pd.DataFrame(
+        {"chrom": ["chr1", "chr2"], "start": [10, 20], "end": [50, 80]}
+    )
+    path = str(tmp_path / "out.bed")
+    GenomicList(data).write_bed(path)
+    written = pd.read_csv(path, sep="\t", header=None, names=["chrom", "start", "end"])
+    assert written["chrom"].tolist() == ["chr1", "chr2"]
+    assert len(written.columns) == 3
+
+
+def test_genomic_list_equality():
+    data = pd.DataFrame({"chrom": ["chr1"], "start": [0], "end": [100]})
+    assert GenomicList(data) == GenomicList(data.copy())
+    assert GenomicList(data) != "not a GenomicList"
+
+
+def test_genomic_list_adjacent_enhancers_survive_resize():
+    """Reproduces the bug: two enhancers 6bp apart should both survive
+    resize to 255bp as independent elements."""
+    data = pd.DataFrame(
+        {
+            "chrom": ["chr19", "chr19"],
+            "start": [30360805, 30361145],
+            "end": [30361139, 30361298],
+        }
+    )
+    gl = GenomicList(data).resize(255)
+    result = gl.filter_size(min_size=255, max_size=255)
+    assert len(result) == 2

--- a/tests/test_negative_sampling.py
+++ b/tests/test_negative_sampling.py
@@ -1,0 +1,120 @@
+import numpy as np
+import pandas as pd
+
+from bolinas.data.negative_sampling import (
+    compute_gc_content,
+    compute_repeat_fraction,
+    match_by_gc_repeat,
+)
+
+
+def test_compute_gc_content_all_gc():
+    seqs = pd.Series(["GCGCGC", "GGGGGG"])
+    result = compute_gc_content(seqs)
+    assert result.tolist() == [1.0, 1.0]
+
+
+def test_compute_gc_content_no_gc():
+    seqs = pd.Series(["ATATAT", "TTTTTT"])
+    result = compute_gc_content(seqs)
+    assert result.tolist() == [0.0, 0.0]
+
+
+def test_compute_gc_content_mixed():
+    seqs = pd.Series(["ATGC"])  # 2 GC out of 4
+    result = compute_gc_content(seqs)
+    assert result.iloc[0] == 0.5
+
+
+def test_compute_gc_content_case_insensitive():
+    seqs = pd.Series(["atgc", "ATGC", "AtGc"])
+    result = compute_gc_content(seqs)
+    np.testing.assert_array_equal(result.to_numpy(), [0.5, 0.5, 0.5])
+
+
+def test_compute_repeat_fraction_all_lowercase():
+    seqs = pd.Series(["atgcatgc"])
+    result = compute_repeat_fraction(seqs)
+    assert result.iloc[0] == 1.0
+
+
+def test_compute_repeat_fraction_no_lowercase():
+    seqs = pd.Series(["ATGCATGC"])
+    result = compute_repeat_fraction(seqs)
+    assert result.iloc[0] == 0.0
+
+
+def test_compute_repeat_fraction_mixed():
+    seqs = pd.Series(["ATGCatgc"])  # 4 lowercase out of 8
+    result = compute_repeat_fraction(seqs)
+    assert result.iloc[0] == 0.5
+
+
+def test_match_by_gc_repeat_basic():
+    """Matched negatives should have similar GC/repeat to positives."""
+    rng = np.random.default_rng(42)
+    n_pos = 100
+    n_cand = 2000
+
+    # Positives: GC ~0.5, repeat ~0.3
+    pos_seqs = pd.Series(
+        [_make_seq(rng, gc=0.5, repeat=0.3, length=100) for _ in range(n_pos)]
+    )
+    # Candidates: wide range of GC and repeat
+    cand_seqs = pd.Series(
+        [
+            _make_seq(rng, gc=rng.uniform(0.2, 0.8), repeat=rng.uniform(0.0, 0.8), length=100)
+            for _ in range(n_cand)
+        ]
+    )
+
+    indices = match_by_gc_repeat(pos_seqs, cand_seqs, seed=42)
+
+    assert len(indices) == n_pos
+    assert len(set(indices)) == n_pos  # all unique
+
+    # Matched negatives should be closer in GC to positives than random sample
+    pos_gc = compute_gc_content(pos_seqs).to_numpy()
+    matched_gc = compute_gc_content(cand_seqs.iloc[indices]).to_numpy()
+    random_gc = compute_gc_content(cand_seqs.iloc[:n_pos]).to_numpy()
+
+    matched_diff = np.abs(pos_gc - matched_gc).mean()
+    random_diff = np.abs(pos_gc - random_gc).mean()
+    assert matched_diff < random_diff
+
+
+def test_match_by_gc_repeat_all_matched_via_bins():
+    """When candidates span the same bins as positives, all should bin-match."""
+    rng = np.random.default_rng(0)
+    n_pos = 50
+    n_cand = 1000
+
+    # Both positives and candidates in a narrow GC/repeat range
+    pos_seqs = pd.Series(
+        [_make_seq(rng, gc=0.45, repeat=0.2, length=100) for _ in range(n_pos)]
+    )
+    cand_seqs = pd.Series(
+        [_make_seq(rng, gc=0.45, repeat=0.2, length=100) for _ in range(n_cand)]
+    )
+
+    indices = match_by_gc_repeat(pos_seqs, cand_seqs, seed=0)
+    assert len(indices) == n_pos
+    assert len(set(indices)) == n_pos
+
+
+def _make_seq(rng: np.random.Generator, gc: float, repeat: float, length: int) -> str:
+    """Generate a synthetic DNA sequence with approximate GC and repeat fraction."""
+    bases_upper = []
+    for _ in range(length):
+        if rng.random() < gc:
+            bases_upper.append(rng.choice(["G", "C"]))
+        else:
+            bases_upper.append(rng.choice(["A", "T"]))
+
+    # Apply repeat masking (lowercase)
+    chars = list(bases_upper)
+    for i in range(length):
+        if rng.random() < repeat:
+            chars[i] = chars[i].lower()
+
+    return "".join(chars)

--- a/tests/test_negative_sampling.py
+++ b/tests/test_negative_sampling.py
@@ -56,16 +56,18 @@ def test_match_by_gc_repeat_basic():
     n_pos = 100
     n_cand = 2000
 
-    # Positives: GC ~0.5, repeat ~0.3
+    # Positives: GC ~0.5, repeat ~0.3, all on chr1
     pos_seqs = pd.Series(
-        [_make_seq(rng, gc=0.5, repeat=0.3, length=100) for _ in range(n_pos)]
+        [_make_seq(rng, gc=0.5, repeat=0.3, length=100) for _ in range(n_pos)],
+        index=[f"1:{i*200}-{i*200+100}" for i in range(n_pos)],
     )
-    # Candidates: wide range of GC and repeat
+    # Candidates: wide range of GC and repeat, all on chr1
     cand_seqs = pd.Series(
         [
             _make_seq(rng, gc=rng.uniform(0.2, 0.8), repeat=rng.uniform(0.0, 0.8), length=100)
             for _ in range(n_cand)
-        ]
+        ],
+        index=[f"1:{(i+n_pos)*200}-{(i+n_pos)*200+100}" for i in range(n_cand)],
     )
 
     indices = match_by_gc_repeat(pos_seqs, cand_seqs, seed=42)
@@ -83,18 +85,54 @@ def test_match_by_gc_repeat_basic():
     assert matched_diff < random_diff
 
 
+def test_match_by_gc_repeat_preserves_chrom_distribution():
+    """Matching must preserve the chromosome distribution of positives."""
+    rng = np.random.default_rng(99)
+
+    chroms = ["1", "2", "X"]
+    n_per_chrom = 50
+    oversample = 20
+
+    pos_seqs_list = []
+    pos_index = []
+    cand_seqs_list = []
+    cand_index = []
+
+    for chrom in chroms:
+        for i in range(n_per_chrom):
+            pos_seqs_list.append(_make_seq(rng, gc=0.5, repeat=0.2, length=100))
+            pos_index.append(f"{chrom}:{i*300}-{i*300+100}")
+        for i in range(n_per_chrom * oversample):
+            cand_seqs_list.append(
+                _make_seq(rng, gc=rng.uniform(0.2, 0.8), repeat=rng.uniform(0.0, 0.8), length=100)
+            )
+            cand_index.append(f"{chrom}:{(i+n_per_chrom)*300}-{(i+n_per_chrom)*300+100}")
+
+    pos_seqs = pd.Series(pos_seqs_list, index=pos_index)
+    cand_seqs = pd.Series(cand_seqs_list, index=cand_index)
+
+    indices = match_by_gc_repeat(pos_seqs, cand_seqs, seed=99)
+
+    # Check that each matched negative is on the same chromosome as its positive
+    pos_chroms = pd.Series(pos_index).str.split(":").str[0].to_numpy()
+    matched_chroms = pd.Series(cand_seqs.index[indices]).str.split(":").str[0].to_numpy()
+    np.testing.assert_array_equal(pos_chroms, matched_chroms)
+
+
 def test_match_by_gc_repeat_all_matched_via_bins():
     """When candidates span the same bins as positives, all should bin-match."""
     rng = np.random.default_rng(0)
     n_pos = 50
     n_cand = 1000
 
-    # Both positives and candidates in a narrow GC/repeat range
+    # Both positives and candidates in a narrow GC/repeat range, single chrom
     pos_seqs = pd.Series(
-        [_make_seq(rng, gc=0.45, repeat=0.2, length=100) for _ in range(n_pos)]
+        [_make_seq(rng, gc=0.45, repeat=0.2, length=100) for _ in range(n_pos)],
+        index=[f"1:{i*200}-{i*200+100}" for i in range(n_pos)],
     )
     cand_seqs = pd.Series(
-        [_make_seq(rng, gc=0.45, repeat=0.2, length=100) for _ in range(n_cand)]
+        [_make_seq(rng, gc=0.45, repeat=0.2, length=100) for _ in range(n_cand)],
+        index=[f"1:{(i+n_pos)*200}-{(i+n_pos)*200+100}" for i in range(n_cand)],
     )
 
     indices = match_by_gc_repeat(pos_seqs, cand_seqs, seed=0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from bolinas.data.utils import (
     get_cds,
     get_downstream_of_CDS,
     get_exons,
+    get_ensembl_functional_exons,
     get_mrna_exons,
     get_ncrna_exons,
     get_promoters,
@@ -2000,3 +2001,62 @@ def test_get_exons():
     assert isinstance(result, GenomicSet)
     assert result.n_intervals() == 3
     assert result.total_size() == 50 + 50 + 100
+
+
+def test_get_ensembl_functional_exons_excludes_retained_intron():
+    ann = pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr1"],
+            "start": [100, 300, 500],
+            "end": [200, 400, 600],
+            "strand": ["+", "+", "+"],
+            "feature": ["exon", "exon", "exon"],
+            "attribute": [
+                'transcript_id "t1"; transcript_biotype "protein_coding"',
+                'transcript_id "t2"; transcript_biotype "retained_intron"',
+                'transcript_id "t3"; transcript_biotype "lncRNA"',
+            ],
+            "source": ["test"] * 3,
+            "score": ["."] * 3,
+            "frame": ["."] * 3,
+        }
+    )
+
+    result = get_ensembl_functional_exons(ann)
+    assert result.n_intervals() == 2
+    assert result.total_size() == 200
+
+
+def test_get_ensembl_functional_exons_excludes_all_problematic_biotypes():
+    biotypes = [
+        "retained_intron",
+        "nonsense_mediated_decay",
+        "protein_coding_CDS_not_defined",
+        "processed_pseudogene",
+        "TEC",
+        "artifact",
+        "non_stop_decay",
+    ]
+    ann = pl.DataFrame(
+        {
+            "chrom": ["chr1"] * (len(biotypes) + 1),
+            "start": [i * 1000 for i in range(len(biotypes) + 1)],
+            "end": [i * 1000 + 100 for i in range(len(biotypes) + 1)],
+            "strand": ["+"] * (len(biotypes) + 1),
+            "feature": ["exon"] * (len(biotypes) + 1),
+            "attribute": [
+                f'transcript_id "t{i}"; transcript_biotype "{bt}"'
+                for i, bt in enumerate(biotypes)
+            ]
+            + ['transcript_id "tgood"; transcript_biotype "protein_coding"'],
+            "source": ["test"] * (len(biotypes) + 1),
+            "score": ["."] * (len(biotypes) + 1),
+            "frame": ["."] * (len(biotypes) + 1),
+        }
+    )
+
+    all_exons = get_exons(ann)
+    functional = get_ensembl_functional_exons(ann)
+
+    assert all_exons.n_intervals() == len(biotypes) + 1
+    assert functional.n_intervals() == 1


### PR DESCRIPTION
## Summary
- Add GC/repeat-matched negative sampling to remove compositional confounds that hinder cross-species generalization
- Improve exon filtering: center-window overlap, functional biotype filtering, `GenomicList` to prevent merging adjacent enhancers
- Include experiment name and `windowingFunction=mean` in bedgraph track headers

## Test plan
- [x] `uv run pytest` — 309 tests pass
- [x] Snakemake dry run and full pipeline run (v6 dataset + model + visualization)
- [x] Results posted on #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)