### PR TITLE
Add conservation scores baseline (#146)

### DIFF
--- a/snakemake/conservation_eval/README.md
+++ b/snakemake/conservation_eval/README.md
@@ -1,0 +1,77 @@
+# Conservation scores baseline (issue #146)
+
+Per-variant conservation scores on TraitGym Mendelian v2 (`bolinas-dna/evals-traitgym_mendelian_v2`) as a classical baseline alongside model-based evals (e.g. Evo 2 in `scripts/evo2_eval/`, issue #131).
+
+## What it does
+
+For each split in `config["splits"]` (default `train` and `test`) and each track in `config["scores"]`:
+
+1. **Download** the bigWig from UCSC / Zoonomia (`results/conservation/{score}.bw`).
+2. **Score** each variant by single-base lookup at its 1-based `pos` (converted to pyBigWig's 0-based half-open `[pos-1, pos)`). NaN is preserved where the bigWig has no aligned data.
+3. **Aggregate** the three scored parquets into one AUPRC table per split (`results/conservation_traitgym_v2/results_table_{split}.md`) plus a long-form `metrics_{split}.parquet`.
+
+## Tracks
+
+| Name | Source URL | Notes |
+| --- | --- | --- |
+| `phyloP_100v` | `hgdownload.soe.ucsc.edu/.../hg38.phyloP100way.bw` | 100-vertebrate phyloP |
+| `phyloP_241m` | `hgdownload.soe.ucsc.edu/.../cactus241way.phyloP.bw` | Zoonomia 241-mammal Cactus phyloP |
+| `phastCons_43p` | `cgl.gi.ucsc.edu/.../phyloPPrimates.bigWig` | Zoonomia 43-primate. Name follows TraitGym; underlying file is phyloP-over-primates. |
+
+URLs are owned by `bolinas.evals.conservation.CONSERVATION_TRACKS` (single source of truth).
+
+## NaN handling
+
+NaN values arise when the bigWig has no alignment at a given locus (e.g. patches, alt contigs, or genuinely unalignable bases). We make a deliberate choice to **`fillna(0)`** before computing AUPRC:
+
+- For phyloP, **0 is semantically meaningful**: neither conserved nor accelerated.
+- For phastCons, **0 is also semantically meaningful**: non-conserved.
+
+This matches the choice in TraitGym's own `eval/workflow/rules/conservation.smk`. Some other benchmarks instead drop NaN variants from evaluation; we don't, for simplicity.
+
+The per-variant parquets (`{score}_{split}.parquet`) preserve raw NaNs so you can apply a different policy without re-running scoring. Filling happens only at the aggregation stage.
+
+NaN counts are surfaced in `results_table_{split}.md` (per `(score, subset)`) so the size of the choice is visible.
+
+## Usage
+
+```bash
+cd snakemake/conservation_eval
+
+# Dry-run to inspect the DAG
+uv run snakemake -n
+
+# Run locally (CPU-only; ~5-10 min total — bigWig downloads dominate)
+uv run snakemake
+```
+
+The default profile (`workflow/profiles/default/config.yaml`) uses S3 storage at `s3://oa-bolinas/snakemake/conservation_eval/`. AWS credentials need S3 access — same setup as `snakemake/evals/` (see that pipeline's README for credentials).
+
+## Outputs
+
+```
+results/
+├── conservation/
+│   ├── phyloP_100v.bw
+│   ├── phyloP_241m.bw
+│   └── phastCons_43p.bw
+└── conservation_traitgym_v2/
+    ├── phyloP_100v_train.parquet         # per-variant score (NaN preserved)
+    ├── phyloP_100v_test.parquet
+    ├── phyloP_241m_train.parquet
+    ├── phyloP_241m_test.parquet
+    ├── phastCons_43p_train.parquet
+    ├── phastCons_43p_test.parquet
+    ├── metrics_train.parquet              # long-form metrics table
+    ├── metrics_test.parquet
+    ├── results_table_train.md             # markdown for issue follow-up
+    └── results_table_test.md
+```
+
+## Library
+
+Snakemake rules are thin glue around `bolinas.evals.conservation`:
+- `score_variants_at_positions(df, bw_path)` — bigWig lookup, NaN preserved.
+- `aggregate_traitgym_metrics(parquet_paths)` — `(metrics_df, markdown)`.
+
+Tests live at `tests/evals/test_conservation.py` (CPU-only, no real bigWig download).

--- a/snakemake/conservation_eval/config/config.yaml
+++ b/snakemake/conservation_eval/config/config.yaml
@@ -1,0 +1,15 @@
+# TraitGym Mendelian v2 dataset on HuggingFace (produced by snakemake/evals/).
+dataset_hf_path: bolinas-dna/evals-traitgym_mendelian_v2
+
+# Splits to score independently. Each produces its own markdown table.
+splits:
+  - train
+  - test
+
+# Conservation tracks. URLs are the single source of truth in
+# bolinas.evals.conservation.CONSERVATION_TRACKS — listing names here just
+# selects which tracks the pipeline runs.
+scores:
+  - phyloP_100v
+  - phyloP_241m
+  - phastCons_43p

--- a/snakemake/conservation_eval/workflow/Snakefile
+++ b/snakemake/conservation_eval/workflow/Snakefile
@@ -1,0 +1,14 @@
+configfile: "config/config.yaml"
+
+
+include: "rules/common.smk"
+include: "rules/download.smk"
+include: "rules/score.smk"
+
+
+rule all:
+    input:
+        expand(
+            "results/conservation_traitgym_v2/results_table_{split}.md",
+            split=config["splits"],
+        ),

--- a/snakemake/conservation_eval/workflow/profiles/default/config.yaml
+++ b/snakemake/conservation_eval/workflow/profiles/default/config.yaml
@@ -1,0 +1,3 @@
+default-storage-provider: s3
+default-storage-prefix: s3://oa-bolinas/snakemake/conservation_eval/
+cores: all

--- a/snakemake/conservation_eval/workflow/rules/common.smk
+++ b/snakemake/conservation_eval/workflow/rules/common.smk
@@ -1,0 +1,20 @@
+import pandas as pd
+
+from datasets import load_dataset
+
+from bolinas.evals.conservation import (
+    CONSERVATION_TRACKS,
+    score_variants_at_positions,
+)
+from bolinas.evals.metrics import compute_metrics
+
+
+SCORES = config["scores"]
+SPLITS = config["splits"]
+DATASET_HF_PATH = config["dataset_hf_path"]
+
+# Sanity-check up-front: every score listed in config must be a known track.
+_unknown = set(SCORES) - set(CONSERVATION_TRACKS)
+assert not _unknown, (
+    f"unknown scores in config: {_unknown}. " f"Known: {sorted(CONSERVATION_TRACKS)}"
+)

--- a/snakemake/conservation_eval/workflow/rules/common.smk
+++ b/snakemake/conservation_eval/workflow/rules/common.smk
@@ -1,9 +1,13 @@
+from pathlib import Path
+
 import pandas as pd
 
 from datasets import load_dataset
 
 from bolinas.evals.conservation import (
     CONSERVATION_TRACKS,
+    REQUIRED_VARIANT_COLUMNS,
+    aggregate_traitgym_metrics,
     score_variants_at_positions,
 )
 from bolinas.evals.metrics import compute_metrics

--- a/snakemake/conservation_eval/workflow/rules/download.smk
+++ b/snakemake/conservation_eval/workflow/rules/download.smk
@@ -1,0 +1,9 @@
+rule download_bigwig:
+    output:
+        "results/conservation/{score}.bw",
+    params:
+        url=lambda wc: CONSERVATION_TRACKS[wc.score],
+    wildcard_constraints:
+        score="|".join(CONSERVATION_TRACKS),
+    shell:
+        "wget -q {params.url} -O {output}"

--- a/snakemake/conservation_eval/workflow/rules/score.smk
+++ b/snakemake/conservation_eval/workflow/rules/score.smk
@@ -8,13 +8,13 @@ rule score_variants:
         split="|".join(SPLITS),
     run:
         ds = load_dataset(DATASET_HF_PATH, split=wildcards.split).to_pandas()
-        for col in ("chrom", "pos", "ref", "alt", "label", "subset"):
+        for col in REQUIRED_VARIANT_COLUMNS:
             assert col in ds.columns, f"dataset missing column {col!r}"
 
         scores = score_variants_at_positions(ds, input.bw)
         assert len(scores) == len(ds)
 
-        out = ds[["chrom", "pos", "ref", "alt", "label", "subset"]].copy()
+        out = ds[list(REQUIRED_VARIANT_COLUMNS)].copy()
         out["score"] = scores
         n_nan = int(out["score"].isna().sum())
         print(
@@ -37,12 +37,7 @@ rule aggregate_metrics:
     wildcard_constraints:
         split="|".join(SPLITS),
     run:
-        from bolinas.evals.conservation import aggregate_traitgym_metrics
-        from pathlib import Path
-
-        # Use input.parquets (locally-fetched paths under S3 storage), not
-        # reconstructed strings — snakemake replaces them with temp paths.
-        # Order matches the expand() above, which iterates SCORES in order.
+        # input.parquets are S3-fetched local temp paths, in expand() order (= SCORES).
         parquet_paths = dict(zip(SCORES, input.parquets))
         metrics, md = aggregate_traitgym_metrics(parquet_paths)
         metrics["split"] = wildcards.split

--- a/snakemake/conservation_eval/workflow/rules/score.smk
+++ b/snakemake/conservation_eval/workflow/rules/score.smk
@@ -40,10 +40,10 @@ rule aggregate_metrics:
         from bolinas.evals.conservation import aggregate_traitgym_metrics
         from pathlib import Path
 
-        parquet_paths = {
-            score: f"results/conservation_traitgym_v2/{score}_{wildcards.split}.parquet"
-            for score in SCORES
-        }
+        # Use input.parquets (locally-fetched paths under S3 storage), not
+        # reconstructed strings — snakemake replaces them with temp paths.
+        # Order matches the expand() above, which iterates SCORES in order.
+        parquet_paths = dict(zip(SCORES, input.parquets))
         metrics, md = aggregate_traitgym_metrics(parquet_paths)
         metrics["split"] = wildcards.split
         metrics.to_parquet(output.metrics, index=False)

--- a/snakemake/conservation_eval/workflow/rules/score.smk
+++ b/snakemake/conservation_eval/workflow/rules/score.smk
@@ -1,0 +1,52 @@
+rule score_variants:
+    input:
+        bw="results/conservation/{score}.bw",
+    output:
+        "results/conservation_traitgym_v2/{score}_{split}.parquet",
+    wildcard_constraints:
+        score="|".join(CONSERVATION_TRACKS),
+        split="|".join(SPLITS),
+    run:
+        ds = load_dataset(DATASET_HF_PATH, split=wildcards.split).to_pandas()
+        for col in ("chrom", "pos", "ref", "alt", "label", "subset"):
+            assert col in ds.columns, f"dataset missing column {col!r}"
+
+        scores = score_variants_at_positions(ds, input.bw)
+        assert len(scores) == len(ds)
+
+        out = ds[["chrom", "pos", "ref", "alt", "label", "subset"]].copy()
+        out["score"] = scores
+        n_nan = int(out["score"].isna().sum())
+        print(
+            f"[conservation_eval] {wildcards.score} {wildcards.split}: "
+            f"n={len(out)} n_nan={n_nan} ({100* n_nan/ len(out):.2f}%) "
+            f"score_min={out['score'].min():.3f} max={out['score'].max():.3f}"
+        )
+        out.to_parquet(output[0], index=False)
+
+
+rule aggregate_metrics:
+    input:
+        parquets=lambda wc: expand(
+            "results/conservation_traitgym_v2/{score}_{{split}}.parquet",
+            score=SCORES,
+        ),
+    output:
+        metrics="results/conservation_traitgym_v2/metrics_{split}.parquet",
+        markdown="results/conservation_traitgym_v2/results_table_{split}.md",
+    wildcard_constraints:
+        split="|".join(SPLITS),
+    run:
+        from bolinas.evals.conservation import aggregate_traitgym_metrics
+        from pathlib import Path
+
+        parquet_paths = {
+            score: f"results/conservation_traitgym_v2/{score}_{wildcards.split}.parquet"
+            for score in SCORES
+        }
+        metrics, md = aggregate_traitgym_metrics(parquet_paths)
+        metrics["split"] = wildcards.split
+        metrics.to_parquet(output.metrics, index=False)
+        Path(output.markdown).write_text(md)
+        print(f"[conservation_eval] wrote {output.markdown}")
+        print(md)

--- a/src/bolinas/evals/conservation.py
+++ b/src/bolinas/evals/conservation.py
@@ -36,6 +36,18 @@ CONSERVATION_TRACKS: dict[str, str] = {
 }
 
 
+# TraitGym variant columns the pipeline preserves end-to-end. Asserted by
+# the score and aggregate stages so a schema drift fails fast.
+REQUIRED_VARIANT_COLUMNS: tuple[str, ...] = (
+    "chrom",
+    "pos",
+    "ref",
+    "alt",
+    "label",
+    "subset",
+)
+
+
 def score_variants_at_positions(
     df: pd.DataFrame,
     bw_path: str | Path,
@@ -112,37 +124,34 @@ def aggregate_traitgym_metrics(
     assert parquet_paths, "parquet_paths must be non-empty"
 
     score_names = list(parquet_paths)
+    required = (*REQUIRED_VARIANT_COLUMNS, "score")
     all_metrics: list[pd.DataFrame] = []
-    nan_counts: dict[str, pd.Series] = {}  # score_name -> Series indexed by subset
-    total_counts: dict[str, pd.Series] = {}
 
     for score_name in score_names:
         df = pd.read_parquet(parquet_paths[score_name])
-        for col in ("chrom", "pos", "ref", "alt", "label", "subset", "score"):
+        for col in required:
             assert col in df.columns, (
                 f"{parquet_paths[score_name]}: missing column {col!r}"
             )
 
-        # Count NaN per (subset) and globally before filling.
-        per_subset_nan = df.groupby("subset")["score"].apply(lambda s: s.isna().sum())
-        per_subset_total = df.groupby("subset").size()
-        nan_counts[score_name] = pd.concat(
-            [pd.Series({"global": int(df["score"].isna().sum())}), per_subset_nan]
-        ).astype(int)
-        total_counts[score_name] = pd.concat(
-            [pd.Series({"global": int(len(df))}), per_subset_total]
-        ).astype(int)
+        # Count NaN per subset before filling; "global" matches compute_metrics'
+        # convention for the all-rows row.
+        nan_per_subset = df.groupby("subset")["score"].apply(
+            lambda s: int(s.isna().sum())
+        )
+        nan_per_subset["global"] = int(df["score"].isna().sum())
+        total_per_subset = df.groupby("subset").size().astype(int)
+        total_per_subset["global"] = len(df)
 
-        scores = df[["score"]].fillna(0)
         m = compute_metrics(
-            dataset=df[["chrom", "pos", "ref", "alt", "label", "subset"]],
-            scores=scores,
+            dataset=df[list(REQUIRED_VARIANT_COLUMNS)],
+            scores=df[["score"]].fillna(0),
             metrics=["AUPRC"],
             score_columns=["score"],
         )
         m["score_name"] = score_name
-        m["n_nan"] = m["subset"].map(nan_counts[score_name]).astype(int)
-        m["n_total"] = m["subset"].map(total_counts[score_name]).astype(int)
+        m["n_nan"] = m["subset"].map(nan_per_subset).astype(int)
+        m["n_total"] = m["subset"].map(total_per_subset).astype(int)
         all_metrics.append(m)
 
     metrics = pd.concat(all_metrics, ignore_index=True)
@@ -154,6 +163,14 @@ def _build_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
     """Render the metrics DataFrame as a two-table markdown report."""
     auprc = metrics[metrics["metric"] == "AUPRC"].copy()
 
+    def _pivot(values_col: str) -> pd.DataFrame:
+        return auprc.pivot_table(
+            index="subset",
+            columns="score_name",
+            values=values_col,
+            aggfunc="first",
+        )
+
     # Per-subset n_pos/n_neg from the first score (subset coverage is
     # score-independent).
     coverage = (
@@ -162,25 +179,17 @@ def _build_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
         .set_index("subset")
     )
 
-    pivot = auprc.pivot_table(
-        index="subset",
-        columns="score_name",
-        values="value",
-        aggfunc="first",
-    )
+    pivot = _pivot("value")
+    nan_pivot = _pivot("n_nan")
+
     # Order: global first, then subsets sorted by n_pos descending.
     rest = [
         s for s in coverage.sort_values("n_pos", ascending=False).index if s != "global"
     ]
-    order = ([s for s in ["global"] if s in pivot.index]) + rest
+    order = (["global"] if "global" in pivot.index else []) + rest
     pivot = pivot.reindex(order)
+    nan_pivot = nan_pivot.reindex(order)
 
-    nan_pivot = auprc.pivot_table(
-        index="subset",
-        columns="score_name",
-        values="n_nan",
-        aggfunc="first",
-    ).reindex(order)
     total_by_subset = (
         auprc[auprc["score_name"] == score_names[0]][["subset", "n_total"]]
         .drop_duplicates(subset="subset")

--- a/src/bolinas/evals/conservation.py
+++ b/src/bolinas/evals/conservation.py
@@ -1,0 +1,225 @@
+"""Per-variant conservation scoring via UCSC bigWig tracks.
+
+Used by ``snakemake/conservation_eval/`` (issue #146) to score TraitGym
+Mendelian v2 variants with three classical conservation tracks:
+
+- ``phyloP_100v``  — UCSC 100-vertebrate phyloP
+- ``phyloP_241m``  — Zoonomia 241-mammal Cactus phyloP
+- ``phastCons_43p`` — Zoonomia 43-primate track
+
+URLs are copied verbatim from TraitGym's ``eval/workflow/rules/conservation.smk``;
+the same bigWigs are also used elsewhere in this repo (enhancer_classification,
+training_dataset/dataset_creation) but each pipeline manages its own download to
+avoid coupling.
+
+NaN policy: this module preserves NaNs from the bigWig (no alignment at that
+locus). Callers decide how to fill them — the ``conservation_eval`` pipeline
+applies ``fillna(0)`` only at the metrics-aggregation step.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyBigWig
+
+from bolinas.evals.metrics import compute_metrics
+
+
+CONSERVATION_TRACKS: dict[str, str] = {
+    "phyloP_100v": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/phyloP100way/hg38.phyloP100way.bw",
+    "phyloP_241m": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/cactus241way/cactus241way.phyloP.bw",
+    # phastCons_43p name is a TraitGym convention; the underlying file is
+    # actually phyloP over 43 primates from the Zoonomia track hub. We keep
+    # the name to stay consistent with TraitGym + existing config in this repo.
+    "phastCons_43p": "https://cgl.gi.ucsc.edu/data/cactus/zoonomia-2021-track-hub/hg38/phyloPPrimates.bigWig",
+}
+
+
+def score_variants_at_positions(
+    df: pd.DataFrame,
+    bw_path: str | Path,
+) -> np.ndarray:
+    """Look up a bigWig value for each variant in ``df``.
+
+    TraitGym variants are 1-based (VCF convention); pyBigWig is 0-based
+    half-open. The conversion ``[pos - 1, pos)`` selects the single base at
+    1-based ``pos``.
+
+    NaNs are preserved: pyBigWig returns ``nan`` at positions with no data.
+
+    Args:
+        df: Must have integer ``pos`` and string ``chrom`` columns. ``chrom``
+            entries without a ``chr`` prefix are auto-prefixed to match UCSC
+            bigWig naming.
+        bw_path: Path to the bigWig file.
+
+    Returns:
+        ``np.ndarray`` of shape ``(len(df),)`` with one float per row.
+    """
+    assert "chrom" in df.columns and "pos" in df.columns, (
+        "df must have chrom + pos columns"
+    )
+    assert pd.api.types.is_integer_dtype(df["pos"]), (
+        f"pos must be integer dtype, got {df['pos'].dtype}"
+    )
+
+    bw = pyBigWig.open(str(bw_path))
+    try:
+        bw_chroms = set(bw.chroms())
+        scores = np.empty(len(df), dtype=np.float64)
+        for i, (chrom, pos) in enumerate(zip(df["chrom"], df["pos"])):
+            chrom_str = str(chrom)
+            if not chrom_str.startswith("chr"):
+                chrom_str = f"chr{chrom_str}"
+            if chrom_str not in bw_chroms:
+                # No track for this chromosome (e.g. patches, alt contigs).
+                scores[i] = np.nan
+                continue
+            # 1-based pos -> 0-based half-open [pos-1, pos): one base.
+            vals = bw.values(chrom_str, int(pos) - 1, int(pos))
+            scores[i] = vals[0] if vals else np.nan
+    finally:
+        bw.close()
+
+    return scores
+
+
+def aggregate_traitgym_metrics(
+    parquet_paths: dict[str, str | Path],
+) -> tuple[pd.DataFrame, str]:
+    """Aggregate per-score scored-variant parquets into a metrics DataFrame
+    and a markdown report.
+
+    Each input parquet is the output of ``score_variants_at_positions`` plus
+    the original TraitGym columns: must contain ``[chrom, pos, ref, alt,
+    label, subset, score]``. The ``score`` column may contain NaN (positions
+    with no alignment in the bigWig).
+
+    For each score: NaN count is recorded per subset, then ``score`` is
+    filled with 0 (semantically meaningful — see module docstring) before
+    AUPRC is computed via ``bolinas.evals.metrics.compute_metrics``.
+
+    Args:
+        parquet_paths: mapping ``score_name -> parquet path``. Order is
+            preserved in the markdown table.
+
+    Returns:
+        ``(metrics_df, markdown)`` where ``metrics_df`` has columns
+        ``[metric, score_type, score_name, subset, value, n_pos, n_neg,
+        n_nan, n_total]``.
+    """
+    assert parquet_paths, "parquet_paths must be non-empty"
+
+    score_names = list(parquet_paths)
+    all_metrics: list[pd.DataFrame] = []
+    nan_counts: dict[str, pd.Series] = {}  # score_name -> Series indexed by subset
+    total_counts: dict[str, pd.Series] = {}
+
+    for score_name in score_names:
+        df = pd.read_parquet(parquet_paths[score_name])
+        for col in ("chrom", "pos", "ref", "alt", "label", "subset", "score"):
+            assert col in df.columns, (
+                f"{parquet_paths[score_name]}: missing column {col!r}"
+            )
+
+        # Count NaN per (subset) and globally before filling.
+        per_subset_nan = df.groupby("subset")["score"].apply(lambda s: s.isna().sum())
+        per_subset_total = df.groupby("subset").size()
+        nan_counts[score_name] = pd.concat(
+            [pd.Series({"global": int(df["score"].isna().sum())}), per_subset_nan]
+        ).astype(int)
+        total_counts[score_name] = pd.concat(
+            [pd.Series({"global": int(len(df))}), per_subset_total]
+        ).astype(int)
+
+        scores = df[["score"]].fillna(0)
+        m = compute_metrics(
+            dataset=df[["chrom", "pos", "ref", "alt", "label", "subset"]],
+            scores=scores,
+            metrics=["AUPRC"],
+            score_columns=["score"],
+        )
+        m["score_name"] = score_name
+        m["n_nan"] = m["subset"].map(nan_counts[score_name]).astype(int)
+        m["n_total"] = m["subset"].map(total_counts[score_name]).astype(int)
+        all_metrics.append(m)
+
+    metrics = pd.concat(all_metrics, ignore_index=True)
+    md = _build_markdown(metrics, score_names)
+    return metrics, md
+
+
+def _build_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
+    """Render the metrics DataFrame as a two-table markdown report."""
+    auprc = metrics[metrics["metric"] == "AUPRC"].copy()
+
+    # Per-subset n_pos/n_neg from the first score (subset coverage is
+    # score-independent).
+    coverage = (
+        auprc[auprc["score_name"] == score_names[0]][["subset", "n_pos", "n_neg"]]
+        .drop_duplicates(subset="subset")
+        .set_index("subset")
+    )
+
+    pivot = auprc.pivot_table(
+        index="subset",
+        columns="score_name",
+        values="value",
+        aggfunc="first",
+    )
+    # Order: global first, then subsets sorted by n_pos descending.
+    rest = [
+        s for s in coverage.sort_values("n_pos", ascending=False).index if s != "global"
+    ]
+    order = ([s for s in ["global"] if s in pivot.index]) + rest
+    pivot = pivot.reindex(order)
+
+    nan_pivot = auprc.pivot_table(
+        index="subset",
+        columns="score_name",
+        values="n_nan",
+        aggfunc="first",
+    ).reindex(order)
+    total_by_subset = (
+        auprc[auprc["score_name"] == score_names[0]][["subset", "n_total"]]
+        .drop_duplicates(subset="subset")
+        .set_index("subset")["n_total"]
+        .reindex(order)
+    )
+
+    lines: list[str] = []
+    lines.append("### TraitGym Mendelian v2 — AUPRC")
+    lines.append("")
+    header = ["subset", "n_pos", "n_neg", *score_names]
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("| " + " | ".join(["---"] * len(header)) + " |")
+    for subset in pivot.index:
+        n_pos = int(coverage.loc[subset, "n_pos"]) if subset in coverage.index else 0
+        n_neg = int(coverage.loc[subset, "n_neg"]) if subset in coverage.index else 0
+        vals = [
+            f"{pivot.loc[subset, s]:.3f}" if pd.notna(pivot.loc[subset, s]) else "—"
+            for s in score_names
+        ]
+        lines.append("| " + " | ".join([subset, str(n_pos), str(n_neg), *vals]) + " |")
+
+    lines.append("")
+    lines.append("### NaN counts")
+    lines.append("")
+    lines.append(
+        "NaN = no alignment at that locus in the bigWig. AUPRC above is computed "
+        "after `.fillna(0)`: 0 is semantically meaningful for both phyloP "
+        "(neither conserved nor accelerated) and phastCons (non-conserved)."
+    )
+    lines.append("")
+    nan_header = ["subset", "n_total", *score_names]
+    lines.append("| " + " | ".join(nan_header) + " |")
+    lines.append("| " + " | ".join(["---"] * len(nan_header)) + " |")
+    for subset in nan_pivot.index:
+        n_total = (
+            int(total_by_subset.loc[subset]) if subset in total_by_subset.index else 0
+        )
+        vals = [str(int(nan_pivot.loc[subset, s])) for s in score_names]
+        lines.append("| " + " | ".join([subset, str(n_total), *vals]) + " |")
+
+    return "\n".join(lines) + "\n"

--- a/tests/evals/test_conservation.py
+++ b/tests/evals/test_conservation.py
@@ -1,0 +1,224 @@
+"""Tests for the conservation-score helpers (issue #146)."""
+
+import numpy as np
+import pandas as pd
+import pyBigWig
+import pytest
+
+from bolinas.evals.conservation import (
+    CONSERVATION_TRACKS,
+    aggregate_traitgym_metrics,
+    score_variants_at_positions,
+)
+
+
+def test_conservation_tracks_keys():
+    """The three expected tracks are present and URLs look like bigWigs."""
+    assert set(CONSERVATION_TRACKS.keys()) == {
+        "phyloP_100v",
+        "phyloP_241m",
+        "phastCons_43p",
+    }
+    for name, url in CONSERVATION_TRACKS.items():
+        assert url.startswith("https://"), f"{name}: URL must be https"
+        assert url.endswith((".bw", ".bigWig")), (
+            f"{name}: URL must point to a bigWig file, got {url}"
+        )
+
+
+def _write_tiny_bigwig(path, entries, chrom_size=1000):
+    """Write a minimal bigWig with the given (chrom, start, end, value) entries."""
+    bw = pyBigWig.open(str(path), "w")
+    bw.addHeader([("chr1", chrom_size)])
+    chroms, starts, ends, values = zip(*entries)
+    bw.addEntries(list(chroms), list(starts), ends=list(ends), values=list(values))
+    bw.close()
+
+
+def test_score_variants_coordinate_conversion(tmp_path):
+    """1-based VCF pos -> 0-based half-open bigWig query.
+
+    bigWig has values at 0-based positions 99 and 199 only; everything
+    else should be NaN.
+    """
+    bw_path = tmp_path / "tiny.bw"
+    _write_tiny_bigwig(
+        bw_path,
+        [
+            ("chr1", 99, 100, 1.5),
+            ("chr1", 199, 200, 2.5),
+        ],
+    )
+
+    df = pd.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr1", "chr1"],
+            "pos": [100, 200, 300, 500],  # 1-based
+        }
+    )
+
+    scores = score_variants_at_positions(df, bw_path)
+
+    assert scores.shape == (4,)
+    assert scores[0] == pytest.approx(1.5)
+    assert scores[1] == pytest.approx(2.5)
+    assert np.isnan(scores[2])
+    assert np.isnan(scores[3])
+
+
+def test_score_variants_preserves_nan(tmp_path):
+    """NaN must be preserved (not silently filled) when no data is present."""
+    bw_path = tmp_path / "tiny.bw"
+    _write_tiny_bigwig(bw_path, [("chr1", 0, 1, 0.0)])
+
+    df = pd.DataFrame({"chrom": ["chr1"], "pos": [500]})  # outside the entry
+    scores = score_variants_at_positions(df, bw_path)
+    assert np.isnan(scores[0])
+
+
+def test_score_variants_chrom_prefix_handling(tmp_path):
+    """Chromosome names without 'chr' prefix should be auto-prefixed."""
+    bw_path = tmp_path / "tiny.bw"
+    _write_tiny_bigwig(bw_path, [("chr1", 99, 100, 3.14)])
+
+    df = pd.DataFrame({"chrom": ["1"], "pos": [100]})  # no 'chr' prefix
+    scores = score_variants_at_positions(df, bw_path)
+    assert scores[0] == pytest.approx(3.14)
+
+
+def test_score_variants_unknown_chromosome(tmp_path):
+    """Variants on chromosomes not in the bigWig return NaN, don't crash."""
+    bw_path = tmp_path / "tiny.bw"
+    _write_tiny_bigwig(bw_path, [("chr1", 99, 100, 1.0)])
+
+    df = pd.DataFrame({"chrom": ["chrM"], "pos": [100]})
+    scores = score_variants_at_positions(df, bw_path)
+    assert np.isnan(scores[0])
+
+
+def test_score_variants_rejects_non_integer_pos(tmp_path):
+    """Float pos column should fail loudly (silent rounding hides bugs)."""
+    bw_path = tmp_path / "tiny.bw"
+    _write_tiny_bigwig(bw_path, [("chr1", 99, 100, 1.0)])
+
+    df = pd.DataFrame({"chrom": ["chr1"], "pos": [100.0]})
+    with pytest.raises(AssertionError, match="pos must be integer"):
+        score_variants_at_positions(df, bw_path)
+
+
+def _scored_parquet(tmp_path, name, scores, labels, subsets):
+    """Write a fake scored-variant parquet matching the score_variants output schema."""
+    path = tmp_path / f"{name}.parquet"
+    n = len(scores)
+    df = pd.DataFrame(
+        {
+            "chrom": ["chr1"] * n,
+            "pos": list(range(1, n + 1)),
+            "ref": ["A"] * n,
+            "alt": ["T"] * n,
+            "label": labels,
+            "subset": subsets,
+            "score": scores,
+        }
+    )
+    df.to_parquet(path, index=False)
+    return path
+
+
+def test_aggregate_traitgym_metrics_nan_accounting(tmp_path):
+    """NaN counts should be correct per subset and globally; AUPRC computed
+    after fillna(0)."""
+    # 6 variants: 3 in subset_A, 3 in subset_B. Score column has 1 NaN
+    # in subset_A, 0 in subset_B.
+    scores = [0.9, np.nan, 0.1, 0.8, 0.2, 0.5]
+    labels = [1, 1, 0, 1, 0, 0]
+    subsets = ["A", "A", "A", "B", "B", "B"]
+    p = _scored_parquet(tmp_path, "phyloP_241m", scores, labels, subsets)
+
+    metrics, md = aggregate_traitgym_metrics({"phyloP_241m": p})
+
+    # Schema check.
+    expected_cols = {
+        "metric",
+        "score_type",
+        "score_name",
+        "subset",
+        "value",
+        "n_pos",
+        "n_neg",
+        "n_nan",
+        "n_total",
+    }
+    assert expected_cols.issubset(set(metrics.columns))
+
+    # NaN accounting.
+    nan_global = metrics[
+        (metrics["score_name"] == "phyloP_241m") & (metrics["subset"] == "global")
+    ]["n_nan"].iloc[0]
+    nan_a = metrics[
+        (metrics["score_name"] == "phyloP_241m") & (metrics["subset"] == "A")
+    ]["n_nan"].iloc[0]
+    nan_b = metrics[
+        (metrics["score_name"] == "phyloP_241m") & (metrics["subset"] == "B")
+    ]["n_nan"].iloc[0]
+    assert nan_global == 1
+    assert nan_a == 1
+    assert nan_b == 0
+
+    # Total counts.
+    tot_global = metrics[
+        (metrics["score_name"] == "phyloP_241m") & (metrics["subset"] == "global")
+    ]["n_total"].iloc[0]
+    assert tot_global == 6
+
+    # Markdown contains the AUPRC and NaN-count tables.
+    assert "AUPRC" in md
+    assert "NaN" in md
+    assert "phyloP_241m" in md
+
+
+def test_aggregate_traitgym_metrics_multi_score_column_order(tmp_path):
+    """Markdown columns appear in the order of parquet_paths.keys()."""
+    scores = [0.5, 0.7, 0.3, 0.2]
+    labels = [1, 1, 0, 0]
+    subsets = ["x", "x", "x", "x"]
+    paths = {
+        "phyloP_100v": _scored_parquet(
+            tmp_path, "phyloP_100v", scores, labels, subsets
+        ),
+        "phyloP_241m": _scored_parquet(
+            tmp_path, "phyloP_241m", scores, labels, subsets
+        ),
+        "phastCons_43p": _scored_parquet(
+            tmp_path, "phastCons_43p", scores, labels, subsets
+        ),
+    }
+    _, md = aggregate_traitgym_metrics(paths)
+
+    # All three names appear; phyloP_100v comes before phyloP_241m (column order).
+    pos_100v = md.find("phyloP_100v")
+    pos_241m = md.find("phyloP_241m")
+    pos_43p = md.find("phastCons_43p")
+    assert 0 < pos_100v < pos_241m < pos_43p
+
+
+def test_score_variants_preserves_input_order(tmp_path):
+    """Output is row-aligned with input — important since the pipeline
+    concats it back as a column."""
+    bw_path = tmp_path / "tiny.bw"
+    _write_tiny_bigwig(
+        bw_path,
+        [
+            ("chr1", 9, 10, 10.0),
+            ("chr1", 19, 20, 20.0),
+            ("chr1", 29, 30, 30.0),
+        ],
+    )
+
+    # Deliberately unsorted positions
+    df = pd.DataFrame({"chrom": ["chr1"] * 3, "pos": [30, 10, 20]})
+    scores = score_variants_at_positions(df, bw_path)
+
+    assert scores[0] == pytest.approx(30.0)
+    assert scores[1] == pytest.approx(10.0)
+    assert scores[2] == pytest.approx(20.0)


### PR DESCRIPTION
🤖 Closes #146.

## Summary

Per-variant conservation scores on TraitGym Mendelian v2 (`bolinas-dna/evals-traitgym_mendelian_v2`, train + test splits) as a classical baseline alongside the model-based evals. Three tracks (matching TraitGym's [`eval/workflow/rules/conservation.smk`](https://github.com/songlab-cal/TraitGym/blob/revision/eval/workflow/rules/conservation.smk)):

- `phyloP_100v` — UCSC 100-vertebrate phyloP
- `phyloP_241m` — Zoonomia 241-mammal Cactus phyloP
- `phastCons_43p` — Zoonomia 43-primate (named per TraitGym; underlying file is phyloP-over-primates)

This is a *very* different workload from PR #140's Evo 2 baseline: pure CPU, single-base pyBigWig lookups, no GPU/SkyPilot. So we follow TraitGym's reference shape (a thin Snakemake pipeline) rather than mirroring the `scripts/evo2_eval/` layout.

**Results posted to issue #146** ([comment](https://github.com/Open-Athena/bolinas-dna/issues/146#issuecomment-4354409427)). Headline numbers: global AUPRC 0.538/0.530 train/test for `phyloP_100v` (best), 0.508/0.483 for `phyloP_241m`, 0.343/0.303 for `phastCons_43p`.

## What's in this PR

- **`src/bolinas/evals/conservation.py`** — `CONSERVATION_TRACKS` URL map (single source of truth), `score_variants_at_positions(df, bw_path)` for the per-variant pyBigWig lookup, and `aggregate_traitgym_metrics` that computes AUPRC per subset and renders the markdown report. NaNs are preserved by the scorer; only the aggregator does `fillna(0)`.
- **`snakemake/conservation_eval/`** — three rules (`download_bigwig`, `score_variants`, `aggregate_metrics`), Snakefile, README, S3-backed default profile mirroring `snakemake/evals/`. Run-blocks are thin glue per CLAUDE.md ("inline Python in Snakemake rules should be thin glue calling into `src/bolinas/`").
- **`tests/evals/test_conservation.py`** — 9 unit tests covering coordinate conversion (1-based VCF → 0-based half-open bigWig), NaN preservation, `chr` prefix handling, unknown-chromosome NaN, integer-`pos` assertion, row-order preservation, and the aggregator's NaN accounting + markdown column ordering. Synthetic bigWigs via `pyBigWig.write()` in `tmp_path`; no real downloads in tests.

## NaN handling

Documented choice: `fillna(0)` at the aggregation stage. 0 is semantically meaningful for both phyloP (neither conserved nor accelerated) and phastCons (non-conserved). Per-variant parquets keep raw NaNs so a different policy can be applied without re-scoring. NaN counts are surfaced per `(score, subset)` in the markdown report so the size of the choice is visible. Same convention as TraitGym's reference rules. Real-data NaN rate ended up at ~0.06–0.13% globally per score.

## Test plan

- [x] `uv run pytest tests/evals/test_conservation.py` — 9/9 pass.
- [x] `uv run pytest tests/evals/` — 28/28 pass (no regressions).
- [x] Pre-commit (ruff format + lint + snakefmt) clean on all touched files.
- [x] Snakemake dry-run from `snakemake/conservation_eval/` shows expected DAG: 3 `download_bigwig` + 6 `score_variants` (3 scores × 2 splits) + 2 `aggregate_metrics`.
- [x] Pipeline run end-to-end on this AWS box (CPU-only, ~3 min wall — bigWig downloads dominate); markdown reports posted to issue #146.

## Out of scope

- AUROC/Spearman columns (only AUPRC for now).
- Refactoring the duplicate `phyloP_241m` downloads in other pipelines (`enhancer_classification`, `training_dataset/dataset_creation`).
- Integration into `snakemake/analysis/`.