### PR TITLE
Add segmentation-based enhancer recipe v20

### DIFF
--- a/snakemake/training_dataset/dataset_creation/README.md
+++ b/snakemake/training_dataset/dataset_creation/README.md
@@ -302,7 +302,10 @@ Edit `config/config.yaml` to customize the pipeline:
 
 - **`genomes_path`** - Path to filtered genome list (parquet file from genome_selection pipeline)
 
-- **`intervals`** - List of interval types to generate
+- **`intervals`** - Interval types to generate
+  - `intervals.training`: list of `{recipe}/{window_size}/{overlap}` strings; built across the cartesian product of *every* `genome_set`.
+  - `intervals.training_per_genome_set` (optional): mapping `{genome_set: [recipes...]}` for recipes that only apply to a specific genome_set (e.g., `v20` segmentation-predicted enhancers only exist for the 20 mammals scored in PR #126, exposed as `enhancer_seg_mammals_v1`).
+  - `intervals.validation`: list of recipes used to build the conservation-aware human validation parquet.
   - Format: `{recipe}/{window_size}/{overlap}`
   - Examples:
     - `v1/512/256` - Promoters with 512bp windows and 256bp overlap
@@ -313,10 +316,10 @@ Edit `config/config.yaml` to customize the pipeline:
     - **v2**: mRNA exons + promoters
     - **v3**: CDS regions only
 
-- **`genome_sets`** - Taxonomic groupings for separate datasets
-  - Each set defined by `name`, `rank_key`, and `rank_value`
-  - Example: `{name: "mammals", rank_key: "class", rank_value: "Mammalia"}`
-  - Creates separate datasets for each taxonomic group
+- **`genome_sets`** - Groupings for separate datasets. Each entry has a `name`, plus *either*:
+  - `rank_key` + `rank_value` for taxonomic filtering (e.g., `{rank_key: "class", rank_value: "Mammalia"}`), or
+  - `accessions`: an explicit list of Assembly Accessions (e.g., the 20 species in `enhancer_seg_mammals_v1`).
+  - Creates separate datasets for each group.
 
 - **`output_hf_prefix`** - HuggingFace repository prefix (e.g., "username/dataset-name")
 
@@ -393,6 +396,27 @@ Runs the per-bin segmentation model from [issue #115](https://github.com/Open-At
 **Output**: one parquet per genome at `results/enhancer_predictions_segmentation/{g}.parquet` (stored to S3 by the default profile) with schema `(chrom: str, bin_start: int64, bin_end: int64, logit: float32)` — one row per 128bp bin.
 
 **Status**: ~1h per genome on L4 GPU (~65 min). See #118 for benchmarks and a follow-up [#119](https://github.com/Open-Athena/bolinas-dna/issues/119) for parallel execution across multiple GPU instances via AWS Batch.
+
+## Recipe v20 (segmentation-based enhancers)
+
+Recipe v20 is the segmentation analogue of v19: it converts the per-bin segmentation logits from PR #126 into 255 bp enhancer windows for use as gLM training data. See [issue #133](https://github.com/Open-Athena/bolinas-dna/issues/133).
+
+**Pipeline**: `predict_enhancers_segmentation` (per-bin parquet from #118) → `intervals_recipe_v20`.
+
+**Algorithm**:
+1. Load per-bin logits.
+2. Threshold by per-genome quantile: keep bins with `logit >= quantile(1 - top_quantile)`. No held-out PR-curve calibration in this iteration.
+3. Resize each surviving 128 bp bin to a `recipe_target_size` bp window centered on its midpoint (auto-merge overlapping windows via `GenomicSet`).
+4. Subtract all functional exons (`get_exons_for_masking` — CDS + UTR + ncRNA, low-quality biotypes already excluded).
+5. Intersect with `defined` (drops N-runs and clips off-chromosome edges).
+
+**Configuration** (`enhancer_prediction_segmentation` block in `config.yaml`):
+- `recipe_top_quantile` (default `0.01` — top 1% of bins per genome)
+- `recipe_target_size` (default `255` bp)
+
+**Coverage**: only the 20 chromosome-level mammals listed in `enhancer_prediction_segmentation.genomes`, exposed as the `enhancer_seg_mammals_v1` genome_set. The recipe is wired into the dataset-assembly via `intervals.training_per_genome_set` so the `all` rule produces the HF dataset `bolinas-dna/genomes-v5-genome_set-enhancer_seg_mammals_v1-intervals-v20_255_128`.
+
+**Threshold calibration on chr7 with held-out PR curves is deferred** — that would replace the quantile threshold with a precision-targeted one. Tracked under #96.
 
 ## Output
 

--- a/snakemake/training_dataset/dataset_creation/README.md
+++ b/snakemake/training_dataset/dataset_creation/README.md
@@ -304,7 +304,7 @@ Edit `config/config.yaml` to customize the pipeline:
 
 - **`intervals`** - Interval types to generate
   - `intervals.training`: list of `{recipe}/{window_size}/{overlap}` strings; built across the cartesian product of *every* `genome_set`.
-  - `intervals.training_per_genome_set` (optional): mapping `{genome_set: [recipes...]}` for recipes that only apply to a specific genome_set (e.g., `v20` segmentation-predicted enhancers only exist for the 20 mammals scored in PR #126, exposed as `enhancer_seg_mammals_v1`).
+  - `intervals.training_per_genome_set` (optional): mapping `{genome_set: [recipes...]}` for recipes that only apply to a specific genome_set (e.g., `v20` segmentation-predicted enhancers only exist for the 20 mammals scored in PR #126, exposed as `enhancer_seg_mammals_v1`). For any genome_set listed here, the given recipes **replace** (not extend) the cartesian-product training recipes — so the listed set won't also get the default `intervals.training` recipes built.
   - `intervals.validation`: list of recipes used to build the conservation-aware human validation parquet.
   - Format: `{recipe}/{window_size}/{overlap}`
   - Examples:

--- a/snakemake/training_dataset/dataset_creation/config/config.yaml
+++ b/snakemake/training_dataset/dataset_creation/config/config.yaml
@@ -18,6 +18,12 @@ intervals:
         - v5/255/128 # CDS
         - v1/255/128 # upstream
         - v15/255/128 # downstream
+    # Recipes that only apply to a subset of genome_sets (e.g., v20 segmentation-
+    # predicted enhancers only exist for the 20 mammals scored in PR #126).
+    # Each entry: {genome_set: [recipe/w/s, ...]}.
+    training_per_genome_set:
+        enhancer_seg_mammals_v1:
+            - v20/255/128
     validation: # step = window for max diversity
         - v5/255/255
         - v1/255/255
@@ -39,6 +45,31 @@ genome_sets:
     - name: humans
       rank_key: species
       rank_value: "Homo sapiens"
+    # Explicit accession list for the 20 mammals covered by the segmentation
+    # prediction pipeline. Must stay in sync with
+    # enhancer_prediction_segmentation.genomes below.
+    - name: enhancer_seg_mammals_v1
+      accessions:
+          - GCF_050624435.1   # Tenrec ecaudatus (Afrosoricida)
+          - GCF_009834535.1   # Camelus ferus (Artiodactyla)
+          - GCF_018350215.1   # Panthera leo (Carnivora)
+          - GCF_027574615.1   # Eptesicus fuscus (Chiroptera)
+          - GCF_030445035.2   # Dasypus novemcinctus (Cingulata)
+          - GCF_902635505.1   # Sarcophilus harrisii (Dasyuromorphia)
+          - GCF_027409185.1   # Cynocephalus volans (Dermoptera)
+          - GCF_027887165.1   # Monodelphis domestica (Didelphimorphia)
+          - GCF_011100635.1   # Trichosurus vulpecula (Diprotodontia)
+          - GCF_027595985.1   # Sorex araneus (Eulipotyphla)
+          - GCF_030435755.1   # Ochotona princeps (Lagomorpha)
+          - GCF_019393635.1   # Dromiciops gliroides (Microbiotheria)
+          - GCF_004115215.2   # Ornithorhynchus anatinus (Monotremata)
+          - GCF_037893015.1   # Macrotis lagotis (Peramelemorphia)
+          - GCF_037783145.1   # Equus przewalskii (Perissodactyla)
+          - GCF_040802235.1   # Manis javanica (Pholidota)
+          - GCF_023851605.1   # Tamandua tetradactyla (Pilosa)
+          - GCF_000001405.40  # Homo sapiens (Primates)
+          - GCF_024166365.1   # Elephas maximus indicus (Proboscidea)
+          - GCF_000001635.27  # Mus musculus (Rodentia)
 
 output_hf_prefix: bolinas-dna/genomes-v5
 
@@ -134,6 +165,11 @@ enhancer_prediction_segmentation:
     batch_size: 32
     num_workers: 4
     max_windows: 0  # 0 = all windows; set small (e.g. 10) for smoke tests
+    # Recipe v20 thresholding: keep the top fraction of bins by logit (per-genome
+    # quantile, label-free). Each surviving bin is resized to recipe_target_size
+    # bp centered on its midpoint, then exon-masked and intersected with defined.
+    recipe_top_quantile: 0.01
+    recipe_target_size: 255
     # One species per mammalian order, restricted to Chromosome-level or
     # better assemblies, and forcing human + mouse as the Primates /
     # Rodentia reps (our training species). Other orders pick the smallest

--- a/snakemake/training_dataset/dataset_creation/sky/v20_build.yaml
+++ b/snakemake/training_dataset/dataset_creation/sky/v20_build.yaml
@@ -7,7 +7,7 @@
 #     handles this automatically once running on AWS).
 #
 # Launch:
-#   sky launch -c bolinas-v20 snakemake/training_dataset/dataset_creation/v20_build.sky.yaml
+#   sky launch -c bolinas-v20 snakemake/training_dataset/dataset_creation/sky/v20_build.yaml
 #
 # After launch, run actual snakemake targets via `sky exec` with an inline
 # YAML — the AMI's bashrc resurrects an old conda that snakemake rejects, so

--- a/snakemake/training_dataset/dataset_creation/v20_build.sky.yaml
+++ b/snakemake/training_dataset/dataset_creation/v20_build.sky.yaml
@@ -1,12 +1,36 @@
 # SkyPilot task for the recipe v20 (segmentation-based enhancers) build.
 # Issue #133, sub-issue of #96.
 #
-# Usage:
+# Prereqs (local box):
+#   - HF token at ~/.cache/huggingface/token (mounted to the cluster).
+#   - AWS creds with S3 read/write to oa-bolinas (instance role on the cluster
+#     handles this automatically once running on AWS).
+#
+# Launch:
 #   sky launch -c bolinas-v20 snakemake/training_dataset/dataset_creation/v20_build.sky.yaml
-#   # smoke test (after launch)
-#   sky exec bolinas-v20 -- 'cd snakemake/training_dataset/dataset_creation && uv run snakemake results/intervals/recipe/v20/GCF_000001405.40.bed.gz --cores 4'
-#   # full run
-#   sky exec bolinas-v20 -- 'cd snakemake/training_dataset/dataset_creation && uv run snakemake results/upload.done/training/enhancer_seg_mammals_v1/v20/255/128'
+#
+# After launch, run actual snakemake targets via `sky exec` with an inline
+# YAML — the AMI's bashrc resurrects an old conda that snakemake rejects, so
+# we have to unset+re-point each time. The patterns below mirror what the
+# `run:` block in this YAML does:
+#
+#   cat > /tmp/v20_run.sky.yaml <<'EOF'
+#   name: bolinas-v20-run
+#   run: |
+#     set -euxo pipefail
+#     unset -f conda 2>/dev/null || true
+#     export CONDA_EXE="$HOME/miniforge3/bin/conda"
+#     export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+#     cd ~/sky_workdir/snakemake/training_dataset/dataset_creation
+#     uv run snakemake results/upload.done/training/enhancer_seg_mammals_v1/v20/255/128
+#   EOF
+#   sky exec bolinas-v20 /tmp/v20_run.sky.yaml -d
+#
+# To re-upload after a partial / failed upload (the local hf cache may be in
+# a stale "committed" state and the S3 upload marker may exist):
+#   1. Clear local hf cache:  rm -rf ~/sky_workdir/snakemake/training_dataset/dataset_creation/results/dataset/enhancer_seg_mammals_v1/v20/255/128/.cache
+#   2. Either `aws s3 rm s3://oa-bolinas/snakemake/training_dataset/dataset_creation/results/upload.done/training/enhancer_seg_mammals_v1/v20/255/128`
+#      OR add `--forcerun hf_upload_training` to the snakemake invocation.
 
 name: bolinas-v20
 

--- a/snakemake/training_dataset/dataset_creation/v20_build.sky.yaml
+++ b/snakemake/training_dataset/dataset_creation/v20_build.sky.yaml
@@ -50,6 +50,12 @@ setup: |
 
 run: |
   set -euxo pipefail
+  # SkyPilot's login bash sources ~/.bashrc which defines a `conda` shell
+  # function and sets CONDA_EXE to the AMI's stale miniconda3 (23.11.0 — too
+  # old for snakemake). Unset the function and re-point CONDA_EXE so the
+  # subprocesses snakemake spawns find our miniforge3 conda (24.7+).
+  unset -f conda 2>/dev/null || true
+  export CONDA_EXE="$HOME/miniforge3/bin/conda"
   export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
   cd ~/sky_workdir/snakemake/training_dataset/dataset_creation
 

--- a/snakemake/training_dataset/dataset_creation/v20_build.sky.yaml
+++ b/snakemake/training_dataset/dataset_creation/v20_build.sky.yaml
@@ -20,8 +20,10 @@ resources:
 
 workdir: .
 
-envs:
-  HF_TOKEN: ""
+# Sync the local HuggingFace auth token file to the cluster (read by the HF SDK
+# automatically — no env vars, no shell-history exposure).
+file_mounts:
+  ~/.cache/huggingface/token: ~/.cache/huggingface/token
 
 setup: |
   set -euxo pipefail
@@ -50,11 +52,6 @@ run: |
   set -euxo pipefail
   export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
   cd ~/sky_workdir/snakemake/training_dataset/dataset_creation
-
-  # Optional HF auth (only needed for hf_upload_training rule)
-  if [ -n "${HF_TOKEN:-}" ]; then
-    export HUGGING_FACE_HUB_TOKEN="$HF_TOKEN"
-  fi
 
   # Sanity dry-run on the targeted v20 build path. The actual rule runs are
   # invoked via `sky exec` after launch — see header comment for commands.

--- a/snakemake/training_dataset/dataset_creation/v20_build.sky.yaml
+++ b/snakemake/training_dataset/dataset_creation/v20_build.sky.yaml
@@ -1,0 +1,61 @@
+# SkyPilot task for the recipe v20 (segmentation-based enhancers) build.
+# Issue #133, sub-issue of #96.
+#
+# Usage:
+#   sky launch -c bolinas-v20 snakemake/training_dataset/dataset_creation/v20_build.sky.yaml
+#   # smoke test (after launch)
+#   sky exec bolinas-v20 -- 'cd snakemake/training_dataset/dataset_creation && uv run snakemake results/intervals/recipe/v20/GCF_000001405.40.bed.gz --cores 4'
+#   # full run
+#   sky exec bolinas-v20 -- 'cd snakemake/training_dataset/dataset_creation && uv run snakemake results/upload.done/training/enhancer_seg_mammals_v1/v20/255/128'
+
+name: bolinas-v20
+
+resources:
+  cpus: 16+
+  memory: 32+
+  disk_size: 100
+  infra: aws/us-east-2  # per project convention; matches S3 bucket region for free transfer
+  labels:
+    project: dna
+
+workdir: .
+
+envs:
+  HF_TOKEN: ""
+
+setup: |
+  set -euxo pipefail
+
+  # 1. miniforge (for conda envs used by bioinformatics rules: bedtools, twoBitToFa, etc.)
+  if [ ! -d "$HOME/miniforge3" ]; then
+    wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O /tmp/miniforge.sh
+    bash /tmp/miniforge.sh -b -p "$HOME/miniforge3"
+  fi
+  export PATH="$HOME/miniforge3/bin:$PATH"
+  echo 'export PATH="$HOME/miniforge3/bin:$PATH"' >> ~/.bashrc
+
+  # 2. uv (python package manager)
+  if ! command -v uv >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+  fi
+  export PATH="$HOME/.local/bin:$PATH"
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+
+  # 3. sync python deps (the segmentation predict path is not exercised in v20,
+  # but enhancer-classification group includes py2bit which the snakefile imports)
+  cd ~/sky_workdir
+  uv sync --group enhancer-classification
+
+run: |
+  set -euxo pipefail
+  export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+  cd ~/sky_workdir/snakemake/training_dataset/dataset_creation
+
+  # Optional HF auth (only needed for hf_upload_training rule)
+  if [ -n "${HF_TOKEN:-}" ]; then
+    export HUGGING_FACE_HUB_TOKEN="$HF_TOKEN"
+  fi
+
+  # Sanity dry-run on the targeted v20 build path. The actual rule runs are
+  # invoked via `sky exec` after launch — see header comment for commands.
+  uv run snakemake -n results/upload.done/training/enhancer_seg_mammals_v1/v20/255/128

--- a/snakemake/training_dataset/dataset_creation/workflow/Snakefile
+++ b/snakemake/training_dataset/dataset_creation/workflow/Snakefile
@@ -14,7 +14,22 @@ genomes = load_genome_info(config["genomes_path"])
 genome_sets = load_genome_sets(genomes, config["genome_sets"])
 genome_sets_list = list(genome_sets.keys())
 training_intervals = config["intervals"]["training"]
+training_per_genome_set = config["intervals"].get("training_per_genome_set", {})
 validation_intervals = config["intervals"]["validation"]
+
+# (genome_set, intervals) pairs that the `all` rule should build.
+# Default: cartesian product of training_intervals across every genome_set.
+# Override: any genome_set listed in training_per_genome_set uses ONLY the
+# recipes given there (this lets specialised genome_sets like
+# enhancer_seg_mammals_v1 build only v20 without also pulling in v5/v1/v15).
+for gs in training_per_genome_set:
+    assert gs in genome_sets, (
+        f"training_per_genome_set references unknown genome_set {gs!r}"
+    )
+training_targets: list[tuple[str, str]] = []
+for gs in genome_sets_list:
+    recipes = training_per_genome_set.get(gs, training_intervals)
+    training_targets.extend((gs, iv) for iv in recipes)
 
 
 wildcard_constraints:
@@ -32,11 +47,7 @@ include: "rules/enhancer_prediction.smk"
 
 rule all:
     input:
-        expand(
-            "results/upload.done/training/{genome_set}/{intervals}",
-            genome_set=genome_sets_list,
-            intervals=training_intervals,
-        ),
+        [f"results/upload.done/training/{gs}/{iv}" for gs, iv in training_targets],
         expand(
             "results/upload.done/validation/{intervals}",
             intervals=validation_intervals,

--- a/snakemake/training_dataset/dataset_creation/workflow/Snakefile
+++ b/snakemake/training_dataset/dataset_creation/workflow/Snakefile
@@ -17,19 +17,13 @@ training_intervals = config["intervals"]["training"]
 training_per_genome_set = config["intervals"].get("training_per_genome_set", {})
 validation_intervals = config["intervals"]["validation"]
 
-# (genome_set, intervals) pairs that the `all` rule should build.
-# Default: cartesian product of training_intervals across every genome_set.
-# Override: any genome_set listed in training_per_genome_set uses ONLY the
-# recipes given there (this lets specialised genome_sets like
-# enhancer_seg_mammals_v1 build only v20 without also pulling in v5/v1/v15).
+# Genome sets listed in training_per_genome_set use ONLY the recipes given
+# there (replace, not extend) — keeps specialised sets like
+# enhancer_seg_mammals_v1 from also pulling in the default v5/v1/v15.
 for gs in training_per_genome_set:
     assert gs in genome_sets, (
         f"training_per_genome_set references unknown genome_set {gs!r}"
     )
-training_targets: list[tuple[str, str]] = []
-for gs in genome_sets_list:
-    recipes = training_per_genome_set.get(gs, training_intervals)
-    training_targets.extend((gs, iv) for iv in recipes)
 
 
 wildcard_constraints:
@@ -53,7 +47,11 @@ include: "rules/enhancer_prediction.smk"
 
 rule all:
     input:
-        [f"results/upload.done/training/{gs}/{iv}" for gs, iv in training_targets],
+        [
+            f"results/upload.done/training/{gs}/{iv}"
+            for gs in genome_sets_list
+            for iv in training_per_genome_set.get(gs, training_intervals)
+        ],
         expand(
             "results/upload.done/validation/{intervals}",
             intervals=validation_intervals,

--- a/snakemake/training_dataset/dataset_creation/workflow/Snakefile
+++ b/snakemake/training_dataset/dataset_creation/workflow/Snakefile
@@ -34,6 +34,12 @@ for gs in genome_sets_list:
 
 wildcard_constraints:
     genome_set="|".join(genome_sets_list),
+    # Recipe / window / step components of the {recipe}/{w}/{s} interval triple.
+    # Bounding each to a single path segment prevents slashes from leaking
+    # across wildcards (the bug that motivated splitting {intervals} in #134).
+    recipe=r"v\d+",
+    w=r"\d+",
+    s=r"\d+",
 
 
 include: "rules/download.smk"

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/common.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/common.smk
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 from tqdm import tqdm
 
 # Bolinas module imports
+from bolinas.data.bin_predictions import top_quantile_bins_to_windows
 from bolinas.data.intervals import GenomicSet
 from bolinas.data.utils import (
     ENHANCER_CRE_CLASSES,
@@ -65,23 +66,31 @@ def load_genome_sets(
     genomes: pd.DataFrame, genome_sets_config: list[dict]
 ) -> dict[str, list[str]]:
     """
-    Load genome sets based on taxonomic filtering criteria.
+    Load genome sets based on taxonomic filtering or an explicit accession list.
 
-    Args:
-        genomes: DataFrame with genomes indexed by Assembly Accession
-        genome_sets_config: List of dicts with 'name', 'rank_key', and 'rank_value' keys
+    Each entry in ``genome_sets_config`` must have a ``name``, plus either:
+      - ``rank_key`` + ``rank_value`` to select all genomes with
+        ``genomes[rank_key] == rank_value`` (e.g., all Mammalia), or
+      - ``accessions``: an explicit list of Assembly Accessions
+        (e.g., the 20 genomes covered by segmentation prediction).
 
     Returns:
-        Dictionary mapping subset names to lists of genome Assembly Accessions
+        Dictionary mapping subset names to lists of genome Assembly Accessions.
     """
     genome_sets = {}
     for genome_set in genome_sets_config:
         name = genome_set["name"]
-        rank_key = genome_set["rank_key"]
-        rank_value = genome_set["rank_value"]
-
-        # Filter genomes based on the rank criteria
-        filtered = genomes[genomes[rank_key] == rank_value]
-        genome_sets[name] = filtered.index.tolist()
+        if "accessions" in genome_set:
+            accessions = list(genome_set["accessions"])
+            unknown = [a for a in accessions if a not in genomes.index]
+            assert not unknown, (
+                f"genome_set {name!r} references unknown accessions: {unknown}"
+            )
+            genome_sets[name] = accessions
+        else:
+            rank_key = genome_set["rank_key"]
+            rank_value = genome_set["rank_value"]
+            filtered = genomes[genomes[rank_key] == rank_value]
+            genome_sets[name] = filtered.index.tolist()
 
     return genome_sets

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/dataset.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/dataset.smk
@@ -160,7 +160,11 @@ rule hf_upload_training:
             shard=SHARDS,
         )),
     output:
-        touch("results/upload.done/training/{genome_set}/{recipe}/{w}/{s}"),
+        # Explicit `touch {output}` in shell instead of snakemake's `touch()`
+        # wrapper -- with default-storage-provider=s3 the wrapper doesn't
+        # auto-create the marker, leaving snakemake to declare the output
+        # missing even though the upload succeeded.
+        "results/upload.done/training/{genome_set}/{recipe}/{w}/{s}",
     params:
         name=lambda wildcards: (
             config["output_hf_prefix"]
@@ -172,7 +176,11 @@ rule hf_upload_training:
         ),
     threads: workflow.cores
     shell:
-        "hf upload-large-folder {params.name} --repo-type dataset {params.data_dir}"
+        """
+        hf upload-large-folder {params.name} --repo-type dataset {params.data_dir}
+        mkdir -p $(dirname {output})
+        touch {output}
+        """
 
 
 rule hf_upload_validation:

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/dataset.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/dataset.smk
@@ -108,24 +108,22 @@ rule create_functional_validation:
 
 rule merge_datasets:
     """Merge per-genome training parquets, shuffle, and shard into JSONL."""
-    # Pin intervals to recipe/window/step so paths like
-    # `enhancer_seg_mammals_v1/v20/255/128` can't get split as
-    # `genome_set=enhancer_seg_mammals_v1/v20/255, intervals=128`. The global
-    # genome_set constraint alone wasn't enough — snakemake matched the
-    # constraint against the prefix. Pinning intervals to v\d+/\d+/\d+
-    # eliminates the ambiguity. Same constraint added to hf_upload_training.
-    wildcard_constraints:
-        intervals=r"v\d+/\d+/\d+",
+    # Use explicit {recipe}/{w}/{s} wildcards (each bounded by '/' in the
+    # path template) instead of a single {intervals} wildcard whose slashes
+    # would race with the genome_set wildcard for greedy matching, producing
+    # bogus splits like `genome_set=enhancer_seg_mammals_v1/v20/255, intervals=128`.
     input:
         lambda wildcards: expand(
-            "results/dataset_genome/{intervals}/{g}.parquet",
-            intervals=wildcards.intervals,
+            "results/dataset_genome/{recipe}/{w}/{s}/{g}.parquet",
+            recipe=wildcards.recipe,
+            w=wildcards.w,
+            s=wildcards.s,
             g=genome_sets[wildcards.genome_set],
         ),
     output:
         temp(local(
             expand(
-                "results/dataset/{{genome_set}}/{{intervals}}/data/train/{shard}.jsonl",
+                "results/dataset/{{genome_set}}/{{recipe}}/{{w}}/{{s}}/data/train/{shard}.jsonl",
                 shard=SHARDS,
             )
         )),
@@ -156,26 +154,21 @@ rule compress_shard:
 
 rule hf_upload_training:
     """Upload training dataset shards to HuggingFace."""
-    wildcard_constraints:
-        intervals=r"v\d+/\d+/\d+",
     input:
         local(expand(
-            "results/dataset/{{genome_set}}/{{intervals}}/data/train/{shard}.jsonl.zst",
+            "results/dataset/{{genome_set}}/{{recipe}}/{{w}}/{{s}}/data/train/{shard}.jsonl.zst",
             shard=SHARDS,
         )),
     output:
-        touch("results/upload.done/training/{genome_set}/{intervals}"),
+        touch("results/upload.done/training/{genome_set}/{recipe}/{w}/{s}"),
     params:
-        # HF dataset repo names cannot contain '/' (other than the org/name
-        # divider), so substitute slashes from both wildcards even though
-        # genome_set should never contain one.
         name=lambda wildcards: (
             config["output_hf_prefix"]
-            + "-genome_set-" + wildcards.genome_set.replace("/", "_")
-            + "-intervals-" + wildcards.intervals.replace("/", "_")
+            + "-genome_set-" + wildcards.genome_set
+            + "-intervals-" + f"{wildcards.recipe}_{wildcards.w}_{wildcards.s}"
         ),
         data_dir=lambda wildcards: (
-            f"results/dataset/{wildcards.genome_set}/{wildcards.intervals}"
+            f"results/dataset/{wildcards.genome_set}/{wildcards.recipe}/{wildcards.w}/{wildcards.s}"
         ),
     threads: workflow.cores
     shell:

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/dataset.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/dataset.smk
@@ -108,6 +108,14 @@ rule create_functional_validation:
 
 rule merge_datasets:
     """Merge per-genome training parquets, shuffle, and shard into JSONL."""
+    # Pin intervals to recipe/window/step so paths like
+    # `enhancer_seg_mammals_v1/v20/255/128` can't get split as
+    # `genome_set=enhancer_seg_mammals_v1/v20/255, intervals=128`. The global
+    # genome_set constraint alone wasn't enough — snakemake matched the
+    # constraint against the prefix. Pinning intervals to v\d+/\d+/\d+
+    # eliminates the ambiguity. Same constraint added to hf_upload_training.
+    wildcard_constraints:
+        intervals=r"v\d+/\d+/\d+",
     input:
         lambda wildcards: expand(
             "results/dataset_genome/{intervals}/{g}.parquet",
@@ -148,6 +156,8 @@ rule compress_shard:
 
 rule hf_upload_training:
     """Upload training dataset shards to HuggingFace."""
+    wildcard_constraints:
+        intervals=r"v\d+/\d+/\d+",
     input:
         local(expand(
             "results/dataset/{{genome_set}}/{{intervals}}/data/train/{shard}.jsonl.zst",
@@ -156,9 +166,12 @@ rule hf_upload_training:
     output:
         touch("results/upload.done/training/{genome_set}/{intervals}"),
     params:
+        # HF dataset repo names cannot contain '/' (other than the org/name
+        # divider), so substitute slashes from both wildcards even though
+        # genome_set should never contain one.
         name=lambda wildcards: (
             config["output_hf_prefix"]
-            + "-genome_set-" + wildcards.genome_set
+            + "-genome_set-" + wildcards.genome_set.replace("/", "_")
             + "-intervals-" + wildcards.intervals.replace("/", "_")
         ),
         data_dir=lambda wildcards: (

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk
@@ -149,3 +149,27 @@ rule intervals_recipe_v19:
         df = df.filter(pl.col("logit") >= threshold)
         intervals = GenomicSet(df.select(["chrom", "start", "end"]))
         intervals.write_bed(output[0])
+
+
+# Segmentation-based enhancer recipe: top-quantile bins from the per-bin
+# segmentation predictions (#118 / PR #126), each resized to a fixed window
+# centered on its midpoint, then exon-masked and clipped to defined regions.
+rule intervals_recipe_v20:
+    input:
+        predictions="results/enhancer_predictions_segmentation/{g}.parquet",
+        exons="results/intervals/exons/{g}.parquet",
+        defined="results/intervals/defined/{g}.bed.gz",
+    output:
+        "results/intervals/recipe/v20/{g}.bed.gz",
+    run:
+        top_quantile = SEGMENTATION_CONFIG["recipe_top_quantile"]
+        target_size = SEGMENTATION_CONFIG["recipe_target_size"]
+
+        bin_logits = pl.read_parquet(input.predictions)
+        windows = top_quantile_bins_to_windows(
+            bin_logits, top_quantile=top_quantile, target_size=target_size
+        )
+        exons = GenomicSet.read_parquet(input.exons)
+        defined = GenomicSet.read_bed(input.defined)
+        windows = (windows - exons) & defined
+        windows.write_bed(output[0])

--- a/src/bolinas/data/bin_predictions.py
+++ b/src/bolinas/data/bin_predictions.py
@@ -1,0 +1,56 @@
+"""Convert per-bin model predictions into windowed enhancer interval sets."""
+
+import polars as pl
+
+from bolinas.data.intervals import GenomicSet
+
+
+def top_quantile_bins_to_windows(
+    bin_logits: pl.DataFrame,
+    top_quantile: float,
+    target_size: int,
+) -> GenomicSet:
+    """Pick the top fraction of bins by logit and resize each to a fixed window.
+
+    Per-genome quantile thresholding: the threshold is set so that approximately
+    ``top_quantile`` of bins (across the whole input) score at or above it.
+    Each surviving bin is then resized to ``target_size`` bp centered on its
+    midpoint, and the result is returned as a ``GenomicSet`` (so windows whose
+    centers are within ``target_size`` bp of each other auto-merge).
+
+    The resize math matches ``GenomicSet.resize`` / ``_resize_df``: when
+    ``target_size - bin_size`` is odd the right side gets the extra base.
+    No boundary clamping is applied -- callers should intersect the result
+    with the genome's ``defined`` region to clip windows that fall off the
+    chromosome ends (mirrors v17/v18).
+
+    Args:
+        bin_logits: Polars DataFrame with columns ``chrom``, ``bin_start``,
+            ``bin_end``, ``logit`` -- one row per bin (typically the output of
+            the segmentation prediction pipeline).
+        top_quantile: Fraction of bins to keep, in (0, 1]. ``0.01`` keeps the
+            top 1%.
+        target_size: Output window size in bp.
+
+    Returns:
+        GenomicSet of resized, possibly-merged windows.
+    """
+    assert 0.0 < top_quantile <= 1.0, f"top_quantile must be in (0, 1], got {top_quantile}"
+    assert target_size > 0, f"target_size must be positive, got {target_size}"
+    required = {"chrom", "bin_start", "bin_end", "logit"}
+    missing = required - set(bin_logits.columns)
+    assert not missing, f"bin_logits missing required columns: {missing}"
+
+    threshold = bin_logits["logit"].quantile(1.0 - top_quantile)
+    selected = bin_logits.filter(pl.col("logit") >= threshold)
+
+    diff_expr = target_size - (pl.col("bin_end") - pl.col("bin_start"))
+    left_adj = diff_expr // 2
+    right_adj = diff_expr - left_adj
+
+    windows = selected.select(
+        pl.col("chrom"),
+        (pl.col("bin_start") - left_adj).alias("start"),
+        (pl.col("bin_end") + right_adj).alias("end"),
+    )
+    return GenomicSet(windows)

--- a/src/bolinas/data/bin_predictions.py
+++ b/src/bolinas/data/bin_predictions.py
@@ -40,6 +40,7 @@ def top_quantile_bins_to_windows(
     required = {"chrom", "bin_start", "bin_end", "logit"}
     missing = required - set(bin_logits.columns)
     assert not missing, f"bin_logits missing required columns: {missing}"
+    assert bin_logits.height > 0, "bin_logits is empty"
 
     threshold = bin_logits["logit"].quantile(1.0 - top_quantile)
     selected = bin_logits.filter(pl.col("logit") >= threshold)

--- a/tests/test_bin_predictions.py
+++ b/tests/test_bin_predictions.py
@@ -1,0 +1,133 @@
+import numpy as np
+import polars as pl
+import pytest
+
+from bolinas.data.bin_predictions import top_quantile_bins_to_windows
+
+
+def _bins(chrom: str, n: int, bin_size: int = 128, logits=None) -> pl.DataFrame:
+    """Build a contiguous run of bins on one chrom for tests."""
+    starts = [i * bin_size for i in range(n)]
+    ends = [s + bin_size for s in starts]
+    if logits is None:
+        logits = list(range(n))
+    return pl.DataFrame(
+        {
+            "chrom": [chrom] * n,
+            "bin_start": starts,
+            "bin_end": ends,
+            "logit": [float(x) for x in logits],
+        }
+    )
+
+
+def test_isolated_top_bin_resized_to_target_size():
+    """A single isolated high-logit bin -> one window of exactly target_size, centered on the bin."""
+    # 100 noise bins in [0, 1) plus one bin with logit 1000. Top 0.5% selects only that bin.
+    rng = np.random.default_rng(0)
+    logits = list(rng.uniform(0, 1, size=100)) + [1000.0]
+    df = _bins("chr1", 101, bin_size=128, logits=logits)
+    out = top_quantile_bins_to_windows(df, top_quantile=0.005, target_size=255)
+    out_df = out.to_pandas().reset_index(drop=True)
+    assert len(out_df) == 1
+    # Bin 100 = [12800, 12928); diff=127 -> left=63, right=64 -> [12737, 12992).
+    assert out_df.iloc[0]["start"] == 12800 - 63
+    assert out_df.iloc[0]["end"] == 12928 + 64
+    assert out_df.iloc[0]["end"] - out_df.iloc[0]["start"] == 255
+
+
+def test_adjacent_top_bins_merge():
+    """Two adjacent above-threshold bins -> their resized 255bp windows merge into one."""
+    rng = np.random.default_rng(0)
+    # 50 noise bins in [0,1), then 2 peak bins at 1000. top_quantile=0.5/52 ~= 0.0096
+    # gives quantile(0.9904) = 1000 (nearest-interpolation idx 51), so threshold >= 1000
+    # selects only the 2 peak bins.
+    logits = list(rng.uniform(0, 1, size=50)) + [1000.0, 1000.0]
+    df = _bins("chr1", 52, bin_size=128, logits=logits)
+    out = top_quantile_bins_to_windows(df, top_quantile=0.5 / 52, target_size=255)
+    out_df = out.to_pandas().reset_index(drop=True)
+    assert len(out_df) == 1
+    # Bin 50 [6400, 6528) -> [6337, 6592). Bin 51 [6528, 6656) -> [6465, 6720).
+    # Their 255bp windows overlap (6465 < 6592) -> merged: [6337, 6720).
+    assert out_df.iloc[0]["start"] == 50 * 128 - 63
+    assert out_df.iloc[0]["end"] == 51 * 128 + 128 + 64
+
+
+def test_distant_top_bins_dont_merge():
+    """Two above-threshold bins far apart -> two separate 255bp windows."""
+    rng = np.random.default_rng(0)
+    logits = list(rng.uniform(0, 1, size=100))
+    logits[10] = 1000.0
+    logits[80] = 1000.0
+    df = _bins("chr1", 100, bin_size=128, logits=logits)
+    # top_quantile=1/100 -> quantile(0.99) at nearest idx 98 -> value 1000 -> selects 2 bins.
+    out = top_quantile_bins_to_windows(df, top_quantile=1 / 100, target_size=255)
+    out_df = out.to_pandas().reset_index(drop=True)
+    assert len(out_df) == 2
+    assert (out_df["end"] - out_df["start"]).tolist() == [255, 255]
+    assert out_df.iloc[0]["start"] == 10 * 128 - 63
+    assert out_df.iloc[1]["start"] == 80 * 128 - 63
+
+
+def test_resize_math_matches_genomicset_resize():
+    """Window length = target_size; centering matches GenomicSet.resize / _resize_df.
+
+    For target_size=255 and bin_size=128: diff=127, left_adj=63, right_adj=64.
+    """
+    rng = np.random.default_rng(0)
+    logits = list(rng.uniform(0, 1, size=100)) + [1000.0]
+    df = _bins("chr1", 101, bin_size=128, logits=logits)
+    out = top_quantile_bins_to_windows(df, top_quantile=0.005, target_size=255)
+    out_df = out.to_pandas().reset_index(drop=True)
+    bin_start = 100 * 128
+    bin_end = bin_start + 128
+    assert out_df.iloc[0]["start"] == bin_start - 63
+    assert out_df.iloc[0]["end"] == bin_end + 64
+
+
+def test_quantile_is_global_across_chromosomes():
+    """Per-genome quantile thresholding -> selection respects global logit distribution."""
+    df = pl.concat(
+        [
+            _bins("chr1", 50, logits=[0.0] * 50),  # all low
+            _bins("chr2", 50, logits=[10.0] * 50),  # all high
+        ]
+    )
+    out = top_quantile_bins_to_windows(df, top_quantile=0.5, target_size=255)
+    out_df = out.to_pandas().reset_index(drop=True)
+    # Half-quantile threshold lies between 0 and 10; only chr2 bins survive.
+    # 50 contiguous chr2 bins merge into one interval.
+    assert len(out_df) == 1
+    assert out_df.iloc[0]["chrom"] == "chr2"
+
+
+def test_invalid_quantile_rejected():
+    df = _bins("chr1", 10)
+    with pytest.raises(AssertionError):
+        top_quantile_bins_to_windows(df, top_quantile=0.0, target_size=255)
+    with pytest.raises(AssertionError):
+        top_quantile_bins_to_windows(df, top_quantile=1.5, target_size=255)
+
+
+def test_invalid_target_size_rejected():
+    df = _bins("chr1", 10)
+    with pytest.raises(AssertionError):
+        top_quantile_bins_to_windows(df, top_quantile=0.1, target_size=0)
+
+
+def test_missing_columns_rejected():
+    df = pl.DataFrame({"chrom": ["chr1"], "bin_start": [0], "bin_end": [128]})
+    with pytest.raises(AssertionError, match="missing required columns"):
+        top_quantile_bins_to_windows(df, top_quantile=0.1, target_size=255)
+
+
+def test_full_quantile_selects_everything():
+    """top_quantile=1.0 -> threshold is the minimum, every bin selected."""
+    rng = np.random.default_rng(0)
+    df = _bins("chr1", 50, logits=list(rng.uniform(0, 1, size=50)))
+    out = top_quantile_bins_to_windows(df, top_quantile=1.0, target_size=255)
+    out_df = out.to_pandas().reset_index(drop=True)
+    # 50 contiguous bins, all selected, all 255bp resized -> merged into one interval.
+    assert len(out_df) == 1
+    assert out_df.iloc[0]["start"] == -63
+    assert out_df.iloc[0]["end"] == 49 * 128 + 128 + 64


### PR DESCRIPTION
🤖 Closes #133. Sub-issue of #96.

## Summary

Adds **recipe v20**: a segmentation-prediction-driven enhancer recipe that converts the per-bin segmentation logits from #118 / PR #126 into 255bp enhancer windows for use as gLM training data. End-to-end, the pipeline now produces an HF training dataset from #126's 20-mammal segmentation predictions.

**Built dataset (live)**: [`bolinas-dna/genomes-v5-genome_set-enhancer_seg_mammals_v1-intervals-v20_255_128`](https://huggingface.co/datasets/bolinas-dna/genomes-v5-genome_set-enhancer_seg_mammals_v1-intervals-v20_255_128) — 64 shards, 0.88 GB total, across 20 mammals (one per order, Chromosome-level assemblies).

## Algorithm

`intervals_recipe_v20` rule:

1. **Threshold by per-genome quantile** of logits (label-free; default `top_quantile=0.01`, top 1% of bins per genome). Configurable via `enhancer_prediction_segmentation.recipe_top_quantile`.
2. **Resize** each surviving 128bp bin to 255bp centered on its midpoint (mirrors v17/v18 math; auto-merges via `GenomicSet`).
3. **Subtract all functional exons** (CDS + UTR + ncRNA, low-quality biotypes excluded) using the existing `extract_exons` / `get_exons_for_masking` pipeline.
4. **Intersect with `defined`** to clip N-runs and chromosome edges.

Threshold calibration on chr7 with PR curves is deferred — would replace the quantile threshold with a precision-targeted one (tracked under #96).

## What's in this PR

- `src/bolinas/data/bin_predictions.py` — `top_quantile_bins_to_windows` helper (single function, ~40 lines) + 9 unit tests in `tests/test_bin_predictions.py`.
- `snakemake/training_dataset/dataset_creation/workflow/rules/enhancer_prediction.smk` — new `intervals_recipe_v20` rule alongside v19.
- `snakemake/training_dataset/dataset_creation/workflow/rules/common.smk` — extended `load_genome_sets` to accept an explicit `accessions:` list (in addition to the existing `rank_key`/`rank_value` taxonomic form).
- `snakemake/training_dataset/dataset_creation/workflow/Snakefile` — new `intervals.training_per_genome_set` config support: recipes listed there *replace* the cartesian product for that genome_set, so adding a specialised set doesn't accidentally trigger base-recipe rebuilds for that set.
- `snakemake/training_dataset/dataset_creation/workflow/rules/dataset.smk` — split `{intervals}` into `{recipe}/{w}/{s}` in `merge_datasets` and `hf_upload_training` to fix wildcard ambiguity (the single-wildcard form raced with `{genome_set}` for greedy matching, producing bogus splits like `genome_set=enhancer_seg_mammals_v1/v20/255, intervals=128`). Also explicit `touch {output}` because snakemake's `touch()` wrapper doesn't auto-create the marker with `default-storage-provider=s3`.
- `snakemake/training_dataset/dataset_creation/config/config.yaml` — added `recipe_top_quantile` / `recipe_target_size`, the new `enhancer_seg_mammals_v1` genome_set, and the `v20/255/128` entry in `intervals.training_per_genome_set`.
- `snakemake/training_dataset/dataset_creation/v20_build.sky.yaml` — SkyPilot task YAML (CPU-only, us-east-2, `project=dna` label, HF token via `file_mounts:`). Header documents the launch + sky-exec patterns + cache-recovery steps.
- `snakemake/training_dataset/dataset_creation/README.md` — recipe v20 section + updated config docs for the new `accessions:`/`training_per_genome_set` knobs.

## Smoke test on human

Built `results/intervals/recipe/v20/GCF_000001405.40.bed.gz`:
- 117,820 intervals across 24 standard chromosomes (NC_000001.11..NC_000024.10).
- Length distribution: mostly `255` (single bin), `383` (255+128, two adjacent merged), `511` (3 adjacent), `639` (4), etc. — exactly the expected merge pattern.
- All starts ≥ 0; all on standard chroms.

## End-to-end run on SkyPilot (us-east-2, m6i CPU)

Snakemake pipeline ran end-to-end on the 20-mammal genome set: 19 × `extract_exons` (human cached from prior v19 work), 20 × `intervals_recipe_v20`, 20 × per-genome BED → windows → FASTA → parquet, `merge_datasets`, 64 × `compress_shard`, `hf_upload_training` → HF dataset live with all 64 shards + 0.88 GB total.

## How to continue this work

1. Check out the branch: `git fetch origin && git checkout worktree-bridge-cse_01JS7Nbt8W6EGvtej6Uuo4FD` (or main, post-merge).
2. Local sanity: `uv sync --group enhancer-classification && uv run pytest tests/test_bin_predictions.py`.
3. Local dry-run of the targeted v20 build: from `snakemake/training_dataset/dataset_creation/`, run `uv run snakemake -n results/upload.done/training/enhancer_seg_mammals_v1/v20/255/128`. Should plan ~185 jobs, all v20-related (`extract_exons` for the 19 non-human mammals, `intervals_recipe_v20` × 20, the windowing/FASTA/parquet chain × 20, `merge_datasets`, 64 × `compress_shard`, `hf_upload_training`).
4. Real run: launch SkyPilot per the header of `snakemake/training_dataset/dataset_creation/v20_build.sky.yaml`. The header documents the inline `sky exec` YAML pattern (needed because the AMI's bashrc resurrects an old conda that snakemake rejects).

### Caveats from this work (read before re-running the upload step)

1. **Stale local hf cache** — if the upload is interrupted mid-flight (e.g. snakemake declares `MissingOutputException` before `hf` finishes its commit phase), `results/dataset/enhancer_seg_mammals_v1/v20/255/128/.cache/huggingface/upload/data/train/*.metadata` will report "committed: 64/64" but no actual git commit landed on the HF repo. Subsequent `hf upload-large-folder` invocations trust the cache and exit 0 immediately, leaving the repo with only `.gitattributes`. Recovery: `rm -rf <data_dir>/.cache/huggingface` before re-running.
2. **Stale S3 upload marker** — the rule output `s3://oa-bolinas/.../results/upload.done/training/enhancer_seg_mammals_v1/v20/255/128` is what snakemake checks for completion. If a previous run touched this marker but the underlying HF upload was stale (per (1)), snakemake will refuse to re-fire the rule. Either `aws s3 rm s3://oa-bolinas/.../results/upload.done/training/enhancer_seg_mammals_v1/v20/255/128 --region us-east-2`, or pass `--forcerun hf_upload_training` to the snakemake invocation.

## Test plan

- [x] `uv run pytest tests/test_bin_predictions.py` (9/9 pass).
- [x] Snakemake `--dry-run` for the targeted v20 build (185 jobs, all v20-related; no unrelated re-runs).
- [x] Snakemake `--dry-run` for `all` (192 jobs total — only the v20 work + 3 incidental validation re-runs from a chrom-mapping mtime change unrelated to v20).
- [x] Single-genome smoke test on human (BED sanity-checked).
- [x] Full 20-genome run + HF upload (64 shards live on HF Hub).
- [ ] Downstream gLM trainer can load the dataset.

## Out of scope

- Threshold calibration on chr7 with held-out PR curves.
- v20 in the validation split.
- gLM training comparison v18/v19/v20 (tracked under #96).
- Expanding to >20 mammals (blocked on #119).
