### PR TITLE
Add agent-research skill for tracking multi-session investigations

### DIFF
--- a/.agents/skills/agent-research/SKILL.md
+++ b/.agents/skills/agent-research/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: agent-research
+description: Long-running, iterative investigation tracked in its own GitHub issue — the issue body is the living results doc, comments are the append-only iteration log, and every code reference is a commit-pinned permalink. Use when the user asks to investigate a question over multiple sessions and track the work in a dedicated issue. Common triggers include "let's investigate X and track it in an issue", "open an issue for this and we'll iterate", "dig into Y across sessions", "why is Z slow — track it", "explore this dataset and log findings as we go". Do NOT use for: running a pipeline by itself (even a snakemake/analysis run), single-session debugging or fixes, one-off questions, or regular feature PRs.
+---
+
+# agent-research
+
+Inspired by [marin's `agent-research` skill](https://github.com/marin-community/marin/blob/main/.agents/skills/agent-research/SKILL.md), trimmed for this repo (see [§ What this skill is NOT](#what-this-skill-is-not) for what was dropped).
+
+## When to use this skill
+
+Use this skill for long-running, exploratory research where an agent iterates on benchmarks, experiments, and hypotheses over multiple sessions.
+
+The workflow optimizes for:
+
+- **Reproducibility** — every claim links to the exact code that produced it.
+- **Clear decision history** — scope changes and course-corrections are visible, not silent.
+- **Fast iteration loops** — short append-only comments; heavier body edits only when the headline story shifts.
+- **Handoff quality** — a cold reader (human or future agent) can open the issue and catch up.
+
+The question might be EDA-flavored, algorithm-optimization-flavored, or pipeline-investigation-flavored — the skill doesn't care. What matters: findings accumulate over more than one session, and the user has asked to track the work in its own issue.
+
+Do NOT use for:
+
+- Running a pipeline by itself — not a trigger, even if it's a `snakemake/analysis/*` run.
+- Single-session debugging or fixes.
+- Tasks without an explicit ask to track them.
+
+## Artifacts
+
+Three things. No more.
+
+- A **GitHub issue** labeled `agent-generated` plus one topic label chosen per case (`eda`, `experiment`, `infrastructure`, etc. — reuse existing labels; don't invent a new workflow label).
+- *Optionally* a `snakemake/analysis/<name>/` pipeline if the investigation produces one. Its README stays strictly how-to-run.
+- Plots and data files attached via the [gh-upload-asset](../gh-upload-asset/SKILL.md) skill.
+
+## Kickoff
+
+1. Draft the issue body using the structure in [§ Issue body structure](#issue-body-structure).
+2. Create the issue:
+
+   ```
+   gh issue create \
+     --title "🤖 <short phrasing of the question>" \
+     --label agent-generated --label <topic> \
+     --body-file <path>
+   ```
+
+   Title is prefixed with `🤖 ` per [CLAUDE.md](../../../CLAUDE.md).
+3. If a pipeline is needed, scaffold `snakemake/analysis/<name>/` following an existing example (e.g. `snakemake/analysis/sequence_similarity/`) and link it from the issue body.
+
+The repo's `.github/ISSUE_TEMPLATE/experiment.md` is WandB-flavored and does not match this workflow — do not route through it.
+
+## Issue body structure
+
+Order matters: the first screenful is the current state, not the history.
+
+- **Question** — what we're trying to learn, 2–4 sentences, written for a reader who knows genomics and ML broadly but not this thread.
+- **Scope** — short bullets of what's in and what's explicitly *out*. Changes here are announced in a `🤖` comment first (see [§ Iteration loop](#iteration-loop)) before being reflected in the body.
+- **Approach** — data inputs, methods, link to the pipeline if any.
+- **Current findings** — living; edited as results settle. Plots via gist links from `gh-upload-asset`.
+- **Open questions / next steps** — edited, not appended.
+- **Tracking** — one-liner: *"Description = current state. Comments = append-only iteration log. Pipeline README (if any) = how-to-run only."*
+
+## Iteration loop
+
+For each new run, finding, or course-correction:
+
+- Upload any plots via `gh-upload-asset`.
+- Post a **new** `gh issue comment` prefixed with `🤖`. One comment per atomic update. Content is append-only: don't edit a comment to change what it said. Formatting fixes (typos, broken markdown, re-wrapping) are fine.
+- **Reference code with permalinks, always.** Every code reference in a comment uses a GitHub permalink pinned to a commit SHA — never `main` or a branch name. Shape:
+
+  ```
+  https://github.com/<owner>/<repo>/blob/<sha>/<path>#L<line>
+  ```
+
+  Quick ways to produce one:
+
+  ```
+  # copy a permalink for the current HEAD, line L in FILE
+  gh browse FILE:L -n -c "$(git rev-parse HEAD)"
+
+  # or construct it yourself
+  SHA=$(git rev-parse HEAD)
+  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+  echo "https://github.com/$REPO/blob/$SHA/FILE#LL"
+  ```
+
+  Links that drift to later code are worse than no link. If the referenced code isn't yet pushed, push first (to the current branch — *not* `main`) so the SHA resolves publicly.
+
+- If the takeaway changes the headline story, **also** edit the issue body's *Current findings* / *Open questions*. Body edits are retroactive-safe; comments are not.
+- **Scope changes get their own comment.** When the thread's direction shifts — adding a question, dropping one, narrowing methodology — post a `🤖` comment that names the shift explicitly ("Scope update: dropping X, adding Y because Z"), *then* update the *Scope* section of the body. Never rewrite *Scope* silently.
+
+## Closure
+
+- Summarize outcomes in the body (*Current findings* becomes final findings; *Open questions* lists what was left).
+- Propose close in a final `🤖` comment.
+- **Wait for explicit user approval before closing.** Agents don't close issues on their own, per [CLAUDE.md](../../../CLAUDE.md) *Autonomy Boundaries*.
+
+## What this skill is NOT
+
+Deliberately dropped from marin's fuller version of this workflow so the skill stays minimal:
+
+- No research logbook files (`.agents/logbooks/*.md`).
+- No Weights & Biases integration.
+- No experiment ID prefixes.
+- No annotated snapshot tags.
+- No dedicated long-lived research branch.
+
+If a thread grows large enough that one of these would help, the user will say so.

--- a/.agents/skills/agent-research/SKILL.md
+++ b/.agents/skills/agent-research/SKILL.md
@@ -86,7 +86,7 @@ For each new run, finding, or course-correction:
   echo "https://github.com/$REPO/blob/$SHA/src/bolinas/intervals.py#L42"
   ```
 
-  Both forms require the SHA to be pushed to a branch visible on GitHub — otherwise the URL will 404 for readers. If the referenced code isn't yet pushed, push first (to the current branch — *not* `main`) before posting the link. Links that drift to later code are worse than no link.
+  Both forms require the SHA to be pushed to a branch visible on GitHub — otherwise the URL will 404 for readers. If the referenced code isn't yet pushed, push first (to the current branch — *not* `main`) before posting the link.
 
 - If the takeaway changes the headline story, **also** edit the issue body's *Current findings* / *Open questions*. Body edits are retroactive-safe; comments are not.
 - **Scope changes get their own comment.** When the thread's direction shifts — adding a question, dropping one, narrowing methodology — post a `🤖` comment that names the shift explicitly ("Scope update: dropping X, adding Y because Z"), *then* update the *Scope* section of the body. Never rewrite *Scope* silently.

--- a/.agents/skills/agent-research/SKILL.md
+++ b/.agents/skills/agent-research/SKILL.md
@@ -46,7 +46,7 @@ Three things. No more.
      --body-file <path>
    ```
 
-   Title is prefixed with `🤖 ` per [CLAUDE.md](../../../CLAUDE.md).
+   Title is prefixed with `🤖 ` to match how recent agent-generated issues are titled (e.g. #120, #123). [CLAUDE.md](../../../CLAUDE.md) mandates the prefix on *comments*; prefixing the title is convention, not a rule.
 3. If a pipeline is needed, scaffold `snakemake/analysis/<name>/` following an existing example (e.g. `snakemake/analysis/sequence_similarity/`) and link it from the issue body.
 
 The repo's `.github/ISSUE_TEMPLATE/experiment.md` is WandB-flavored and does not match this workflow — do not route through it.
@@ -74,19 +74,19 @@ For each new run, finding, or course-correction:
   https://github.com/<owner>/<repo>/blob/<sha>/<path>#L<line>
   ```
 
-  Quick ways to produce one:
+  Quick ways to produce one (substitute your own `<path>` and `<line>`):
 
   ```
-  # copy a permalink for the current HEAD, line L in FILE
-  gh browse FILE:L -n -c "$(git rev-parse HEAD)"
+  # copy a permalink for the current HEAD, a specific line in a file
+  gh browse src/bolinas/intervals.py:42 -n -c "$(git rev-parse HEAD)"
 
   # or construct it yourself
   SHA=$(git rev-parse HEAD)
   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-  echo "https://github.com/$REPO/blob/$SHA/FILE#LL"
+  echo "https://github.com/$REPO/blob/$SHA/src/bolinas/intervals.py#L42"
   ```
 
-  Links that drift to later code are worse than no link. If the referenced code isn't yet pushed, push first (to the current branch — *not* `main`) so the SHA resolves publicly.
+  Both forms require the SHA to be pushed to a branch visible on GitHub — otherwise the URL will 404 for readers. If the referenced code isn't yet pushed, push first (to the current branch — *not* `main`) before posting the link. Links that drift to later code are worse than no link.
 
 - If the takeaway changes the headline story, **also** edit the issue body's *Current findings* / *Open questions*. Body edits are retroactive-safe; comments are not.
 - **Scope changes get their own comment.** When the thread's direction shifts — adding a question, dropping one, narrowing methodology — post a `🤖` comment that names the shift explicitly ("Scope update: dropping X, adding Y because Z"), *then* update the *Scope* section of the body. Never rewrite *Scope* silently.

--- a/.agents/skills/agent-research/SKILL.md
+++ b/.agents/skills/agent-research/SKILL.md
@@ -68,25 +68,15 @@ For each new run, finding, or course-correction:
 
 - Upload any plots via `gh-upload-asset`.
 - Post a **new** `gh issue comment` prefixed with `🤖`. One comment per atomic update. Content is append-only: don't edit a comment to change what it said. Formatting fixes (typos, broken markdown, re-wrapping) are fine.
-- **Reference code with permalinks, always.** Every code reference in a comment uses a GitHub permalink pinned to a commit SHA — never `main` or a branch name. Shape:
+- **Pin code references to a commit SHA, never `main` or a branch name.** Pick the granularity that matches what you're showing:
+  - a single line or range when specific lines matter: `/blob/<sha>/<path>#L42` or `#L42-L68`
+  - a whole file when the file is the thing: `/blob/<sha>/<path>`
+  - a subdirectory when the iteration touches several related files: `/tree/<sha>/<path>/`
+  - a commit or range when "here's what this round of work did" is the point: `/commit/<sha>` or `/compare/<a>...<b>`
 
-  ```
-  https://github.com/<owner>/<repo>/blob/<sha>/<path>#L<line>
-  ```
+  `gh browse <path>[:<line>] -n -c "$(git rev-parse HEAD)"` handles the line / file / directory shapes. For commit links, construct directly: `https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/commit/$(git rev-parse HEAD)`.
 
-  Quick ways to produce one (substitute your own `<path>` and `<line>`):
-
-  ```
-  # copy a permalink for the current HEAD, a specific line in a file
-  gh browse src/bolinas/intervals.py:42 -n -c "$(git rev-parse HEAD)"
-
-  # or construct it yourself
-  SHA=$(git rev-parse HEAD)
-  REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-  echo "https://github.com/$REPO/blob/$SHA/src/bolinas/intervals.py#L42"
-  ```
-
-  Both forms require the SHA to be pushed to a branch visible on GitHub — otherwise the URL will 404 for readers. If the referenced code isn't yet pushed, push first (to the current branch — *not* `main`) before posting the link.
+  Whatever the shape, the SHA has to be pushed to a branch GitHub can see — push to the current branch (*not* `main`) before posting, otherwise the URL 404s.
 
 - If the takeaway changes the headline story, **also** edit the issue body's *Current findings* / *Open questions*. Body edits are retroactive-safe; comments are not.
 - **Scope changes get their own comment.** When the thread's direction shifts — adding a question, dropping one, narrowing methodology — post a `🤖` comment that names the shift explicitly ("Scope update: dropping X, adding Y because Z"), *then* update the *Scope* section of the body. Never rewrite *Scope* silently.

--- a/.agents/skills/agent-research/SKILL.md
+++ b/.agents/skills/agent-research/SKILL.md
@@ -41,12 +41,12 @@ Three things. No more.
 
    ```
    gh issue create \
-     --title "🤖 <short phrasing of the question>" \
+     --title "<short phrasing of the question>" \
      --label agent-generated --label <topic> \
      --body-file <path>
    ```
 
-   Title is prefixed with `🤖 ` to match how recent agent-generated issues are titled (e.g. #120, #123). [CLAUDE.md](../../../CLAUDE.md) mandates the prefix on *comments*; prefixing the title is convention, not a rule.
+   No `🤖` prefix on the title — [CLAUDE.md](../../../CLAUDE.md) mandates the prefix on *comments*, and the `agent-generated` label already signals provenance.
 3. If a pipeline is needed, scaffold `snakemake/analysis/<name>/` following an existing example (e.g. `snakemake/analysis/sequence_similarity/`) and link it from the issue body.
 
 The repo's `.github/ISSUE_TEMPLATE/experiment.md` is WandB-flavored and does not match this workflow — do not route through it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ If you are asked to implement a specific backend, just stick to that. Do not gen
 ## GitHub Communication
 
 - When an agent creates a PR or issue, add the `agent-generated` label.
-- Agent comments on PRs/issues must begin with `🤖` unless the exact text was explicitly approved by the user.
+- Agent comments on PRs/issues must begin with `🤖`.
 - For iterative investigations the user wants tracked in their own issue, use the `agent-research` skill — issue body is the living doc, comments are the append-only log with commit-pinned permalinks to code.
 
 ## Autonomy Boundaries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ If you are asked to implement a specific backend, just stick to that. Do not gen
 
 - When an agent creates a PR or issue, add the `agent-generated` label.
 - Agent comments on PRs/issues must begin with `🤖` unless the exact text was explicitly approved by the user.
+- For iterative investigations the user wants tracked in their own issue, use the `agent-research` skill — issue body is the living doc, comments are the append-only log with commit-pinned permalinks to code.
 
 ## Autonomy Boundaries
 


### PR DESCRIPTION
🤖

## Summary

- New Agent Skill at `.agents/skills/agent-research/SKILL.md`, inspired by [marin's `agent-research` skill](https://github.com/marin-community/marin/blob/main/.agents/skills/agent-research/SKILL.md) and trimmed to the minimum useful in this repo.
- Codifies a convention already practiced here (see #120, #122, #123 and the existing `feedback_analysis_tracking.md` memory note): **issue body = living results doc, comments = append-only iteration log, pipeline README (if any) = how-to-run only**.
- Adds the scope discipline from marin — scope changes are announced in a 🤖 comment before the body's *Scope* section is rewritten, so the thread's direction stays legible.
- Requires commit-pinned permalinks for every code reference in comments (no links to `main` or branches that will drift).
- One-line pointer added to `AGENTS.md` under *GitHub Communication*.

Triggers: "let's investigate X and track it in an issue", "open an issue for this and we'll iterate", "dig into Y across sessions", "explore this dataset and log findings", etc. Explicit non-triggers: running a pipeline by itself, single-session fixes, one-off questions.

Deliberately **not** included (easy to add later if a thread actually needs them): W&B integration, logbook files, research branch lifecycle, experiment ID prefixes, snapshot tags, confidence labels.

## Test plan

- [ ] Next multi-session investigation kicks off through the skill — check whether any step feels missing or redundant, revise then.
- [ ] Confirm the skill surfaces in the skills list on a fresh session (should auto-discover under `.agents/skills/`, same as `gh-upload-asset`).
- [ ] Confirm topic labels (`eda`, `experiment`, `infrastructure`, `agent-generated`) exist — all four present at PR time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)