### PR TITLE
Multi-species training and evaluation (#96)

### DIFF
--- a/snakemake/enhancer_classification/config/config.yaml
+++ b/snakemake/enhancer_classification/config/config.yaml
@@ -187,6 +187,91 @@ splits:
                     "Y",
                 ]
             validation: ["7"]
+    v4a:
+        homo_sapiens:
+            train:
+                [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                    "6",
+                    "8",
+                    "9",
+                    "10",
+                    "11",
+                    "12",
+                    "13",
+                    "14",
+                    "15",
+                    "16",
+                    "17",
+                    "18",
+                    "19",
+                    "20",
+                    "21",
+                    "22",
+                    "X",
+                    "Y",
+                ]
+            validation: ["7"]
+        mus_musculus:
+            validation: ["5"]
+    v4b:
+        homo_sapiens:
+            train:
+                [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                    "6",
+                    "8",
+                    "9",
+                    "10",
+                    "11",
+                    "12",
+                    "13",
+                    "14",
+                    "15",
+                    "16",
+                    "17",
+                    "18",
+                    "19",
+                    "20",
+                    "21",
+                    "22",
+                    "X",
+                    "Y",
+                ]
+            validation: ["7"]
+        mus_musculus:
+            train:
+                [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "6",
+                    "7",
+                    "8",
+                    "9",
+                    "10",
+                    "11",
+                    "12",
+                    "13",
+                    "14",
+                    "15",
+                    "16",
+                    "17",
+                    "18",
+                    "19",
+                    "X",
+                    "Y",
+                ]
+            validation: ["5"]
 
 negative_sampling:
     gc_repeat_matched:
@@ -218,6 +303,18 @@ datasets:
         split: v3
         intervals: noexon/conserved/phastCons_43p/20/ELS
         negative_sampling: gc_repeat_matched
+    v8a:
+        split: v4a
+        intervals:
+            homo_sapiens: noexon/conserved/phastCons_43p/20/ELS
+            mus_musculus: noexon/conserved/phastCons_euarchontoglires/20/ELS
+        negative_sampling: gc_repeat_matched
+    v8b:
+        split: v4b
+        intervals:
+            homo_sapiens: noexon/conserved/phastCons_43p/20/ELS
+            mus_musculus: noexon/conserved/phastCons_euarchontoglires/20/ELS
+        negative_sampling: gc_repeat_matched
 
 # Thresholds from: Sullivan, Patrick F., et al. "Leveraging base-pair mammalian
 # constraint to understand genetic variation and human disease."
@@ -232,6 +329,14 @@ conservation:
         phastCons_43p:
             url: "https://cgl.gi.ucsc.edu/data/cactus/zoonomia-2021-track-hub/hg38/phyloPPrimates.bigWig"
             threshold: 0.961
+    mus_musculus:
+        # Euarchontoglires phastCons from UCSC mm10 60-way multiz alignment
+        # (20 species: rodents + primates + treeshrew).
+        # Threshold calibrated so genome-wide conserved fraction (~3.46%)
+        # matches human phastCons_43p at 0.961 (~3.48%).
+        phastCons_euarchontoglires:
+            url: "https://hgdownload.soe.ucsc.edu/goldenPath/mm10/phastCons60way/mm10.60way.phastCons60wayEuarchontoGlire.bw"
+            threshold: 0.986
 
 max_samples:
     validation: 16384
@@ -259,13 +364,15 @@ models:
         mlp_hidden_dim: 256
 
 experiments:
-    - { model: finetune, dataset: v7 }
+    - { model: finetune, dataset: v8a }
+    - { model: finetune, dataset: v8b }
 
 visualization:
     window_size: 255
     step_size: 32
     checkpoints:
-        - { model: finetune, dataset: v7 }
+        - { model: finetune, dataset: v8a }
+        - { model: finetune, dataset: v8b }
     regions:
         - genome: homo_sapiens
           chrom: "7"

--- a/snakemake/enhancer_classification/workflow/rules/common.smk
+++ b/snakemake/enhancer_classification/workflow/rules/common.smk
@@ -23,7 +23,11 @@ DATASET_NAMES = list(config["datasets"].keys())
 ALL_INTERVALS: set[str] = set()
 ALL_SPLIT_NAMES: set[str] = set()
 for _dataset_config in config["datasets"].values():
-    ALL_INTERVALS.add(_dataset_config["intervals"])
+    _intervals_cfg = _dataset_config["intervals"]
+    if isinstance(_intervals_cfg, dict):
+        ALL_INTERVALS.update(_intervals_cfg.values())
+    else:
+        ALL_INTERVALS.add(_intervals_cfg)
     _split_config = config["splits"][_dataset_config["split"]]
     for _species_splits in _split_config.values():
         ALL_SPLIT_NAMES.update(_species_splits.keys())
@@ -42,6 +46,17 @@ for _dataset_config in config["datasets"].values():
     ALL_NEG_TYPES.add(_dataset_config.get("negative_sampling", "random"))
 
 TRAIN_SPLIT = "train"
+
+
+def resolve_intervals(intervals_cfg: str | dict, species: str) -> str:
+    """Resolve the intervals path for a species.
+
+    Supports both a single string (all species share the same path) and
+    a per-species dict mapping.
+    """
+    if isinstance(intervals_cfg, dict):
+        return intervals_cfg[species]
+    return intervals_cfg
 
 MODEL_DEFAULTS = config["models"]["default"]
 

--- a/snakemake/enhancer_classification/workflow/rules/data.smk
+++ b/snakemake/enhancer_classification/workflow/rules/data.smk
@@ -469,7 +469,7 @@ rule build_dataset:
     input:
         lambda wc: [
             f"results/parquet/"
-            f"{config['datasets'][wc.dataset]['intervals']}/"
+            f"{resolve_intervals(config['datasets'][wc.dataset]['intervals'], species)}/"
             f"{config['datasets'][wc.dataset].get('negative_sampling', 'random')}/"
             f"{species}.parquet"
             for species, splits in (

--- a/src/bolinas/enhancer_classification/train.py
+++ b/src/bolinas/enhancer_classification/train.py
@@ -15,9 +15,12 @@ import json
 from pathlib import Path
 
 import lightning as L
+import numpy as np
 import polars as pl
 import torch
 from lightning.pytorch.loggers import CSVLogger, WandbLogger
+from scipy.special import expit
+from sklearn.metrics import average_precision_score, roc_auc_score
 from torch.utils.data import DataLoader
 
 from bolinas.enhancer_classification.dataset import EnhancerDataset
@@ -115,17 +118,24 @@ def main() -> None:
         default_root_dir=output_dir,
     )
 
+    # Capture W&B run ID before training finalizes it
+    wandb_logger = next(
+        (lg for lg in loggers if isinstance(lg, WandbLogger)), None
+    )
+    wandb_run_id: str | None = None
+    if wandb_logger is not None:
+        wandb_run_id = wandb_logger.experiment.id
+
     trainer.fit(model, train_dataloaders=train_loader, val_dataloaders=val_loader)
 
     # Save checkpoint
     trainer.save_checkpoint(output_ckpt)
 
-    # Write metrics summary
+    # Collect metrics
     metrics = {
         "val_auroc": float(trainer.callback_metrics.get("val_auroc", 0.0)),
         "val_auprc": float(trainer.callback_metrics.get("val_auprc", 0.0)),
     }
-    output_metrics.write_text(json.dumps(metrics, indent=2))
 
     # Save per-sample validation predictions (collected during validation_step)
     if args.output_val_predictions:
@@ -138,6 +148,34 @@ def main() -> None:
         )
         val_meta = val_meta.with_columns(pl.Series("logit", logits_array))
         val_meta.write_parquet(output_val_predictions)
+
+        # Per-species metrics
+        for genome in val_meta["genome"].unique().sort().to_list():
+            subset = val_meta.filter(pl.col("genome") == genome)
+            labels = subset["label"].to_numpy()
+            probs = expit(subset["logit"].to_numpy())
+            if len(np.unique(labels)) == 2:
+                metrics[f"val_auroc/{genome}"] = float(roc_auc_score(labels, probs))
+                metrics[f"val_auprc/{genome}"] = float(
+                    average_precision_score(labels, probs)
+                )
+
+        # Log per-species metrics to W&B (run was finalized by Lightning,
+        # so reopen it with resume="must" using the captured run ID)
+        import wandb
+
+        per_species = {k: v for k, v in metrics.items() if "/" in k}
+        if per_species and wandb_run_id is not None:
+            run = wandb.init(
+                project=WANDB_PROJECT,
+                entity=WANDB_ENTITY,
+                id=wandb_run_id,
+                resume="must",
+            )
+            run.log(per_species)
+            run.finish()
+
+    output_metrics.write_text(json.dumps(metrics, indent=2))
 
 
 if __name__ == "__main__":

--- a/src/bolinas/enhancer_classification/train.py
+++ b/src/bolinas/enhancer_classification/train.py
@@ -12,12 +12,14 @@ Usage::
 
 import argparse
 import json
+import logging
 from pathlib import Path
 
 import lightning as L
 import numpy as np
 import polars as pl
 import torch
+import wandb
 from lightning.pytorch.loggers import CSVLogger, WandbLogger
 from scipy.special import expit
 from sklearn.metrics import average_precision_score, roc_auc_score
@@ -25,6 +27,8 @@ from torch.utils.data import DataLoader
 
 from bolinas.enhancer_classification.dataset import EnhancerDataset
 from bolinas.enhancer_classification.model import EnhancerClassifier
+
+log = logging.getLogger(__name__)
 
 torch.set_float32_matmul_precision("medium")
 
@@ -137,35 +141,34 @@ def main() -> None:
         "val_auprc": float(trainer.callback_metrics.get("val_auprc", 0.0)),
     }
 
-    # Save per-sample validation predictions (collected during validation_step)
+    # Per-sample validation predictions and per-species metrics
+    logits_array = model.val_logits.compute().cpu().numpy()
+    val_meta = pl.read_parquet(
+        args.val_parquet,
+        columns=["genome", "chrom", "start", "end", "strand", "label"],
+    )
+    val_meta = val_meta.with_columns(pl.Series("logit", logits_array))
+
     if args.output_val_predictions:
-        output_val_predictions = Path(args.output_val_predictions)
-        logits_array = model.val_logits.compute().cpu().numpy()
+        Path(args.output_val_predictions).parent.mkdir(parents=True, exist_ok=True)
+        val_meta.write_parquet(args.output_val_predictions)
 
-        val_meta = pl.read_parquet(
-            args.val_parquet,
-            columns=["genome", "chrom", "start", "end", "strand", "label"],
-        )
-        val_meta = val_meta.with_columns(pl.Series("logit", logits_array))
-        val_meta.write_parquet(output_val_predictions)
+    # Per-species metrics
+    for genome in val_meta["genome"].unique().sort().to_list():
+        subset = val_meta.filter(pl.col("genome") == genome)
+        labels = subset["label"].to_numpy()
+        probs = expit(subset["logit"].to_numpy())
+        if len(np.unique(labels)) == 2:
+            metrics[f"val_auroc/{genome}"] = float(roc_auc_score(labels, probs))
+            metrics[f"val_auprc/{genome}"] = float(
+                average_precision_score(labels, probs)
+            )
 
-        # Per-species metrics
-        for genome in val_meta["genome"].unique().sort().to_list():
-            subset = val_meta.filter(pl.col("genome") == genome)
-            labels = subset["label"].to_numpy()
-            probs = expit(subset["logit"].to_numpy())
-            if len(np.unique(labels)) == 2:
-                metrics[f"val_auroc/{genome}"] = float(roc_auc_score(labels, probs))
-                metrics[f"val_auprc/{genome}"] = float(
-                    average_precision_score(labels, probs)
-                )
-
-        # Log per-species metrics to W&B (run was finalized by Lightning,
-        # so reopen it with resume="must" using the captured run ID)
-        import wandb
-
-        per_species = {k: v for k, v in metrics.items() if "/" in k}
-        if per_species and wandb_run_id is not None:
+    # Log per-species metrics to W&B (run was finalized by Lightning,
+    # so reopen it with resume="must" using the captured run ID)
+    per_species = {k: v for k, v in metrics.items() if "/" in k}
+    if per_species and wandb_run_id is not None:
+        try:
             run = wandb.init(
                 project=WANDB_PROJECT,
                 entity=WANDB_ENTITY,
@@ -174,6 +177,8 @@ def main() -> None:
             )
             run.log(per_species)
             run.finish()
+        except Exception:
+            log.warning("Failed to log per-species metrics to W&B", exc_info=True)
 
     output_metrics.write_text(json.dumps(metrics, indent=2))
 

--- a/src/bolinas/enhancer_classification/train.py
+++ b/src/bolinas/enhancer_classification/train.py
@@ -147,6 +147,9 @@ def main() -> None:
         args.val_parquet,
         columns=["genome", "chrom", "start", "end", "strand", "label"],
     )
+    assert len(logits_array) == len(val_meta), (
+        f"Logit count ({len(logits_array)}) != validation rows ({len(val_meta)})"
+    )
     val_meta = val_meta.with_columns(pl.Series("logit", logits_array))
 
     if args.output_val_predictions:
@@ -154,19 +157,22 @@ def main() -> None:
         val_meta.write_parquet(args.output_val_predictions)
 
     # Per-species metrics
+    per_species: dict[str, float] = {}
     for genome in val_meta["genome"].unique().sort().to_list():
         subset = val_meta.filter(pl.col("genome") == genome)
         labels = subset["label"].to_numpy()
         probs = expit(subset["logit"].to_numpy())
         if len(np.unique(labels)) == 2:
-            metrics[f"val_auroc/{genome}"] = float(roc_auc_score(labels, probs))
-            metrics[f"val_auprc/{genome}"] = float(
+            per_species[f"val_auroc/{genome}"] = float(
+                roc_auc_score(labels, probs)
+            )
+            per_species[f"val_auprc/{genome}"] = float(
                 average_precision_score(labels, probs)
             )
+    metrics.update(per_species)
 
     # Log per-species metrics to W&B (run was finalized by Lightning,
     # so reopen it with resume="must" using the captured run ID)
-    per_species = {k: v for k, v in metrics.items() if "/" in k}
     if per_species and wandb_run_id is not None:
         try:
             run = wandb.init(


### PR DESCRIPTION
## Summary
- Add mouse conservation filtering (Euarchontoglires phastCons, threshold 0.986 calibrated to match human genome-wide conserved fraction)
- Support per-species interval paths in dataset config, since human and mouse use different conservation tracks
- Add per-species validation metrics (AUROC/AUPRC per species logged to W&B)
- Two new experiments: v8a (human-only training) and v8b (human+mouse training), both evaluated on human chr7 + mouse chr5

Results: human-only model generalizes well to mouse (0.929 AUROC); adding mouse data improves mouse AUROC to 0.935 without affecting human (0.907). See [iteration 5 comment](https://github.com/Open-Athena/bolinas-dna/issues/96#issuecomment-4238541736).

## Test plan
- [x] Dry-run backward compatibility with v7
- [x] Dry-run v8a/v8b DAG resolution
- [x] Full pipeline run (38 jobs completed successfully)
- [x] Verified dataset compositions (v8a train: human only; v8a/v8b validation: both species; v8b train: both species)
- [x] Per-species metrics in metrics.json and W&B

🤖 Generated with [Claude Code](https://claude.com/claude-code)