### PR TITLE
Add chr7 validation split for ZRS evaluation (#96)

### DIFF
--- a/snakemake/enhancer_classification/config/config.yaml
+++ b/snakemake/enhancer_classification/config/config.yaml
@@ -158,6 +158,35 @@ splits:
                     "Y",
                 ]
             validation: ["19"]
+    v3:
+        homo_sapiens:
+            train:
+                [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                    "6",
+                    "8",
+                    "9",
+                    "10",
+                    "11",
+                    "12",
+                    "13",
+                    "14",
+                    "15",
+                    "16",
+                    "17",
+                    "18",
+                    "19",
+                    "20",
+                    "21",
+                    "22",
+                    "X",
+                    "Y",
+                ]
+            validation: ["7"]
 
 negative_sampling:
     gc_repeat_matched:
@@ -183,6 +212,10 @@ datasets:
         intervals: noexon/conserved/phastCons_43p/20/ELS
     v6:
         split: v2
+        intervals: noexon/conserved/phastCons_43p/20/ELS
+        negative_sampling: gc_repeat_matched
+    v7:
+        split: v3
         intervals: noexon/conserved/phastCons_43p/20/ELS
         negative_sampling: gc_repeat_matched
 
@@ -226,13 +259,13 @@ models:
         mlp_hidden_dim: 256
 
 experiments:
-    - { model: finetune, dataset: v6 }
+    - { model: finetune, dataset: v7 }
 
 visualization:
     window_size: 255
     step_size: 32
     checkpoints:
-        - { model: finetune, dataset: v6 }
+        - { model: finetune, dataset: v7 }
     regions:
         - genome: homo_sapiens
           chrom: "7"


### PR DESCRIPTION
## Summary
- Add split v3 (chr7 validation, chr19 back in training) and dataset v7 for evaluating on the ZRS enhancer region as held-out data
- Update experiment and visualization config to use v7

## Test plan
- [x] Snakemake dry-run passes
- [x] Pipeline ran successfully (metrics, viz, misclassified regions)
- [x] Results posted to #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)