### PR TITLE
Source-curation sweep around v30: phyloP/phastCons × 20/50 bp

### DIFF
--- a/snakemake/training_dataset/dataset_creation/README.md
+++ b/snakemake/training_dataset/dataset_creation/README.md
@@ -448,6 +448,19 @@ Naming convention: underscored, semantic `{source_name}_{mapper}_{preset}` (no d
 
 **Status:** v1 (issue [#123](https://github.com/Open-Athena/bolinas-dna/issues/123)): mmseqs2 only, flank 0, `-s 7.5 --max-accept 1`. On hg38→mm39 this projects 375,932 `ELS_conserved_20` enhancers to **229,288 mouse intervals (61.0% recall)**, vs. minimap2 `-cx map-ont`'s 20.7% (prior PR #125 baseline) — consistent with the ~3× recall advantage reported in [#120](https://github.com/Open-Athena/bolinas-dna/issues/120) at comparable precision. Run time: ~2 min wall (createdb 7 s, search 110 s, convertalis 0.3 s) on r6i.8xlarge (32 vCPU, 256 GB RAM), ~26 GB peak RSS. Sensitivity sweep, flank sweep, soft-mask filtering, and alternative aligners (e.g. lastz for the high-recall end of the frontier) are left for future iterations.
 
+### Source-curation sweep around v30 (recipes v31/v32/v33)
+
+Following [#136](https://github.com/Open-Athena/bolinas-dna/issues/136), where projection-based curation (v30) outperformed segmentation-based curation, three sibling recipes vary the upstream cCRE conservation filter while keeping the projection method (mmseqs2 `-s 7.5`), target genome set (`mammals_seg20`), and downstream windowing/exon-masking identical to v30. Each is just a thin wrapper over a different `interval_mappings` entry.
+
+| Recipe | Conservation track | Per-base cutoff | Per-cCRE filter | Source mapping |
+|---|---|---|---|---|
+| v30 (baseline) | phyloP-241way | ≥2.27 | ≥20 bp | `ELS_conserved_20_mmseqs2_s75` |
+| v31 | phyloP-241way | ≥2.27 | ≥50 bp | `ELS_conserved_50_mmseqs2_s75` |
+| v32 | phastCons-43p | ≥0.961 | ≥20 bp | `ELS_phastCons_43p_conserved_20_mmseqs2_s75` |
+| v33 | phastCons-43p | ≥0.961 | ≥50 bp | `ELS_phastCons_43p_conserved_50_mmseqs2_s75` |
+
+phastCons-43p is the Zoonomia 43-primate phastCons track (URL in `enhancer_classification/config/config.yaml:329-331`); 0.961 is calibrated to a ~3.46% conserved-base fraction matching phyloP-241way 2.27 at the per-base level. The per-cCRE filter is absolute conserved bp (`pct_conserved × size ≥ N`); 20 bp is ~7% of the median ELS length (272 bp), 50 bp ~18%. Caveat: phastCons-43p selects primate-conserved cCREs by construction, so v32/v33 may project worse to non-primate mammals than v30/v31.
+
 ## Output
 
 Datasets are uploaded to HuggingFace Hub at the specified `output_hf_prefix`.

--- a/snakemake/training_dataset/dataset_creation/config/config.cloud.yaml
+++ b/snakemake/training_dataset/dataset_creation/config/config.cloud.yaml
@@ -17,3 +17,33 @@ interval_mappings:
       split_memory_limit: "220G"
       mem_mb: 220000
       flank_bp: 0
+    - name: ELS_conserved_50_mmseqs2_s75
+      source_parquet: results/cre/ELS_conserved_50.parquet
+      source_chrom_style: ucsc_stripped
+      source_genome: GCF_000001405.40
+      mapper: mmseqs2
+      sensitivity: 7.5
+      max_accept: 1
+      split_memory_limit: "220G"
+      mem_mb: 220000
+      flank_bp: 0
+    - name: ELS_phastCons_43p_conserved_20_mmseqs2_s75
+      source_parquet: results/cre/ELS_phastCons_43p_conserved_20.parquet
+      source_chrom_style: ucsc_stripped
+      source_genome: GCF_000001405.40
+      mapper: mmseqs2
+      sensitivity: 7.5
+      max_accept: 1
+      split_memory_limit: "220G"
+      mem_mb: 220000
+      flank_bp: 0
+    - name: ELS_phastCons_43p_conserved_50_mmseqs2_s75
+      source_parquet: results/cre/ELS_phastCons_43p_conserved_50.parquet
+      source_chrom_style: ucsc_stripped
+      source_genome: GCF_000001405.40
+      mapper: mmseqs2
+      sensitivity: 7.5
+      max_accept: 1
+      split_memory_limit: "220G"
+      mem_mb: 220000
+      flank_bp: 0

--- a/snakemake/training_dataset/dataset_creation/config/config.yaml
+++ b/snakemake/training_dataset/dataset_creation/config/config.yaml
@@ -26,6 +26,9 @@ intervals:
             - v20/255/128
         mammals_seg20:
             - v30/255/128 # mmseqs2-projected ELS_conserved_20 minus functional exons
+            - v31/255/128 # v30 with phyloP-241way per-cCRE filter raised to ≥50 bp
+            - v32/255/128 # v30 with phastCons-43p track at ≥0.961, ≥20 bp
+            - v33/255/128 # v30 with phastCons-43p track at ≥0.961, ≥50 bp
     validation: # step = window for max diversity
         - v5/255/255
         - v1/255/255
@@ -132,6 +135,38 @@ interval_mappings:
       split_memory_limit: "12G"
       mem_mb: 14000
       flank_bp: 0
+    # Source-curation sweep around the v30 baseline above: same projection
+    # parameters, only the upstream cCRE conservation filter changes.
+    - name: ELS_conserved_50_mmseqs2_s75
+      source_parquet: results/cre/ELS_conserved_50.parquet
+      source_chrom_style: ucsc_stripped
+      source_genome: GCF_000001405.40
+      mapper: mmseqs2
+      sensitivity: 7.5
+      max_accept: 1
+      split_memory_limit: "12G"
+      mem_mb: 14000
+      flank_bp: 0
+    - name: ELS_phastCons_43p_conserved_20_mmseqs2_s75
+      source_parquet: results/cre/ELS_phastCons_43p_conserved_20.parquet
+      source_chrom_style: ucsc_stripped
+      source_genome: GCF_000001405.40
+      mapper: mmseqs2
+      sensitivity: 7.5
+      max_accept: 1
+      split_memory_limit: "12G"
+      mem_mb: 14000
+      flank_bp: 0
+    - name: ELS_phastCons_43p_conserved_50_mmseqs2_s75
+      source_parquet: results/cre/ELS_phastCons_43p_conserved_50.parquet
+      source_chrom_style: ucsc_stripped
+      source_genome: GCF_000001405.40
+      mapper: mmseqs2
+      sensitivity: 7.5
+      max_accept: 1
+      split_memory_limit: "12G"
+      mem_mb: 14000
+      flank_bp: 0
 
 output_hf_prefix: bolinas-dna/genomes-v5
 
@@ -204,6 +239,10 @@ region_labels:
 # innovation across hundreds of placental mammals." Science 380.6643 (2023): eabn3943.
 conservation:
     phylop_cutoff: 2.27 # bases with phyloP >= this value are considered conserved
+    # Zoonomia 43-primate phastCons. 0.961 is calibrated to a ~3.46% conserved
+    # base fraction matching phyloP-241way 2.27 (~3.48%); see
+    # snakemake/enhancer_classification/config/config.yaml:329-331.
+    phastcons_43p_cutoff: 0.961
 
 # Promoter variants for comparison plot
 promoter_comparison_regions:

--- a/snakemake/training_dataset/dataset_creation/sky/run_hf_upload_curation_sweep.yaml
+++ b/snakemake/training_dataset/dataset_creation/sky/run_hf_upload_curation_sweep.yaml
@@ -1,0 +1,66 @@
+name: training-dataset-hf-upload-curation-sweep
+
+# End-to-end HF upload for the v31/v32/v33 source-curation sweep on
+# mammals_seg20 (PR #141): window_seq → FASTA → parquet (per species)
+# → merge/shuffle/shard → compress → HF upload (training + validation).
+#
+# The mmseqs2 projections and per-species recipe beds are produced by
+# sky/run_mmseqs2_mammals_seg20_curation_sweep.yaml (run first, on the same
+# cluster via `sky exec`).
+
+resources:
+    infra: aws/us-east-2
+    instance_type: r6i.8xlarge   # 32 vCPU, 256 GB RAM (merge_datasets
+                                 # loads 20 species into one dataframe).
+    disk_size: 300
+    labels:
+        project: dna
+
+workdir: .
+
+# Mounts the user's HF token to the cluster so `hf upload` can publish to
+# their HF namespace. Same pattern as run_hf_upload_v30.yaml.
+file_mounts:
+    ~/.cache/huggingface: ~/.cache/huggingface
+
+setup: |
+    set -euxo pipefail
+
+    if [ ! -d "$HOME/miniforge3" ]; then
+        curl -fsSL -o /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+        bash /tmp/miniforge.sh -b -p "$HOME/miniforge3"
+        rm /tmp/miniforge.sh
+    fi
+
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+
+    grep -q 'miniforge3/bin' "$HOME/.bashrc" || \
+        echo 'export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+
+    export PATH="$HOME/.local/bin:$PATH"
+    uv sync --group enhancer-classification
+
+run: |
+    set -euxo pipefail
+
+    source "$HOME/miniforge3/etc/profile.d/conda.sh"
+    export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+    export CONDA_EXE="$HOME/miniforge3/bin/conda"
+
+    cd snakemake/training_dataset/dataset_creation
+
+    # Target the v31/v32/v33 / mammals_seg20 datasets explicitly so this run
+    # only touches the sweep DAG slice — the historical v5/v1/v15/v30
+    # datasets in `rule all` aren't requested here.
+    uv run --project ../../.. --group enhancer-classification snakemake \
+        --cores 32 \
+        --use-conda \
+        --resources mem_mb=220000 \
+        --configfile config/config.yaml config/config.cloud.yaml \
+        --printshellcmds \
+        --rerun-incomplete \
+        results/upload.done/training/mammals_seg20/v31/255/128 \
+        results/upload.done/training/mammals_seg20/v32/255/128 \
+        results/upload.done/training/mammals_seg20/v33/255/128

--- a/snakemake/training_dataset/dataset_creation/sky/run_mmseqs2_mammals_seg20_curation_sweep.yaml
+++ b/snakemake/training_dataset/dataset_creation/sky/run_mmseqs2_mammals_seg20_curation_sweep.yaml
@@ -1,0 +1,65 @@
+name: training-dataset-mmseqs2-mammals-seg20-curation-sweep
+
+# Source-curation sweep around v30 (PR #141, follow-up to #136). Builds the
+# per-species v31/v32/v33 recipe bed.gz for the mammals_seg20 set, in
+# addition to the existing v30 baseline. Each recipe runs the same mmseqs2
+# projection + exon-masked recipe step as v30 over a different upstream
+# cCRE conservation filter:
+#   v31 — phyloP-241way >= 2.27, per-cCRE >= 50 bp conserved
+#   v32 — phastCons-43p >= 0.961, per-cCRE >= 20 bp conserved
+#   v33 — phastCons-43p >= 0.961, per-cCRE >= 50 bp conserved
+#
+# Serial on one r6i.8xlarge: ~2 min/species × 20 × 3 ≈ 2 h wall mmseqs2,
+# plus per-cCRE phastCons calculation (~3 min for 1.7M cCREs) one-time.
+
+resources:
+    infra: aws/us-east-2
+    instance_type: r6i.8xlarge   # 32 vCPU, 256 GB RAM
+    disk_size: 300               # genome 2bits + mmseqs DBs + 6.5 GB phastCons-43p bigWig + conda envs
+    labels:
+        project: dna
+
+workdir: .
+
+setup: |
+    set -euxo pipefail
+
+    if [ ! -d "$HOME/miniforge3" ]; then
+        curl -fsSL -o /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+        bash /tmp/miniforge.sh -b -p "$HOME/miniforge3"
+        rm /tmp/miniforge.sh
+    fi
+
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+
+    grep -q 'miniforge3/bin' "$HOME/.bashrc" || \
+        echo 'export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+
+    export PATH="$HOME/.local/bin:$PATH"
+    uv sync --group enhancer-classification
+
+run: |
+    set -euxo pipefail
+
+    source "$HOME/miniforge3/etc/profile.d/conda.sh"
+    export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+    export CONDA_EXE="$HOME/miniforge3/bin/conda"
+    conda --version
+
+    cd snakemake/training_dataset/dataset_creation
+
+    # Build the v31/v32/v33 recipe bed.gz outputs for all 20 species. The
+    # combined convenience rule chains: phastCons-43p bigWig download +
+    # cre_conservation_phastcons_43p + cre_filter_* + mmseqs2 projection
+    # (×3 mappings × 20 species) + recipe wrapper. Excludes the downstream
+    # HF upload — see run_hf_upload_curation_sweep.yaml.
+    uv run --project ../../.. --group enhancer-classification snakemake \
+        all_intervals_recipe_curation_sweep_mammals_seg20 \
+        --cores 32 \
+        --use-conda \
+        --resources mem_mb=220000 \
+        --configfile config/config.yaml config/config.cloud.yaml \
+        --printshellcmds \
+        --rerun-incomplete

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/cre.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/cre.smk
@@ -81,3 +81,50 @@ rule cre_filter_conserved_enhancers:
             .select(["chrom", "start", "end"])
             .write_parquet(output[0])
         )
+
+
+# Parallel of cre_conservation but using the Zoonomia 43-primate phastCons
+# track. Threshold (0.961) is calibrated to ~3.5% conserved-base fraction,
+# matching phyloP-241way 2.27 for cross-track comparability.
+rule cre_conservation_phastcons_43p:
+    input:
+        cre="results/cre/ELS.parquet",
+        conservation="results/conservation/phastCons_43p.bw",
+    output:
+        "results/cre/ELS_phastCons_43p.parquet",
+    run:
+        cutoff = config["conservation"]["phastcons_43p_cutoff"]
+        df = pl.read_parquet(input.cre)
+
+        bw = pyBigWig.open(input.conservation)
+        pct_conserved = df.select(
+            pl.struct(["chrom", "start", "end"])
+            .map_elements(
+                lambda x: np.mean(
+                    bw.values("chr" + x["chrom"], x["start"], x["end"], numpy=True)
+                    >= cutoff
+                ),
+                return_dtype=pl.Float64,
+            )
+            .cast(pl.Float32)
+            .alias("pct_conserved")
+        )
+        bw.close()
+
+        df.hstack(pct_conserved).write_parquet(output[0])
+
+
+rule cre_filter_phastcons_43p_conserved_enhancers:
+    input:
+        "results/cre/ELS_phastCons_43p.parquet",
+    output:
+        "results/cre/ELS_phastCons_43p_conserved_{n}.parquet",
+    run:
+        min_conserved = int(wildcards.n)
+        df = pl.read_parquet(input[0])
+        size = df["end"] - df["start"]
+        (
+            df.filter((df["pct_conserved"] * size) >= min_conserved)
+            .select(["chrom", "start", "end"])
+            .write_parquet(output[0])
+        )

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/intervals.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/intervals.smk
@@ -615,3 +615,17 @@ rule intervals_recipe_v33:
         scannable = GenomicSet.read_bed(input.scannable)
         intervals = intervals & scannable
         intervals.write_bed(output[0])
+
+
+rule all_intervals_recipe_curation_sweep_mammals_seg20:
+    """Convenience target for the v31/v32/v33 curation sweep on mammals_seg20:
+    every per-species recipe bed.gz across the three new mappings. Excludes
+    v30 (already built) and the HF upload step. Used by
+    sky/run_mmseqs2_mammals_seg20_curation_sweep.yaml.
+    """
+    input:
+        expand(
+            "results/intervals/recipe/{recipe}/{g}.bed.gz",
+            recipe=["v31", "v32", "v33"],
+            g=genome_sets.get("mammals_seg20", []),
+        ),

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/intervals.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/intervals.smk
@@ -569,3 +569,49 @@ rule all_intervals_recipe_v30_mammals_seg20:
             "results/intervals/recipe/v30/{g}.bed.gz",
             g=genome_sets.get("mammals_seg20", []),
         ),
+
+
+# Source-curation sweep around v30 (issue: phyloP/phastCons × 20/50 bp).
+# Each recipe wraps a different ELS_*_mmseqs2_s75 mapping with the same
+# resize(255) + scannable intersect as v30, so the four datasets differ
+# only in the upstream cCRE conservation filter.
+rule intervals_recipe_v31:
+    input:
+        projected="results/intervals/ELS_conserved_50_mmseqs2_s75/{g}.parquet",
+        scannable="results/intervals/scannable/{g}.bed.gz",
+    output:
+        "results/intervals/recipe/v31/{g}.bed.gz",
+    run:
+        intervals = GenomicSet.read_parquet(input.projected)
+        intervals = intervals.resize(255)
+        scannable = GenomicSet.read_bed(input.scannable)
+        intervals = intervals & scannable
+        intervals.write_bed(output[0])
+
+
+rule intervals_recipe_v32:
+    input:
+        projected="results/intervals/ELS_phastCons_43p_conserved_20_mmseqs2_s75/{g}.parquet",
+        scannable="results/intervals/scannable/{g}.bed.gz",
+    output:
+        "results/intervals/recipe/v32/{g}.bed.gz",
+    run:
+        intervals = GenomicSet.read_parquet(input.projected)
+        intervals = intervals.resize(255)
+        scannable = GenomicSet.read_bed(input.scannable)
+        intervals = intervals & scannable
+        intervals.write_bed(output[0])
+
+
+rule intervals_recipe_v33:
+    input:
+        projected="results/intervals/ELS_phastCons_43p_conserved_50_mmseqs2_s75/{g}.parquet",
+        scannable="results/intervals/scannable/{g}.bed.gz",
+    output:
+        "results/intervals/recipe/v33/{g}.bed.gz",
+    run:
+        intervals = GenomicSet.read_parquet(input.projected)
+        intervals = intervals.resize(255)
+        scannable = GenomicSet.read_bed(input.scannable)
+        intervals = intervals & scannable
+        intervals.write_bed(output[0])

--- a/snakemake/training_dataset/dataset_creation/workflow/rules/stats.smk
+++ b/snakemake/training_dataset/dataset_creation/workflow/rules/stats.smk
@@ -8,6 +8,17 @@ rule download_phylop_conservation:
         "wget -O {output} https://hgdownload.soe.ucsc.edu/goldenPath/hg38/cactus241way/cactus241way.phyloP.bw"
 
 
+# Zoonomia/Cactus 43-primate phastCons. The remote filename says "phyloP" but
+# this is the phastCons track (0-1 score, threshold 0.961 calibrated to a ~3.5%
+# conserved-base fraction matching phyloP-241way 2.27).
+# See snakemake/enhancer_classification/config/config.yaml:329-331.
+rule download_phastcons_43p_conservation:
+    output:
+        "results/conservation/phastCons_43p.bw",
+    shell:
+        "wget -O {output} https://cgl.gi.ucsc.edu/data/cactus/zoonomia-2021-track-hub/hg38/phyloPPrimates.bigWig"
+
+
 rule all_functional_region_stats:
     input:
         expand(


### PR DESCRIPTION
## Summary

Following [#136](https://github.com/Open-Athena/bolinas-dna/issues/136) (where projection-based curation `proj_v30` outperformed segmentation by 2.3× on TraitGym Mendelian v2 distal AUPRC, and beat Evo2-40B by 1.79× at 67× fewer params), this PR adds three sibling recipes to v30 that vary the **upstream cCRE conservation filter** while keeping projection method (mmseqs2 `-s 7.5`), target genome set (`mammals_seg20`), and downstream windowing/exon-masking identical:

- **v31** — phyloP-241way ≥ 2.27, per-cCRE ≥ 50 bp conserved
- **v32** — phastCons-43p ≥ 0.961, per-cCRE ≥ 20 bp conserved
- **v33** — phastCons-43p ≥ 0.961, per-cCRE ≥ 50 bp conserved

Together with the existing `v30` (phyloP/20), this is a 2×2 design across **conservation track** (mammal-wide phyloP-241way vs primate-specific phastCons-43p) × **per-cCRE bp filter** (20 bp ≈ 7% of median ELS length, 50 bp ≈ 18%).

phastCons-43p is the Zoonomia 43-primate phastCons track; threshold 0.961 calibrated to a ~3.46% conserved-base fraction matching phyloP-241way 2.27 (per `enhancer_classification/config/config.yaml:329-331`).

## Source-count sanity check (hg38 ELS, 1,718,669 cCREs)

Run locally on the downloaded phastCons-43p bigWig before launching the cloud build:

| Filter | Surviving cCREs | % of ELS |
|---|---|---|
| phyloP-241way ≥2.27 / ≥20 bp (existing v30) | 375,932 | 21.9% |
| **phastCons-43p ≥0.961 / ≥20 bp (v32)** | **392,044** | **22.8%** |
| **phastCons-43p ≥0.961 / ≥50 bp (v33)** | **253,759** | **14.8%** |
| phyloP-241way ≥2.27 / ≥50 bp (v31) | TBD on cloud | — |

Excellent calibration agreement at 20 bp (phastCons/20 within 5% of phyloP/20). The per-base conserved fraction on cCREs is 8.49% (vs the ~3.46% genome-wide target) — expected since cCREs are pre-enriched for conservation; what matters is the per-cCRE filter agreement.

**Caveat to verify on the projection step:** phastCons-43p selects primate-conserved cCREs by construction. They may project worse to non-primate mammals than v30/v31's mammal-wide phyloP set — worth a per-target recall smoke test (mm39, opossum) before training.

## Compute estimate

Anchored on `README.md:449` (mmseqs2 ~2 min wall per mammal target on r6i.8xlarge):
- Per new dataset: ~2–5 h wall (20 × mmseqs2 + windowing + exon-mask + extract + shard + upload).
- 3 new datasets in parallel on 3 instances: ~2–5 h wall.

One-time setup: phastCons-43p bigWig is **6.5 GB** (the plan estimate of ~1 GB was off; worth knowing for cloud disk sizing); per-cCRE conservation computation took ~3 min for 1.7M cCREs locally.

## Files changed

- `stats.smk` — `download_phastcons_43p_conservation` rule
- `cre.smk` — `cre_conservation_phastcons_43p` + `cre_filter_phastcons_43p_conserved_enhancers` rules
- `intervals.smk` — `intervals_recipe_v31`/`_v32`/`_v33` wrappers (each mirrors v30 with a different input mapping)
- `config.yaml` — `phastcons_43p_cutoff: 0.961`, three new `interval_mappings` entries, three new `training_per_genome_set.mammals_seg20` recipes
- `README.md` — sweep table + caveat note

## Test plan

- [x] Source-count sanity check on hg38 ELS — verified phastCons calibration vs phyloP baseline (above)
- [x] Snakemake dry-run of `results/intervals/recipe/v33/GCF_000001405.40.bed.gz` — confirmed only the new rules fire; no upstream re-trigger of existing v30
- [ ] Cloud build of all 3 new datasets (mammals_seg20 × 3 mappings) on r6i.8xlarge
- [ ] Per-target projection-recall smoke test on mm39 — flag if phastCons-43p drops below ~30% recall (vs proj_v30's 61% phyloP baseline)
- [ ] HF upload to `bolinas-dna/genomes-v5-genome_set-mammals_seg20-intervals-{v31,v32,v33}_255_128`
- [ ] Train 0.6B Qwen3 on each (mirror #136 setup: 10K steps × 4096 batch × v5p-8 × ~14 h) → TraitGym Mendelian v2 + LL-gap eval

🤖 Generated with [Claude Code](https://claude.com/claude-code)