### PR TITLE
Whole-genome enhancer prediction with per-bin segmentation (#118)

### DIFF
--- a/scripts/benchmark_segmentation_predict.py
+++ b/scripts/benchmark_segmentation_predict.py
@@ -23,7 +23,6 @@ from bolinas.enhancer_segmentation.predict_genome import predict_genome
 
 logger = logging.getLogger(__name__)
 
-WINDOW_SIZE = 65536
 BIN_SIZE = 128
 
 
@@ -36,21 +35,23 @@ def main() -> None:
     parser.add_argument("--genome", type=Path, required=True)
     parser.add_argument("--checkpoint", type=Path, required=True)
     parser.add_argument("--chrom", type=str, default="22")
+    parser.add_argument("--window-size", type=int, default=65536)
     parser.add_argument("--batch-size", type=int, default=32)
     parser.add_argument("--num-workers", type=int, default=4)
     parser.add_argument("--output", type=Path, default=None)
     args = parser.parse_args()
+    window_size = args.window_size
 
     tb = py2bit.open(str(args.genome))
     chrom_size = tb.chroms()[args.chrom]
     tb.close()
 
-    starts = list(range(0, chrom_size, WINDOW_SIZE))
+    starts = list(range(0, chrom_size, window_size))
     windows = pl.DataFrame(
         {
             "chrom": [args.chrom] * len(starts),
             "start": starts,
-            "end": [s + WINDOW_SIZE for s in starts],
+            "end": [s + window_size for s in starts],
         }
     )
 
@@ -59,7 +60,7 @@ def main() -> None:
         args.chrom,
         chrom_size,
         len(windows),
-        len(windows) * (WINDOW_SIZE // BIN_SIZE),
+        len(windows) * (window_size // BIN_SIZE),
     )
 
     result = predict_genome(

--- a/scripts/benchmark_segmentation_predict.py
+++ b/scripts/benchmark_segmentation_predict.py
@@ -1,0 +1,83 @@
+"""One-off benchmark: segmentation prediction on a single human chromosome.
+
+Tiles one chromosome with non-overlapping 64kbp windows, runs the
+segmentation model, and reports wall time + throughput.
+
+Usage::
+
+    uv run python scripts/benchmark_segmentation_predict.py \
+        --genome results/genome/GCF_000001405.40.2bit \
+        --checkpoint results/segmentation/model/xfmr2_w64k_s42_full/seg_v1_64k/best.ckpt \
+        --chrom 22 \
+        --output /tmp/benchmark_chr22.parquet
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+import polars as pl
+import py2bit
+
+from bolinas.enhancer_segmentation.predict_genome import predict_genome
+
+logger = logging.getLogger(__name__)
+
+WINDOW_SIZE = 65536
+BIN_SIZE = 128
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="Benchmark segmentation on one chromosome."
+    )
+    parser.add_argument("--genome", type=Path, required=True)
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--chrom", type=str, default="22")
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    tb = py2bit.open(str(args.genome))
+    chrom_size = tb.chroms()[args.chrom]
+    tb.close()
+
+    starts = list(range(0, chrom_size, WINDOW_SIZE))
+    windows = pl.DataFrame(
+        {
+            "chrom": [args.chrom] * len(starts),
+            "start": starts,
+            "end": [s + WINDOW_SIZE for s in starts],
+        }
+    )
+
+    logger.info(
+        "Chromosome %s: %d bp, %d windows (%d bins)",
+        args.chrom,
+        chrom_size,
+        len(windows),
+        len(windows) * (WINDOW_SIZE // BIN_SIZE),
+    )
+
+    result = predict_genome(
+        genome_path=args.genome,
+        checkpoint_path=args.checkpoint,
+        windows=windows,
+        bin_size=BIN_SIZE,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+    )
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        result.write_parquet(args.output)
+        logger.info("Wrote %s", args.output)
+
+    logger.info("Logit stats: %s", result["logit"].describe())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_segmentation_predict.py
+++ b/scripts/benchmark_segmentation_predict.py
@@ -19,7 +19,10 @@ from pathlib import Path
 import polars as pl
 import py2bit
 
-from bolinas.enhancer_segmentation.predict_genome import predict_genome
+from bolinas.enhancer_segmentation.predict_genome import (
+    predict_genome,
+    tile_chromosomes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,14 +49,8 @@ def main() -> None:
     chrom_size = tb.chroms()[args.chrom]
     tb.close()
 
-    starts = list(range(0, chrom_size, window_size))
-    windows = pl.DataFrame(
-        {
-            "chrom": [args.chrom] * len(starts),
-            "start": starts,
-            "end": [s + window_size for s in starts],
-        }
-    )
+    tiles = tile_chromosomes({args.chrom: chrom_size}, window_size)
+    windows = pl.DataFrame(tiles, schema=["chrom", "start", "end"], orient="row")
 
     logger.info(
         "Chromosome %s: %d bp, %d windows (%d bins)",

--- a/snakemake/training_dataset/dataset_creation/README.md
+++ b/snakemake/training_dataset/dataset_creation/README.md
@@ -378,6 +378,7 @@ Runs the per-bin segmentation model from [issue #115](https://github.com/Open-At
 - Install enhancer-classification dependencies: `uv sync --group enhancer-classification`
 - A trained `EnhancerSegmenter` checkpoint (configured via `enhancer_prediction_segmentation.checkpoint` in `config.yaml`; supports `s3://` URIs via Snakemake `storage()`)
 - A GPU for the prediction rule
+- ~5GB free local disk per active job for the Snakemake S3 cache (genome ~2–3GB + checkpoint ~1.5GB). The cache is cleaned up between jobs.
 
 **Configuration** (`enhancer_prediction_segmentation` block in `config.yaml`):
 - `checkpoint`: path or S3 URI to the Lightning checkpoint

--- a/snakemake/training_dataset/dataset_creation/README.md
+++ b/snakemake/training_dataset/dataset_creation/README.md
@@ -368,6 +368,31 @@ Recipe v19 produces enhancer intervals from a trained `EnhancerClassifier` (see 
 
 **Status**: working but slow (~1.4h per genome on L4 GPU). For a faster alternative being explored, see [issue #115](https://github.com/Open-Athena/bolinas-dna/issues/115) (per-bin segmentation).
 
+## Whole-genome segmentation prediction
+
+Runs the per-bin segmentation model from [issue #115](https://github.com/Open-Athena/bolinas-dna/issues/115) across whole genomes, producing 128bp-resolution enhancer logits — see [issue #118](https://github.com/Open-Athena/bolinas-dna/issues/118).
+
+**Pipeline**: `segmentation_prediction_windows` → `predict_enhancers_segmentation`. Aggregate target: `all_enhancer_predictions_segmentation`.
+
+**Prerequisites**:
+- Install enhancer-classification dependencies: `uv sync --group enhancer-classification`
+- A trained `EnhancerSegmenter` checkpoint (configured via `enhancer_prediction_segmentation.checkpoint` in `config.yaml`; supports `s3://` URIs via Snakemake `storage()`)
+- A GPU for the prediction rule
+
+**Configuration** (`enhancer_prediction_segmentation` block in `config.yaml`):
+- `checkpoint`: path or S3 URI to the Lightning checkpoint
+- `window_size`: window size in bp (64kbp for the default 64k-context transformer model)
+- `bin_size`: output bin size in bp (128 for the default model)
+- `batch_size`, `num_workers`: inference DataLoader settings
+- `max_windows`: truncate to first N windows for smoke tests (0 = no limit)
+- `genomes`: list of Assembly Accessions to predict
+
+**Window tiling**: only full-context windows are emitted — the model was trained on unpadded sequence and is not robust to N-padded inputs. Consequence: contigs smaller than `window_size` and chromosome tails not aligned to `window_size` are uncovered. This restricts the selection to Chromosome-level assemblies; see #118 for discussion of future improvements (training with padding, smaller-context model).
+
+**Output**: one parquet per genome at `results/enhancer_predictions_segmentation/{g}.parquet` (stored to S3 by the default profile) with schema `(chrom: str, bin_start: int64, bin_end: int64, logit: float32)` — one row per 128bp bin.
+
+**Status**: ~1h per genome on L4 GPU (~65 min). See #118 for benchmarks and a follow-up [#119](https://github.com/Open-Athena/bolinas-dna/issues/119) for parallel execution across multiple GPU instances via AWS Batch.
+
 ## Output
 
 Datasets are uploaded to HuggingFace Hub at the specified `output_hf_prefix`.

--- a/snakemake/training_dataset/dataset_creation/config/config.yaml
+++ b/snakemake/training_dataset/dataset_creation/config/config.yaml
@@ -133,6 +133,7 @@ enhancer_prediction_segmentation:
     bin_size: 128
     batch_size: 32
     num_workers: 4
+    max_windows: 0  # 0 = all windows; set small (e.g. 10) for smoke tests
     # One species per mammalian order, restricted to Chromosome-level or
     # better assemblies, and forcing human + mouse as the Primates /
     # Rodentia reps (our training species). Other orders pick the smallest

--- a/snakemake/training_dataset/dataset_creation/config/config.yaml
+++ b/snakemake/training_dataset/dataset_creation/config/config.yaml
@@ -133,31 +133,50 @@ enhancer_prediction_segmentation:
     bin_size: 128
     batch_size: 32
     num_workers: 4
-    # One species per mammalian order (23 orders, seed=42).
+    # One species per mammalian order, restricted to Chromosome-level or
+    # better assemblies, and forcing human + mouse as the Primates /
+    # Rodentia reps (our training species). Other orders pick the smallest
+    # genome at Chromosome level. Orders with no Chromosome-level assembly
+    # (Macroscelidea, Scandentia, Sirenia) are dropped — they only have
+    # highly fragmented Scaffold-level genomes.
+    #
+    # Generated via:
+    #
+    #     import pandas as pd
+    #     FORCE_INCLUDE = ["GCF_000001405.40", "GCF_000001635.27"]
+    #     g = pd.read_parquet("config/genomes.parquet")
+    #     mammals = g[g["class"] == "Mammalia"].copy()
+    #     forced = mammals[mammals["Assembly Accession"].isin(FORCE_INCLUDE)]
+    #     others = mammals[
+    #         ~mammals["Assembly Accession"].isin(FORCE_INCLUDE)
+    #         & ~mammals["order"].isin(set(forced["order"]))
+    #         & (mammals["Assembly Level"] == "Chromosome")
+    #     ].copy()
+    #     picked = others.sort_values(
+    #         ["Assembly Stats Total Sequence Length", "Organism Name"]
+    #     ).drop_duplicates("order")
+    #     selected = pd.concat([forced, picked]).sort_values("order")
     genomes:
-        - GCF_050624435.1   # Tenrec ecaudatus (Afrosoricida)
-        - GCF_025265405.1   # Mesoplodon densirostris (Artiodactyla)
-        - GCF_008692635.1   # Crocuta crocuta (Carnivora)
-        - GCF_001890085.2   # Hipposideros armiger (Chiroptera)
-        - GCF_030445035.2   # Dasypus novemcinctus (Cingulata)
-        - GCF_902635505.1   # Sarcophilus harrisii (Dasyuromorphia)
-        - GCF_027409185.1   # Cynocephalus volans (Dermoptera)
-        - GCF_027887165.1   # Monodelphis domestica (Didelphimorphia)
-        - GCF_028372415.1   # Notamacropus eugenii (Diprotodontia)
-        - GCF_027595985.1   # Sorex araneus (Eulipotyphla)
-        - GCF_964237555.1   # Oryctolagus cuniculus (Lagomorpha)
-        - GCF_000299155.1   # Elephantulus edwardii (Macroscelidea)
-        - GCF_019393635.1   # Dromiciops gliroides (Microbiotheria)
-        - GCF_015852505.1   # Tachyglossus aculeatus (Monotremata)
-        - GCF_037893015.1   # Macrotis lagotis (Peramelemorphia)
-        - GCF_020826845.1   # Diceros bicornis (Perissodactyla)
-        - GCF_040802235.1   # Manis javanica (Pholidota)
-        - GCF_015220235.1   # Choloepus didactylus (Pilosa)
-        - GCF_000001405.40  # Homo sapiens (Primates)
-        - GCF_024166365.1   # Elephas maximus (Proboscidea)
-        - GCF_000001635.27  # Mus musculus (Rodentia)
-        - GCF_000334495.1   # Tupaia chinensis (Scandentia)
-        - GCF_000243295.1   # Trichechus manatus (Sirenia)
+        - GCF_050624435.1   # Tenrec ecaudatus (Afrosoricida, 3.9GB)
+        - GCF_009834535.1   # Camelus ferus (Artiodactyla, 2.1GB)
+        - GCF_018350215.1   # Panthera leo (Carnivora, 2.3GB)
+        - GCF_027574615.1   # Eptesicus fuscus (Chiroptera, 2.0GB)
+        - GCF_030445035.2   # Dasypus novemcinctus (Cingulata, 3.6GB)
+        - GCF_902635505.1   # Sarcophilus harrisii (Dasyuromorphia, 3.1GB)
+        - GCF_027409185.1   # Cynocephalus volans (Dermoptera, 2.8GB)
+        - GCF_027887165.1   # Monodelphis domestica (Didelphimorphia, 3.6GB)
+        - GCF_011100635.1   # Trichosurus vulpecula (Diprotodontia, 3.4GB)
+        - GCF_027595985.1   # Sorex araneus (Eulipotyphla, 2.4GB)
+        - GCF_030435755.1   # Ochotona princeps (Lagomorpha, 2.6GB)
+        - GCF_019393635.1   # Dromiciops gliroides (Microbiotheria, 3.3GB)
+        - GCF_004115215.2   # Ornithorhynchus anatinus (Monotremata, 1.9GB)
+        - GCF_037893015.1   # Macrotis lagotis (Peramelemorphia, 3.7GB)
+        - GCF_037783145.1   # Equus przewalskii (Perissodactyla, 2.5GB)
+        - GCF_040802235.1   # Manis javanica (Pholidota, 2.6GB)
+        - GCF_023851605.1   # Tamandua tetradactyla (Pilosa, 3.2GB)
+        - GCF_000001405.40  # Homo sapiens (Primates, 3.1GB)
+        - GCF_024166365.1   # Elephas maximus indicus (Proboscidea, 3.4GB)
+        - GCF_000001635.27  # Mus musculus (Rodentia, 2.7GB)
 
 genome_subset_bed:
     - GCF_000001405.40 # Human

--- a/snakemake/training_dataset/dataset_creation/config/config.yaml
+++ b/snakemake/training_dataset/dataset_creation/config/config.yaml
@@ -133,6 +133,31 @@ enhancer_prediction_segmentation:
     bin_size: 128
     batch_size: 32
     num_workers: 4
+    # One species per mammalian order (23 orders, seed=42).
+    genomes:
+        - GCF_050624435.1   # Tenrec ecaudatus (Afrosoricida)
+        - GCF_025265405.1   # Mesoplodon densirostris (Artiodactyla)
+        - GCF_008692635.1   # Crocuta crocuta (Carnivora)
+        - GCF_001890085.2   # Hipposideros armiger (Chiroptera)
+        - GCF_030445035.2   # Dasypus novemcinctus (Cingulata)
+        - GCF_902635505.1   # Sarcophilus harrisii (Dasyuromorphia)
+        - GCF_027409185.1   # Cynocephalus volans (Dermoptera)
+        - GCF_027887165.1   # Monodelphis domestica (Didelphimorphia)
+        - GCF_028372415.1   # Notamacropus eugenii (Diprotodontia)
+        - GCF_027595985.1   # Sorex araneus (Eulipotyphla)
+        - GCF_964237555.1   # Oryctolagus cuniculus (Lagomorpha)
+        - GCF_000299155.1   # Elephantulus edwardii (Macroscelidea)
+        - GCF_019393635.1   # Dromiciops gliroides (Microbiotheria)
+        - GCF_015852505.1   # Tachyglossus aculeatus (Monotremata)
+        - GCF_037893015.1   # Macrotis lagotis (Peramelemorphia)
+        - GCF_020826845.1   # Diceros bicornis (Perissodactyla)
+        - GCF_040802235.1   # Manis javanica (Pholidota)
+        - GCF_015220235.1   # Choloepus didactylus (Pilosa)
+        - GCF_000001405.40  # Homo sapiens (Primates)
+        - GCF_024166365.1   # Elephas maximus (Proboscidea)
+        - GCF_000001635.27  # Mus musculus (Rodentia)
+        - GCF_000334495.1   # Tupaia chinensis (Scandentia)
+        - GCF_000243295.1   # Trichechus manatus (Sirenia)
 
 genome_subset_bed:
     - GCF_000001405.40 # Human

--- a/snakemake/training_dataset/dataset_creation/config/config.yaml
+++ b/snakemake/training_dataset/dataset_creation/config/config.yaml
@@ -127,6 +127,13 @@ enhancer_prediction:
     num_workers: 4
     threshold: 0.0  # logit threshold for recipe v19 (set after genome-wide analysis)
 
+enhancer_prediction_segmentation:
+    checkpoint: "s3://oa-bolinas/snakemake/enhancer_classification/results/segmentation/model/xfmr2_w64k_s42_full/seg_v1_64k/best.ckpt"
+    window_size: 65536
+    bin_size: 128
+    batch_size: 32
+    num_workers: 4
+
 genome_subset_bed:
     - GCF_000001405.40 # Human
     - GCF_000001635.27 # Mouse

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/common.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/common.smk
@@ -2,6 +2,7 @@
 import numpy as np
 import pandas as pd
 import polars as pl
+import py2bit
 import pyBigWig
 import matplotlib.pyplot as plt
 from tqdm import tqdm

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/common.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/common.smk
@@ -31,6 +31,7 @@ from bolinas.data.utils import (
     write_pandas_to_bed,
 )
 from bolinas.enhancer_classification.predict import sliding_windows
+from bolinas.enhancer_segmentation.predict_genome import tile_chromosomes
 
 tqdm.pandas()
 

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
@@ -95,9 +95,16 @@ rule segmentation_prediction_windows:
         chrom_sizes = tb.chroms()
         tb.close()
 
+        # Only emit windows that fit entirely within a chromosome — the
+        # model was trained on full-context windows and is not robust to
+        # N-padded input. Contigs smaller than window_size and the last
+        # (chrom_size mod window_size) bases of each chromosome are
+        # therefore uncovered. See discussion on issue #118.
         chroms, starts, ends = [], [], []
         for chrom, size in chrom_sizes.items():
-            for w_start in range(0, size, window_size):
+            n_windows = size // window_size
+            for i in range(n_windows):
+                w_start = i * window_size
                 chroms.append(chrom)
                 starts.append(w_start)
                 ends.append(w_start + window_size)

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
@@ -128,6 +128,7 @@ rule predict_enhancers_segmentation:
         bin_size=SEGMENTATION_CONFIG["bin_size"],
         batch_size=SEGMENTATION_CONFIG["batch_size"],
         num_workers=SEGMENTATION_CONFIG["num_workers"],
+        max_windows=SEGMENTATION_CONFIG["max_windows"],
     threads: workflow.cores
     shell:
         """
@@ -138,6 +139,7 @@ rule predict_enhancers_segmentation:
             --bin-size {params.bin_size} \
             --batch-size {params.batch_size} \
             --num-workers {params.num_workers} \
+            --max-windows {params.max_windows} \
             --output {output}
         """
 

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
@@ -114,7 +114,10 @@ rule predict_enhancers_segmentation:
         max_windows=SEGMENTATION_CONFIG["max_windows"],
     threads: workflow.cores
     shell:
+        # Persist the torch.compile cache across per-genome invocations so
+        # every genome after the first skips the ~30s Inductor compile step.
         """
+        TORCHINDUCTOR_CACHE_DIR=.snakemake/torchinductor_cache \
         uv run python -m bolinas.enhancer_segmentation.predict_genome \
             --genome {input.genome} \
             --checkpoint {input.checkpoint} \

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
@@ -90,31 +90,14 @@ rule segmentation_prediction_windows:
     output:
         "results/enhancer_predictions_segmentation/windows/{g}.parquet",
     run:
-        window_size = SEGMENTATION_CONFIG["window_size"]
         tb = py2bit.open(input[0])
         chrom_sizes = tb.chroms()
         tb.close()
 
-        # Only emit windows that fit entirely within a chromosome — the
-        # model was trained on full-context windows and is not robust to
-        # N-padded input. Contigs smaller than window_size and the last
-        # (chrom_size mod window_size) bases of each chromosome are
-        # therefore uncovered. See discussion on issue #118.
-        chroms, starts, ends = [], [], []
-        for chrom, size in chrom_sizes.items():
-            n_windows = size // window_size
-            for i in range(n_windows):
-                w_start = i * window_size
-                chroms.append(chrom)
-                starts.append(w_start)
-                ends.append(w_start + window_size)
-
-        windows = pl.DataFrame({
-            "chrom": chroms,
-            "start": starts,
-            "end": ends,
-        })
-        windows.write_parquet(output[0])
+        tiles = tile_chromosomes(chrom_sizes, SEGMENTATION_CONFIG["window_size"])
+        pl.DataFrame(tiles, schema=["chrom", "start", "end"], orient="row").write_parquet(
+            output[0]
+        )
 
 
 rule predict_enhancers_segmentation:

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
@@ -1,4 +1,5 @@
 ENHANCER_CONFIG = config["enhancer_prediction"]
+SEGMENTATION_CONFIG = config["enhancer_prediction_segmentation"]
 
 
 wildcard_constraints:
@@ -77,6 +78,57 @@ rule predict_enhancers:
             --genome {input.genome} \
             --checkpoint {input.checkpoint} \
             --windows {input.windows} \
+            --batch-size {params.batch_size} \
+            --num-workers {params.num_workers} \
+            --output {output}
+        """
+
+
+rule segmentation_prediction_windows:
+    input:
+        "results/genome/{g}.2bit",
+    output:
+        "results/enhancer_predictions_segmentation/windows/{g}.parquet",
+    run:
+        window_size = SEGMENTATION_CONFIG["window_size"]
+        tb = py2bit.open(input[0])
+        chrom_sizes = tb.chroms()
+        tb.close()
+
+        chroms, starts, ends = [], [], []
+        for chrom, size in chrom_sizes.items():
+            for w_start in range(0, size, window_size):
+                chroms.append(chrom)
+                starts.append(w_start)
+                ends.append(w_start + window_size)
+
+        windows = pl.DataFrame({
+            "chrom": chroms,
+            "start": starts,
+            "end": ends,
+        })
+        windows.write_parquet(output[0])
+
+
+rule predict_enhancers_segmentation:
+    input:
+        genome="results/genome/{g}.2bit",
+        windows="results/enhancer_predictions_segmentation/windows/{g}.parquet",
+        checkpoint=storage(SEGMENTATION_CONFIG["checkpoint"]),
+    output:
+        "results/enhancer_predictions_segmentation/{g}.parquet",
+    params:
+        bin_size=SEGMENTATION_CONFIG["bin_size"],
+        batch_size=SEGMENTATION_CONFIG["batch_size"],
+        num_workers=SEGMENTATION_CONFIG["num_workers"],
+    threads: workflow.cores
+    shell:
+        """
+        uv run python -m bolinas.enhancer_segmentation.predict_genome \
+            --genome {input.genome} \
+            --checkpoint {input.checkpoint} \
+            --windows {input.windows} \
+            --bin-size {params.bin_size} \
             --batch-size {params.batch_size} \
             --num-workers {params.num_workers} \
             --output {output}

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
@@ -135,6 +135,14 @@ rule predict_enhancers_segmentation:
         """
 
 
+rule all_enhancer_predictions_segmentation:
+    input:
+        expand(
+            "results/enhancer_predictions_segmentation/{g}.parquet",
+            g=SEGMENTATION_CONFIG["genomes"],
+        ),
+
+
 rule intervals_recipe_v19:
     input:
         "results/enhancer_predictions/{g}.parquet",

--- a/src/bolinas/enhancer_classification/genome_window_dataset.py
+++ b/src/bolinas/enhancer_classification/genome_window_dataset.py
@@ -1,0 +1,43 @@
+"""Shared dataset for window-based model inference over a genome."""
+
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import torch
+from alphagenome_pytorch.utils.sequence import sequence_to_onehot
+from torch.utils.data import Dataset
+
+from bolinas.enhancer_classification.genome import Genome
+
+
+class GenomeWindowDataset(Dataset):
+    """Map-style dataset of genomic windows for model inference.
+
+    Each DataLoader worker opens its own ``py2bit`` / FASTA handle on first
+    access. For 2bit files this means shared memory-mapped pages across
+    workers; the full genome is never materialized as one-hot tensors.
+
+    Args:
+        genome_path: Path to genome file (.2bit or .fa/.fa.gz).
+        windows: DataFrame with ``chrom``, ``start``, ``end`` columns.
+    """
+
+    def __init__(self, genome_path: Path, windows: pl.DataFrame) -> None:
+        self._genome_path = genome_path
+        self._chroms = windows["chrom"].to_numpy().astype(str)
+        self._starts = windows["start"].to_numpy().astype(np.int64)
+        self._ends = windows["end"].to_numpy().astype(np.int64)
+        self._genome: Genome | None = None
+
+    def __len__(self) -> int:
+        return len(self._starts)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        if self._genome is None:
+            self._genome = Genome(self._genome_path)
+        seq = self._genome(
+            self._chroms[idx], int(self._starts[idx]), int(self._ends[idx])
+        )
+        onehot = sequence_to_onehot(seq).astype(np.float32)
+        return torch.from_numpy(onehot)

--- a/src/bolinas/enhancer_classification/predict_genome.py
+++ b/src/bolinas/enhancer_classification/predict_genome.py
@@ -22,46 +22,12 @@ import lightning as L
 import numpy as np
 import polars as pl
 import torch
-from alphagenome_pytorch.utils.sequence import sequence_to_onehot
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import DataLoader
 
-from bolinas.enhancer_classification.genome import Genome
+from bolinas.enhancer_classification.genome_window_dataset import GenomeWindowDataset
 from bolinas.enhancer_classification.model import EnhancerClassifier
 
 logger = logging.getLogger(__name__)
-
-
-class GenomeWindowDataset(Dataset):
-    """Map-style dataset of sliding windows over genomic regions.
-
-    Window coordinates are pre-computed from a parquet file. Sequences are
-    lazily extracted from the genome in ``__getitem__``, so the full genome
-    is never materialized as one-hot tensors.
-
-    Each DataLoader worker opens its own ``py2bit`` / FASTA handle. For 2bit
-    files this means shared memory-mapped pages across workers.
-
-    Args:
-        genome_path: Path to genome file (.2bit or .fa/.fa.gz).
-        windows: DataFrame with ``chrom``, ``start``, ``end`` columns.
-    """
-
-    def __init__(self, genome_path: Path, windows: pl.DataFrame) -> None:
-        self._genome_path = genome_path
-        self._chroms = windows["chrom"].to_numpy()
-        self._starts = windows["start"].to_numpy().astype(np.int64)
-        self._ends = windows["end"].to_numpy().astype(np.int64)
-        self._genome: Genome | None = None
-
-    def __len__(self) -> int:
-        return len(self._starts)
-
-    def __getitem__(self, idx: int) -> torch.Tensor:
-        if self._genome is None:
-            self._genome = Genome(self._genome_path)
-        seq = self._genome(str(self._chroms[idx]), int(self._starts[idx]), int(self._ends[idx]))
-        onehot = sequence_to_onehot(seq).astype(np.float32)
-        return torch.from_numpy(onehot)
 
 
 def predict_genome(
@@ -125,9 +91,7 @@ def predict_genome(
         len(all_logits) / elapsed,
     )
 
-    return windows.with_columns(
-        pl.Series("logit", all_logits, dtype=pl.Float32)
-    )
+    return windows.with_columns(pl.Series("logit", all_logits, dtype=pl.Float32))
 
 
 def parse_args() -> argparse.Namespace:
@@ -146,12 +110,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--batch-size", type=int, default=512, help="Inference batch size"
     )
-    parser.add_argument(
-        "--num-workers", type=int, default=4, help="DataLoader workers"
-    )
-    parser.add_argument(
-        "--output", type=Path, required=True, help="Output parquet"
-    )
+    parser.add_argument("--num-workers", type=int, default=4, help="DataLoader workers")
+    parser.add_argument("--output", type=Path, required=True, help="Output parquet")
     return parser.parse_args()
 
 
@@ -161,7 +121,9 @@ def main() -> None:
 
     logger.info("Loading windows from %s", args.windows)
     windows = pl.read_parquet(args.windows)
-    logger.info("  %d windows across %d chromosomes", len(windows), windows["chrom"].n_unique())
+    logger.info(
+        "  %d windows across %d chromosomes", len(windows), windows["chrom"].n_unique()
+    )
 
     result = predict_genome(
         genome_path=args.genome,

--- a/src/bolinas/enhancer_segmentation/predict_genome.py
+++ b/src/bolinas/enhancer_segmentation/predict_genome.py
@@ -30,6 +30,26 @@ from bolinas.enhancer_segmentation.model import EnhancerSegmenter
 logger = logging.getLogger(__name__)
 
 
+def tile_chromosomes(
+    chrom_sizes: dict[str, int], window_size: int
+) -> list[tuple[str, int, int]]:
+    """Emit non-overlapping full-context windows for each chromosome.
+
+    Only windows that fit entirely within a chromosome are emitted —
+    the model was trained on unpadded sequence and cannot be trusted
+    on N-padded input. Contigs shorter than ``window_size`` and the
+    last ``size % window_size`` bases of each chromosome are therefore
+    uncovered. See discussion on issue #118.
+    """
+    windows: list[tuple[str, int, int]] = []
+    for chrom, size in chrom_sizes.items():
+        n_windows = size // window_size
+        for i in range(n_windows):
+            start = i * window_size
+            windows.append((chrom, start, start + window_size))
+    return windows
+
+
 class GenomeWindowDataset(Dataset):
     """Map-style dataset of genomic windows for segmentation inference.
 
@@ -84,6 +104,13 @@ def predict_genome(
         DataFrame with columns ``chrom``, ``bin_start``, ``bin_end``, ``logit``
         — one row per bin across all windows.
     """
+    window_size = int(windows["end"][0] - windows["start"][0])
+    if window_size % bin_size != 0:
+        raise ValueError(
+            f"window_size ({window_size}) must be a multiple of bin_size ({bin_size})"
+        )
+    expected_num_bins = window_size // bin_size
+
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     if torch.cuda.is_available():
@@ -117,6 +144,12 @@ def predict_genome(
     assert predictions is not None
     all_logits = np.concatenate([p.float().numpy() for p in predictions])
     num_bins = all_logits.shape[1]
+    if num_bins != expected_num_bins:
+        raise ValueError(
+            f"Model produced {num_bins} bins per window but window_size "
+            f"({window_size}) / bin_size ({bin_size}) = {expected_num_bins}. "
+            f"Check that --bin-size matches the model's native downsampling."
+        )
     total_bins = len(windows) * num_bins
 
     logger.info(

--- a/src/bolinas/enhancer_segmentation/predict_genome.py
+++ b/src/bolinas/enhancer_segmentation/predict_genome.py
@@ -161,6 +161,12 @@ def parse_args() -> argparse.Namespace:
         "--batch-size", type=int, default=32, help="Inference batch size"
     )
     parser.add_argument("--num-workers", type=int, default=4, help="DataLoader workers")
+    parser.add_argument(
+        "--max-windows",
+        type=int,
+        default=0,
+        help="Truncate windows to first N for smoke tests (0 = no limit)",
+    )
     parser.add_argument("--output", type=Path, required=True, help="Output parquet")
     return parser.parse_args()
 
@@ -171,6 +177,9 @@ def main() -> None:
 
     logger.info("Loading windows from %s", args.windows)
     windows = pl.read_parquet(args.windows)
+    if args.max_windows > 0:
+        windows = windows.head(args.max_windows)
+        logger.info("  Truncated to first %d windows for smoke test", args.max_windows)
     logger.info(
         "  %d windows across %d chromosomes", len(windows), windows["chrom"].n_unique()
     )

--- a/src/bolinas/enhancer_segmentation/predict_genome.py
+++ b/src/bolinas/enhancer_segmentation/predict_genome.py
@@ -21,10 +21,9 @@ import lightning as L
 import numpy as np
 import polars as pl
 import torch
-from alphagenome_pytorch.utils.sequence import sequence_to_onehot
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import DataLoader
 
-from bolinas.enhancer_classification.genome import Genome
+from bolinas.enhancer_classification.genome_window_dataset import GenomeWindowDataset
 from bolinas.enhancer_segmentation.model import EnhancerSegmenter
 
 logger = logging.getLogger(__name__)
@@ -48,38 +47,6 @@ def tile_chromosomes(
             start = i * window_size
             windows.append((chrom, start, start + window_size))
     return windows
-
-
-class GenomeWindowDataset(Dataset):
-    """Map-style dataset of genomic windows for segmentation inference.
-
-    Window coordinates come from a pre-computed parquet file. Sequences are
-    lazily extracted from the genome in ``__getitem__``, so each DataLoader
-    worker opens its own file handle (shared memory-mapped pages for 2bit).
-
-    Args:
-        genome_path: Path to genome file (.2bit or .fa/.fa.gz).
-        windows: DataFrame with ``chrom``, ``start``, ``end`` columns.
-    """
-
-    def __init__(self, genome_path: Path, windows: pl.DataFrame) -> None:
-        self._genome_path = genome_path
-        self._chroms = windows["chrom"].to_numpy()
-        self._starts = windows["start"].to_numpy().astype(np.int64)
-        self._ends = windows["end"].to_numpy().astype(np.int64)
-        self._genome: Genome | None = None
-
-    def __len__(self) -> int:
-        return len(self._starts)
-
-    def __getitem__(self, idx: int) -> torch.Tensor:
-        if self._genome is None:
-            self._genome = Genome(self._genome_path)
-        seq = self._genome(
-            str(self._chroms[idx]), int(self._starts[idx]), int(self._ends[idx])
-        )
-        onehot = sequence_to_onehot(seq).astype(np.float32)
-        return torch.from_numpy(onehot)
 
 
 def predict_genome(
@@ -119,7 +86,8 @@ def predict_genome(
     model = EnhancerSegmenter.load_from_checkpoint(checkpoint_path, map_location=device)
     model.to(device)
     model.eval()
-    model = torch.compile(model)
+    if torch.cuda.is_available():
+        model = torch.compile(model)
 
     dataset = GenomeWindowDataset(genome_path, windows)
     dataloader = DataLoader(
@@ -141,7 +109,8 @@ def predict_genome(
     predictions = trainer.predict(model, dataloader)
     elapsed = time.perf_counter() - t0
 
-    assert predictions is not None
+    if predictions is None:
+        raise RuntimeError("trainer.predict returned None")
     all_logits = np.concatenate([p.float().numpy() for p in predictions])
     num_bins = all_logits.shape[1]
     if num_bins != expected_num_bins:

--- a/src/bolinas/enhancer_segmentation/predict_genome.py
+++ b/src/bolinas/enhancer_segmentation/predict_genome.py
@@ -1,0 +1,193 @@
+"""Whole-genome enhancer prediction with per-bin segmentation model.
+
+Tiles genomic regions with non-overlapping windows and runs the
+EnhancerSegmenter to produce per-bin logits at 128bp resolution.
+
+Usage::
+
+    python -m bolinas.enhancer_segmentation.predict_genome \
+        --genome genome.2bit \
+        --checkpoint best.ckpt \
+        --windows windows.parquet \
+        --output predictions.parquet
+"""
+
+import argparse
+import logging
+import time
+from pathlib import Path
+
+import lightning as L
+import numpy as np
+import polars as pl
+import torch
+from alphagenome_pytorch.utils.sequence import sequence_to_onehot
+from torch.utils.data import DataLoader, Dataset
+
+from bolinas.enhancer_classification.genome import Genome
+from bolinas.enhancer_segmentation.model import EnhancerSegmenter
+
+logger = logging.getLogger(__name__)
+
+
+class GenomeWindowDataset(Dataset):
+    """Map-style dataset of genomic windows for segmentation inference.
+
+    Window coordinates come from a pre-computed parquet file. Sequences are
+    lazily extracted from the genome in ``__getitem__``, so each DataLoader
+    worker opens its own file handle (shared memory-mapped pages for 2bit).
+
+    Args:
+        genome_path: Path to genome file (.2bit or .fa/.fa.gz).
+        windows: DataFrame with ``chrom``, ``start``, ``end`` columns.
+    """
+
+    def __init__(self, genome_path: Path, windows: pl.DataFrame) -> None:
+        self._genome_path = genome_path
+        self._chroms = windows["chrom"].to_numpy()
+        self._starts = windows["start"].to_numpy().astype(np.int64)
+        self._ends = windows["end"].to_numpy().astype(np.int64)
+        self._genome: Genome | None = None
+
+    def __len__(self) -> int:
+        return len(self._starts)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        if self._genome is None:
+            self._genome = Genome(self._genome_path)
+        seq = self._genome(
+            str(self._chroms[idx]), int(self._starts[idx]), int(self._ends[idx])
+        )
+        onehot = sequence_to_onehot(seq).astype(np.float32)
+        return torch.from_numpy(onehot)
+
+
+def predict_genome(
+    genome_path: Path,
+    checkpoint_path: Path,
+    windows: pl.DataFrame,
+    bin_size: int = 128,
+    batch_size: int = 32,
+    num_workers: int = 4,
+) -> pl.DataFrame:
+    """Run segmentation prediction on pre-computed windows.
+
+    Args:
+        genome_path: Path to genome file (.2bit or .fa/.fa.gz).
+        checkpoint_path: Path to trained EnhancerSegmenter checkpoint.
+        windows: DataFrame with ``chrom``, ``start``, ``end`` columns.
+        bin_size: Size of each output bin in bp.
+        batch_size: Inference batch size.
+        num_workers: Number of DataLoader workers.
+
+    Returns:
+        DataFrame with columns ``chrom``, ``bin_start``, ``bin_end``, ``logit``
+        — one row per bin across all windows.
+    """
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    if torch.cuda.is_available():
+        torch.set_float32_matmul_precision("medium")
+
+    model = EnhancerSegmenter.load_from_checkpoint(checkpoint_path, map_location=device)
+    model.to(device)
+    model.eval()
+    model = torch.compile(model)
+
+    dataset = GenomeWindowDataset(genome_path, windows)
+    dataloader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        pin_memory=torch.cuda.is_available(),
+        persistent_workers=num_workers > 0,
+    )
+
+    trainer = L.Trainer(
+        accelerator="auto",
+        precision="bf16-mixed" if torch.cuda.is_available() else "32-true",
+        logger=False,
+        enable_checkpointing=False,
+    )
+
+    t0 = time.perf_counter()
+    predictions = trainer.predict(model, dataloader)
+    elapsed = time.perf_counter() - t0
+
+    assert predictions is not None
+    all_logits = np.concatenate([p.float().numpy() for p in predictions])
+    num_bins = all_logits.shape[1]
+    total_bins = len(windows) * num_bins
+
+    logger.info(
+        "Predicted %d windows (%d bins) in %.1fs (%.0f bins/sec)",
+        len(windows),
+        total_bins,
+        elapsed,
+        total_bins / elapsed,
+    )
+
+    chroms = np.repeat(windows["chrom"].to_numpy(), num_bins)
+    window_starts = np.repeat(windows["start"].to_numpy(), num_bins)
+    bin_indices = np.tile(np.arange(num_bins, dtype=np.int32), len(windows))
+    bin_starts = window_starts + bin_indices * bin_size
+    bin_ends = bin_starts + bin_size
+
+    return pl.DataFrame(
+        {
+            "chrom": chroms,
+            "bin_start": bin_starts,
+            "bin_end": bin_ends,
+            "logit": all_logits.reshape(-1).astype(np.float32),
+        }
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Predict per-bin enhancer logits across genomic regions."
+    )
+    parser.add_argument(
+        "--genome", type=Path, required=True, help="Genome file (.2bit or .fa.gz)"
+    )
+    parser.add_argument(
+        "--checkpoint", type=Path, required=True, help="Lightning checkpoint"
+    )
+    parser.add_argument(
+        "--windows", type=Path, required=True, help="Window coordinates parquet"
+    )
+    parser.add_argument("--bin-size", type=int, default=128, help="Bin size in bp")
+    parser.add_argument(
+        "--batch-size", type=int, default=32, help="Inference batch size"
+    )
+    parser.add_argument("--num-workers", type=int, default=4, help="DataLoader workers")
+    parser.add_argument("--output", type=Path, required=True, help="Output parquet")
+    return parser.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = parse_args()
+
+    logger.info("Loading windows from %s", args.windows)
+    windows = pl.read_parquet(args.windows)
+    logger.info(
+        "  %d windows across %d chromosomes", len(windows), windows["chrom"].n_unique()
+    )
+
+    result = predict_genome(
+        genome_path=args.genome,
+        checkpoint_path=args.checkpoint,
+        windows=windows,
+        bin_size=args.bin_size,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    result.write_parquet(args.output)
+    logger.info("Wrote %s (%d bins)", args.output, len(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/enhancer_segmentation/test_predict_genome.py
+++ b/tests/enhancer_segmentation/test_predict_genome.py
@@ -1,0 +1,36 @@
+"""Tests for whole-genome segmentation tiling."""
+
+from bolinas.enhancer_segmentation.predict_genome import tile_chromosomes
+
+WINDOW = 65536
+
+
+def test_single_exact_window():
+    tiles = tile_chromosomes({"chr1": WINDOW}, WINDOW)
+    assert tiles == [("chr1", 0, WINDOW)]
+
+
+def test_skips_contig_shorter_than_window():
+    tiles = tile_chromosomes({"tiny": WINDOW - 1}, WINDOW)
+    assert tiles == []
+
+
+def test_drops_partial_tail_window():
+    tiles = tile_chromosomes({"chr1": 3 * WINDOW + 100}, WINDOW)
+    assert tiles == [
+        ("chr1", 0, WINDOW),
+        ("chr1", WINDOW, 2 * WINDOW),
+        ("chr1", 2 * WINDOW, 3 * WINDOW),
+    ]
+
+
+def test_multiple_chromosomes():
+    tiles = tile_chromosomes(
+        {"chr1": 2 * WINDOW, "chr2": WINDOW, "tiny": 100},
+        WINDOW,
+    )
+    assert tiles == [
+        ("chr1", 0, WINDOW),
+        ("chr1", WINDOW, 2 * WINDOW),
+        ("chr2", 0, WINDOW),
+    ]


### PR DESCRIPTION
🤖 Closes #118.

## Summary

Whole-genome enhancer scoring using the per-bin segmentation model from #115. For each input genome, we tile chromosomes into non-overlapping 64kbp windows and run `EnhancerSegmenter` (`xfmr2_w64k_s42_full`) to produce per-bin enhancer logits at 128bp resolution. Output is one parquet per genome with `(chrom, bin_start, bin_end, logit)`.

Predictions have been generated for **20 diverse mammals** (one species per order across 20 mammalian orders, all Chromosome-level assemblies, forcing human + mouse as the Primates/Rodentia reps). All outputs are in S3 at `s3://oa-bolinas/snakemake/training_dataset/dataset_creation/results/enhancer_predictions_segmentation/{g}.parquet`.

## What's in this PR

- `src/bolinas/enhancer_segmentation/predict_genome.py` — whole-genome prediction CLI with `GenomeWindowDataset` + Lightning `Trainer.predict()`, `torch.compile` + bf16. Outputs one row per 128bp bin. Includes `--max-windows` for smoke tests.
- `scripts/benchmark_segmentation_predict.py` — one-off benchmark that tiles a single chromosome.
- Snakemake rules in `snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk`:
  - `segmentation_prediction_windows` — tiles chromosomes; only emits full-context windows.
  - `predict_enhancers_segmentation` — runs the CLI.
  - `all_enhancer_predictions_segmentation` — aggregate target.
- Config block `enhancer_prediction_segmentation` in `config/config.yaml` with the 20-genome list. The selection script is included as a comment above the list.
- README section documenting the pipeline.
- Added `py2bit` to `common.smk` imports.

## Design decisions (from discussion on #118)

- **Non-overlapping 64kbp windows** — natural for segmentation; no sliding needed.
- **No exon subtraction** — model trained without it (#115).
- **No N-padding at inference** — model was trained on full-context windows only. Padded windows are out-of-distribution and would corrupt even the "real" bins inside them through the transformer's receptive field. So we only emit windows that fit entirely within a chromosome.
- **Chromosome-level assemblies only** — Scaffold-level assemblies have too many sub-`window_size` contigs that would get zero coverage. 3 orders (Macroscelidea, Scandentia, Sirenia) are therefore not represented; they only have Scaffold-level assemblies in the current genome set.
- **Force-include human and mouse** as our training species regardless of the smallest-genome tiebreaker.

## Benchmarks (L4 GPU)

| Model | Window | Layers | Wall time on chr22 | Throughput | Extrapolated full human |
|---|---|---|---|---|---|
| `xfmr2_w64k_s42_full` | 64kbp | 2 transformer | 149s | ~6,200 bins/sec steady | ~66 min |
| `fast` (CNN-only) | 16kbp | 0 | 69s | ~5,750 bins/sec | ~70 min |

We use the 64k transformer model because AUPRC (0.388) is materially better than the CNN-only baseline and the wall-time difference per genome is negligible.

Observed in the full run: ~60–90 min per genome (larger/more-fragmented genomes take longer), ~24h total for all 20.

## What is explicitly out of scope

Per the refined issue scope, this PR only computes per-bin logits. Downstream (future PRs, tracked on #118):
1. Thresholding the per-bin logits and merging adjacent positives into enhancer intervals (a new "recipe vN" analogous to v19).
2. Calibrating the threshold on held-out chr7 at natural class proportions.
3. Integrating the resulting intervals into gLM training datasets.

## Things left for a future agent / iteration

1. **Padding-robust inference** — the model can't score the last (chrom_size mod 64kbp) bases of any chromosome, nor any contig smaller than 64kbp. To handle these without OOD issues you'd either train with N-padded examples, train a smaller-context model, or implement an overlapping-window scheme with aggregation. See the "Edge-handling discussion (future work)" comment on #118 for the full reasoning.
2. **Parallel execution** — #119 tracks this. ~27h on a single L4 was fine for the 20-genome first pass, but scaling to 80 genomes serially is painful. Next step is the Snakemake AWS Batch executor (`snakemake-executor-plugin-aws-batch`) with `g6e.xlarge` (L40S) spot instances (~$0.15/genome estimated).
3. **Downstream threshold calibration and interval merging** — the natural follow-up, out of scope of #118.
4. **Observability** — currently the only signal is the Lightning progress bar in the log file. If this pipeline becomes routine, it's worth emitting a structured summary (per-genome bin count, logit distribution, wall time) at completion.

## How to continue this work

1. Check out the branch: `git fetch origin && git checkout claude/funny-buck`.
2. Set up the environment: `uv sync --group enhancer-classification` (from the worktree root).
3. Everything is run through Snakemake from `snakemake/training_dataset/dataset_creation/`. Add `~/miniforge3/bin` to `PATH` first, then:
   ```
   uv run snakemake -n all_enhancer_predictions_segmentation   # dry-run
   uv run snakemake all_enhancer_predictions_segmentation      # full run
   uv run snakemake results/enhancer_predictions_segmentation/GCF_000001405.40.parquet  # single genome
   ```
4. For smoke tests, set `enhancer_prediction_segmentation.max_windows: 10` in `config.yaml`, run one genome, verify S3 output, revert.
5. Existing prediction outputs are in S3; Snakemake will skip genomes already present. To re-predict a genome, delete its parquet first.

## Test plan

- [x] `uv run pytest` passes (no new tests; all existing ones still green modulo the pre-existing alphagenome-pytorch dependency issue).
- [x] Smoke test with `max_windows=10` on the human genome — end-to-end write + S3 upload path verified.
- [x] Full run on 20 mammals completed; all 20 parquets land in S3 with correct schema and bin counts.
- [ ] Downstream consumers (future recipe) load the parquets cleanly.