### PR TITLE
Add 4 conservation tracks; switch AUPRC table to macro-mean (#146)

### DIFF
--- a/snakemake/conservation_eval/README.md
+++ b/snakemake/conservation_eval/README.md
@@ -18,8 +18,8 @@ For each split in `config["splits"]` (default `train` and `test`) and each track
 | `phastCons_100v` | `hgdownload.soe.ucsc.edu/.../hg38.phastCons100way.bw` | 100-vertebrate phastCons (UCSC multiz) |
 | `phyloP_241m` | `hgdownload.soe.ucsc.edu/.../cactus241way.phyloP.bw` | Zoonomia 241-mammal Cactus phyloP |
 | `phyloP_447m` | `hgdownload.soe.ucsc.edu/.../hg38.phyloP447way.bw` | UCSC 447-way phyloP (Zoonomia + densely-sampled primates, Kuderna et al. 2023) |
-| `phyloP_470m` | `hgdownload.soe.ucsc.edu/.../hg38.phyloP470way.bw` | UCSC 470-way phyloP (newest mammal Cactus) |
-| `phastCons_470m` | `hgdownload.soe.ucsc.edu/.../hg38.phastCons470way.bw` | UCSC 470-way phastCons (newest mammal Cactus) |
+| `phyloP_470m` | `hgdownload.soe.ucsc.edu/.../hg38.phyloP470way.bw` | UCSC 470-way phyloP (multiz; parallel work to 447-way Cactus, not a successor) |
+| `phastCons_470m` | `hgdownload.soe.ucsc.edu/.../hg38.phastCons470way.bw` | UCSC 470-way phastCons (multiz; parallel work to 447-way Cactus, not a successor) |
 | `phastCons_43p` | `cgl.gi.ucsc.edu/.../phyloPPrimates.bigWig` | Zoonomia 43-primate. Name follows TraitGym; underlying file is phyloP-over-primates. |
 
 URLs are owned by `bolinas.evals.conservation.CONSERVATION_TRACKS` (single source of truth).

--- a/snakemake/conservation_eval/README.md
+++ b/snakemake/conservation_eval/README.md
@@ -8,14 +8,18 @@ For each split in `config["splits"]` (default `train` and `test`) and each track
 
 1. **Download** the bigWig from UCSC / Zoonomia (`results/conservation/{score}.bw`).
 2. **Score** each variant by single-base lookup at its 1-based `pos` (converted to pyBigWig's 0-based half-open `[pos-1, pos)`). NaN is preserved where the bigWig has no aligned data.
-3. **Aggregate** the three scored parquets into one AUPRC table per split (`results/conservation_traitgym_v2/results_table_{split}.md`) plus a long-form `metrics_{split}.parquet`.
+3. **Aggregate** the scored parquets into one AUPRC table per split (`results/conservation_traitgym_v2/results_table_{split}.md`) plus a long-form `metrics_{split}.parquet`.
 
 ## Tracks
 
 | Name | Source URL | Notes |
 | --- | --- | --- |
-| `phyloP_100v` | `hgdownload.soe.ucsc.edu/.../hg38.phyloP100way.bw` | 100-vertebrate phyloP |
+| `phyloP_100v` | `hgdownload.soe.ucsc.edu/.../hg38.phyloP100way.bw` | 100-vertebrate phyloP (UCSC multiz) |
+| `phastCons_100v` | `hgdownload.soe.ucsc.edu/.../hg38.phastCons100way.bw` | 100-vertebrate phastCons (UCSC multiz) |
 | `phyloP_241m` | `hgdownload.soe.ucsc.edu/.../cactus241way.phyloP.bw` | Zoonomia 241-mammal Cactus phyloP |
+| `phyloP_447m` | `hgdownload.soe.ucsc.edu/.../hg38.phyloP447way.bw` | UCSC 447-way phyloP (Zoonomia + densely-sampled primates, Kuderna et al. 2023) |
+| `phyloP_470m` | `hgdownload.soe.ucsc.edu/.../hg38.phyloP470way.bw` | UCSC 470-way phyloP (newest mammal Cactus) |
+| `phastCons_470m` | `hgdownload.soe.ucsc.edu/.../hg38.phastCons470way.bw` | UCSC 470-way phastCons (newest mammal Cactus) |
 | `phastCons_43p` | `cgl.gi.ucsc.edu/.../phyloPPrimates.bigWig` | Zoonomia 43-primate. Name follows TraitGym; underlying file is phyloP-over-primates. |
 
 URLs are owned by `bolinas.evals.conservation.CONSERVATION_TRACKS` (single source of truth).
@@ -41,7 +45,8 @@ cd snakemake/conservation_eval
 # Dry-run to inspect the DAG
 uv run snakemake -n
 
-# Run locally (CPU-only; ~5-10 min total — bigWig downloads dominate)
+# Run locally (CPU-only — wall time is dominated by bigWig downloads;
+# the full 7-track set is ~50 GB total)
 uv run snakemake
 ```
 
@@ -52,20 +57,11 @@ The default profile (`workflow/profiles/default/config.yaml`) uses S3 storage at
 ```
 results/
 ├── conservation/
-│   ├── phyloP_100v.bw
-│   ├── phyloP_241m.bw
-│   └── phastCons_43p.bw
+│   └── {score}.bw                         # one per track in config["scores"]
 └── conservation_traitgym_v2/
-    ├── phyloP_100v_train.parquet         # per-variant score (NaN preserved)
-    ├── phyloP_100v_test.parquet
-    ├── phyloP_241m_train.parquet
-    ├── phyloP_241m_test.parquet
-    ├── phastCons_43p_train.parquet
-    ├── phastCons_43p_test.parquet
-    ├── metrics_train.parquet              # long-form metrics table
-    ├── metrics_test.parquet
-    ├── results_table_train.md             # markdown for issue follow-up
-    └── results_table_test.md
+    ├── {score}_{split}.parquet            # per-variant score (NaN preserved)
+    ├── metrics_{split}.parquet            # long-form metrics table
+    └── results_table_{split}.md           # markdown for issue follow-up
 ```
 
 ## Library

--- a/snakemake/conservation_eval/README.md
+++ b/snakemake/conservation_eval/README.md
@@ -8,7 +8,7 @@ For each split in `config["splits"]` (default `train` and `test`) and each track
 
 1. **Download** the bigWig from UCSC / Zoonomia (`results/conservation/{score}.bw`).
 2. **Score** each variant by single-base lookup at its 1-based `pos` (converted to pyBigWig's 0-based half-open `[pos-1, pos)`). NaN is preserved where the bigWig has no aligned data.
-3. **Aggregate** the scored parquets into one AUPRC table per split (`results/conservation_traitgym_v2/results_table_{split}.md`) plus a long-form `metrics_{split}.parquet`.
+3. **Aggregate** the scored parquets into one AUPRC table per split (`results/conservation_traitgym_v2/results_table_{split}.md`) plus a long-form `metrics_{split}.parquet`. The AUPRC table reports per-subset values plus an unweighted mean across subsets (macro-AUPRC) at the top — global AUPRC isn't shown because it's dominated by the largest subset (missense).
 
 ## Tracks
 

--- a/snakemake/conservation_eval/config/config.yaml
+++ b/snakemake/conservation_eval/config/config.yaml
@@ -11,5 +11,9 @@ splits:
 # selects which tracks the pipeline runs.
 scores:
   - phyloP_100v
+  - phastCons_100v
   - phyloP_241m
+  - phyloP_447m
+  - phyloP_470m
+  - phastCons_470m
   - phastCons_43p

--- a/src/bolinas/evals/conservation.py
+++ b/src/bolinas/evals/conservation.py
@@ -7,8 +7,8 @@ Mendelian v2 variants with classical conservation tracks:
 - ``phastCons_100v`` — UCSC 100-vertebrate phastCons (multiz alignment)
 - ``phyloP_241m``    — Zoonomia 241-mammal Cactus phyloP
 - ``phyloP_447m``    — UCSC 447-way phyloP (Zoonomia + densely-sampled primates, Cactus)
-- ``phyloP_470m``    — UCSC 470-way phyloP (newest mammal Cactus)
-- ``phastCons_470m`` — UCSC 470-way phastCons (newest mammal Cactus)
+- ``phyloP_470m``    — UCSC 470-way phyloP (multiz; parallel work to the 447-way Cactus, not a successor)
+- ``phastCons_470m`` — UCSC 470-way phastCons (multiz; parallel work to the 447-way Cactus, not a successor)
 - ``phastCons_43p``  — Zoonomia 43-primate track (TraitGym name; underlying file is phyloP-over-primates)
 
 The first three tracks (``phyloP_100v``, ``phyloP_241m``, ``phastCons_43p``)
@@ -40,7 +40,9 @@ CONSERVATION_TRACKS: dict[str, str] = {
     "phyloP_241m": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/cactus241way/cactus241way.phyloP.bw",
     # UCSC 447-way Cactus (Zoonomia + densely-sampled primates, Kuderna et al. 2023).
     "phyloP_447m": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/phyloP447way/hg38.phyloP447way.bw",
-    # UCSC 470-way Cactus (newest mammal alignment).
+    # UCSC 470-way: multiz alignment (per UCSC track description), parallel
+    # work to the 447-way Cactus rather than a successor. Distinct aligner,
+    # different coverage characteristics — not "newer/better mammal alignment".
     "phyloP_470m": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/phyloP470way/hg38.phyloP470way.bw",
     "phastCons_470m": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/phastCons470way/hg38.phastCons470way.bw",
     # phastCons_43p name is a TraitGym convention; the underlying file is

--- a/src/bolinas/evals/conservation.py
+++ b/src/bolinas/evals/conservation.py
@@ -1,16 +1,22 @@
 """Per-variant conservation scoring via UCSC bigWig tracks.
 
 Used by ``snakemake/conservation_eval/`` (issue #146) to score TraitGym
-Mendelian v2 variants with three classical conservation tracks:
+Mendelian v2 variants with classical conservation tracks:
 
-- ``phyloP_100v``  — UCSC 100-vertebrate phyloP
-- ``phyloP_241m``  — Zoonomia 241-mammal Cactus phyloP
-- ``phastCons_43p`` — Zoonomia 43-primate track
+- ``phyloP_100v``    — UCSC 100-vertebrate phyloP (multiz alignment)
+- ``phastCons_100v`` — UCSC 100-vertebrate phastCons (multiz alignment)
+- ``phyloP_241m``    — Zoonomia 241-mammal Cactus phyloP
+- ``phyloP_447m``    — UCSC 447-way phyloP (Zoonomia + densely-sampled primates, Cactus)
+- ``phyloP_470m``    — UCSC 470-way phyloP (newest mammal Cactus)
+- ``phastCons_470m`` — UCSC 470-way phastCons (newest mammal Cactus)
+- ``phastCons_43p``  — Zoonomia 43-primate track (TraitGym name; underlying file is phyloP-over-primates)
 
-URLs are copied verbatim from TraitGym's ``eval/workflow/rules/conservation.smk``;
-the same bigWigs are also used elsewhere in this repo (enhancer_classification,
-training_dataset/dataset_creation) but each pipeline manages its own download to
-avoid coupling.
+The first three tracks (``phyloP_100v``, ``phyloP_241m``, ``phastCons_43p``)
+are the original TraitGym set; their URLs are copied verbatim from
+TraitGym's ``eval/workflow/rules/conservation.smk``. The same bigWigs are
+also used elsewhere in this repo (enhancer_classification,
+training_dataset/dataset_creation) but each pipeline manages its own
+download to avoid coupling.
 
 NaN policy: this module preserves NaNs from the bigWig (no alignment at that
 locus). Callers decide how to fill them — the ``conservation_eval`` pipeline
@@ -27,8 +33,16 @@ from bolinas.evals.metrics import compute_metrics
 
 
 CONSERVATION_TRACKS: dict[str, str] = {
+    # 100-vertebrate UCSC multiz alignment.
     "phyloP_100v": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/phyloP100way/hg38.phyloP100way.bw",
+    "phastCons_100v": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/phastCons100way/hg38.phastCons100way.bw",
+    # Zoonomia 241-mammal Cactus alignment.
     "phyloP_241m": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/cactus241way/cactus241way.phyloP.bw",
+    # UCSC 447-way Cactus (Zoonomia + densely-sampled primates, Kuderna et al. 2023).
+    "phyloP_447m": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/phyloP447way/hg38.phyloP447way.bw",
+    # UCSC 470-way Cactus (newest mammal alignment).
+    "phyloP_470m": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/phyloP470way/hg38.phyloP470way.bw",
+    "phastCons_470m": "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/phastCons470way/hg38.phastCons470way.bw",
     # phastCons_43p name is a TraitGym convention; the underlying file is
     # actually phyloP over 43 primates from the Zoonomia track hub. We keep
     # the name to stay consistent with TraitGym + existing config in this repo.

--- a/src/bolinas/evals/conservation.py
+++ b/src/bolinas/evals/conservation.py
@@ -174,7 +174,15 @@ def aggregate_traitgym_metrics(
 
 
 def _build_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
-    """Render the metrics DataFrame as a two-table markdown report."""
+    """Render the metrics DataFrame as a two-table markdown report.
+
+    AUPRC table: per-subset rows plus an unweighted ``mean`` row across
+    subsets at the top (macro-AUPRC). The ``global`` row is intentionally
+    excluded — it would be dominated by the largest subset (missense).
+
+    NaN-counts table: keeps the ``global`` row (it's a real total count,
+    not an aggregate of AUPRCs).
+    """
     auprc = metrics[metrics["metric"] == "AUPRC"].copy()
 
     def _pivot(values_col: str) -> pd.DataFrame:
@@ -185,10 +193,12 @@ def _build_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
             aggfunc="first",
         )
 
-    # Per-subset n_pos/n_neg from the first score (subset coverage is
-    # score-independent).
+    # Per-subset n_pos/n_neg/n_total from the first score (subset coverage
+    # is score-independent).
     coverage = (
-        auprc[auprc["score_name"] == score_names[0]][["subset", "n_pos", "n_neg"]]
+        auprc[auprc["score_name"] == score_names[0]][
+            ["subset", "n_pos", "n_neg", "n_total"]
+        ]
         .drop_duplicates(subset="subset")
         .set_index("subset")
     )
@@ -196,35 +206,47 @@ def _build_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
     pivot = _pivot("value")
     nan_pivot = _pivot("n_nan")
 
-    # Order: global first, then subsets sorted by n_pos descending.
-    rest = [
+    # Per-subset rows ordered by n_pos descending; "global" is excluded
+    # from the AUPRC table but kept for the NaN-counts table.
+    per_subset = [
         s for s in coverage.sort_values("n_pos", ascending=False).index if s != "global"
     ]
-    order = (["global"] if "global" in pivot.index else []) + rest
-    pivot = pivot.reindex(order)
-    nan_pivot = nan_pivot.reindex(order)
+    pivot_subsets = pivot.reindex(per_subset)
 
-    total_by_subset = (
-        auprc[auprc["score_name"] == score_names[0]][["subset", "n_total"]]
-        .drop_duplicates(subset="subset")
-        .set_index("subset")["n_total"]
-        .reindex(order)
-    )
+    # Unweighted mean of per-subset AUPRCs (one value per score). NaN-skip
+    # so a missing subset value for one score doesn't take down the mean.
+    mean_row = pivot_subsets.mean(axis=0, skipna=True)
 
     lines: list[str] = []
     lines.append("### TraitGym Mendelian v2 — AUPRC")
     lines.append("")
+    lines.append(
+        "Per-subset AUPRC. The top `mean` row is the unweighted mean across "
+        "subsets (macro-AUPRC); each subset contributes equally regardless "
+        "of its size."
+    )
+    lines.append("")
     header = ["subset", "n_pos", "n_neg", *score_names]
     lines.append("| " + " | ".join(header) + " |")
     lines.append("| " + " | ".join(["---"] * len(header)) + " |")
-    for subset in pivot.index:
-        n_pos = int(coverage.loc[subset, "n_pos"]) if subset in coverage.index else 0
-        n_neg = int(coverage.loc[subset, "n_neg"]) if subset in coverage.index else 0
+
+    mean_vals = [
+        f"{mean_row[s]:.3f}" if pd.notna(mean_row[s]) else "—" for s in score_names
+    ]
+    lines.append("| " + " | ".join(["mean", "—", "—", *mean_vals]) + " |")
+
+    for subset in per_subset:
+        n_pos = int(coverage.loc[subset, "n_pos"])
+        n_neg = int(coverage.loc[subset, "n_neg"])
         vals = [
             f"{pivot.loc[subset, s]:.3f}" if pd.notna(pivot.loc[subset, s]) else "—"
             for s in score_names
         ]
         lines.append("| " + " | ".join([subset, str(n_pos), str(n_neg), *vals]) + " |")
+
+    # NaN counts: keep the global row at the top, then per-subset rows.
+    nan_order = (["global"] if "global" in nan_pivot.index else []) + per_subset
+    nan_pivot_ordered = nan_pivot.reindex(nan_order)
 
     lines.append("")
     lines.append("### NaN counts")
@@ -238,11 +260,11 @@ def _build_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
     nan_header = ["subset", "n_total", *score_names]
     lines.append("| " + " | ".join(nan_header) + " |")
     lines.append("| " + " | ".join(["---"] * len(nan_header)) + " |")
-    for subset in nan_pivot.index:
+    for subset in nan_pivot_ordered.index:
         n_total = (
-            int(total_by_subset.loc[subset]) if subset in total_by_subset.index else 0
+            int(coverage.loc[subset, "n_total"]) if subset in coverage.index else 0
         )
-        vals = [str(int(nan_pivot.loc[subset, s])) for s in score_names]
+        vals = [str(int(nan_pivot_ordered.loc[subset, s])) for s in score_names]
         lines.append("| " + " | ".join([subset, str(n_total), *vals]) + " |")
 
     return "\n".join(lines) + "\n"

--- a/tests/evals/test_conservation.py
+++ b/tests/evals/test_conservation.py
@@ -206,6 +206,60 @@ def test_aggregate_traitgym_metrics_multi_score_column_order(tmp_path):
     assert 0 < pos_100v < pos_241m < pos_43p
 
 
+def test_aggregate_traitgym_metrics_mean_row_replaces_global(tmp_path):
+    """AUPRC table has a 'mean' row (unweighted across subsets) at the top
+    and *no* 'global' row. The NaN-counts table still includes global."""
+    # 8 variants, two subsets of size 4. The two subsets' AUPRCs differ,
+    # so unweighted mean ≠ global AUPRC and we can tell them apart.
+    # subset A: perfectly separable -> AUPRC = 1.0
+    # subset B: anti-correlated     -> AUPRC ≈ 0.4
+    scores = [0.9, 0.8, 0.2, 0.1, 0.1, 0.2, 0.8, 0.9]
+    labels = [1, 1, 0, 0, 1, 1, 0, 0]
+    subsets = ["A", "A", "A", "A", "B", "B", "B", "B"]
+    p = _scored_parquet(tmp_path, "score1", scores, labels, subsets)
+
+    metrics, md = aggregate_traitgym_metrics({"score1": p})
+
+    # Split markdown into the two tables.
+    auprc_section, nan_section = md.split("### NaN counts")
+    assert "AUPRC" in auprc_section
+
+    # AUPRC table: must have a 'mean' row, must NOT have a 'global' row.
+    auprc_rows = [
+        ln
+        for ln in auprc_section.splitlines()
+        if ln.startswith("| ") and "---" not in ln
+    ]
+    # First row is the header; data rows follow.
+    data_rows = auprc_rows[1:]
+    row_labels = [r.split("|")[1].strip() for r in data_rows]
+    assert "mean" in row_labels
+    assert "global" not in row_labels
+    assert row_labels[0] == "mean", "mean row must be at the top of the AUPRC table"
+
+    # NaN-counts table: still has global.
+    nan_rows = [
+        ln for ln in nan_section.splitlines() if ln.startswith("| ") and "---" not in ln
+    ]
+    nan_data = nan_rows[1:]
+    nan_labels = [r.split("|")[1].strip() for r in nan_data]
+    assert "global" in nan_labels
+
+    # Mean value matches the unweighted mean of per-subset AUPRCs in metrics_df.
+    per_subset_auprc = metrics[
+        (metrics["metric"] == "AUPRC")
+        & (metrics["score_name"] == "score1")
+        & (metrics["subset"].isin(["A", "B"]))
+    ]["value"]
+    expected_mean = float(per_subset_auprc.mean())
+
+    mean_row_str = next(r for r in data_rows if r.split("|")[1].strip() == "mean")
+    # Cells: ['', 'mean', 'n_pos', 'n_neg', 'score1', '']
+    cells = [c.strip() for c in mean_row_str.split("|")]
+    rendered_mean = float(cells[4])
+    assert rendered_mean == pytest.approx(expected_mean, abs=1e-3)
+
+
 def test_score_variants_preserves_input_order(tmp_path):
     """Output is row-aligned with input — important since the pipeline
     concats it back as a column."""

--- a/tests/evals/test_conservation.py
+++ b/tests/evals/test_conservation.py
@@ -13,10 +13,14 @@ from bolinas.evals.conservation import (
 
 
 def test_conservation_tracks_keys():
-    """The three expected tracks are present and URLs look like bigWigs."""
+    """The expected tracks are present and URLs look like bigWigs."""
     assert set(CONSERVATION_TRACKS.keys()) == {
         "phyloP_100v",
+        "phastCons_100v",
         "phyloP_241m",
+        "phyloP_447m",
+        "phyloP_470m",
+        "phastCons_470m",
         "phastCons_43p",
     }
     for name, url in CONSERVATION_TRACKS.items():


### PR DESCRIPTION
🤖 Follow-up to #146 / #148 — adds four more conservation tracks and changes the AUPRC table to a macro-mean view.

## Summary

- **4 new tracks** — `phastCons_100v`, `phyloP_447m`, `phyloP_470m`, `phastCons_470m`. URLs added to `bolinas.evals.conservation.CONSERVATION_TRACKS` (single source of truth) and listed in `snakemake/conservation_eval/config/config.yaml`. Brings the matrix to phyloP × phastCons across 100v / 241m / 447m / 470m alignments + the original 43p primate track.
- **AUPRC table format change** — per-subset rows plus an unweighted mean across subsets (macro-AUPRC) at the top. Global row dropped from the AUPRC table because it's dominated by the largest subset (`missense_variant`, ~60% of variants). NaN-counts table keeps the global row (it's a real total count).

## Headline numbers (macro-AUPRC across 8 subsets)

| | train | test |
| --- | --- | --- |
| `phyloP_447m`    | **0.512** | **0.467** |
| `phyloP_241m`    | 0.504 | 0.460 |
| `phyloP_470m`    | 0.490 | 0.447 |
| `phyloP_100v`    | 0.479 | 0.441 |
| `phastCons_100v` | 0.367 | 0.355 |
| `phastCons_43p`  | 0.364 | 0.327 |
| `phastCons_470m` | 0.331 | 0.322 |

- `phyloP_447m` (Zoonomia + dense-primates Cactus) is the best single track on both splits, narrowly ahead of `phyloP_241m`.
- The **470-way is multiz-based, not Cactus** — parallel work to the 447-way Cactus rather than a successor (per UCSC's track description: "generated using multiz"). The lower AUPRC and ~10× higher NaN rate (~0.7% global vs <0.1% for the other tracks) are consistent with multiz vs. Cactus differences in coverage and gap handling, not an alignment-quality regression. We're still including 470-way for completeness; the comparison is informative.
- All phyloP tracks beat all phastCons tracks across the board.

Full per-subset tables for both splits posted to issue #146.

## What changed

- `src/bolinas/evals/conservation.py` — 4 new entries in `CONSERVATION_TRACKS`; `_build_markdown` rewritten to compute macro-mean and drop `global` from the AUPRC table.
- `snakemake/conservation_eval/config/config.yaml` — 4 new track names in `scores`.
- `snakemake/conservation_eval/README.md` — track table extended; AUPRC-format note added.
- `tests/evals/test_conservation.py` — `test_conservation_tracks_keys` updated to the 7-track set; new `test_aggregate_traitgym_metrics_mean_row_replaces_global` covers the macro-mean computation and the AUPRC-vs-NaN layout difference.

## Test plan

- [x] `uv run pytest tests/evals/test_conservation.py` — 10/10 pass.
- [x] Pre-commit (ruff + ruff-format + snakefmt) clean on all touched files.
- [x] Snakemake dry-run: expected DAG = 4 new `download_bigwig` + 8 new `score_variants` (4 × 2 splits) + 2 forced `aggregate_metrics`. Existing 3 tracks are not re-scored.
- [x] Pipeline run end-to-end on this AWS box (~9 min wall — bigWig downloads dominate, ~32 GB additional download). Outputs in `s3://oa-bolinas/snakemake/conservation_eval/`.

## Out of scope

- `phyloP_239p` / `447wayLRT` — discussed and skipped for this PR.