### PR TITLE
Add zoonomia_projection_dataset pipeline + bolinas.conservation library

### DIFF
--- a/snakemake/zoonomia_projection_dataset/README.md
+++ b/snakemake/zoonomia_projection_dataset/README.md
@@ -69,7 +69,7 @@ For each 255 bp window, `bolinas.conservation.scoring.score_windows`:
 - computes `np.nanmean(values)` → `mean_phylop`,
 - emits `proportion_conserved = conserved_bases / window_size` (NaN counted as 0 in the denominator-of-window-size sense).
 
-Single-threaded, ~40 min for the human autosomes + X + Y (~24M windows). If this becomes a bottleneck, split by chrom (24× speedup with chrom-wildcarded fan-out).
+Parallelised by chromosome via Snakemake's ``{chrom}`` wildcard fan-out (24 workers on autosomes + X + Y), then a small ``merge_scored`` rule concatenates the per-chrom Parquets. ~5 min wall on an 8-vCPU box.
 
 ## Run
 

--- a/snakemake/zoonomia_projection_dataset/README.md
+++ b/snakemake/zoonomia_projection_dataset/README.md
@@ -1,0 +1,118 @@
+# `zoonomia_projection_dataset`
+
+Conservation-filtered human-genome BED windows for cross-mammal projection.
+
+## What it produces
+
+For each `min_proportion_conserved` cutoff in `config/config.yaml`:
+
+- `results/scored/homo_sapiens/phyloP_447m_windows.parquet` — every 255 bp human window (step 128, autosomes + X + Y, ACGT only) scored against `phyloP_447m`. Schema:
+  - `chrom, start, end, name` — 0-based half-open BED
+  - `conserved_bases` — count of bases ≥ calibrated threshold
+  - `proportion_conserved` — `conserved_bases / 255`, NaN counted as 0
+  - `mean_phylop` — mean phyloP over covered bases (raw track)
+  - `n_valid_bases` — bases with bigWig signal (excludes NaN)
+- `results/bed/homo_sapiens/min{min_p}.bed.gz` — filtered BED, one per cutoff.
+
+The downstream cross-mammal projection pipeline (out of scope here) consumes the filtered BEDs.
+
+## Why
+
+The next experiment (issue #149) trains a mammalian gLM on human-anchored intervals projected onto ~100 mammals via the Zoonomia 447-mammalian Cactus alignment. That projection needs a curated human-window set. This pipeline produces it.
+
+## Window size = 255 bp (not 256)
+
+The model adds a BOS token. A 255 bp BED becomes a 256-token context after tokenization. Same convention as `enhancer_classification`.
+
+## phyloP_447m threshold (calibration)
+
+`phyloP_447m` doesn't have an established threshold like `phyloP_241m` (which we use at 2.27 throughout the repo). We pick the `phyloP_447m` threshold so the genome-wide count of bases passing it equals the count of bases passing `phyloP_241m >= 2.27` — same passing-nucleotide count, different track.
+
+This calibration is a **one-off analysis**, not a pipeline rule. To run it:
+
+```bash
+uv run python scripts/calibrate_447m_threshold.py \
+    --output results/calibration/calibration.json
+# Prints the calibrated threshold; paste it into config.yaml under
+# phyloP_447m_threshold and commit.
+```
+
+The script downloads both bigWigs and builds per-base histograms over defined (ACGT) regions of autosomes + X + Y, then linearly interpolates the threshold within the bracketing histogram bin. Asserts `abs_relative_error < 0.01`.
+
+## Pipeline (Snakemake)
+
+```
+download_genome → genome_to_2bit → chrom_sizes_filtered → undefined_regions
+                                                              ↓
+                                          make_windows (tile + N-filter)
+                                                              ↓
+download_bigwig (phyloP_447m)  →  binarize_447m  ─┐
+                                  download_bigwig │
+                                  (phyloP_447m)   ├→ score_windows → filter_bed
+                                                  ┘
+```
+
+Two `bigWigAverageOverBed` passes per scoring run:
+
+- binary track → `sum` (= `conserved_bases`), `mean0` (= `proportion_conserved`)
+- raw track → `mean` (= `mean_phylop`), `covered` (= `n_valid_bases`)
+
+NaN handling falls out from using `sum` and `mean0` (see [NaN semantics](#nan-semantics) below).
+
+## Run
+
+```bash
+# From repo root:
+git checkout -b feat/zoonomia-projection-dataset origin/main
+cd snakemake/zoonomia_projection_dataset
+
+# (Optional but recommended: run the calibration first; paste threshold into config.)
+uv run python scripts/calibrate_447m_threshold.py
+
+# Dry-run (CLAUDE.md mandate before any real run)
+uv run snakemake --profile workflow/profiles/default -n
+
+# Full pipeline
+uv run snakemake --profile workflow/profiles/default
+
+# Tests for the library code
+uv run pytest tests/conservation/
+```
+
+## SkyPilot
+
+CPU-only pipeline. Recommended box: `c6id.2xlarge` in `us-east-2` (8 vCPU, 16 GB RAM, 474 GB local NVMe, ~$0.40/hr). NVMe matters — the bigWigs are ~30 GB each and gp3 EBS is ~10× slower.
+
+Tag instances with `project=dna` (cluster lifecycle: launch once, reuse via `sky exec`, `sky down` only at session end).
+
+## NaN semantics
+
+`phyloP_447m` has NaN at positions with no alignment. We want NaN counted as **non-conserved** (0).
+
+Using `bigWigAverageOverBed`'s `sum` and `mean0` columns (not `mean`):
+
+- `sum` = number of conserved bases. NaN positions contribute 0 either because they're absent from the binary bigWig or because they were filled to 0 — same answer.
+- `mean0 = sum / size` = proportion conserved over the **full** 255 bp denominator. NaN remains in the denominator and contributes 0 to the numerator → counted as non-conserved.
+- `mean = sum / covered` is the column we *don't* want — that one excludes NaN.
+
+Sanity-checked in `tests/conservation/test_scoring.py`.
+
+## Layout
+
+```
+config/config.yaml                  # genome URL, window/step, threshold (placeholder), filters
+workflow/Snakefile                  # rule orchestration
+workflow/profiles/default/          # cores, S3 storage, conda
+workflow/envs/bioinformatics.yaml   # bedtools, kentUtils, wiggletools
+workflow/rules/
+  common.smk                        # imports + sanity checks
+  genome.smk                        # download_genome → 2bit → chrom_sizes → N-regions
+  download.smk                      # phyloP bigWig
+  windows.smk                       # tile + N-filter (one rule)
+  score.smk                         # binarize + score
+  filter.smk                        # filtered BED per cutoff
+scripts/
+  calibrate_447m_threshold.py       # one-off; uses src/bolinas/conservation/
+```
+
+Library code lives in `src/bolinas/conservation/` (testable; reused by both the calibration script and the score rule).

--- a/snakemake/zoonomia_projection_dataset/README.md
+++ b/snakemake/zoonomia_projection_dataset/README.md
@@ -28,14 +28,22 @@ The model adds a BOS token. A 255 bp BED becomes a 256-token context after token
 
 `phyloP_447m` doesn't have an established threshold like `phyloP_241m` (which we use at 2.27 throughout the repo). We pick the `phyloP_447m` threshold so the genome-wide count of bases passing it equals the count of bases passing `phyloP_241m >= 2.27` — same passing-nucleotide count, different track.
 
-This calibration is a **one-off analysis**, not a pipeline rule. To run it:
+This calibration is a **one-off analysis**, not a pipeline rule. To run it on SkyPilot:
+
+```bash
+sky launch -c zoonomia-calibration -y sky/calibrate.yaml
+sky logs zoonomia-calibration   # last lines print the threshold
+sky down  zoonomia-calibration
+```
+
+Or locally, if you have kentUtils on PATH and the bigWigs reachable:
 
 ```bash
 uv run python scripts/calibrate_447m_threshold.py \
     --output results/calibration/calibration.json
-# Prints the calibrated threshold; paste it into config.yaml under
-# phyloP_447m_threshold and commit.
 ```
+
+Either way: paste the printed threshold into `config.yaml` under `phyloP_447m_threshold` and commit.
 
 The script downloads both bigWigs and builds per-base histograms over defined (ACGT) regions of autosomes + X + Y, then linearly interpolates the threshold within the bracketing histogram bin. Asserts `abs_relative_error < 0.01`.
 

--- a/snakemake/zoonomia_projection_dataset/README.md
+++ b/snakemake/zoonomia_projection_dataset/README.md
@@ -54,18 +54,22 @@ download_genome → genome_to_2bit → chrom_sizes_filtered → undefined_region
                                                               ↓
                                           make_windows (tile + N-filter)
                                                               ↓
-download_bigwig (phyloP_447m)  →  binarize_447m  ─┐
-                                  download_bigwig │
-                                  (phyloP_447m)   ├→ score_windows → filter_bed
-                                                  ┘
+                          download_bigwig (phyloP_447m)
+                                                              ↓
+                                                 score_windows → filter_bed
 ```
 
-Two `bigWigAverageOverBed` passes per scoring run:
+Scoring uses **pyBigWig directly** in a Snakemake `run:` block — no kentUtils binary chain. We tried `bigWigToBedGraph | awk threshold | bedGraphToBigWig` and `bigWigAverageOverBed`, but the bioconda kentUtils binaries refuse to read from stdin pipes (they need a regular file because they seek). Materialising the per-base bedGraph would cost ~30 GB temp disk for marginal speed.
 
-- binary track → `sum` (= `conserved_bases`), `mean0` (= `proportion_conserved`)
-- raw track → `mean` (= `mean_phylop`), `covered` (= `n_valid_bases`)
+For each 255 bp window, `bolinas.conservation.scoring.score_windows`:
 
-NaN handling falls out from using `sum` and `mean0` (see [NaN semantics](#nan-semantics) below).
+- fetches per-base values via `pyBigWig.values(...)` (returns NaN at gaps),
+- counts finite values → `n_valid_bases`,
+- counts `values >= threshold` → `conserved_bases` (NaN compares as False, so NaN positions are naturally non-conserved without explicit zero-filling),
+- computes `np.nanmean(values)` → `mean_phylop`,
+- emits `proportion_conserved = conserved_bases / window_size` (NaN counted as 0 in the denominator-of-window-size sense).
+
+Single-threaded, ~40 min for the human autosomes + X + Y (~24M windows). If this becomes a bottleneck, split by chrom (24× speedup with chrom-wildcarded fan-out).
 
 ## Run
 
@@ -96,6 +100,17 @@ Tag instances with `project=dna` (cluster lifecycle: launch once, reuse via `sky
 ## NaN semantics
 
 `phyloP_447m` has NaN at positions with no alignment. We want NaN counted as **non-conserved** (0).
+
+Implemented in `bolinas.conservation.scoring.score_windows`:
+
+```python
+values = bw.values(chrom, start, end, numpy=True)        # NaN at gaps
+n_valid = int(np.isfinite(values).sum())                 # excludes NaN
+conserved = int((values >= threshold).sum())             # NaN >= t is False
+proportion = conserved / (end - start)                   # full window denom
+```
+
+Sanity-checked in `tests/conservation/test_scoring.py::test_score_windows_nan_counted_as_zero`.
 
 Using `bigWigAverageOverBed`'s `sum` and `mean0` columns (not `mean`):
 

--- a/snakemake/zoonomia_projection_dataset/README.md
+++ b/snakemake/zoonomia_projection_dataset/README.md
@@ -112,21 +112,13 @@ proportion = conserved / (end - start)                   # full window denom
 
 Sanity-checked in `tests/conservation/test_scoring.py::test_score_windows_nan_counted_as_zero`.
 
-Using `bigWigAverageOverBed`'s `sum` and `mean0` columns (not `mean`):
-
-- `sum` = number of conserved bases. NaN positions contribute 0 either because they're absent from the binary bigWig or because they were filled to 0 — same answer.
-- `mean0 = sum / size` = proportion conserved over the **full** 255 bp denominator. NaN remains in the denominator and contributes 0 to the numerator → counted as non-conserved.
-- `mean = sum / covered` is the column we *don't* want — that one excludes NaN.
-
-Sanity-checked in `tests/conservation/test_scoring.py`.
-
 ## Layout
 
 ```
 config/config.yaml                  # genome URL, window/step, threshold (placeholder), filters
 workflow/Snakefile                  # rule orchestration
 workflow/profiles/default/          # cores, S3 storage, conda
-workflow/envs/bioinformatics.yaml   # bedtools, kentUtils, wiggletools
+workflow/envs/bioinformatics.yaml   # bedtools, kentUtils (faToTwoBit, twoBitInfo)
 workflow/rules/
   common.smk                        # imports + sanity checks
   genome.smk                        # download_genome → 2bit → chrom_sizes → N-regions

--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -1,17 +1,11 @@
-species: homo_sapiens
-
-genome_urls:
-  homo_sapiens: "https://ftp.ensembl.org/pub/release-115/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+genome_url: "https://ftp.ensembl.org/pub/release-115/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
 
 # Bare Ensembl chrom names (1, 2, ..., X, Y). Bigwig queries internally
 # prepend "chr" because UCSC tracks use "chr1"-style names.
 standard_chroms:
-  homo_sapiens:
-    [
-      "1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
-      "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
-      "21", "22", "X", "Y",
-    ]
+  ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+   "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+   "21", "22", "X", "Y"]
 
 window_size: 255
 step_size: 128
@@ -24,8 +18,7 @@ step_size: 128
 # error and ~10x faster wall than all 24 chroms.
 phyloP_447m_threshold: 2.2162
 
-# Filter on proportion of valid bases passing threshold
-# (= bigWigAverageOverBed `mean0` of the binarized bigWig, NaN counted as 0).
+# Filter cutoffs on `proportion_conserved` per window (one BED output per cutoff).
 filters:
   - { min_proportion_conserved: 0.10 }
   - { min_proportion_conserved: 0.20 }

--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -16,13 +16,12 @@ standard_chroms:
 window_size: 255
 step_size: 128
 
-# phyloP_447m threshold calibrated to match phyloP_241m's genome-wide passing
-# nucleotide count at threshold 2.27.
-# Computed by snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py
-# (one-off; result also written to results/calibration/calibration.json on the
-# branch that committed this value).
-# TODO: replace placeholder with calibrated value after running the script.
-phyloP_447m_threshold: 2.27
+# phyloP_447m threshold calibrated to match phyloP_241m's chr1 passing
+# nucleotide count at threshold 2.27 (exact match: 9,179,695 bases on chr1
+# pass either threshold). Computed by sky/calibrate.yaml -> scripts/calibrate_447m_threshold.py
+# on hg38 chr1 only — single-chrom calibration gives well below 1% relative
+# error and ~10x faster wall than all 24 chroms.
+phyloP_447m_threshold: 2.2240
 
 # Filter on proportion of valid bases passing threshold
 # (= bigWigAverageOverBed `mean0` of the binarized bigWig, NaN counted as 0).

--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -1,0 +1,31 @@
+species: homo_sapiens
+
+genome_urls:
+  homo_sapiens: "https://ftp.ensembl.org/pub/release-115/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+
+# Bare Ensembl chrom names (1, 2, ..., X, Y). Bigwig queries internally
+# prepend "chr" because UCSC tracks use "chr1"-style names.
+standard_chroms:
+  homo_sapiens:
+    [
+      "1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+      "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+      "21", "22", "X", "Y",
+    ]
+
+window_size: 255
+step_size: 128
+
+# phyloP_447m threshold calibrated to match phyloP_241m's genome-wide passing
+# nucleotide count at threshold 2.27.
+# Computed by snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py
+# (one-off; result also written to results/calibration/calibration.json on the
+# branch that committed this value).
+# TODO: replace placeholder with calibrated value after running the script.
+phyloP_447m_threshold: 2.27
+
+# Filter on proportion of valid bases passing threshold
+# (= bigWigAverageOverBed `mean0` of the binarized bigWig, NaN counted as 0).
+filters:
+  - { min_proportion_conserved: 0.10 }
+  - { min_proportion_conserved: 0.20 }

--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -16,12 +16,13 @@ standard_chroms:
 window_size: 255
 step_size: 128
 
-# phyloP_447m threshold calibrated to match phyloP_241m's chr1 passing
-# nucleotide count at threshold 2.27 (exact match: 9,179,695 bases on chr1
-# pass either threshold). Computed by sky/calibrate.yaml -> scripts/calibrate_447m_threshold.py
+# phyloP_447m threshold calibrated to match phyloP_241m's *proportion* of
+# non-NaN bases passing at threshold 2.27 (chr1: both tracks pass 4.0656%
+# of their non-NaN bases — controls for different coverage on the two
+# tracks). Computed by sky/calibrate.yaml -> scripts/calibrate_447m_threshold.py
 # on hg38 chr1 only — single-chrom calibration gives well below 1% relative
 # error and ~10x faster wall than all 24 chroms.
-phyloP_447m_threshold: 2.2240
+phyloP_447m_threshold: 2.2162
 
 # Filter on proportion of valid bases passing threshold
 # (= bigWigAverageOverBed `mean0` of the binarized bigWig, NaN counted as 0).

--- a/snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py
+++ b/snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py
@@ -1,0 +1,237 @@
+"""One-off: calibrate ``phyloP_447m`` threshold to match ``phyloP_241m`` count.
+
+Run once on a SkyPilot box (or anywhere with both bigWigs reachable). Builds
+per-base histograms over defined ACGT regions of both ``phyloP_241m`` and
+``phyloP_447m``, then finds the ``phyloP_447m`` threshold whose genome-wide
+passing count matches ``phyloP_241m >= 2.27``. Prints the threshold and
+writes a JSON file with the full calibration record (counts, totals,
+relative error, hist meta).
+
+After running, paste the printed threshold into ``config/config.yaml``
+under ``phyloP_447m_threshold`` and commit.
+
+Usage::
+
+    uv run python snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py \\
+        --output results/calibration/calibration.json \\
+        --bigwig-dir /path/to/local/bigwigs \\
+        --genome-2bit /path/to/hg38.2bit
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from bolinas.conservation.calibration import calibrate_to_match_count
+from bolinas.conservation.histogram import (
+    PhylopHistogram,
+    build_histogram_for_chrom,
+)
+from bolinas.evals.conservation import CONSERVATION_TRACKS
+
+
+REFERENCE_TRACK = "phyloP_241m"
+TARGET_TRACK = "phyloP_447m"
+REFERENCE_THRESHOLD = 2.27
+
+STANDARD_CHROMS_HUMAN = [str(i) for i in range(1, 23)] + ["X", "Y"]
+
+
+def _wget(url: str, dest: Path) -> None:
+    if dest.exists():
+        print(f"  exists, skipping: {dest}")
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    print(f"  fetching {url} -> {dest}")
+    subprocess.run(["wget", "-q", "-O", str(dest), url], check=True)
+
+
+def _read_undefined_bed(path: Path) -> pd.DataFrame:
+    """Read a 3-column BED of undefined (N) regions, no header."""
+    df = pd.read_csv(
+        path,
+        sep="\t",
+        header=None,
+        names=["chrom", "start", "end"],
+        dtype={"chrom": str},
+    )
+    return df
+
+
+def _build_defined_intervals_per_chrom(
+    chrom_sizes: pd.DataFrame, undefined: pd.DataFrame, chroms: list[str]
+) -> dict[str, pd.DataFrame]:
+    """Per-chrom 0-based half-open intervals covering the defined (ACGT) bases.
+
+    Computed as ``[0, chrom_size)`` minus the union of N-region intervals on
+    the same chrom. Pure pandas — no bedtools dependency in this script.
+    """
+    out: dict[str, pd.DataFrame] = {}
+    for chrom in chroms:
+        size = int(chrom_sizes.loc[chrom_sizes["chrom"] == chrom, "size"].iloc[0])
+        undef = (
+            undefined[undefined["chrom"] == chrom]
+            .sort_values("start")
+            .reset_index(drop=True)
+        )
+        # Walk through N regions, emitting the gaps as defined intervals.
+        rows: list[dict] = []
+        cursor = 0
+        for _, u in undef.iterrows():
+            us, ue = int(u["start"]), int(u["end"])
+            if us > cursor:
+                rows.append({"chrom": chrom, "start": cursor, "end": us})
+            cursor = max(cursor, ue)
+        if cursor < size:
+            rows.append({"chrom": chrom, "start": cursor, "end": size})
+        df = pd.DataFrame(rows, columns=["chrom", "start", "end"])
+        if not df.empty:
+            assert (df["end"] > df["start"]).all()
+            assert (df["end"].shift(-1, fill_value=size) >= df["end"]).all()
+        out[chrom] = df
+    return out
+
+
+def _build_genome_histogram(
+    bw_path: Path,
+    defined_per_chrom: dict[str, pd.DataFrame],
+    edges: np.ndarray,
+) -> PhylopHistogram:
+    """Sum per-chrom histograms into one whole-genome histogram."""
+    total: PhylopHistogram | None = None
+    for chrom, defined in defined_per_chrom.items():
+        if defined.empty:
+            continue
+        print(
+            f"  histogram: {bw_path.name} chrom {chrom} "
+            f"({(defined['end'] - defined['start']).sum()} bp)"
+        )
+        h = build_histogram_for_chrom(bw_path, chrom, defined, edges)
+        total = h if total is None else total + h
+    assert total is not None
+    return total
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("results/calibration/calibration.json"),
+        help="Where to write the calibration JSON.",
+    )
+    parser.add_argument(
+        "--bigwig-dir",
+        type=Path,
+        default=Path("results/calibration/bigwig"),
+        help="Where to download / cache the bigWigs.",
+    )
+    parser.add_argument(
+        "--genome-2bit",
+        type=Path,
+        default=Path("results/genome/homo_sapiens.2bit"),
+        help="hg38 .2bit file for chrom-sizes + N-region extraction. "
+        "If missing, will be built from the Ensembl FASTA.",
+    )
+    parser.add_argument(
+        "--genome-url",
+        default="https://ftp.ensembl.org/pub/release-115/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz",
+    )
+    parser.add_argument("--hist-min", type=float, default=-20.0)
+    parser.add_argument("--hist-max", type=float, default=20.0)
+    parser.add_argument("--hist-bins", type=int, default=1000)
+    args = parser.parse_args()
+
+    edges = np.linspace(args.hist_min, args.hist_max, args.hist_bins + 1)
+
+    # 1) Stage genome 2bit + chrom sizes + N-regions
+    if not args.genome_2bit.exists():
+        fa_gz = args.genome_2bit.with_suffix(".fa.gz")
+        _wget(args.genome_url, fa_gz)
+        args.genome_2bit.parent.mkdir(parents=True, exist_ok=True)
+        print(f"  faToTwoBit -> {args.genome_2bit}")
+        subprocess.run(
+            f"zcat {fa_gz} | faToTwoBit stdin {args.genome_2bit}",
+            shell=True,
+            check=True,
+        )
+
+    chrom_sizes_path = args.genome_2bit.with_suffix(".chrom.sizes")
+    undefined_path = args.genome_2bit.with_suffix(".undefined.bed")
+    if not chrom_sizes_path.exists():
+        subprocess.run(
+            ["twoBitInfo", str(args.genome_2bit), str(chrom_sizes_path)], check=True
+        )
+    if not undefined_path.exists():
+        with open(undefined_path, "w") as f:
+            subprocess.run(
+                ["twoBitInfo", str(args.genome_2bit), "/dev/stdout", "-nBed"],
+                check=True,
+                stdout=f,
+            )
+
+    chrom_sizes = pd.read_csv(
+        chrom_sizes_path,
+        sep="\t",
+        header=None,
+        names=["chrom", "size"],
+        dtype={"chrom": str},
+    )
+    chrom_sizes = chrom_sizes[chrom_sizes["chrom"].isin(STANDARD_CHROMS_HUMAN)]
+    assert len(chrom_sizes) == len(STANDARD_CHROMS_HUMAN), (
+        f"missing chroms in 2bit: {set(STANDARD_CHROMS_HUMAN) - set(chrom_sizes['chrom'])}"
+    )
+    undefined = _read_undefined_bed(undefined_path)
+
+    defined_per_chrom = _build_defined_intervals_per_chrom(
+        chrom_sizes, undefined, STANDARD_CHROMS_HUMAN
+    )
+    total_defined = sum(
+        int((d["end"] - d["start"]).sum()) for d in defined_per_chrom.values()
+    )
+    print(f"defined bases (autosomes + X + Y): {total_defined:,}")
+
+    # 2) Stage both bigWigs
+    args.bigwig_dir.mkdir(parents=True, exist_ok=True)
+    ref_bw = args.bigwig_dir / f"{REFERENCE_TRACK}.bw"
+    tgt_bw = args.bigwig_dir / f"{TARGET_TRACK}.bw"
+    _wget(CONSERVATION_TRACKS[REFERENCE_TRACK], ref_bw)
+    _wget(CONSERVATION_TRACKS[TARGET_TRACK], tgt_bw)
+
+    # 3) Build per-track genome-wide histograms
+    print(f"\nbuilding {REFERENCE_TRACK} histogram...")
+    ref_hist = _build_genome_histogram(ref_bw, defined_per_chrom, edges)
+    print(f"  {REFERENCE_TRACK}: {ref_hist.total():,} non-NaN, {ref_hist.n_nan:,} NaN")
+
+    print(f"\nbuilding {TARGET_TRACK} histogram...")
+    tgt_hist = _build_genome_histogram(tgt_bw, defined_per_chrom, edges)
+    print(f"  {TARGET_TRACK}: {tgt_hist.total():,} non-NaN, {tgt_hist.n_nan:,} NaN")
+
+    # 4) Calibrate
+    print(
+        f"\ncalibrating {TARGET_TRACK} to match {REFERENCE_TRACK} >= {REFERENCE_THRESHOLD}..."
+    )
+    out = calibrate_to_match_count(
+        tgt_hist,
+        ref_hist,
+        ref_threshold=REFERENCE_THRESHOLD,
+        target_name=TARGET_TRACK,
+        ref_name=REFERENCE_TRACK,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(out, indent=2))
+    print(f"\nwrote {args.output}")
+    print(json.dumps(out, indent=2))
+    print(
+        f"\n>>> Set in config.yaml: phyloP_447m_threshold: {out[TARGET_TRACK]['threshold']:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py
+++ b/snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py
@@ -146,7 +146,19 @@ def main() -> None:
     parser.add_argument("--hist-min", type=float, default=-20.0)
     parser.add_argument("--hist-max", type=float, default=20.0)
     parser.add_argument("--hist-bins", type=int, default=1000)
+    parser.add_argument(
+        "--chroms",
+        nargs="+",
+        default=STANDARD_CHROMS_HUMAN,
+        help="Chromosomes to histogram (Ensembl bare names). Defaults to all "
+        "autosomes + X + Y. Pass a smaller subset (e.g. `--chroms 1`) to "
+        "speed up calibration: a single large autosome already gives "
+        "well below 1% relative error in the calibrated threshold.",
+    )
     args = parser.parse_args()
+    chroms = list(args.chroms)
+    unknown = set(chroms) - set(STANDARD_CHROMS_HUMAN)
+    assert not unknown, f"unknown chrom names: {unknown}"
 
     edges = np.linspace(args.hist_min, args.hist_max, args.hist_bins + 1)
 
@@ -183,19 +195,20 @@ def main() -> None:
         names=["chrom", "size"],
         dtype={"chrom": str},
     )
-    chrom_sizes = chrom_sizes[chrom_sizes["chrom"].isin(STANDARD_CHROMS_HUMAN)]
-    assert len(chrom_sizes) == len(STANDARD_CHROMS_HUMAN), (
-        f"missing chroms in 2bit: {set(STANDARD_CHROMS_HUMAN) - set(chrom_sizes['chrom'])}"
+    chrom_sizes = chrom_sizes[chrom_sizes["chrom"].isin(chroms)]
+    assert len(chrom_sizes) == len(chroms), (
+        f"missing chroms in 2bit: {set(chroms) - set(chrom_sizes['chrom'])}"
     )
     undefined = _read_undefined_bed(undefined_path)
 
     defined_per_chrom = _build_defined_intervals_per_chrom(
-        chrom_sizes, undefined, STANDARD_CHROMS_HUMAN
+        chrom_sizes, undefined, chroms
     )
     total_defined = sum(
         int((d["end"] - d["start"]).sum()) for d in defined_per_chrom.values()
     )
-    print(f"defined bases (autosomes + X + Y): {total_defined:,}")
+    print(f"chroms used for calibration: {chroms}")
+    print(f"defined bases (over selected chroms): {total_defined:,}")
 
     # 2) Stage both bigWigs
     args.bigwig_dir.mkdir(parents=True, exist_ok=True)

--- a/snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py
+++ b/snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py
@@ -19,8 +19,6 @@ Usage::
         --genome-2bit /path/to/hg38.2bit
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import subprocess

--- a/snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py
+++ b/snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py
@@ -1,11 +1,12 @@
-"""One-off: calibrate ``phyloP_447m`` threshold to match ``phyloP_241m`` count.
+"""One-off: calibrate ``phyloP_447m`` threshold to match the *proportion* of
+non-NaN bases passing in ``phyloP_241m``.
 
 Run once on a SkyPilot box (or anywhere with both bigWigs reachable). Builds
 per-base histograms over defined ACGT regions of both ``phyloP_241m`` and
-``phyloP_447m``, then finds the ``phyloP_447m`` threshold whose genome-wide
-passing count matches ``phyloP_241m >= 2.27``. Prints the threshold and
-writes a JSON file with the full calibration record (counts, totals,
-relative error, hist meta).
+``phyloP_447m``, then finds the ``phyloP_447m`` threshold whose
+proportion-of-non-NaN-bases passing matches ``phyloP_241m >= 2.27``.
+Prints the threshold and writes a JSON file with the full calibration
+record (counts, proportions, totals, relative error, hist meta).
 
 After running, paste the printed threshold into ``config/config.yaml``
 under ``phyloP_447m_threshold`` and commit.
@@ -28,7 +29,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from bolinas.conservation.calibration import calibrate_to_match_count
+from bolinas.conservation.calibration import calibrate_to_match_proportion
 from bolinas.conservation.histogram import (
     PhylopHistogram,
     build_histogram_for_chrom,
@@ -226,11 +227,12 @@ def main() -> None:
     tgt_hist = _build_genome_histogram(tgt_bw, defined_per_chrom, edges)
     print(f"  {TARGET_TRACK}: {tgt_hist.total():,} non-NaN, {tgt_hist.n_nan:,} NaN")
 
-    # 4) Calibrate
+    # 4) Calibrate (match proportion of non-NaN bases passing, not raw count)
     print(
-        f"\ncalibrating {TARGET_TRACK} to match {REFERENCE_TRACK} >= {REFERENCE_THRESHOLD}..."
+        f"\ncalibrating {TARGET_TRACK} to match {REFERENCE_TRACK} >= {REFERENCE_THRESHOLD} "
+        f"(proportion of non-NaN bases passing)..."
     )
-    out = calibrate_to_match_count(
+    out = calibrate_to_match_proportion(
         tgt_hist,
         ref_hist,
         ref_threshold=REFERENCE_THRESHOLD,

--- a/snakemake/zoonomia_projection_dataset/sky/calibrate.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/calibrate.yaml
@@ -1,0 +1,71 @@
+name: zoonomia-calibration
+
+# One-off: calibrate phyloP_447m threshold to match phyloP_241m count at 2.27.
+# Downloads both bigWigs (~30 GB each) and the hg38 FASTA, builds per-base
+# histograms over autosomes + X + Y defined regions, finds the matching
+# threshold, writes calibration.json. ~30 min wall.
+#
+# After this completes:
+#   1) sync the calibration.json off the box
+#   2) update snakemake/zoonomia_projection_dataset/config/config.yaml
+#      `phyloP_447m_threshold` to the printed value
+#   3) commit + push
+
+resources:
+    infra: aws/us-east-2
+    instance_type: c6id.2xlarge      # 8 vCPU, 16 GB RAM, 474 GB local NVMe
+    disk_size: 100                   # gp3 root vol; bigWigs go to NVMe (see run:)
+    labels:
+        project: dna
+
+workdir: .
+
+setup: |
+    set -euxo pipefail
+
+    if [ ! -d "$HOME/miniforge3" ]; then
+        curl -fsSL -o /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+        bash /tmp/miniforge.sh -b -p "$HOME/miniforge3"
+        rm /tmp/miniforge.sh
+    fi
+
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+
+    grep -q 'miniforge3/bin' "$HOME/.bashrc" || \
+        echo 'export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+
+    export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+
+    # kentUtils (twoBitInfo, faToTwoBit) needed by the calibration script.
+    # Install once into the base conda env.
+    mamba install -y -c bioconda ucsc-fatotwobit ucsc-twobitinfo
+
+    uv sync
+
+run: |
+    set -euxo pipefail
+
+    source "$HOME/miniforge3/etc/profile.d/conda.sh"
+    export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+
+    # Use the local NVMe for the bigWigs + 2bit so we don't blow out the
+    # gp3 root volume. The c6id NVMe is auto-mounted at /opt/dlami/nvme on
+    # the SkyPilot AWS DLAMI; fall back to /tmp if not present.
+    if [ -d /opt/dlami/nvme ]; then
+        WORK=/opt/dlami/nvme/zoonomia-calibration
+    else
+        WORK=/tmp/zoonomia-calibration
+    fi
+    mkdir -p "$WORK"
+
+    df -h "$WORK"
+
+    uv run python snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py \
+        --output snakemake/zoonomia_projection_dataset/results/calibration/calibration.json \
+        --bigwig-dir "$WORK/bigwig" \
+        --genome-2bit "$WORK/homo_sapiens.2bit"
+
+    # Sanity-print the result so it shows up at the end of `sky logs`.
+    cat snakemake/zoonomia_projection_dataset/results/calibration/calibration.json

--- a/snakemake/zoonomia_projection_dataset/sky/calibrate.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/calibrate.yaml
@@ -62,10 +62,15 @@ run: |
 
     df -h "$WORK"
 
+    # chr1 alone (~230 Mbp defined, ~3% passing at phyloP_241m >= 2.27 →
+    # ~7M passing bases) gives well below 1% relative error in the
+    # calibrated threshold. Iterating all 24 chroms is overkill for
+    # statistical precision and would add ~30 min wall.
     uv run python snakemake/zoonomia_projection_dataset/scripts/calibrate_447m_threshold.py \
         --output snakemake/zoonomia_projection_dataset/results/calibration/calibration.json \
         --bigwig-dir "$WORK/bigwig" \
-        --genome-2bit "$WORK/homo_sapiens.2bit"
+        --genome-2bit "$WORK/homo_sapiens.2bit" \
+        --chroms 1
 
     # Sanity-print the result so it shows up at the end of `sky logs`.
     cat snakemake/zoonomia_projection_dataset/results/calibration/calibration.json

--- a/snakemake/zoonomia_projection_dataset/sky/run.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/run.yaml
@@ -1,0 +1,52 @@
+name: zoonomia-projection-dataset
+
+# Run the full pipeline: tile + N-filter, binarize phyloP_447m at the
+# calibrated threshold (from config.yaml), bigWigAverageOverBed × 2 over
+# the binary + raw tracks, filter to per-cutoff BEDs. ~30-45 min wall.
+#
+# Prereq: phyloP_447m_threshold must be set in
+# snakemake/zoonomia_projection_dataset/config/config.yaml (run sky/calibrate.yaml
+# first if it's still the placeholder 2.27).
+
+resources:
+    infra: aws/us-east-2
+    instance_type: c6id.2xlarge      # 8 vCPU, 16 GB RAM, 474 GB local NVMe
+    disk_size: 100
+    labels:
+        project: dna
+
+workdir: .
+
+setup: |
+    set -euxo pipefail
+
+    if [ ! -d "$HOME/miniforge3" ]; then
+        curl -fsSL -o /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+        bash /tmp/miniforge.sh -b -p "$HOME/miniforge3"
+        rm /tmp/miniforge.sh
+    fi
+
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+
+    grep -q 'miniforge3/bin' "$HOME/.bashrc" || \
+        echo 'export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+
+    export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+    uv sync
+
+run: |
+    set -euxo pipefail
+
+    source "$HOME/miniforge3/etc/profile.d/conda.sh"
+    export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+    export CONDA_EXE="$HOME/miniforge3/bin/conda"
+
+    cd snakemake/zoonomia_projection_dataset
+
+    uv run --project ../.. snakemake \
+        --profile workflow/profiles/default \
+        --use-conda \
+        --printshellcmds \
+        --rerun-incomplete

--- a/snakemake/zoonomia_projection_dataset/workflow/Snakefile
+++ b/snakemake/zoonomia_projection_dataset/workflow/Snakefile
@@ -12,7 +12,6 @@ include: "rules/filter.smk"
 rule all:
     input:
         expand(
-            "results/bed/{species}/min{min_p}.bed.gz",
-            species=[config["species"]],
+            "results/bed/min{min_p}.bed.gz",
             min_p=[f"{f['min_proportion_conserved']:.2f}" for f in config["filters"]],
         ),

--- a/snakemake/zoonomia_projection_dataset/workflow/Snakefile
+++ b/snakemake/zoonomia_projection_dataset/workflow/Snakefile
@@ -1,0 +1,18 @@
+configfile: "config/config.yaml"
+
+
+include: "rules/common.smk"
+include: "rules/genome.smk"
+include: "rules/download.smk"
+include: "rules/windows.smk"
+include: "rules/score.smk"
+include: "rules/filter.smk"
+
+
+rule all:
+    input:
+        expand(
+            "results/bed/{species}/min{min_p}.bed.gz",
+            species=[config["species"]],
+            min_p=[f"{f['min_proportion_conserved']:.2f}" for f in config["filters"]],
+        ),

--- a/snakemake/zoonomia_projection_dataset/workflow/envs/bioinformatics.yaml
+++ b/snakemake/zoonomia_projection_dataset/workflow/envs/bioinformatics.yaml
@@ -1,0 +1,10 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bedtools
+  - ucsc-fatotwobit
+  - ucsc-twobitinfo
+  - ucsc-twobittofa
+  - ucsc-bigwigaverageoverbed
+  - wiggletools

--- a/snakemake/zoonomia_projection_dataset/workflow/envs/bioinformatics.yaml
+++ b/snakemake/zoonomia_projection_dataset/workflow/envs/bioinformatics.yaml
@@ -7,4 +7,6 @@ dependencies:
   - ucsc-twobitinfo
   - ucsc-twobittofa
   - ucsc-bigwigaverageoverbed
-  - wiggletools
+  - ucsc-bigwigtobedgraph
+  - ucsc-bedgraphtobigwig
+  - ucsc-bigwiginfo

--- a/snakemake/zoonomia_projection_dataset/workflow/envs/bioinformatics.yaml
+++ b/snakemake/zoonomia_projection_dataset/workflow/envs/bioinformatics.yaml
@@ -6,7 +6,3 @@ dependencies:
   - ucsc-fatotwobit
   - ucsc-twobitinfo
   - ucsc-twobittofa
-  - ucsc-bigwigaverageoverbed
-  - ucsc-bigwigtobedgraph
-  - ucsc-bedgraphtobigwig
-  - ucsc-bigwiginfo

--- a/snakemake/zoonomia_projection_dataset/workflow/profiles/default/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/workflow/profiles/default/config.yaml
@@ -1,0 +1,4 @@
+default-storage-provider: s3
+default-storage-prefix: s3://oa-bolinas/snakemake/zoonomia_projection_dataset/
+cores: all
+use-conda: true

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/common.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/common.smk
@@ -1,0 +1,27 @@
+"""Shared imports and constants for ``zoonomia_projection_dataset``.
+
+URLs come from ``CONSERVATION_TRACKS`` — single source of truth in
+``src/bolinas/evals/conservation.py``. Only ``phyloP_447m`` is downloaded
+at pipeline runtime; ``phyloP_241m`` is fetched only by the one-off
+calibration script.
+"""
+
+import gzip
+
+import numpy as np
+import pandas as pd
+import polars as pl
+
+from bolinas.evals.conservation import CONSERVATION_TRACKS
+from bolinas.conservation.scoring import parse_bigwig_average_over_bed
+
+
+SPECIES = config["species"]
+WINDOW_SIZE = int(config["window_size"])
+STEP_SIZE = int(config["step_size"])
+PHYLOP_447M_THRESHOLD = float(config["phyloP_447m_threshold"])
+
+# Sanity-check: track must be in the registry.
+assert "phyloP_447m" in CONSERVATION_TRACKS, (
+    "phyloP_447m must be present in bolinas.evals.conservation.CONSERVATION_TRACKS"
+)

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/common.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/common.smk
@@ -19,6 +19,7 @@ SPECIES = config["species"]
 WINDOW_SIZE = int(config["window_size"])
 STEP_SIZE = int(config["step_size"])
 PHYLOP_447M_THRESHOLD = float(config["phyloP_447m_threshold"])
+STANDARD_CHROMS = list(config["standard_chroms"][SPECIES])
 
 # Sanity-check: track must be in the registry.
 assert "phyloP_447m" in CONSERVATION_TRACKS, (

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/common.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/common.smk
@@ -13,7 +13,6 @@ import pandas as pd
 import polars as pl
 
 from bolinas.evals.conservation import CONSERVATION_TRACKS
-from bolinas.conservation.scoring import parse_bigwig_average_over_bed
 
 
 SPECIES = config["species"]

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/common.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/common.smk
@@ -4,6 +4,10 @@ URLs come from ``CONSERVATION_TRACKS`` — single source of truth in
 ``src/bolinas/evals/conservation.py``. Only ``phyloP_447m`` is downloaded
 at pipeline runtime; ``phyloP_241m`` is fetched only by the one-off
 calibration script.
+
+Pipeline is hg38-only by design — the phyloP bigWigs are human-anchored
+and the downstream cross-mammal projection is human-anchored too. No
+``{species}`` wildcard.
 """
 
 import gzip
@@ -15,11 +19,10 @@ import polars as pl
 from bolinas.evals.conservation import CONSERVATION_TRACKS
 
 
-SPECIES = config["species"]
 WINDOW_SIZE = int(config["window_size"])
 STEP_SIZE = int(config["step_size"])
 PHYLOP_447M_THRESHOLD = float(config["phyloP_447m_threshold"])
-STANDARD_CHROMS = list(config["standard_chroms"][SPECIES])
+STANDARD_CHROMS = list(config["standard_chroms"])
 
 # Sanity-check: track must be in the registry.
 assert "phyloP_447m" in CONSERVATION_TRACKS, (

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/download.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/download.smk
@@ -1,0 +1,16 @@
+"""Download phyloP_447m bigWig.
+
+URL comes from ``bolinas.evals.conservation.CONSERVATION_TRACKS`` — single
+source of truth shared with ``conservation_eval``.
+"""
+
+
+rule download_bigwig:
+    output:
+        "results/bigwig/{track}.bw",
+    params:
+        url=lambda wc: CONSERVATION_TRACKS[wc.track],
+    wildcard_constraints:
+        track="|".join(CONSERVATION_TRACKS),
+    shell:
+        "wget -q {params.url} -O {output}"

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/filter.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/filter.smk
@@ -3,23 +3,15 @@
 
 rule filter_bed:
     input:
-        "results/scored/{species}/phyloP_447m_windows.parquet",
+        "results/scored/phyloP_447m_windows.parquet",
     output:
-        "results/bed/{species}/min{min_p}.bed.gz",
+        "results/bed/min{min_p}.bed.gz",
     run:
         min_p = float(wildcards.min_p)
         assert 0.0 <= min_p <= 1.0, f"min_p out of range: {min_p}"
         df = pl.read_parquet(input[0])
-        kept = df.filter(pl.col("proportion_conserved") >= min_p).select(
-            ["chrom", "start", "end", "name", "conserved_bases", "proportion_conserved"]
-        )
+        kept = df.filter(pl.col("proportion_conserved") >= min_p)
         assert len(kept) <= len(df)
-        # 0-based half-open BED, gzipped. 6 columns: chrom, start, end, name,
-        # score (using conserved_bases), and strand "." -- this is BED6-ish but
-        # downstream we only need the first 4. Using BED6 here to be friendly
-        # to bedtools / bigWig consumers later. Actually BED6 wants strand;
-        # standard convention is to put numeric score in col 5, strand in col 6.
-        # We'll write 4-column BED to keep it simple.
         with gzip.open(output[0], "wt") as fout:
             for row in kept.iter_rows(named=True):
                 fout.write(

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/filter.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/filter.smk
@@ -1,0 +1,27 @@
+"""Filter scored windows by ``proportion_conserved`` and write a BED."""
+
+
+rule filter_bed:
+    input:
+        "results/scored/{species}/phyloP_447m_windows.parquet",
+    output:
+        "results/bed/{species}/min{min_p}.bed.gz",
+    run:
+        min_p = float(wildcards.min_p)
+        assert 0.0 <= min_p <= 1.0, f"min_p out of range: {min_p}"
+        df = pl.read_parquet(input[0])
+        kept = df.filter(pl.col("proportion_conserved") >= min_p).select(
+            ["chrom", "start", "end", "name", "conserved_bases", "proportion_conserved"]
+        )
+        assert len(kept) <= len(df)
+        # 0-based half-open BED, gzipped. 6 columns: chrom, start, end, name,
+        # score (using conserved_bases), and strand "." -- this is BED6-ish but
+        # downstream we only need the first 4. Using BED6 here to be friendly
+        # to bedtools / bigWig consumers later. Actually BED6 wants strand;
+        # standard convention is to put numeric score in col 5, strand in col 6.
+        # We'll write 4-column BED to keep it simple.
+        with gzip.open(output[0], "wt") as fout:
+            for row in kept.iter_rows(named=True):
+                fout.write(
+                    f"{row['chrom']}\t{row['start']}\t{row['end']}\t{row['name']}\n"
+                )

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/genome.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/genome.smk
@@ -1,4 +1,4 @@
-"""Genome download + 2bit + chrom_sizes + N-region BED.
+"""Genome download + 2bit + chrom_sizes + N-region BED for hg38.
 
 Patterns copied from ``snakemake/enhancer_classification/workflow/rules/data.smk``
 to keep this pipeline standalone (no cross-pipeline imports).
@@ -7,18 +7,18 @@ to keep this pipeline standalone (no cross-pipeline imports).
 
 rule download_genome:
     output:
-        "results/genome/{species}.fa.gz",
+        "results/genome/hg38.fa.gz",
     params:
-        url=lambda wildcards: config["genome_urls"][wildcards.species],
+        url=config["genome_url"],
     shell:
         "wget -q -O {output} {params.url}"
 
 
 rule genome_to_2bit:
     input:
-        "results/genome/{species}.fa.gz",
+        "results/genome/hg38.fa.gz",
     output:
-        "results/genome/{species}.2bit",
+        "results/genome/hg38.2bit",
     conda:
         "../envs/bioinformatics.yaml"
     shell:
@@ -27,9 +27,9 @@ rule genome_to_2bit:
 
 rule chrom_sizes:
     input:
-        "results/genome/{species}.2bit",
+        "results/genome/hg38.2bit",
     output:
-        "results/genome/{species}.chrom.sizes",
+        "results/genome/hg38.chrom.sizes",
     conda:
         "../envs/bioinformatics.yaml"
     shell:
@@ -37,18 +37,16 @@ rule chrom_sizes:
 
 
 rule chrom_sizes_filtered:
-    """Restrict to ``standard_chroms[{species}]`` (autosomes + X + Y for human)."""
+    """Restrict to ``standard_chroms`` (autosomes + X + Y)."""
     input:
-        "results/genome/{species}.chrom.sizes",
+        "results/genome/hg38.chrom.sizes",
     output:
-        "results/genome/{species}.chrom.sizes.filtered",
+        "results/genome/hg38.chrom.sizes.filtered",
     run:
-        standard = config["standard_chroms"][wildcards.species]
         df = pd.read_csv(input[0], sep="\t", header=None, names=["chrom", "size"])
-        df = df[df["chrom"].isin(standard)]
-        assert len(df) == len(standard), (
-            f"missing chroms in 2bit for {wildcards.species}: "
-            f"{set(standard) - set(df['chrom'])}"
+        df = df[df["chrom"].isin(STANDARD_CHROMS)]
+        assert len(df) == len(STANDARD_CHROMS), (
+            f"missing chroms in 2bit: {set(STANDARD_CHROMS) - set(df['chrom'])}"
         )
         df.to_csv(output[0], sep="\t", header=False, index=False)
 
@@ -56,9 +54,9 @@ rule chrom_sizes_filtered:
 rule undefined_regions:
     """N-region BED. ``twoBitInfo -nBed`` reports stretches of undefined bases."""
     input:
-        "results/genome/{species}.2bit",
+        "results/genome/hg38.2bit",
     output:
-        "results/genome/{species}.undefined.bed",
+        "results/genome/hg38.undefined.bed",
     conda:
         "../envs/bioinformatics.yaml"
     shell:

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/genome.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/genome.smk
@@ -1,0 +1,65 @@
+"""Genome download + 2bit + chrom_sizes + N-region BED.
+
+Patterns copied from ``snakemake/enhancer_classification/workflow/rules/data.smk``
+to keep this pipeline standalone (no cross-pipeline imports).
+"""
+
+
+rule download_genome:
+    output:
+        "results/genome/{species}.fa.gz",
+    params:
+        url=lambda wildcards: config["genome_urls"][wildcards.species],
+    shell:
+        "wget -q -O {output} {params.url}"
+
+
+rule genome_to_2bit:
+    input:
+        "results/genome/{species}.fa.gz",
+    output:
+        "results/genome/{species}.2bit",
+    conda:
+        "../envs/bioinformatics.yaml"
+    shell:
+        "zcat {input} | faToTwoBit stdin {output}"
+
+
+rule chrom_sizes:
+    input:
+        "results/genome/{species}.2bit",
+    output:
+        "results/genome/{species}.chrom.sizes",
+    conda:
+        "../envs/bioinformatics.yaml"
+    shell:
+        "twoBitInfo {input} {output}"
+
+
+rule chrom_sizes_filtered:
+    """Restrict to ``standard_chroms[{species}]`` (autosomes + X + Y for human)."""
+    input:
+        "results/genome/{species}.chrom.sizes",
+    output:
+        "results/genome/{species}.chrom.sizes.filtered",
+    run:
+        standard = config["standard_chroms"][wildcards.species]
+        df = pd.read_csv(input[0], sep="\t", header=None, names=["chrom", "size"])
+        df = df[df["chrom"].isin(standard)]
+        assert len(df) == len(standard), (
+            f"missing chroms in 2bit for {wildcards.species}: "
+            f"{set(standard) - set(df['chrom'])}"
+        )
+        df.to_csv(output[0], sep="\t", header=False, index=False)
+
+
+rule undefined_regions:
+    """N-region BED. ``twoBitInfo -nBed`` reports stretches of undefined bases."""
+    input:
+        "results/genome/{species}.2bit",
+    output:
+        "results/genome/{species}.undefined.bed",
+    conda:
+        "../envs/bioinformatics.yaml"
+    shell:
+        "twoBitInfo {input} /dev/stdout -nBed > {output}"

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
@@ -19,11 +19,17 @@ from a conda env, but Snakemake only activates ``conda:`` for ``shell:`` /
 rule binarize_447m:
     """Binarize phyloP_447m: 1 where value >= threshold, gap elsewhere.
 
-    Wiggletools' ``gte T x`` propagates gaps, which is the desired
-    behaviour: NaN-bases in the input are absent from the binary track.
-    Combined with ``bigWigAverageOverBed``'s ``mean0`` column (denominator
-    = window size, not covered length), NaN ends up counted as
-    non-conserved.
+    kentUtils chain: bigWigToBedGraph | awk threshold | bedGraphToBigWig.
+    NaN positions in the input bigWig are absent from the bigWigToBedGraph
+    output (no row emitted), so they remain absent from the binary bigWig
+    too. Combined with ``bigWigAverageOverBed``'s ``mean0`` column
+    (denominator = window size, not covered length), NaN ends up counted
+    as non-conserved.
+
+    The ``bigWigInfo -chroms`` step extracts chrom sizes from the input
+    bigWig itself (matching its UCSC ``chr1``-style naming), avoiding any
+    chrom-name mismatch between the Ensembl-named chrom_sizes.filtered
+    artifact and the UCSC-named bigWig.
     """
     input:
         "results/bigwig/phyloP_447m.bw",
@@ -35,7 +41,12 @@ rule binarize_447m:
         threshold=PHYLOP_447M_THRESHOLD,
     shell:
         r"""
-        wiggletools write_bw {output} gte {params.threshold} {input}
+        TMPSIZES=$(mktemp)
+        trap "rm -f $TMPSIZES" EXIT
+        bigWigInfo -chroms {input} | awk '/^\t/ {{ print $1"\t"$3 }}' > $TMPSIZES
+        bigWigToBedGraph {input} stdout \
+          | awk -v t={params.threshold} 'BEGIN {{OFS="\t"}} {{ print $1, $2, $3, ($4 >= t) ? 1 : 0 }}' \
+          | bedGraphToBigWig stdin $TMPSIZES {output}
         """
 
 

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
@@ -1,43 +1,40 @@
-"""Per-window phyloP_447m scoring via pyBigWig.
+"""Per-window phyloP_447m scoring via pyBigWig, parallelised across chroms.
 
 We previously tried a kentUtils chain
-(``bigWigToBedGraph | awk | bedGraphToBigWig`` plus
+(``bigWigToBedGraph | awk threshold | bedGraphToBigWig`` plus
 ``bigWigAverageOverBed``) but the bioconda kentUtils binaries don't accept
 pipes on ``stdin`` — both ``bedGraphToBigWig`` and ``faToTwoBit`` insist on
-a regular file. Materialising the per-base bedGraph would need ~30 GB of
-temp disk and a separate kentUtils-shell + run-block split because
-``run:`` blocks don't activate the rule's conda env.
+a regular file. So scoring is done in pyBigWig in a Snakemake ``run:``
+block, fanned out across chromosomes.
 
-So we do everything in one ``run:`` block with pyBigWig (which is in
-the project's uv env, no conda needed). For each window we:
-  - fetch the per-base values as a NumPy array,
-  - count finite values (``n_valid_bases``),
-  - count finite values >= threshold (``conserved_bases``),
-  - compute ``np.nanmean`` over finite values (``mean_phylop``).
+Each ``score_windows_chrom`` worker:
+  - reads the full windows BED (small — gzipped ~5 MB),
+  - filters to its chrom,
+  - opens the bigWig once and loops, calling ``bw.values(...)`` per window,
+  - writes a per-chrom Parquet.
 
-NaN handling: bases where the bigWig has no signal are explicitly counted
-as **non-conserved** (= 0) — the count is over the full window length, so
-``proportion_conserved = conserved_bases / window_size`` matches what
-``bigWigAverageOverBed``'s ``mean0`` column would have produced.
+Then ``merge_scored`` concatenates the 24 per-chrom Parquets into one
+final Parquet sorted by ``(chrom, start)``.
 
-Performance budget: pyBigWig is ~10K windows/sec/core on 255 bp windows.
-24M windows → ~40 min single-threaded. The single ``run:`` block can't
-parallelise across cores easily; if this becomes a bottleneck, split by
-chrom (24× speedup with chrom-wildcarded fan-out).
+Throughput: pyBigWig is ~10K windows/s/core. 24 chroms × ~1M windows each =
+~24M total. Single-threaded would take ~40–60 min wall; on 8 vCPU
+chrom-parallel it's roughly 24/8 = 3 batches × 1.5 min = ~5 min wall.
 """
 
 from bolinas.conservation.scoring import score_windows as _score_windows
 
 
-rule score_windows:
-    """Score every 255 bp window against phyloP_447m at the calibrated threshold."""
+rule score_windows_chrom:
+    """Score 255 bp windows on a single chromosome against phyloP_447m."""
     input:
         windows="results/windows/{species}.bed.gz",
         bw="results/bigwig/phyloP_447m.bw",
     output:
-        "results/scored/{species}/phyloP_447m_windows.parquet",
+        "results/scored/{species}/per_chrom/phyloP_447m_{chrom}.parquet",
     params:
         threshold=PHYLOP_447M_THRESHOLD,
+    wildcard_constraints:
+        chrom="|".join(STANDARD_CHROMS),
     run:
         windows_df = pl.read_csv(
             input.windows,
@@ -50,31 +47,46 @@ rule score_windows:
                 "end": pl.Int64,
                 "name": pl.Utf8,
             },
+        ).filter(pl.col("chrom") == wildcards.chrom)
+        assert len(windows_df) > 0, (
+            f"no windows on chrom {wildcards.chrom!r}; standard_chroms in config"
+            f" must match what's in the windows BED"
         )
-        assert (windows_df["end"] - windows_df["start"] == WINDOW_SIZE).all(), (
-            "windows BED has rows of unexpected length"
-        )
+        assert (windows_df["end"] - windows_df["start"] == WINDOW_SIZE).all()
 
         scored = _score_windows(input.bw, windows_df, params.threshold)
 
-        # Defensive asserts on the scoring result.
         assert len(scored) == len(windows_df)
         assert (scored["conserved_bases"] >= 0).all()
         assert (
             (scored["conserved_bases"] <= scored["n_valid_bases"])
             | (scored["n_valid_bases"] == 0)
-        ).all(), "conserved_bases > n_valid_bases for some rows"
+        ).all()
         assert (scored["n_valid_bases"] <= WINDOW_SIZE).all()
         assert scored["proportion_conserved"].min() >= 0.0
         assert scored["proportion_conserved"].max() <= 1.0
-        # proportion_conserved == conserved_bases / WINDOW_SIZE
-        mismatch = (
-            scored["proportion_conserved"]
-            - scored["conserved_bases"].cast(pl.Float32) / WINDOW_SIZE
-        ).abs().max()
-        assert mismatch < 1e-3, (
-            f"proportion_conserved disagrees with conserved_bases/window_size "
-            f"by {mismatch}"
-        )
+        scored.sort("start").write_parquet(output[0])
 
-        scored.sort(["chrom", "start"]).write_parquet(output[0])
+
+rule merge_scored:
+    """Concatenate per-chrom Parquets into a single sorted Parquet."""
+    input:
+        expand(
+            "results/scored/{{species}}/per_chrom/phyloP_447m_{chrom}.parquet",
+            chrom=STANDARD_CHROMS,
+        ),
+    output:
+        "results/scored/{species}/phyloP_447m_windows.parquet",
+    run:
+        dfs = [pl.read_parquet(p) for p in input]
+        seen_chroms = {df["chrom"].unique().item() for df in dfs}
+        assert seen_chroms == set(STANDARD_CHROMS), (
+            f"missing chroms in per-chrom Parquets: "
+            f"{set(STANDARD_CHROMS) - seen_chroms}"
+        )
+        merged = pl.concat(dfs).sort(["chrom", "start"])
+        # Defensive cross-check after concat.
+        assert (merged["end"] - merged["start"] == WINDOW_SIZE).all()
+        assert (merged["conserved_bases"] >= 0).all()
+        assert (merged["proportion_conserved"] <= 1.0).all()
+        merged.write_parquet(output[0])

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
@@ -6,20 +6,24 @@ Two passes of ``bigWigAverageOverBed`` per window set:
 2. raw track      → ``mean`` (= mean phyloP), ``covered`` (= n_valid_bases)
 
 UCSC bigWig tracks use ``chr1``-style chrom names; the windows BED uses
-Ensembl bare names. We rewrite chrom names on-the-fly with awk before
-``bigWigAverageOverBed``.
+Ensembl bare names. The ``bigwig_average_over_bed`` rule rewrites chrom
+names on-the-fly with awk before each ``bigWigAverageOverBed`` call.
+
+Note on rule splitting: ``bigWigAverageOverBed`` and ``wiggletools`` come
+from a conda env, but Snakemake only activates ``conda:`` for ``shell:`` /
+``script:`` rules — not ``run:``. So the kentUtils invocations live in
+``shell:`` rules and the join/assertion logic lives in a ``run:`` rule.
 """
 
 
 rule binarize_447m:
-    """Binarize phyloP_447m: 1 where value >= threshold, 0/missing elsewhere.
+    """Binarize phyloP_447m: 1 where value >= threshold, gap elsewhere.
 
-    Wiggletools' ``apply gte T x`` propagates gaps, which is the desired
+    Wiggletools' ``gte T x`` propagates gaps, which is the desired
     behaviour: NaN-bases in the input are absent from the binary track.
     Combined with ``bigWigAverageOverBed``'s ``mean0`` column (denominator
     = window size, not covered length), NaN ends up counted as
-    non-conserved — see the pipeline README and the test in
-    ``tests/conservation/`` if you need a sanity check.
+    non-conserved.
     """
     input:
         "results/bigwig/phyloP_447m.bw",
@@ -35,107 +39,115 @@ rule binarize_447m:
         """
 
 
-rule score_windows:
-    """Per-window phyloP_447m scoring via two bigWigAverageOverBed passes."""
+rule bigwig_average_over_bed:
+    """Two bigWigAverageOverBed passes against the chr-prefixed windows BED.
+
+    Emits ``binary.tsv`` (= conserved_bases / proportion_conserved) and
+    ``raw.tsv`` (= mean_phylop / n_valid_bases). Joining + Parquet writing
+    happens in the next rule.
+    """
     input:
         windows="results/windows/{species}.bed.gz",
         binary_bw="results/bigwig/phyloP_447m.binary.bw",
         raw_bw="results/bigwig/phyloP_447m.bw",
     output:
-        "results/scored/{species}/phyloP_447m_windows.parquet",
+        binary_tsv=temp("results/scored/{species}/phyloP_447m.binary.tsv"),
+        raw_tsv=temp("results/scored/{species}/phyloP_447m.raw.tsv"),
     conda:
         "../envs/bioinformatics.yaml"
+    shell:
+        r"""
+        TMPBED=$(mktemp --suffix=.bed)
+        trap "rm -f $TMPBED" EXIT
+        zcat {input.windows} \
+          | awk 'BEGIN{{OFS="\t"}} {{ if ($1 !~ /^chr/) $1="chr"$1; print }}' \
+          > $TMPBED
+        bigWigAverageOverBed {input.binary_bw} $TMPBED {output.binary_tsv}
+        bigWigAverageOverBed {input.raw_bw}    $TMPBED {output.raw_tsv}
+        """
+
+
+rule score_windows:
+    """Join the two bigWigAverageOverBed TSVs back to the windows BED → Parquet.
+
+    Columns:
+      chrom, start, end, name (from windows.bed.gz, bare Ensembl chrom names)
+      conserved_bases (Int32) = `sum`  from binary track
+      proportion_conserved (Float32) = `mean0` from binary track (= sum / size,
+                                       NaN counted as 0 → desired semantics)
+      mean_phylop (Float32) = `mean` from raw track (over covered bases only)
+      n_valid_bases (Int32) = `covered` from raw track
+    """
+    input:
+        windows="results/windows/{species}.bed.gz",
+        binary_tsv="results/scored/{species}/phyloP_447m.binary.tsv",
+        raw_tsv="results/scored/{species}/phyloP_447m.raw.tsv",
+    output:
+        "results/scored/{species}/phyloP_447m_windows.parquet",
     run:
-        import subprocess
-        import tempfile
-        from pathlib import Path
+        binary = parse_bigwig_average_over_bed(input.binary_tsv)
+        raw = parse_bigwig_average_over_bed(input.raw_tsv)
+        assert binary.shape == raw.shape, "binary/raw row counts must match"
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp = Path(tmp_dir)
-            # Rewrite chrom names: Ensembl "1" → UCSC "chr1" for bigWig lookup.
-            chr_bed = tmp / "windows.chr.bed"
-            with gzip.open(input.windows, "rt") as fin, open(chr_bed, "w") as fout:
-                for line in fin:
-                    parts = line.rstrip("\n").split("\t")
-                    parts[0] = (
-                        parts[0] if parts[0].startswith("chr") else f"chr{parts[0]}"
-                    )
-                    fout.write("\t".join(parts) + "\n")
+        # Rejoin with original (non-chr-prefixed) windows BED on `name`.
+        windows_df = pl.read_csv(
+            input.windows,
+            separator="\t",
+            has_header=False,
+            new_columns=["chrom", "start", "end", "name"],
+            schema_overrides={
+                "chrom": pl.Utf8,
+                "start": pl.Int64,
+                "end": pl.Int64,
+                "name": pl.Utf8,
+            },
+        )
+        assert (windows_df["end"] - windows_df["start"] == WINDOW_SIZE).all(), (
+            "windows BED has rows of unexpected length"
+        )
 
-            binary_tsv = tmp / "binary.tsv"
-            raw_tsv = tmp / "raw.tsv"
+        merged = (
+            windows_df.join(
+                binary.select(
+                    pl.col("name"),
+                    pl.col("sum").cast(pl.Int32).alias("conserved_bases"),
+                    pl.col("mean0").cast(pl.Float32).alias("proportion_conserved"),
+                ),
+                on="name",
+                how="inner",
+            )
+            .join(
+                raw.select(
+                    pl.col("name"),
+                    pl.col("mean").cast(pl.Float32).alias("mean_phylop"),
+                    pl.col("covered").cast(pl.Int32).alias("n_valid_bases"),
+                ),
+                on="name",
+                how="inner",
+            )
+            .sort(["chrom", "start"])
+        )
 
-            subprocess.run(
-                ["bigWigAverageOverBed", input.binary_bw, str(chr_bed), str(binary_tsv)],
-                check=True,
-            )
-            subprocess.run(
-                ["bigWigAverageOverBed", input.raw_bw, str(chr_bed), str(raw_tsv)],
-                check=True,
-            )
+        assert len(merged) == len(windows_df), (
+            f"join shrunk row count: {len(windows_df)} → {len(merged)}; "
+            f"some window names did not match bigWigAverageOverBed output"
+        )
+        assert (merged["conserved_bases"] >= 0).all()
+        assert (
+            (merged["conserved_bases"] <= merged["n_valid_bases"])
+            | (merged["n_valid_bases"] == 0)
+        ).all(), "conserved_bases > n_valid_bases for some rows"
+        assert (merged["n_valid_bases"] <= WINDOW_SIZE).all()
+        assert merged["proportion_conserved"].min() >= 0.0
+        assert merged["proportion_conserved"].max() <= 1.0
+        # mean0 = sum / size: cross-check
+        mismatch = (
+            merged["proportion_conserved"]
+            - merged["conserved_bases"].cast(pl.Float32) / WINDOW_SIZE
+        ).abs().max()
+        assert mismatch < 1e-3, (
+            f"proportion_conserved disagrees with conserved_bases/window_size "
+            f"by {mismatch}"
+        )
 
-            binary = parse_bigwig_average_over_bed(binary_tsv)
-            raw = parse_bigwig_average_over_bed(raw_tsv)
-            assert binary.shape == raw.shape, "binary/raw row counts must match"
-            # Rejoin with original (non-chr-prefixed) windows BED on `name`.
-            windows_df = pl.read_csv(
-                input.windows,
-                separator="\t",
-                has_header=False,
-                new_columns=["chrom", "start", "end", "name"],
-                schema_overrides={
-                    "chrom": pl.Utf8,
-                    "start": pl.Int64,
-                    "end": pl.Int64,
-                    "name": pl.Utf8,
-                },
-            )
-            assert (windows_df["end"] - windows_df["start"] == WINDOW_SIZE).all(), (
-                "windows BED has rows of unexpected length"
-            )
-
-            merged = (
-                windows_df.join(
-                    binary.select(
-                        pl.col("name"),
-                        pl.col("sum").cast(pl.Int32).alias("conserved_bases"),
-                        pl.col("mean0").cast(pl.Float32).alias("proportion_conserved"),
-                    ),
-                    on="name",
-                    how="inner",
-                )
-                .join(
-                    raw.select(
-                        pl.col("name"),
-                        pl.col("mean").cast(pl.Float32).alias("mean_phylop"),
-                        pl.col("covered").cast(pl.Int32).alias("n_valid_bases"),
-                    ),
-                    on="name",
-                    how="inner",
-                )
-                .sort(["chrom", "start"])
-            )
-
-            assert len(merged) == len(windows_df), (
-                f"join shrunk row count: {len(windows_df)} → {len(merged)}; "
-                f"some window names did not match bigWigAverageOverBed output"
-            )
-            assert (merged["conserved_bases"] >= 0).all()
-            assert (
-                (merged["conserved_bases"] <= merged["n_valid_bases"])
-                | (merged["n_valid_bases"] == 0)
-            ).all(), "conserved_bases > n_valid_bases for some rows"
-            assert (merged["n_valid_bases"] <= WINDOW_SIZE).all()
-            assert merged["proportion_conserved"].min() >= 0.0
-            assert merged["proportion_conserved"].max() <= 1.0
-            # mean0 = sum / size: cross-check
-            mismatch = (
-                merged["proportion_conserved"]
-                - merged["conserved_bases"].cast(pl.Float32) / WINDOW_SIZE
-            ).abs().max()
-            assert mismatch < 1e-3, (
-                f"proportion_conserved disagrees with conserved_bases/window_size "
-                f"by {mismatch}"
-            )
-
-            merged.write_parquet(output[0])
+        merged.write_parquet(output[0])

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
@@ -14,10 +14,10 @@ from bolinas.conservation.scoring import score_windows as _score_windows
 rule score_windows_chrom:
     """Score 255 bp windows on a single chromosome against phyloP_447m."""
     input:
-        windows="results/windows/{species}/{chrom}.bed.gz",
+        windows="results/windows/{chrom}.bed.gz",
         bw="results/bigwig/phyloP_447m.bw",
     output:
-        "results/scored/{species}/per_chrom/phyloP_447m_{chrom}.parquet",
+        "results/scored/per_chrom/phyloP_447m_{chrom}.parquet",
     params:
         threshold=PHYLOP_447M_THRESHOLD,
     wildcard_constraints:
@@ -64,11 +64,11 @@ rule merge_scored:
     """Concatenate per-chrom Parquets into a single sorted Parquet."""
     input:
         expand(
-            "results/scored/{{species}}/per_chrom/phyloP_447m_{chrom}.parquet",
+            "results/scored/per_chrom/phyloP_447m_{chrom}.parquet",
             chrom=STANDARD_CHROMS,
         ),
     output:
-        "results/scored/{species}/phyloP_447m_windows.parquet",
+        "results/scored/phyloP_447m_windows.parquet",
     run:
         dfs = [pl.read_parquet(p) for p in input]
         seen_chroms = {df["chrom"].unique().item() for df in dfs}

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
@@ -1,24 +1,11 @@
-"""Per-window phyloP_447m scoring via pyBigWig, parallelised across chroms.
+"""Per-window phyloP_447m scoring, fanned out across chroms.
 
-We previously tried a kentUtils chain
-(``bigWigToBedGraph | awk threshold | bedGraphToBigWig`` plus
-``bigWigAverageOverBed``) but the bioconda kentUtils binaries don't accept
-pipes on ``stdin`` — both ``bedGraphToBigWig`` and ``faToTwoBit`` insist on
-a regular file. So scoring is done in pyBigWig in a Snakemake ``run:``
-block, fanned out across chromosomes.
+Each ``score_windows_chrom`` reads its per-chrom BED, scores via pyBigWig
+(see ``bolinas.conservation.scoring.score_windows``), and writes a
+per-chrom Parquet. ``merge_scored`` concatenates them.
 
-Each ``score_windows_chrom`` worker:
-  - reads the full windows BED (small — gzipped ~5 MB),
-  - filters to its chrom,
-  - opens the bigWig once and loops, calling ``bw.values(...)`` per window,
-  - writes a per-chrom Parquet.
-
-Then ``merge_scored`` concatenates the 24 per-chrom Parquets into one
-final Parquet sorted by ``(chrom, start)``.
-
-Throughput: pyBigWig is ~10K windows/s/core. 24 chroms × ~1M windows each =
-~24M total. Single-threaded would take ~40–60 min wall; on 8 vCPU
-chrom-parallel it's roughly 24/8 = 3 batches × 1.5 min = ~5 min wall.
+Throughput on the 8-vCPU c6id.2xlarge: ~5 min wall for human autosomes +
+X + Y (~22.9M windows).
 """
 
 from bolinas.conservation.scoring import score_windows as _score_windows
@@ -36,6 +23,9 @@ rule score_windows_chrom:
     wildcard_constraints:
         chrom="|".join(STANDARD_CHROMS),
     resources:
+        # ~30 MB BED + polars frame + pyBigWig handle peak around 1 GB; cap
+        # at 1.5 GB so Snakemake's scheduler caps concurrency below the
+        # 16 GB ceiling of c6id.2xlarge (an earlier run OOMed at 8x).
         mem_mb=1500,
     run:
         windows_df = pl.read_csv(

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
@@ -1,106 +1,44 @@
-"""Binarize phyloP_447m at the calibrated threshold, then score windows.
+"""Per-window phyloP_447m scoring via pyBigWig.
 
-Two passes of ``bigWigAverageOverBed`` per window set:
+We previously tried a kentUtils chain
+(``bigWigToBedGraph | awk | bedGraphToBigWig`` plus
+``bigWigAverageOverBed``) but the bioconda kentUtils binaries don't accept
+pipes on ``stdin`` — both ``bedGraphToBigWig`` and ``faToTwoBit`` insist on
+a regular file. Materialising the per-base bedGraph would need ~30 GB of
+temp disk and a separate kentUtils-shell + run-block split because
+``run:`` blocks don't activate the rule's conda env.
 
-1. binary track   → ``sum`` (= conserved_bases), ``mean0`` (= proportion conserved)
-2. raw track      → ``mean`` (= mean phyloP), ``covered`` (= n_valid_bases)
+So we do everything in one ``run:`` block with pyBigWig (which is in
+the project's uv env, no conda needed). For each window we:
+  - fetch the per-base values as a NumPy array,
+  - count finite values (``n_valid_bases``),
+  - count finite values >= threshold (``conserved_bases``),
+  - compute ``np.nanmean`` over finite values (``mean_phylop``).
 
-UCSC bigWig tracks use ``chr1``-style chrom names; the windows BED uses
-Ensembl bare names. The ``bigwig_average_over_bed`` rule rewrites chrom
-names on-the-fly with awk before each ``bigWigAverageOverBed`` call.
+NaN handling: bases where the bigWig has no signal are explicitly counted
+as **non-conserved** (= 0) — the count is over the full window length, so
+``proportion_conserved = conserved_bases / window_size`` matches what
+``bigWigAverageOverBed``'s ``mean0`` column would have produced.
 
-Note on rule splitting: ``bigWigAverageOverBed`` and ``wiggletools`` come
-from a conda env, but Snakemake only activates ``conda:`` for ``shell:`` /
-``script:`` rules — not ``run:``. So the kentUtils invocations live in
-``shell:`` rules and the join/assertion logic lives in a ``run:`` rule.
+Performance budget: pyBigWig is ~10K windows/sec/core on 255 bp windows.
+24M windows → ~40 min single-threaded. The single ``run:`` block can't
+parallelise across cores easily; if this becomes a bottleneck, split by
+chrom (24× speedup with chrom-wildcarded fan-out).
 """
 
-
-rule binarize_447m:
-    """Binarize phyloP_447m: 1 where value >= threshold, gap elsewhere.
-
-    kentUtils chain: bigWigToBedGraph | awk threshold | bedGraphToBigWig.
-    NaN positions in the input bigWig are absent from the bigWigToBedGraph
-    output (no row emitted), so they remain absent from the binary bigWig
-    too. Combined with ``bigWigAverageOverBed``'s ``mean0`` column
-    (denominator = window size, not covered length), NaN ends up counted
-    as non-conserved.
-
-    The ``bigWigInfo -chroms`` step extracts chrom sizes from the input
-    bigWig itself (matching its UCSC ``chr1``-style naming), avoiding any
-    chrom-name mismatch between the Ensembl-named chrom_sizes.filtered
-    artifact and the UCSC-named bigWig.
-    """
-    input:
-        "results/bigwig/phyloP_447m.bw",
-    output:
-        "results/bigwig/phyloP_447m.binary.bw",
-    conda:
-        "../envs/bioinformatics.yaml"
-    params:
-        threshold=PHYLOP_447M_THRESHOLD,
-    shell:
-        r"""
-        TMPSIZES=$(mktemp)
-        trap "rm -f $TMPSIZES" EXIT
-        bigWigInfo -chroms {input} | awk '/^\t/ {{ print $1"\t"$3 }}' > $TMPSIZES
-        bigWigToBedGraph {input} stdout \
-          | awk -v t={params.threshold} 'BEGIN {{OFS="\t"}} {{ print $1, $2, $3, ($4 >= t) ? 1 : 0 }}' \
-          | bedGraphToBigWig stdin $TMPSIZES {output}
-        """
-
-
-rule bigwig_average_over_bed:
-    """Two bigWigAverageOverBed passes against the chr-prefixed windows BED.
-
-    Emits ``binary.tsv`` (= conserved_bases / proportion_conserved) and
-    ``raw.tsv`` (= mean_phylop / n_valid_bases). Joining + Parquet writing
-    happens in the next rule.
-    """
-    input:
-        windows="results/windows/{species}.bed.gz",
-        binary_bw="results/bigwig/phyloP_447m.binary.bw",
-        raw_bw="results/bigwig/phyloP_447m.bw",
-    output:
-        binary_tsv=temp("results/scored/{species}/phyloP_447m.binary.tsv"),
-        raw_tsv=temp("results/scored/{species}/phyloP_447m.raw.tsv"),
-    conda:
-        "../envs/bioinformatics.yaml"
-    shell:
-        r"""
-        TMPBED=$(mktemp --suffix=.bed)
-        trap "rm -f $TMPBED" EXIT
-        zcat {input.windows} \
-          | awk 'BEGIN{{OFS="\t"}} {{ if ($1 !~ /^chr/) $1="chr"$1; print }}' \
-          > $TMPBED
-        bigWigAverageOverBed {input.binary_bw} $TMPBED {output.binary_tsv}
-        bigWigAverageOverBed {input.raw_bw}    $TMPBED {output.raw_tsv}
-        """
+from bolinas.conservation.scoring import score_windows as _score_windows
 
 
 rule score_windows:
-    """Join the two bigWigAverageOverBed TSVs back to the windows BED → Parquet.
-
-    Columns:
-      chrom, start, end, name (from windows.bed.gz, bare Ensembl chrom names)
-      conserved_bases (Int32) = `sum`  from binary track
-      proportion_conserved (Float32) = `mean0` from binary track (= sum / size,
-                                       NaN counted as 0 → desired semantics)
-      mean_phylop (Float32) = `mean` from raw track (over covered bases only)
-      n_valid_bases (Int32) = `covered` from raw track
-    """
+    """Score every 255 bp window against phyloP_447m at the calibrated threshold."""
     input:
         windows="results/windows/{species}.bed.gz",
-        binary_tsv="results/scored/{species}/phyloP_447m.binary.tsv",
-        raw_tsv="results/scored/{species}/phyloP_447m.raw.tsv",
+        bw="results/bigwig/phyloP_447m.bw",
     output:
         "results/scored/{species}/phyloP_447m_windows.parquet",
+    params:
+        threshold=PHYLOP_447M_THRESHOLD,
     run:
-        binary = parse_bigwig_average_over_bed(input.binary_tsv)
-        raw = parse_bigwig_average_over_bed(input.raw_tsv)
-        assert binary.shape == raw.shape, "binary/raw row counts must match"
-
-        # Rejoin with original (non-chr-prefixed) windows BED on `name`.
         windows_df = pl.read_csv(
             input.windows,
             separator="\t",
@@ -117,48 +55,26 @@ rule score_windows:
             "windows BED has rows of unexpected length"
         )
 
-        merged = (
-            windows_df.join(
-                binary.select(
-                    pl.col("name"),
-                    pl.col("sum").cast(pl.Int32).alias("conserved_bases"),
-                    pl.col("mean0").cast(pl.Float32).alias("proportion_conserved"),
-                ),
-                on="name",
-                how="inner",
-            )
-            .join(
-                raw.select(
-                    pl.col("name"),
-                    pl.col("mean").cast(pl.Float32).alias("mean_phylop"),
-                    pl.col("covered").cast(pl.Int32).alias("n_valid_bases"),
-                ),
-                on="name",
-                how="inner",
-            )
-            .sort(["chrom", "start"])
-        )
+        scored = _score_windows(input.bw, windows_df, params.threshold)
 
-        assert len(merged) == len(windows_df), (
-            f"join shrunk row count: {len(windows_df)} → {len(merged)}; "
-            f"some window names did not match bigWigAverageOverBed output"
-        )
-        assert (merged["conserved_bases"] >= 0).all()
+        # Defensive asserts on the scoring result.
+        assert len(scored) == len(windows_df)
+        assert (scored["conserved_bases"] >= 0).all()
         assert (
-            (merged["conserved_bases"] <= merged["n_valid_bases"])
-            | (merged["n_valid_bases"] == 0)
+            (scored["conserved_bases"] <= scored["n_valid_bases"])
+            | (scored["n_valid_bases"] == 0)
         ).all(), "conserved_bases > n_valid_bases for some rows"
-        assert (merged["n_valid_bases"] <= WINDOW_SIZE).all()
-        assert merged["proportion_conserved"].min() >= 0.0
-        assert merged["proportion_conserved"].max() <= 1.0
-        # mean0 = sum / size: cross-check
+        assert (scored["n_valid_bases"] <= WINDOW_SIZE).all()
+        assert scored["proportion_conserved"].min() >= 0.0
+        assert scored["proportion_conserved"].max() <= 1.0
+        # proportion_conserved == conserved_bases / WINDOW_SIZE
         mismatch = (
-            merged["proportion_conserved"]
-            - merged["conserved_bases"].cast(pl.Float32) / WINDOW_SIZE
+            scored["proportion_conserved"]
+            - scored["conserved_bases"].cast(pl.Float32) / WINDOW_SIZE
         ).abs().max()
         assert mismatch < 1e-3, (
             f"proportion_conserved disagrees with conserved_bases/window_size "
             f"by {mismatch}"
         )
 
-        merged.write_parquet(output[0])
+        scored.sort(["chrom", "start"]).write_parquet(output[0])

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
@@ -27,7 +27,7 @@ from bolinas.conservation.scoring import score_windows as _score_windows
 rule score_windows_chrom:
     """Score 255 bp windows on a single chromosome against phyloP_447m."""
     input:
-        windows="results/windows/{species}.bed.gz",
+        windows="results/windows/{species}/{chrom}.bed.gz",
         bw="results/bigwig/phyloP_447m.bw",
     output:
         "results/scored/{species}/per_chrom/phyloP_447m_{chrom}.parquet",
@@ -35,6 +35,8 @@ rule score_windows_chrom:
         threshold=PHYLOP_447M_THRESHOLD,
     wildcard_constraints:
         chrom="|".join(STANDARD_CHROMS),
+    resources:
+        mem_mb=1500,
     run:
         windows_df = pl.read_csv(
             input.windows,
@@ -47,10 +49,10 @@ rule score_windows_chrom:
                 "end": pl.Int64,
                 "name": pl.Utf8,
             },
-        ).filter(pl.col("chrom") == wildcards.chrom)
-        assert len(windows_df) > 0, (
-            f"no windows on chrom {wildcards.chrom!r}; standard_chroms in config"
-            f" must match what's in the windows BED"
+        )
+        assert len(windows_df) > 0, f"no windows in {input.windows}"
+        assert (windows_df["chrom"] == wildcards.chrom).all(), (
+            f"per-chrom BED has rows on other chroms: {windows_df['chrom'].unique()}"
         )
         assert (windows_df["end"] - windows_df["start"] == WINDOW_SIZE).all()
 

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/score.smk
@@ -1,0 +1,141 @@
+"""Binarize phyloP_447m at the calibrated threshold, then score windows.
+
+Two passes of ``bigWigAverageOverBed`` per window set:
+
+1. binary track   → ``sum`` (= conserved_bases), ``mean0`` (= proportion conserved)
+2. raw track      → ``mean`` (= mean phyloP), ``covered`` (= n_valid_bases)
+
+UCSC bigWig tracks use ``chr1``-style chrom names; the windows BED uses
+Ensembl bare names. We rewrite chrom names on-the-fly with awk before
+``bigWigAverageOverBed``.
+"""
+
+
+rule binarize_447m:
+    """Binarize phyloP_447m: 1 where value >= threshold, 0/missing elsewhere.
+
+    Wiggletools' ``apply gte T x`` propagates gaps, which is the desired
+    behaviour: NaN-bases in the input are absent from the binary track.
+    Combined with ``bigWigAverageOverBed``'s ``mean0`` column (denominator
+    = window size, not covered length), NaN ends up counted as
+    non-conserved — see the pipeline README and the test in
+    ``tests/conservation/`` if you need a sanity check.
+    """
+    input:
+        "results/bigwig/phyloP_447m.bw",
+    output:
+        "results/bigwig/phyloP_447m.binary.bw",
+    conda:
+        "../envs/bioinformatics.yaml"
+    params:
+        threshold=PHYLOP_447M_THRESHOLD,
+    shell:
+        r"""
+        wiggletools write_bw {output} gte {params.threshold} {input}
+        """
+
+
+rule score_windows:
+    """Per-window phyloP_447m scoring via two bigWigAverageOverBed passes."""
+    input:
+        windows="results/windows/{species}.bed.gz",
+        binary_bw="results/bigwig/phyloP_447m.binary.bw",
+        raw_bw="results/bigwig/phyloP_447m.bw",
+    output:
+        "results/scored/{species}/phyloP_447m_windows.parquet",
+    conda:
+        "../envs/bioinformatics.yaml"
+    run:
+        import subprocess
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            # Rewrite chrom names: Ensembl "1" → UCSC "chr1" for bigWig lookup.
+            chr_bed = tmp / "windows.chr.bed"
+            with gzip.open(input.windows, "rt") as fin, open(chr_bed, "w") as fout:
+                for line in fin:
+                    parts = line.rstrip("\n").split("\t")
+                    parts[0] = (
+                        parts[0] if parts[0].startswith("chr") else f"chr{parts[0]}"
+                    )
+                    fout.write("\t".join(parts) + "\n")
+
+            binary_tsv = tmp / "binary.tsv"
+            raw_tsv = tmp / "raw.tsv"
+
+            subprocess.run(
+                ["bigWigAverageOverBed", input.binary_bw, str(chr_bed), str(binary_tsv)],
+                check=True,
+            )
+            subprocess.run(
+                ["bigWigAverageOverBed", input.raw_bw, str(chr_bed), str(raw_tsv)],
+                check=True,
+            )
+
+            binary = parse_bigwig_average_over_bed(binary_tsv)
+            raw = parse_bigwig_average_over_bed(raw_tsv)
+            assert binary.shape == raw.shape, "binary/raw row counts must match"
+            # Rejoin with original (non-chr-prefixed) windows BED on `name`.
+            windows_df = pl.read_csv(
+                input.windows,
+                separator="\t",
+                has_header=False,
+                new_columns=["chrom", "start", "end", "name"],
+                schema_overrides={
+                    "chrom": pl.Utf8,
+                    "start": pl.Int64,
+                    "end": pl.Int64,
+                    "name": pl.Utf8,
+                },
+            )
+            assert (windows_df["end"] - windows_df["start"] == WINDOW_SIZE).all(), (
+                "windows BED has rows of unexpected length"
+            )
+
+            merged = (
+                windows_df.join(
+                    binary.select(
+                        pl.col("name"),
+                        pl.col("sum").cast(pl.Int32).alias("conserved_bases"),
+                        pl.col("mean0").cast(pl.Float32).alias("proportion_conserved"),
+                    ),
+                    on="name",
+                    how="inner",
+                )
+                .join(
+                    raw.select(
+                        pl.col("name"),
+                        pl.col("mean").cast(pl.Float32).alias("mean_phylop"),
+                        pl.col("covered").cast(pl.Int32).alias("n_valid_bases"),
+                    ),
+                    on="name",
+                    how="inner",
+                )
+                .sort(["chrom", "start"])
+            )
+
+            assert len(merged) == len(windows_df), (
+                f"join shrunk row count: {len(windows_df)} → {len(merged)}; "
+                f"some window names did not match bigWigAverageOverBed output"
+            )
+            assert (merged["conserved_bases"] >= 0).all()
+            assert (
+                (merged["conserved_bases"] <= merged["n_valid_bases"])
+                | (merged["n_valid_bases"] == 0)
+            ).all(), "conserved_bases > n_valid_bases for some rows"
+            assert (merged["n_valid_bases"] <= WINDOW_SIZE).all()
+            assert merged["proportion_conserved"].min() >= 0.0
+            assert merged["proportion_conserved"].max() <= 1.0
+            # mean0 = sum / size: cross-check
+            mismatch = (
+                merged["proportion_conserved"]
+                - merged["conserved_bases"].cast(pl.Float32) / WINDOW_SIZE
+            ).abs().max()
+            assert mismatch < 1e-3, (
+                f"proportion_conserved disagrees with conserved_bases/window_size "
+                f"by {mismatch}"
+            )
+
+            merged.write_parquet(output[0])

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/windows.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/windows.smk
@@ -10,10 +10,10 @@ unique after merging across chroms.
 rule make_windows:
     """255 bp windows on a single chromosome, dropping any that overlap N regions."""
     input:
-        sizes="results/genome/{species}.chrom.sizes.filtered",
-        undefined="results/genome/{species}.undefined.bed",
+        sizes="results/genome/hg38.chrom.sizes.filtered",
+        undefined="results/genome/hg38.undefined.bed",
     output:
-        "results/windows/{species}/{chrom}.bed.gz",
+        "results/windows/{chrom}.bed.gz",
     wildcard_constraints:
         chrom="|".join(STANDARD_CHROMS),
     conda:

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/windows.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/windows.smk
@@ -1,0 +1,30 @@
+"""Tile + N-filter the genome into fixed-length windows.
+
+Combined into one rule. ``bedtools makewindows`` produces tiled windows from
+the chrom-sizes file; we keep only those of exactly ``window_size`` (drops
+the trailing partial windows on each chrom), then drop any window that
+overlaps an undefined-region BED interval. Each window gets a sequential
+``win_NNNNNNNNN`` name in column 4 (required by ``bigWigAverageOverBed``).
+"""
+
+
+rule make_windows:
+    input:
+        sizes="results/genome/{species}.chrom.sizes.filtered",
+        undefined="results/genome/{species}.undefined.bed",
+    output:
+        "results/windows/{species}.bed.gz",
+    conda:
+        "../envs/bioinformatics.yaml"
+    params:
+        w=WINDOW_SIZE,
+        s=STEP_SIZE,
+    shell:
+        r"""
+        bedtools makewindows -g {input.sizes} -w {params.w} -s {params.s} \
+          | awk -v w={params.w} 'BEGIN {{OFS="\t"}} $3 - $2 == w {{
+              printf "%s\t%d\t%d\twin_%09d\n", $1, $2, $3, NR
+          }}' \
+          | bedtools intersect -a stdin -b {input.undefined} -v \
+          | gzip > {output}
+        """

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/windows.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/windows.smk
@@ -1,13 +1,9 @@
 """Tile + N-filter the genome into fixed-length windows, per chromosome.
 
-Per-chrom outputs because score_windows_chrom fans out by ``{chrom}`` and
-having each worker load only its own ~30 MB BED (instead of the full
-700 MB) is the difference between fitting in 16 GB and OOMing on
-``c6id.2xlarge``.
-
-``bedtools makewindows`` is invoked on a single-row chrom_sizes file so it
-emits windows for one chrom only. Window names embed the chrom so they're
-globally unique across per-chrom BEDs (downstream concatenation needs that).
+Per-chrom outputs (rather than one whole-genome BED) so each
+score_windows_chrom worker reads only its ~30 MB BED instead of ~700 MB.
+Window names embed the chrom (``win_<chrom>_<NNNNNNNNN>``) so they stay
+unique after merging across chroms.
 """
 
 

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/windows.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/windows.smk
@@ -1,19 +1,25 @@
-"""Tile + N-filter the genome into fixed-length windows.
+"""Tile + N-filter the genome into fixed-length windows, per chromosome.
 
-Combined into one rule. ``bedtools makewindows`` produces tiled windows from
-the chrom-sizes file; we keep only those of exactly ``window_size`` (drops
-the trailing partial windows on each chrom), then drop any window that
-overlaps an undefined-region BED interval. Each window gets a sequential
-``win_NNNNNNNNN`` name in column 4 (required by ``bigWigAverageOverBed``).
+Per-chrom outputs because score_windows_chrom fans out by ``{chrom}`` and
+having each worker load only its own ~30 MB BED (instead of the full
+700 MB) is the difference between fitting in 16 GB and OOMing on
+``c6id.2xlarge``.
+
+``bedtools makewindows`` is invoked on a single-row chrom_sizes file so it
+emits windows for one chrom only. Window names embed the chrom so they're
+globally unique across per-chrom BEDs (downstream concatenation needs that).
 """
 
 
 rule make_windows:
+    """255 bp windows on a single chromosome, dropping any that overlap N regions."""
     input:
         sizes="results/genome/{species}.chrom.sizes.filtered",
         undefined="results/genome/{species}.undefined.bed",
     output:
-        "results/windows/{species}.bed.gz",
+        "results/windows/{species}/{chrom}.bed.gz",
+    wildcard_constraints:
+        chrom="|".join(STANDARD_CHROMS),
     conda:
         "../envs/bioinformatics.yaml"
     params:
@@ -21,10 +27,12 @@ rule make_windows:
         s=STEP_SIZE,
     shell:
         r"""
-        bedtools makewindows -g {input.sizes} -w {params.w} -s {params.s} \
-          | awk -v w={params.w} 'BEGIN {{OFS="\t"}} $3 - $2 == w {{
-              printf "%s\t%d\t%d\twin_%09d\n", $1, $2, $3, NR
-          }}' \
+        TMPSIZES=$(mktemp)
+        trap "rm -f $TMPSIZES" EXIT
+        awk -v c={wildcards.chrom} '$1 == c' {input.sizes} > $TMPSIZES
+        bedtools makewindows -g $TMPSIZES -w {params.w} -s {params.s} \
+          | awk -v w={params.w} -v c={wildcards.chrom} 'BEGIN {{OFS="\t"}}
+              $3 - $2 == w {{ printf "%s\t%d\t%d\twin_%s_%09d\n", $1, $2, $3, c, NR }}' \
           | bedtools intersect -a stdin -b {input.undefined} -v \
           | gzip > {output}
         """

--- a/src/bolinas/conservation/__init__.py
+++ b/src/bolinas/conservation/__init__.py
@@ -1,0 +1,7 @@
+"""Conservation-track utilities used by ``snakemake/zoonomia_projection_dataset/``.
+
+- ``histogram``: per-base value histograms over defined regions of a phyloP bigWig.
+- ``calibration``: pick a threshold for one track that matches the genome-wide
+  passing nucleotide count of another track at a reference threshold.
+- ``scoring``: parse ``bigWigAverageOverBed`` output into a typed Polars frame.
+"""

--- a/src/bolinas/conservation/calibration.py
+++ b/src/bolinas/conservation/calibration.py
@@ -9,8 +9,6 @@ proportions controls for that and is more semantically faithful to "the
 top X% of conserved bases".
 """
 
-from __future__ import annotations
-
 from .histogram import PhylopHistogram
 
 

--- a/src/bolinas/conservation/calibration.py
+++ b/src/bolinas/conservation/calibration.py
@@ -1,0 +1,70 @@
+"""Threshold calibration: match the genome-wide passing-nucleotide count of
+one phyloP track to that of another at a fixed reference threshold.
+
+Use case: pick a threshold for ``phyloP_447m`` such that the number of bases
+genome-wide with ``phyloP_447m >= T`` equals the number of bases with
+``phyloP_241m >= 2.27`` (the canonical 241m threshold used elsewhere in the
+repo).
+"""
+
+from __future__ import annotations
+
+from .histogram import PhylopHistogram
+
+
+def calibrate_to_match_count(
+    target_hist: PhylopHistogram,
+    ref_hist: PhylopHistogram,
+    ref_threshold: float,
+    *,
+    target_name: str = "target",
+    ref_name: str = "reference",
+) -> dict:
+    """Find ``T`` for ``target_hist`` such that ``target_hist.count_ge(T) ≈ ref_count``.
+
+    ``ref_count = ref_hist.count_ge(ref_threshold)``. The returned threshold
+    is linearly interpolated within the bracketing bin of ``target_hist``;
+    precision is bounded by the bin width.
+
+    Returns a JSON-serialisable dict with both tracks' thresholds, counts,
+    the relative error, and the bin metadata. Asserts that the absolute
+    relative error between the matched count and the reference count is
+    under 1% — well below the bin-width-driven precision floor for sensible
+    bin counts.
+    """
+    ref_count = ref_hist.count_ge(ref_threshold)
+    target_threshold = target_hist.threshold_for_count(ref_count)
+    target_count = target_hist.count_ge(target_threshold)
+
+    if ref_count > 0:
+        rel_err = abs(target_count / ref_count - 1.0)
+    else:
+        rel_err = 0.0
+    assert rel_err < 0.01, (
+        f"calibration failed: {target_name} count {target_count} vs "
+        f"{ref_name} count {ref_count} (rel err {rel_err:.4f}); "
+        f"likely the histogram bin width is too coarse."
+    )
+
+    return {
+        ref_name: {
+            "threshold": float(ref_threshold),
+            "count": int(ref_count),
+            "total_bases": int(ref_hist.total()),
+            "n_nan": int(ref_hist.n_nan),
+        },
+        target_name: {
+            "threshold": float(target_threshold),
+            "count": int(target_count),
+            "count_target": int(ref_count),
+            "abs_relative_error": float(rel_err),
+            "total_bases": int(target_hist.total()),
+            "n_nan": int(target_hist.n_nan),
+        },
+        "hist_meta": {
+            "n_bins": int(target_hist.n_bins),
+            "min": float(target_hist.edges[0]),
+            "max": float(target_hist.edges[-1]),
+            "bin_width": float(target_hist.edges[1] - target_hist.edges[0]),
+        },
+    }

--- a/src/bolinas/conservation/calibration.py
+++ b/src/bolinas/conservation/calibration.py
@@ -1,10 +1,12 @@
-"""Threshold calibration: match the genome-wide passing-nucleotide count of
-one phyloP track to that of another at a fixed reference threshold.
+"""Threshold calibration: match the *proportion* of non-NaN bases passing
+between two phyloP tracks.
 
-Use case: pick a threshold for ``phyloP_447m`` such that the number of bases
-genome-wide with ``phyloP_447m >= T`` equals the number of bases with
-``phyloP_241m >= 2.27`` (the canonical 241m threshold used elsewhere in the
-repo).
+Use case: pick a threshold for ``phyloP_447m`` such that the fraction of
+non-NaN bases with ``phyloP_447m >= T`` equals the fraction of non-NaN
+bases with ``phyloP_241m >= 2.27``. Proportion-based (not count-based)
+because the two tracks have slightly different coverage — matching
+proportions controls for that and is more semantically faithful to "the
+top X% of conserved bases".
 """
 
 from __future__ import annotations
@@ -12,7 +14,7 @@ from __future__ import annotations
 from .histogram import PhylopHistogram
 
 
-def calibrate_to_match_count(
+def calibrate_to_match_proportion(
     target_hist: PhylopHistogram,
     ref_hist: PhylopHistogram,
     ref_threshold: float,
@@ -20,29 +22,39 @@ def calibrate_to_match_count(
     target_name: str = "target",
     ref_name: str = "reference",
 ) -> dict:
-    """Find ``T`` for ``target_hist`` such that ``target_hist.count_ge(T) ≈ ref_count``.
+    """Find ``T`` for ``target_hist`` such that ``target proportion ≈ ref proportion``.
 
-    ``ref_count = ref_hist.count_ge(ref_threshold)``. The returned threshold
-    is linearly interpolated within the bracketing bin of ``target_hist``;
-    precision is bounded by the bin width.
+    Where proportion is ``count_ge(threshold) / total()`` (non-NaN bases
+    only). The returned threshold is linearly interpolated within the
+    bracketing bin of ``target_hist``; precision is bounded by the bin
+    width.
 
     Returns a JSON-serialisable dict with both tracks' thresholds, counts,
-    the relative error, and the bin metadata. Asserts that the absolute
-    relative error between the matched count and the reference count is
-    under 1% — well below the bin-width-driven precision floor for sensible
+    proportions, the relative error, and the bin metadata. Asserts that
+    the absolute relative error between the matched proportions is under
+    1% — well below the bin-width-driven precision floor for sensible
     bin counts.
     """
     ref_count = ref_hist.count_ge(ref_threshold)
-    target_threshold = target_hist.threshold_for_count(ref_count)
-    target_count = target_hist.count_ge(target_threshold)
+    ref_total = ref_hist.total()
+    assert ref_total > 0, "reference histogram has no non-NaN bases"
+    ref_proportion = ref_count / ref_total
 
-    if ref_count > 0:
-        rel_err = abs(target_count / ref_count - 1.0)
+    target_total = target_hist.total()
+    assert target_total > 0, "target histogram has no non-NaN bases"
+    target_count_target = int(round(ref_proportion * target_total))
+
+    target_threshold = target_hist.threshold_for_count(target_count_target)
+    target_count = target_hist.count_ge(target_threshold)
+    target_proportion = target_count / target_total
+
+    if ref_proportion > 0:
+        rel_err = abs(target_proportion / ref_proportion - 1.0)
     else:
         rel_err = 0.0
     assert rel_err < 0.01, (
-        f"calibration failed: {target_name} count {target_count} vs "
-        f"{ref_name} count {ref_count} (rel err {rel_err:.4f}); "
+        f"calibration failed: {target_name} proportion {target_proportion:.6f} vs "
+        f"{ref_name} proportion {ref_proportion:.6f} (rel err {rel_err:.4f}); "
         f"likely the histogram bin width is too coarse."
     )
 
@@ -50,15 +62,17 @@ def calibrate_to_match_count(
         ref_name: {
             "threshold": float(ref_threshold),
             "count": int(ref_count),
-            "total_bases": int(ref_hist.total()),
+            "proportion": float(ref_proportion),
+            "total_bases": int(ref_total),
             "n_nan": int(ref_hist.n_nan),
         },
         target_name: {
             "threshold": float(target_threshold),
             "count": int(target_count),
-            "count_target": int(ref_count),
+            "count_target": int(target_count_target),
+            "proportion": float(target_proportion),
             "abs_relative_error": float(rel_err),
-            "total_bases": int(target_hist.total()),
+            "total_bases": int(target_total),
             "n_nan": int(target_hist.n_nan),
         },
         "hist_meta": {

--- a/src/bolinas/conservation/histogram.py
+++ b/src/bolinas/conservation/histogram.py
@@ -21,6 +21,8 @@ import numpy as np
 import pandas as pd
 import pyBigWig
 
+from .scoring import _bw_chrom
+
 
 @dataclass
 class PhylopHistogram:
@@ -175,7 +177,7 @@ def build_histogram_for_chrom(
     n_nan = 0
     expected_total = 0
 
-    bw_chrom = chrom if chrom.startswith(chrom_prefix) else f"{chrom_prefix}{chrom}"
+    bw_chrom = _bw_chrom(chrom, chrom_prefix)
     bw = pyBigWig.open(str(bw_path))
     try:
         chroms_in_bw = bw.chroms()

--- a/src/bolinas/conservation/histogram.py
+++ b/src/bolinas/conservation/histogram.py
@@ -1,0 +1,209 @@
+"""Per-base phyloP-value histograms over defined genome regions.
+
+These histograms are the input to ``calibration.calibrate_to_match_count``:
+given the histogram for the reference track (e.g. ``phyloP_241m``) at a
+reference threshold, find the threshold for a target track (e.g.
+``phyloP_447m``) whose genome-wide passing-nucleotide count matches.
+
+Bases with no bigWig signal are counted in ``n_nan`` (separately from the
+``counts`` array). Values outside ``[edges[0], edges[-1]]`` go into the
+first/last bin (``np.clip`` semantics) — pick a wide-enough range that this
+clipping is negligible. For phyloP-mammal tracks ``[-20, 20]`` covers the
+distribution with margin.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyBigWig
+
+
+@dataclass
+class PhylopHistogram:
+    """Histogram of per-base phyloP values plus a separate NaN count.
+
+    ``counts`` is a length-``n_bins`` integer array; ``edges`` is the
+    length-``n_bins + 1`` float array of bin edges. Bin i covers
+    ``[edges[i], edges[i + 1])``.
+    """
+
+    counts: np.ndarray
+    edges: np.ndarray
+    n_nan: int
+
+    def __post_init__(self) -> None:
+        assert self.counts.ndim == 1
+        assert self.edges.ndim == 1
+        assert len(self.edges) == len(self.counts) + 1, (
+            f"edges length must be counts length + 1, "
+            f"got {len(self.edges)} vs {len(self.counts)}"
+        )
+        assert np.all(np.diff(self.edges) > 0), "edges must be strictly increasing"
+        assert (self.counts >= 0).all(), "counts must be non-negative"
+        assert self.n_nan >= 0
+
+    @property
+    def n_bins(self) -> int:
+        return int(len(self.counts))
+
+    def total(self) -> int:
+        """Total non-NaN bases counted."""
+        return int(self.counts.sum())
+
+    def total_with_nan(self) -> int:
+        """Total bases counted, including NaN."""
+        return self.total() + self.n_nan
+
+    def count_ge(self, threshold: float) -> int:
+        """Count of non-NaN bases with value >= ``threshold``.
+
+        Within the bracketing bin we linearly interpolate to handle a
+        threshold that falls between bin edges. Bins fully above
+        ``threshold`` contribute their full count.
+        """
+        if threshold <= self.edges[0]:
+            return self.total()
+        if threshold >= self.edges[-1]:
+            return 0
+
+        i = int(np.searchsorted(self.edges, threshold, side="right")) - 1
+        # i is the index of the bin containing `threshold`.
+        # Linear interpolation within that bin: assume values uniform on [edges[i], edges[i+1]).
+        bin_lo = self.edges[i]
+        bin_hi = self.edges[i + 1]
+        frac_above = (bin_hi - threshold) / (bin_hi - bin_lo)
+        partial = int(round(self.counts[i] * frac_above))
+        full = int(self.counts[i + 1 :].sum())
+        return partial + full
+
+    def threshold_for_count(self, target_count: int) -> float:
+        """Find threshold T such that ``count_ge(T) ≈ target_count``.
+
+        Returns the linearly-interpolated threshold within the bracketing
+        bin. Monotone-decreasing inverse of ``count_ge``.
+        """
+        if target_count <= 0:
+            return float(self.edges[-1])
+        total = self.total()
+        if target_count >= total:
+            return float(self.edges[0])
+
+        # Reverse cumsum from the top: cum[i] = count of bases in bins [i, n_bins).
+        rev_cum = np.concatenate(
+            [np.cumsum(self.counts[::-1])[::-1], np.array([0])]
+        )  # length n_bins + 1; rev_cum[i] = sum of counts[i:]
+        # Find smallest i with rev_cum[i] >= target_count.
+        i = int(np.searchsorted(-rev_cum, -target_count))
+        # rev_cum is non-increasing, so searchsorted on the negated array gives
+        # the first position where rev_cum drops below target_count.
+        # Safety: the i we want is one less (the bin we're inside).
+        i = max(0, i - 1)
+        # Now bin i contains the threshold. rev_cum[i] >= target_count, rev_cum[i+1] < target_count.
+        bin_lo = self.edges[i]
+        bin_hi = self.edges[i + 1]
+        in_bin = self.counts[i]
+        if in_bin == 0:
+            return float(bin_hi)
+        # Need (rev_cum[i + 1] + frac * in_bin) == target_count, where `frac` is the
+        # fraction of the bin above the threshold; threshold = bin_hi - frac * (bin_hi - bin_lo).
+        needed_in_bin = target_count - rev_cum[i + 1]
+        frac = needed_in_bin / in_bin
+        frac = float(np.clip(frac, 0.0, 1.0))
+        return float(bin_hi - frac * (bin_hi - bin_lo))
+
+    def __add__(self, other: "PhylopHistogram") -> "PhylopHistogram":
+        assert np.array_equal(self.edges, other.edges), (
+            "Histograms must share the same edges to be added."
+        )
+        return PhylopHistogram(
+            counts=self.counts + other.counts,
+            edges=self.edges.copy(),
+            n_nan=self.n_nan + other.n_nan,
+        )
+
+    def save(self, path: str | Path) -> None:
+        np.savez(
+            path,
+            counts=self.counts,
+            edges=self.edges,
+            n_nan=np.array([self.n_nan], dtype=np.int64),
+        )
+
+    @classmethod
+    def load(cls, path: str | Path) -> "PhylopHistogram":
+        d = np.load(path)
+        return cls(
+            counts=d["counts"].astype(np.int64),
+            edges=d["edges"].astype(np.float64),
+            n_nan=int(d["n_nan"][0]),
+        )
+
+
+def build_histogram_for_chrom(
+    bw_path: str | Path,
+    chrom: str,
+    defined_intervals: pd.DataFrame,
+    edges: np.ndarray,
+    chrom_prefix: str = "chr",
+) -> PhylopHistogram:
+    """Build a histogram of phyloP values for ``chrom`` over ``defined_intervals``.
+
+    ``defined_intervals`` is a 0-based half-open ``[chrom, start, end]`` frame
+    restricted to a single chromosome — typically the per-chrom slice of a
+    genome-wide "defined regions" BED (i.e. ACGT, no N runs). The bigWig is
+    expected to use UCSC-style ``chr1`` chromosome names; if ``chrom`` lacks
+    that prefix, ``chrom_prefix`` is prepended.
+
+    Returns a ``PhylopHistogram`` covering only the bases inside
+    ``defined_intervals``. Asserts that the total accounted bases matches
+    the sum of interval lengths (``hist.total() + hist.n_nan ==
+    sum(end - start)``).
+    """
+    assert defined_intervals["chrom"].nunique() == 1, (
+        "defined_intervals must contain exactly one chromosome"
+    )
+    assert defined_intervals["chrom"].iloc[0] == chrom, (
+        f"chrom mismatch: dataframe has {defined_intervals['chrom'].iloc[0]!r}, "
+        f"expected {chrom!r}"
+    )
+    n_bins = len(edges) - 1
+    counts = np.zeros(n_bins, dtype=np.int64)
+    n_nan = 0
+    expected_total = 0
+
+    bw_chrom = chrom if chrom.startswith(chrom_prefix) else f"{chrom_prefix}{chrom}"
+    bw = pyBigWig.open(str(bw_path))
+    try:
+        chroms_in_bw = bw.chroms()
+        assert bw_chrom in chroms_in_bw, (
+            f"bigWig {bw_path} has no chrom {bw_chrom!r}; "
+            f"available example: {next(iter(chroms_in_bw))}"
+        )
+        for _, row in defined_intervals.iterrows():
+            start, end = int(row["start"]), int(row["end"])
+            assert start < end, f"empty/inverted interval: {chrom}:{start}-{end}"
+            expected_total += end - start
+            values = np.asarray(
+                bw.values(bw_chrom, start, end, numpy=True), dtype=np.float64
+            )
+            nan_mask = np.isnan(values)
+            n_nan += int(nan_mask.sum())
+            finite = values[~nan_mask]
+            if finite.size:
+                hist, _ = np.histogram(np.clip(finite, edges[0], edges[-1]), bins=edges)
+                counts += hist.astype(np.int64)
+    finally:
+        bw.close()
+
+    h = PhylopHistogram(
+        counts=counts, edges=np.asarray(edges, dtype=np.float64), n_nan=n_nan
+    )
+    assert h.total() + h.n_nan == expected_total, (
+        f"histogram total ({h.total()}) + n_nan ({h.n_nan}) "
+        f"!= expected bases ({expected_total}) for {chrom}"
+    )
+    return h

--- a/src/bolinas/conservation/histogram.py
+++ b/src/bolinas/conservation/histogram.py
@@ -12,8 +12,6 @@ clipping is negligible. For phyloP-mammal tracks ``[-20, 20]`` covers the
 distribution with margin.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/src/bolinas/conservation/scoring.py
+++ b/src/bolinas/conservation/scoring.py
@@ -1,19 +1,115 @@
-"""Parse ``bigWigAverageOverBed`` TSV output into a typed Polars frame.
+"""Per-window phyloP scoring via pyBigWig.
 
-``bigWigAverageOverBed`` (UCSC kentUtils) emits one TSV row per BED entry
-with columns:
-  name, size, covered, sum, mean0, mean
+Two reasons we use pyBigWig directly instead of the kentUtils
+``bigWigAverageOverBed`` route:
 
-Documented at https://genome.ucsc.edu/goldenPath/help/bigWig.html (search
-"bigWigAverageOverBed"). When the bigWig has no values across an interval,
-``covered=0`` and ``mean`` is ``n/a`` (we coerce that to NaN).
+1. The bioconda kentUtils binaries (``bedGraphToBigWig``, ``faToTwoBit``)
+   don't accept pipes on ``stdin`` — they need a regular file. The
+   ``binarize via bigWigToBedGraph | awk | bedGraphToBigWig`` chain we
+   tried fails on the ``stdin`` step. Materialising the per-base bedGraph
+   to a temp file would cost ~30 GB and another full I/O pass.
+2. ``run:`` blocks don't activate the rule's conda env, so calling
+   ``bigWigAverageOverBed`` via ``subprocess`` from a ``run:`` block needs
+   a separate shell rule and TSV-parsing step. Doing the math directly
+   in Python keeps it to one rule and one library function.
+
+Performance: pyBigWig handles ~10K windows/sec/core on 255 bp windows.
+24M windows → ~40 min single-threaded; parallelisable across windows.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 import polars as pl
+import pyBigWig
+
+def score_windows(
+    bw_path: str | Path,
+    windows: pl.DataFrame,
+    threshold: float,
+    *,
+    chrom_prefix: str = "chr",
+) -> pl.DataFrame:
+    """Score each window in ``windows`` against the bigWig at ``bw_path``.
+
+    Args:
+        bw_path: path to the phyloP bigWig (UCSC ``chr1``-style chrom names).
+        windows: polars frame with columns ``chrom``, ``start``, ``end``;
+            ``chrom`` may be either ``"1"`` or ``"chr1"``-style — bare names
+            are auto-prefixed with ``chrom_prefix`` for the bigWig lookup.
+        threshold: phyloP value at/above which a base is "conserved".
+        chrom_prefix: prefix to add to bare chrom names (default ``"chr"``).
+
+    Returns:
+        ``windows`` with four extra columns:
+          - ``conserved_bases`` (Int32): count of bases with value ≥
+            ``threshold``. NaN positions are counted as **non-conserved**
+            (= 0), so the count is over the whole window length, not just
+            the covered (non-NaN) bases.
+          - ``proportion_conserved`` (Float32): ``conserved_bases / (end - start)``.
+          - ``mean_phylop`` (Float32): mean of finite values in the window
+            (NaN if no finite values).
+          - ``n_valid_bases`` (Int32): count of bases where the bigWig has
+            a finite value (i.e. excludes NaN).
+    """
+    assert {"chrom", "start", "end"}.issubset(windows.columns), (
+        f"windows must have chrom/start/end columns; got {windows.columns}"
+    )
+
+    conserved_bases = np.empty(len(windows), dtype=np.int32)
+    proportion_conserved = np.empty(len(windows), dtype=np.float32)
+    mean_phylop = np.empty(len(windows), dtype=np.float32)
+    n_valid_bases = np.empty(len(windows), dtype=np.int32)
+
+    bw = pyBigWig.open(str(bw_path))
+    try:
+        bw_chroms = set(bw.chroms())
+        chroms = windows["chrom"].to_list()
+        starts = windows["start"].to_list()
+        ends = windows["end"].to_list()
+        for i, (chrom, start, end) in enumerate(zip(chroms, starts, ends)):
+            start = int(start)
+            end = int(end)
+            size = end - start
+            assert size > 0, f"empty window at index {i}: {chrom}:{start}-{end}"
+            bw_chrom = (
+                chrom if chrom.startswith(chrom_prefix) else f"{chrom_prefix}{chrom}"
+            )
+            if bw_chrom not in bw_chroms:
+                conserved_bases[i] = 0
+                proportion_conserved[i] = 0.0
+                mean_phylop[i] = np.nan
+                n_valid_bases[i] = 0
+                continue
+            values = np.asarray(
+                bw.values(bw_chrom, start, end, numpy=True), dtype=np.float64
+            )
+            finite_mask = np.isfinite(values)
+            n_finite = int(finite_mask.sum())
+            # NaN treated as non-conserved: NaN >= threshold evaluates to
+            # False in NumPy regardless of threshold, so the NaN positions
+            # are naturally excluded from the conserved-bases count
+            # *without* needing to fill them. (Don't fill with 0 — that
+            # breaks the case where threshold <= 0.)
+            n_conserved = int((values >= threshold).sum())
+            conserved_bases[i] = n_conserved
+            proportion_conserved[i] = n_conserved / size
+            mean_phylop[i] = float(np.nanmean(values)) if n_finite > 0 else np.nan
+            n_valid_bases[i] = n_finite
+    finally:
+        bw.close()
+
+    return windows.with_columns(
+        [
+            pl.Series("conserved_bases", conserved_bases, dtype=pl.Int32),
+            pl.Series("proportion_conserved", proportion_conserved, dtype=pl.Float32),
+            pl.Series("mean_phylop", mean_phylop, dtype=pl.Float32),
+            pl.Series("n_valid_bases", n_valid_bases, dtype=pl.Int32),
+        ]
+    )
+
 
 _COLUMNS: tuple[str, ...] = ("name", "size", "covered", "sum", "mean0", "mean")
 

--- a/src/bolinas/conservation/scoring.py
+++ b/src/bolinas/conservation/scoring.py
@@ -4,8 +4,6 @@ Performance: pyBigWig handles ~10K windows/sec/core on 255 bp windows;
 parallelise across chroms in the calling pipeline.
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import numpy as np

--- a/src/bolinas/conservation/scoring.py
+++ b/src/bolinas/conservation/scoring.py
@@ -1,20 +1,7 @@
 """Per-window phyloP scoring via pyBigWig.
 
-Two reasons we use pyBigWig directly instead of the kentUtils
-``bigWigAverageOverBed`` route:
-
-1. The bioconda kentUtils binaries (``bedGraphToBigWig``, ``faToTwoBit``)
-   don't accept pipes on ``stdin`` — they need a regular file. The
-   ``binarize via bigWigToBedGraph | awk | bedGraphToBigWig`` chain we
-   tried fails on the ``stdin`` step. Materialising the per-base bedGraph
-   to a temp file would cost ~30 GB and another full I/O pass.
-2. ``run:`` blocks don't activate the rule's conda env, so calling
-   ``bigWigAverageOverBed`` via ``subprocess`` from a ``run:`` block needs
-   a separate shell rule and TSV-parsing step. Doing the math directly
-   in Python keeps it to one rule and one library function.
-
-Performance: pyBigWig handles ~10K windows/sec/core on 255 bp windows.
-24M windows → ~40 min single-threaded; parallelisable across windows.
+Performance: pyBigWig handles ~10K windows/sec/core on 255 bp windows;
+parallelise across chroms in the calling pipeline.
 """
 
 from __future__ import annotations
@@ -24,6 +11,16 @@ from pathlib import Path
 import numpy as np
 import polars as pl
 import pyBigWig
+
+
+def _bw_chrom(chrom: str, prefix: str = "chr") -> str:
+    """Add ``prefix`` to ``chrom`` unless it's already there.
+
+    Bridges Ensembl bare chrom names (``"1"``) to the ``"chr1"`` style
+    that UCSC bigWigs use.
+    """
+    return chrom if chrom.startswith(prefix) else f"{prefix}{chrom}"
+
 
 def score_windows(
     bw_path: str | Path,
@@ -74,9 +71,7 @@ def score_windows(
             end = int(end)
             size = end - start
             assert size > 0, f"empty window at index {i}: {chrom}:{start}-{end}"
-            bw_chrom = (
-                chrom if chrom.startswith(chrom_prefix) else f"{chrom_prefix}{chrom}"
-            )
+            bw_chrom = _bw_chrom(chrom, chrom_prefix)
             if bw_chrom not in bw_chroms:
                 conserved_bases[i] = 0
                 proportion_conserved[i] = 0.0
@@ -109,46 +104,3 @@ def score_windows(
             pl.Series("n_valid_bases", n_valid_bases, dtype=pl.Int32),
         ]
     )
-
-
-_COLUMNS: tuple[str, ...] = ("name", "size", "covered", "sum", "mean0", "mean")
-
-
-def parse_bigwig_average_over_bed(tsv_path: str | Path) -> pl.DataFrame:
-    """Read a ``bigWigAverageOverBed`` TSV into a Polars frame.
-
-    Output schema:
-      name (str), size (i64), covered (i64), sum (f64), mean0 (f64), mean (f64)
-
-    The ``mean`` column is NaN where ``covered == 0`` (no bigWig signal in
-    the interval). All asserts are run after parsing: invariants that
-    should hold for every row are checked here so a malformed TSV fails
-    fast at the parsing boundary.
-    """
-    df = pl.read_csv(
-        tsv_path,
-        separator="\t",
-        has_header=False,
-        new_columns=list(_COLUMNS),
-        schema_overrides={
-            "name": pl.Utf8,
-            "size": pl.Int64,
-            "covered": pl.Int64,
-            "sum": pl.Float64,
-            "mean0": pl.Float64,
-            "mean": pl.Float64,
-        },
-        null_values=["n/a"],
-    )
-
-    assert set(df.columns) == set(_COLUMNS), (
-        f"unexpected columns from bigWigAverageOverBed: {df.columns}"
-    )
-    assert (df["size"] > 0).all(), "non-positive size in bigWigAverageOverBed output"
-    assert (df["covered"] >= 0).all(), (
-        "negative `covered` in bigWigAverageOverBed output"
-    )
-    assert (df["covered"] <= df["size"]).all(), (
-        "`covered` > `size` in bigWigAverageOverBed output"
-    )
-    return df

--- a/src/bolinas/conservation/scoring.py
+++ b/src/bolinas/conservation/scoring.py
@@ -1,0 +1,58 @@
+"""Parse ``bigWigAverageOverBed`` TSV output into a typed Polars frame.
+
+``bigWigAverageOverBed`` (UCSC kentUtils) emits one TSV row per BED entry
+with columns:
+  name, size, covered, sum, mean0, mean
+
+Documented at https://genome.ucsc.edu/goldenPath/help/bigWig.html (search
+"bigWigAverageOverBed"). When the bigWig has no values across an interval,
+``covered=0`` and ``mean`` is ``n/a`` (we coerce that to NaN).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+_COLUMNS: tuple[str, ...] = ("name", "size", "covered", "sum", "mean0", "mean")
+
+
+def parse_bigwig_average_over_bed(tsv_path: str | Path) -> pl.DataFrame:
+    """Read a ``bigWigAverageOverBed`` TSV into a Polars frame.
+
+    Output schema:
+      name (str), size (i64), covered (i64), sum (f64), mean0 (f64), mean (f64)
+
+    The ``mean`` column is NaN where ``covered == 0`` (no bigWig signal in
+    the interval). All asserts are run after parsing: invariants that
+    should hold for every row are checked here so a malformed TSV fails
+    fast at the parsing boundary.
+    """
+    df = pl.read_csv(
+        tsv_path,
+        separator="\t",
+        has_header=False,
+        new_columns=list(_COLUMNS),
+        schema_overrides={
+            "name": pl.Utf8,
+            "size": pl.Int64,
+            "covered": pl.Int64,
+            "sum": pl.Float64,
+            "mean0": pl.Float64,
+            "mean": pl.Float64,
+        },
+        null_values=["n/a"],
+    )
+
+    assert set(df.columns) == set(_COLUMNS), (
+        f"unexpected columns from bigWigAverageOverBed: {df.columns}"
+    )
+    assert (df["size"] > 0).all(), "non-positive size in bigWigAverageOverBed output"
+    assert (df["covered"] >= 0).all(), (
+        "negative `covered` in bigWigAverageOverBed output"
+    )
+    assert (df["covered"] <= df["size"]).all(), (
+        "`covered` > `size` in bigWigAverageOverBed output"
+    )
+    return df

--- a/tests/conservation/test_calibration.py
+++ b/tests/conservation/test_calibration.py
@@ -56,7 +56,9 @@ def test_calibrate_proportion_invariant_to_total_size(edges: np.ndarray) -> None
     tgt_hist_small = _hist(tgt_vals_small, edges)
     tgt_hist_big = _hist(tgt_vals_big, edges)
 
-    out_small = calibrate_to_match_proportion(tgt_hist_small, ref_hist, ref_threshold=2.27)
+    out_small = calibrate_to_match_proportion(
+        tgt_hist_small, ref_hist, ref_threshold=2.27
+    )
     out_big = calibrate_to_match_proportion(tgt_hist_big, ref_hist, ref_threshold=2.27)
     # Same distribution → same threshold within sampling noise
     assert abs(out_small["target"]["threshold"] - out_big["target"]["threshold"]) < 0.1

--- a/tests/conservation/test_calibration.py
+++ b/tests/conservation/test_calibration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from bolinas.conservation.calibration import calibrate_to_match_count
+from bolinas.conservation.calibration import calibrate_to_match_proportion
 from bolinas.conservation.histogram import PhylopHistogram
 
 
@@ -14,9 +14,9 @@ def edges() -> np.ndarray:
     return np.linspace(-20.0, 20.0, 1001)
 
 
-def _hist(values: np.ndarray, edges: np.ndarray) -> PhylopHistogram:
+def _hist(values: np.ndarray, edges: np.ndarray, n_nan: int = 0) -> PhylopHistogram:
     counts, _ = np.histogram(np.clip(values, edges[0], edges[-1]), bins=edges)
-    return PhylopHistogram(counts=counts.astype(np.int64), edges=edges, n_nan=0)
+    return PhylopHistogram(counts=counts.astype(np.int64), edges=edges, n_nan=n_nan)
 
 
 def test_calibrate_identity(edges: np.ndarray) -> None:
@@ -24,7 +24,7 @@ def test_calibrate_identity(edges: np.ndarray) -> None:
     rng = np.random.default_rng(0)
     values = rng.normal(0.0, 2.0, size=200_000)
     hist = _hist(values, edges)
-    out = calibrate_to_match_count(hist, hist, ref_threshold=2.27)
+    out = calibrate_to_match_proportion(hist, hist, ref_threshold=2.27)
     # Must be within one bin's worth (0.04) of the reference
     assert abs(out["target"]["threshold"] - 2.27) < 0.05
 
@@ -39,17 +39,56 @@ def test_calibrate_known_shift(edges: np.ndarray) -> None:
     ref_hist = _hist(ref_vals, edges)
     tgt_hist = _hist(tgt_vals, edges)
 
-    out = calibrate_to_match_count(tgt_hist, ref_hist, ref_threshold=2.27)
-    # The target threshold should be ~ 1 above the reference threshold,
-    # within sampling noise + bin width
+    out = calibrate_to_match_proportion(tgt_hist, ref_hist, ref_threshold=2.27)
     assert abs(out["target"]["threshold"] - (2.27 + 1.0)) < 0.1
+
+
+def test_calibrate_proportion_invariant_to_total_size(edges: np.ndarray) -> None:
+    """Doubling the target's total non-NaN bases (with the same distribution
+    shape) should NOT change the calibrated threshold — proportion-based
+    calibration is invariant to total coverage. Count-based would scale."""
+    rng = np.random.default_rng(0)
+    ref_vals = rng.normal(0.0, 2.0, size=200_000)
+    ref_hist = _hist(ref_vals, edges)
+
+    tgt_vals_small = rng.normal(0.0, 2.0, size=200_000)
+    tgt_vals_big = rng.normal(0.0, 2.0, size=400_000)
+    tgt_hist_small = _hist(tgt_vals_small, edges)
+    tgt_hist_big = _hist(tgt_vals_big, edges)
+
+    out_small = calibrate_to_match_proportion(tgt_hist_small, ref_hist, ref_threshold=2.27)
+    out_big = calibrate_to_match_proportion(tgt_hist_big, ref_hist, ref_threshold=2.27)
+    # Same distribution → same threshold within sampling noise
+    assert abs(out_small["target"]["threshold"] - out_big["target"]["threshold"]) < 0.1
+
+
+def test_calibrate_n_nan_does_not_affect_proportion(edges: np.ndarray) -> None:
+    """``n_nan`` is tracked separately from ``counts``; it should not enter
+    the proportion calculation. Adding NaN bases to either side must leave
+    the calibrated threshold unchanged."""
+    rng = np.random.default_rng(0)
+    ref_vals = rng.normal(0.0, 2.0, size=200_000)
+    tgt_vals = rng.normal(1.0, 2.0, size=200_000)
+
+    out_no_nan = calibrate_to_match_proportion(
+        _hist(tgt_vals, edges, n_nan=0),
+        _hist(ref_vals, edges, n_nan=0),
+        ref_threshold=2.27,
+    )
+    out_with_nan = calibrate_to_match_proportion(
+        _hist(tgt_vals, edges, n_nan=10_000_000),
+        _hist(ref_vals, edges, n_nan=5_000_000),
+        ref_threshold=2.27,
+    )
+    # Identical thresholds (NaN counts not in numerator or denominator)
+    assert out_no_nan["target"]["threshold"] == out_with_nan["target"]["threshold"]
 
 
 def test_calibration_dict_shape(edges: np.ndarray) -> None:
     """Returned dict has the expected structure for downstream JSON output."""
     rng = np.random.default_rng(0)
-    hist = _hist(rng.normal(0, 2, size=100_000), edges)
-    out = calibrate_to_match_count(
+    hist = _hist(rng.normal(0, 2, size=100_000), edges, n_nan=42)
+    out = calibrate_to_match_proportion(
         hist,
         hist,
         ref_threshold=2.0,
@@ -57,35 +96,23 @@ def test_calibration_dict_shape(edges: np.ndarray) -> None:
         ref_name="phyloP_241m",
     )
     assert set(out.keys()) == {"phyloP_241m", "phyloP_447m", "hist_meta"}
-    assert set(out["phyloP_241m"]) == {"threshold", "count", "total_bases", "n_nan"}
+    assert set(out["phyloP_241m"]) == {
+        "threshold",
+        "count",
+        "proportion",
+        "total_bases",
+        "n_nan",
+    }
     assert set(out["phyloP_447m"]) == {
         "threshold",
         "count",
         "count_target",
+        "proportion",
         "abs_relative_error",
         "total_bases",
         "n_nan",
     }
     assert set(out["hist_meta"]) == {"n_bins", "min", "max", "bin_width"}
     assert out["phyloP_447m"]["abs_relative_error"] < 0.01
-
-
-def test_calibration_fails_loudly_with_too_coarse_bins() -> None:
-    """If the bin width swallows the reference count entirely, calibration
-    should error rather than silently return a bogus threshold."""
-    edges = np.array([-20.0, -10.0, 0.0, 10.0, 20.0])  # width 10 — extremely coarse
-    rng = np.random.default_rng(0)
-    ref_vals = rng.normal(0, 0.5, size=10_000)  # nearly all in bin [-10, 0)
-    tgt_vals = rng.normal(0, 0.5, size=10_000)
-    ref_hist = _hist(ref_vals, edges)
-    tgt_hist = _hist(tgt_vals, edges)
-    # ref_threshold near a bin edge to amplify mismatch
-    # With this coarse a histogram and a threshold at 0.0, calibration should
-    # still find a matching threshold (both distributions are identical), so
-    # this test mostly checks we don't crash. Accept either success or the
-    # explicit assertion.
-    try:
-        out = calibrate_to_match_count(tgt_hist, ref_hist, ref_threshold=2.27)
-        assert out["target"]["abs_relative_error"] < 0.01
-    except AssertionError as e:
-        assert "bin width" in str(e) or "calibration failed" in str(e)
+    assert 0.0 <= out["phyloP_241m"]["proportion"] <= 1.0
+    assert 0.0 <= out["phyloP_447m"]["proportion"] <= 1.0

--- a/tests/conservation/test_calibration.py
+++ b/tests/conservation/test_calibration.py
@@ -1,7 +1,5 @@
 """Tests for ``bolinas.conservation.calibration``."""
 
-from __future__ import annotations
-
 import numpy as np
 import pytest
 

--- a/tests/conservation/test_calibration.py
+++ b/tests/conservation/test_calibration.py
@@ -1,0 +1,91 @@
+"""Tests for ``bolinas.conservation.calibration``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bolinas.conservation.calibration import calibrate_to_match_count
+from bolinas.conservation.histogram import PhylopHistogram
+
+
+@pytest.fixture
+def edges() -> np.ndarray:
+    return np.linspace(-20.0, 20.0, 1001)
+
+
+def _hist(values: np.ndarray, edges: np.ndarray) -> PhylopHistogram:
+    counts, _ = np.histogram(np.clip(values, edges[0], edges[-1]), bins=edges)
+    return PhylopHistogram(counts=counts.astype(np.int64), edges=edges, n_nan=0)
+
+
+def test_calibrate_identity(edges: np.ndarray) -> None:
+    """Same histogram on both sides → matched threshold equals the reference."""
+    rng = np.random.default_rng(0)
+    values = rng.normal(0.0, 2.0, size=200_000)
+    hist = _hist(values, edges)
+    out = calibrate_to_match_count(hist, hist, ref_threshold=2.27)
+    # Must be within one bin's worth (0.04) of the reference
+    assert abs(out["target"]["threshold"] - 2.27) < 0.05
+
+
+def test_calibrate_known_shift(edges: np.ndarray) -> None:
+    """Reference is N(0, 2); target is N(1, 2). Calibrated threshold should be
+    ~ 1 above the reference threshold (since target distribution is shifted +1)."""
+    rng = np.random.default_rng(0)
+    n = 500_000
+    ref_vals = rng.normal(0.0, 2.0, size=n)
+    tgt_vals = rng.normal(1.0, 2.0, size=n)
+    ref_hist = _hist(ref_vals, edges)
+    tgt_hist = _hist(tgt_vals, edges)
+
+    out = calibrate_to_match_count(tgt_hist, ref_hist, ref_threshold=2.27)
+    # The target threshold should be ~ 1 above the reference threshold,
+    # within sampling noise + bin width
+    assert abs(out["target"]["threshold"] - (2.27 + 1.0)) < 0.1
+
+
+def test_calibration_dict_shape(edges: np.ndarray) -> None:
+    """Returned dict has the expected structure for downstream JSON output."""
+    rng = np.random.default_rng(0)
+    hist = _hist(rng.normal(0, 2, size=100_000), edges)
+    out = calibrate_to_match_count(
+        hist,
+        hist,
+        ref_threshold=2.0,
+        target_name="phyloP_447m",
+        ref_name="phyloP_241m",
+    )
+    assert set(out.keys()) == {"phyloP_241m", "phyloP_447m", "hist_meta"}
+    assert set(out["phyloP_241m"]) == {"threshold", "count", "total_bases", "n_nan"}
+    assert set(out["phyloP_447m"]) == {
+        "threshold",
+        "count",
+        "count_target",
+        "abs_relative_error",
+        "total_bases",
+        "n_nan",
+    }
+    assert set(out["hist_meta"]) == {"n_bins", "min", "max", "bin_width"}
+    assert out["phyloP_447m"]["abs_relative_error"] < 0.01
+
+
+def test_calibration_fails_loudly_with_too_coarse_bins() -> None:
+    """If the bin width swallows the reference count entirely, calibration
+    should error rather than silently return a bogus threshold."""
+    edges = np.array([-20.0, -10.0, 0.0, 10.0, 20.0])  # width 10 — extremely coarse
+    rng = np.random.default_rng(0)
+    ref_vals = rng.normal(0, 0.5, size=10_000)  # nearly all in bin [-10, 0)
+    tgt_vals = rng.normal(0, 0.5, size=10_000)
+    ref_hist = _hist(ref_vals, edges)
+    tgt_hist = _hist(tgt_vals, edges)
+    # ref_threshold near a bin edge to amplify mismatch
+    # With this coarse a histogram and a threshold at 0.0, calibration should
+    # still find a matching threshold (both distributions are identical), so
+    # this test mostly checks we don't crash. Accept either success or the
+    # explicit assertion.
+    try:
+        out = calibrate_to_match_count(tgt_hist, ref_hist, ref_threshold=2.27)
+        assert out["target"]["abs_relative_error"] < 0.01
+    except AssertionError as e:
+        assert "bin width" in str(e) or "calibration failed" in str(e)

--- a/tests/conservation/test_histogram.py
+++ b/tests/conservation/test_histogram.py
@@ -1,7 +1,5 @@
 """Tests for ``bolinas.conservation.histogram``."""
 
-from __future__ import annotations
-
 import numpy as np
 import pytest
 

--- a/tests/conservation/test_histogram.py
+++ b/tests/conservation/test_histogram.py
@@ -1,0 +1,113 @@
+"""Tests for ``bolinas.conservation.histogram``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from bolinas.conservation.histogram import PhylopHistogram
+
+
+@pytest.fixture
+def edges() -> np.ndarray:
+    return np.linspace(-20.0, 20.0, 1001)  # 1000 bins, width 0.04
+
+
+@pytest.fixture
+def synthetic_values() -> np.ndarray:
+    rng = np.random.default_rng(42)
+    return rng.normal(loc=0.0, scale=2.0, size=100_000).astype(np.float64)
+
+
+def _hist_from_values(values: np.ndarray, edges: np.ndarray) -> PhylopHistogram:
+    counts, _ = np.histogram(np.clip(values, edges[0], edges[-1]), bins=edges)
+    return PhylopHistogram(counts=counts.astype(np.int64), edges=edges, n_nan=0)
+
+
+def test_count_ge_matches_naive(
+    edges: np.ndarray, synthetic_values: np.ndarray
+) -> None:
+    # Linear interpolation introduces an error bounded by the count density
+    # times the bin width — for a Gaussian on 100k samples that's well
+    # under 200.
+    hist = _hist_from_values(synthetic_values, edges)
+    for t in (-5.0, -1.0, 0.0, 1.5, 3.0, 5.0):
+        assert abs(hist.count_ge(t) - int((synthetic_values >= t).sum())) < 200
+
+
+def test_count_ge_extremes(edges: np.ndarray) -> None:
+    hist = _hist_from_values(np.array([0.0, 1.0, 2.0, 3.0]), edges)
+    # Below the histogram range: all 4 are above
+    assert hist.count_ge(-1000.0) == 4
+    # Above the histogram range: zero
+    assert hist.count_ge(1000.0) == 0
+
+
+def test_threshold_for_count_inverse(
+    edges: np.ndarray, synthetic_values: np.ndarray
+) -> None:
+    hist = _hist_from_values(synthetic_values, edges)
+    total = hist.total()
+    # Round-trip a sample of target counts
+    for target in (10, 100, 1_000, 10_000, 50_000, total - 100):
+        t = hist.threshold_for_count(target)
+        # Re-counting should give a count near the target (within bin precision).
+        recovered = hist.count_ge(t)
+        # Within ~1% or 50 bases, whichever is larger.
+        tolerance = max(50, target // 100)
+        assert abs(recovered - target) < tolerance, (
+            f"target={target}, threshold={t}, recovered={recovered}"
+        )
+
+
+def test_threshold_for_count_monotone(
+    edges: np.ndarray, synthetic_values: np.ndarray
+) -> None:
+    """As the target count increases, the matching threshold must not increase."""
+    hist = _hist_from_values(synthetic_values, edges)
+    targets = [100, 1_000, 10_000, 50_000]
+    thresholds = [hist.threshold_for_count(t) for t in targets]
+    for a, b in zip(thresholds, thresholds[1:]):
+        assert a >= b, f"non-monotone: targets {targets}, thresholds {thresholds}"
+
+
+def test_threshold_for_count_extremes(
+    edges: np.ndarray, synthetic_values: np.ndarray
+) -> None:
+    hist = _hist_from_values(synthetic_values, edges)
+    # target_count == 0 → threshold at the top of the range
+    assert hist.threshold_for_count(0) == edges[-1]
+    # target_count >= total → threshold at the bottom
+    assert hist.threshold_for_count(hist.total() + 100) == edges[0]
+
+
+def test_add_histograms(edges: np.ndarray) -> None:
+    h1 = _hist_from_values(np.array([1.0, 2.0, 3.0]), edges)
+    h1.n_nan = 7
+    h2 = _hist_from_values(np.array([1.0, 4.0]), edges)
+    h2.n_nan = 3
+    h12 = h1 + h2
+    assert h12.n_nan == 10
+    assert h12.total() == 5
+    assert h12.count_ge(2.5) == 2  # values 3.0 and 4.0
+
+
+def test_add_histograms_edge_mismatch(edges: np.ndarray) -> None:
+    h1 = _hist_from_values(np.array([1.0]), edges)
+    other_edges = np.linspace(-10.0, 10.0, 501)
+    h2 = _hist_from_values(np.array([1.0]), other_edges)
+    with pytest.raises(AssertionError, match="same edges"):
+        _ = h1 + h2
+
+
+def test_save_load_roundtrip(edges: np.ndarray, tmp_path) -> None:
+    h = _hist_from_values(np.array([0.0, 1.0, 2.0, 3.0, 4.0]), edges)
+    h.n_nan = 42
+    p = tmp_path / "h.npz"
+    h.save(p)
+    loaded = PhylopHistogram.load(p)
+    assert np.array_equal(loaded.counts, h.counts)
+    assert np.array_equal(loaded.edges, h.edges)
+    assert loaded.n_nan == h.n_nan
+    assert loaded.total() == h.total()
+    assert loaded.count_ge(2.5) == h.count_ge(2.5)

--- a/tests/conservation/test_scoring.py
+++ b/tests/conservation/test_scoring.py
@@ -2,9 +2,141 @@
 
 from __future__ import annotations
 
-import polars as pl
+import math
 
-from bolinas.conservation.scoring import parse_bigwig_average_over_bed
+import numpy as np
+import polars as pl
+import pyBigWig
+import pytest
+
+from bolinas.conservation.scoring import (
+    parse_bigwig_average_over_bed,
+    score_windows,
+)
+
+
+@pytest.fixture
+def synthetic_bigwig(tmp_path):
+    """Build a tiny ``chr1`` bigWig with three regions:
+      - [0, 30):    value 2.0   (above any threshold below 2.0)
+      - [30, 60):   no value    (NaN — gap in bigWig)
+      - [60, 100):  value -1.0  (below any threshold above -1.0)
+    """
+    bw_path = tmp_path / "test.bw"
+    bw = pyBigWig.open(str(bw_path), "w")
+    bw.addHeader([("chr1", 100)])
+    bw.addEntries(
+        ["chr1"] * 30,
+        list(range(0, 30)),
+        ends=list(range(1, 31)),
+        values=[2.0] * 30,
+    )
+    bw.addEntries(
+        ["chr1"] * 40,
+        list(range(60, 100)),
+        ends=list(range(61, 101)),
+        values=[-1.0] * 40,
+    )
+    bw.close()
+    return bw_path
+
+
+def test_score_windows_basic(synthetic_bigwig) -> None:
+    """Single 100 bp window covering the whole synthetic chromosome."""
+    windows = pl.DataFrame(
+        {"chrom": ["1"], "start": [0], "end": [100], "name": ["w1"]}
+    )
+    result = score_windows(synthetic_bigwig, windows, threshold=1.0)
+    row = result.row(0, named=True)
+    assert row["conserved_bases"] == 30
+    assert math.isclose(row["proportion_conserved"], 0.30, abs_tol=1e-5)
+    assert row["n_valid_bases"] == 70
+    # mean over 70 valid bases: (30*2 + 40*-1) / 70 = 20/70 ≈ 0.2857
+    assert math.isclose(row["mean_phylop"], 20 / 70, abs_tol=1e-3)
+
+
+def test_score_windows_nan_counted_as_zero(synthetic_bigwig) -> None:
+    """A window of pure NaN scores 0 conserved bases, n_valid 0."""
+    windows = pl.DataFrame(
+        {"chrom": ["1"], "start": [30], "end": [60], "name": ["w_nan"]}
+    )
+    result = score_windows(synthetic_bigwig, windows, threshold=0.0)
+    row = result.row(0, named=True)
+    assert row["conserved_bases"] == 0
+    assert math.isclose(row["proportion_conserved"], 0.0, abs_tol=1e-5)
+    assert row["n_valid_bases"] == 0
+    assert math.isnan(row["mean_phylop"])
+
+
+def test_score_windows_threshold_inclusive(synthetic_bigwig) -> None:
+    """A value exactly at threshold is conserved (>= semantics)."""
+    windows = pl.DataFrame(
+        {"chrom": ["1"], "start": [0], "end": [30], "name": ["w_above"]}
+    )
+    result = score_windows(synthetic_bigwig, windows, threshold=2.0)
+    row = result.row(0, named=True)
+    assert row["conserved_bases"] == 30
+
+
+def test_score_windows_chrom_prefix(synthetic_bigwig) -> None:
+    """Both ``"1"`` and ``"chr1"`` chrom labels resolve to the same bigWig chrom."""
+    bare = score_windows(
+        synthetic_bigwig,
+        pl.DataFrame({"chrom": ["1"], "start": [0], "end": [30], "name": ["w"]}),
+        threshold=1.0,
+    )
+    chr_prefixed = score_windows(
+        synthetic_bigwig,
+        pl.DataFrame({"chrom": ["chr1"], "start": [0], "end": [30], "name": ["w"]}),
+        threshold=1.0,
+    )
+    assert bare.row(0, named=True)["conserved_bases"] == 30
+    assert chr_prefixed.row(0, named=True)["conserved_bases"] == 30
+
+
+def test_score_windows_unknown_chrom(synthetic_bigwig) -> None:
+    """A chrom not in the bigWig produces zeros and NaN mean (instead of crashing)."""
+    windows = pl.DataFrame(
+        {"chrom": ["99"], "start": [0], "end": [30], "name": ["w_missing"]}
+    )
+    result = score_windows(synthetic_bigwig, windows, threshold=1.0)
+    row = result.row(0, named=True)
+    assert row["conserved_bases"] == 0
+    assert row["n_valid_bases"] == 0
+    assert math.isnan(row["mean_phylop"])
+
+
+def test_score_windows_dtypes(synthetic_bigwig) -> None:
+    """Schema is the contract used by downstream Parquet / filter rules."""
+    windows = pl.DataFrame(
+        {"chrom": ["1"], "start": [0], "end": [100], "name": ["w1"]}
+    )
+    result = score_windows(synthetic_bigwig, windows, threshold=1.0)
+    assert result.schema["conserved_bases"] == pl.Int32
+    assert result.schema["proportion_conserved"] == pl.Float32
+    assert result.schema["mean_phylop"] == pl.Float32
+    assert result.schema["n_valid_bases"] == pl.Int32
+
+
+def test_score_windows_proportion_consistent_with_count(synthetic_bigwig) -> None:
+    """``proportion_conserved == conserved_bases / (end - start)`` exactly."""
+    rng = np.random.default_rng(0)
+    rows = [
+        {
+            "chrom": "1",
+            "start": int(s),
+            "end": int(s + 50),
+            "name": f"w{i}",
+        }
+        for i, s in enumerate(rng.integers(0, 50, size=10))
+    ]
+    windows = pl.DataFrame(rows)
+    result = score_windows(synthetic_bigwig, windows, threshold=1.0)
+    for row in result.iter_rows(named=True):
+        size = row["end"] - row["start"]
+        assert math.isclose(
+            row["proportion_conserved"], row["conserved_bases"] / size, abs_tol=1e-5
+        )
 
 
 def test_parse_bigwig_average_over_bed_dtypes(tmp_path) -> None:

--- a/tests/conservation/test_scoring.py
+++ b/tests/conservation/test_scoring.py
@@ -1,0 +1,49 @@
+"""Tests for ``bolinas.conservation.scoring``."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from bolinas.conservation.scoring import parse_bigwig_average_over_bed
+
+
+def test_parse_bigwig_average_over_bed_dtypes(tmp_path) -> None:
+    """Schema, dtypes, and columns match the bigWigAverageOverBed contract."""
+    p = tmp_path / "out.tsv"
+    p.write_text(
+        "win_001\t255\t255\t100.5\t0.394\t0.394\n"
+        "win_002\t255\t250\t40.0\t0.157\t0.160\n"
+    )
+    df = parse_bigwig_average_over_bed(p)
+    assert df.columns == ["name", "size", "covered", "sum", "mean0", "mean"]
+    assert df.schema["name"] == pl.Utf8
+    assert df.schema["size"] == pl.Int64
+    assert df.schema["covered"] == pl.Int64
+    assert df.schema["sum"] == pl.Float64
+    assert df.schema["mean0"] == pl.Float64
+    assert df.schema["mean"] == pl.Float64
+    assert df.shape == (2, 6)
+
+
+def test_parse_bigwig_average_over_bed_handles_zero_covered(tmp_path) -> None:
+    """When ``covered == 0``, ``mean`` is ``n/a`` in the TSV; we coerce to NaN."""
+    p = tmp_path / "out.tsv"
+    p.write_text("win_001\t255\t0\t0.0\t0.0\tn/a\n")
+    df = parse_bigwig_average_over_bed(p)
+    assert df["covered"][0] == 0
+    assert df["sum"][0] == 0.0
+    assert df["mean0"][0] == 0.0
+    assert df["mean"].is_null().all()
+
+
+def test_parse_bigwig_average_over_bed_binary_track(tmp_path) -> None:
+    """For a binarized bigWig, sum == conserved_bases and mean0 == proportion.
+    Smoke test of the math we depend on downstream."""
+    p = tmp_path / "out.tsv"
+    p.write_text(
+        # window of size 255, all 255 covered, 80 conserved bases
+        "win_001\t255\t255\t80\t0.31373\t0.31373\n"
+    )
+    df = parse_bigwig_average_over_bed(p)
+    assert df["sum"][0] == 80.0
+    assert abs(df["mean0"][0] - 80 / 255) < 1e-3

--- a/tests/conservation/test_scoring.py
+++ b/tests/conservation/test_scoring.py
@@ -1,7 +1,5 @@
 """Tests for ``bolinas.conservation.scoring``."""
 
-from __future__ import annotations
-
 import math
 
 import numpy as np

--- a/tests/conservation/test_scoring.py
+++ b/tests/conservation/test_scoring.py
@@ -9,18 +9,15 @@ import polars as pl
 import pyBigWig
 import pytest
 
-from bolinas.conservation.scoring import (
-    parse_bigwig_average_over_bed,
-    score_windows,
-)
+from bolinas.conservation.scoring import score_windows
 
 
 @pytest.fixture
 def synthetic_bigwig(tmp_path):
     """Build a tiny ``chr1`` bigWig with three regions:
-      - [0, 30):    value 2.0   (above any threshold below 2.0)
-      - [30, 60):   no value    (NaN — gap in bigWig)
-      - [60, 100):  value -1.0  (below any threshold above -1.0)
+    - [0, 30):    value 2.0   (above any threshold below 2.0)
+    - [30, 60):   no value    (NaN — gap in bigWig)
+    - [60, 100):  value -1.0  (below any threshold above -1.0)
     """
     bw_path = tmp_path / "test.bw"
     bw = pyBigWig.open(str(bw_path), "w")
@@ -43,9 +40,7 @@ def synthetic_bigwig(tmp_path):
 
 def test_score_windows_basic(synthetic_bigwig) -> None:
     """Single 100 bp window covering the whole synthetic chromosome."""
-    windows = pl.DataFrame(
-        {"chrom": ["1"], "start": [0], "end": [100], "name": ["w1"]}
-    )
+    windows = pl.DataFrame({"chrom": ["1"], "start": [0], "end": [100], "name": ["w1"]})
     result = score_windows(synthetic_bigwig, windows, threshold=1.0)
     row = result.row(0, named=True)
     assert row["conserved_bases"] == 30
@@ -108,9 +103,7 @@ def test_score_windows_unknown_chrom(synthetic_bigwig) -> None:
 
 def test_score_windows_dtypes(synthetic_bigwig) -> None:
     """Schema is the contract used by downstream Parquet / filter rules."""
-    windows = pl.DataFrame(
-        {"chrom": ["1"], "start": [0], "end": [100], "name": ["w1"]}
-    )
+    windows = pl.DataFrame({"chrom": ["1"], "start": [0], "end": [100], "name": ["w1"]})
     result = score_windows(synthetic_bigwig, windows, threshold=1.0)
     assert result.schema["conserved_bases"] == pl.Int32
     assert result.schema["proportion_conserved"] == pl.Float32
@@ -137,45 +130,3 @@ def test_score_windows_proportion_consistent_with_count(synthetic_bigwig) -> Non
         assert math.isclose(
             row["proportion_conserved"], row["conserved_bases"] / size, abs_tol=1e-5
         )
-
-
-def test_parse_bigwig_average_over_bed_dtypes(tmp_path) -> None:
-    """Schema, dtypes, and columns match the bigWigAverageOverBed contract."""
-    p = tmp_path / "out.tsv"
-    p.write_text(
-        "win_001\t255\t255\t100.5\t0.394\t0.394\n"
-        "win_002\t255\t250\t40.0\t0.157\t0.160\n"
-    )
-    df = parse_bigwig_average_over_bed(p)
-    assert df.columns == ["name", "size", "covered", "sum", "mean0", "mean"]
-    assert df.schema["name"] == pl.Utf8
-    assert df.schema["size"] == pl.Int64
-    assert df.schema["covered"] == pl.Int64
-    assert df.schema["sum"] == pl.Float64
-    assert df.schema["mean0"] == pl.Float64
-    assert df.schema["mean"] == pl.Float64
-    assert df.shape == (2, 6)
-
-
-def test_parse_bigwig_average_over_bed_handles_zero_covered(tmp_path) -> None:
-    """When ``covered == 0``, ``mean`` is ``n/a`` in the TSV; we coerce to NaN."""
-    p = tmp_path / "out.tsv"
-    p.write_text("win_001\t255\t0\t0.0\t0.0\tn/a\n")
-    df = parse_bigwig_average_over_bed(p)
-    assert df["covered"][0] == 0
-    assert df["sum"][0] == 0.0
-    assert df["mean0"][0] == 0.0
-    assert df["mean"].is_null().all()
-
-
-def test_parse_bigwig_average_over_bed_binary_track(tmp_path) -> None:
-    """For a binarized bigWig, sum == conserved_bases and mean0 == proportion.
-    Smoke test of the math we depend on downstream."""
-    p = tmp_path / "out.tsv"
-    p.write_text(
-        # window of size 255, all 255 covered, 80 conserved bases
-        "win_001\t255\t255\t80\t0.31373\t0.31373\n"
-    )
-    df = parse_bigwig_average_over_bed(p)
-    assert df["sum"][0] == 80.0
-    assert abs(df["mean0"][0] - 80 / 255) < 1e-3


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

Adds a new Snakemake pipeline `snakemake/zoonomia_projection_dataset/` that produces a curated set of human BED windows (255 bp, step 128, autosomes + X + Y, ACGT-only) scored against `phyloP_447m` at a calibrated threshold. These windows are the input artifact for the future cross-mammal projection pipeline (issue #149) — the next experiment plans to project them onto ~100 mammals via the Zoonomia 447-mammalian Cactus alignment.

Also adds `src/bolinas/conservation/`: a small library with `PhylopHistogram`, proportion-matching threshold calibration, and a per-window pyBigWig scoring helper. 20 tests.

## Decisions baked in

- **Window size 255 bp, step 128.** 255 (not 256) so the model's BOS token brings total context to 256.
- **Track of interest: `phyloP_447m`.** `phyloP_241m` is used only as the calibration reference.
- **Calibration: `phyloP_447m_threshold = 2.2162`** matches `phyloP_241m`'s 4.0656% pass rate on chr1 at 2.27. Single-chrom (chr1) calibration gives `abs_relative_error = 1e-8` — well below 1% — and runs ~10× faster than all-chroms.
- **Scoring via pyBigWig** in a Snakemake `run:` block, fanned out across 24 chroms. We tried `bigWigToBedGraph | awk threshold | bedGraphToBigWig` first; bioconda kentUtils binaries refuse stdin pipes, so we pivoted to direct pyBigWig.
- **NaN counted as non-conserved.** `(values >= threshold).sum()` excludes NaN naturally (NumPy `nan >= t` is `False`); explicit test guards against future "fixes" with `np.nan_to_num`.

## What it produces

- `results/scored/homo_sapiens/phyloP_447m_windows.parquet` — every window with `conserved_bases`, `proportion_conserved`, `mean_phylop`, `n_valid_bases`.
- `results/bed/homo_sapiens/min{0.10,0.20}.bed.gz` — filtered BED per cutoff.

End-to-end run on SkyPilot completed:

| | rows | size |
|---|---|---|
| `phyloP_447m_windows.parquet` | **22,948,560** | 164 MiB |
| `min0.10.bed.gz` (≥10% conserved) | ~1.94M (8.5%) | 18 MiB |
| `min0.20.bed.gz` (≥20% conserved) | ~1.13M (5.0%) | 11 MiB |

Outputs are in `s3://oa-bolinas/snakemake/zoonomia_projection_dataset/`.

## Test plan

- [x] `uv run pytest tests/conservation/` — 20 tests pass (histogram math, calibration identity / known shift / coverage invariance / NaN-invariance, scoring with synthetic bigWig including NaN-as-non-conserved + threshold inclusivity + chrom-prefix flexibility + dtype contract)
- [x] `uv run ruff check` clean
- [x] `uv run snakemake --profile workflow/profiles/default -n` — DAG valid (52 jobs)
- [x] End-to-end pipeline run on `c6id.2xlarge` in `us-east-2` succeeded (~5 min wall after 24-way chrom parallelism)
- [x] Calibration script run on the same cluster: `phyloP_447m` threshold 2.2162 matches `phyloP_241m` proportion at 2.27 with `abs_relative_error = 1e-8`
- [x] Spot-check of merged Parquet: 22,948,560 rows, all 24 standard chroms present, every window length is 255, `proportion_conserved` ∈ [0, 1], `mean(proportion_conserved) = 0.0369` (consistent with the 4.07% calibration target)

## Follow-ups (not in this PR)

- Batched per-chrom pyBigWig reads in `score_windows` (3–5× speedup); current 5-min wall is acceptable so deferred.
- Once the projection pipeline lands, this pipeline's `min0.10.bed.gz` / `min0.20.bed.gz` becomes its input.

## Files

- `snakemake/zoonomia_projection_dataset/` — new pipeline (Snakefile, profile, conda env, 5 rule files, 2 sky tasks, 1 calibration script, README)
- `src/bolinas/conservation/` — new library (`histogram.py`, `calibration.py`, `scoring.py`)
- `tests/conservation/` — 20 tests