### PR TITLE
HF datasets zoonomia-v1-v1 / -v1-v2 + 2-axis versioning (#149)

### DIFF
--- a/snakemake/zoonomia_projection_dataset/README.md
+++ b/snakemake/zoonomia_projection_dataset/README.md
@@ -118,12 +118,12 @@ The 2bit (`results/projection/genomes/{species}.2bit`) is the archival per-speci
 
 The per-species sequence Parquet (`results/projection/min{p}/sequences/{species}.parquet`) extends the projection schema with a `sequence` column (one row per cleanly-projected window, exactly 255 bp). The sequence is **strand-aware**: rows with `t_strand=="-"` already hold the reverse-complemented target string (handled natively by `bedtools getfasta -s`), so downstream consumers don't need to re-revcomp. The merged `all_species_with_sequence.parquet` is the canonical artifact for HuggingFace push and downstream subsetting.
 
-`rule subset_dataset` — v3 subsetting (filter once, project to all species):
+`rule subset_dataset_derived` — v3 subsetting (filter once, project to all species):
 
 The cross-mammal projection (halLiftover) is run **once** on the full conservation-filtered window set; subsets of the resulting cohort are produced by lazy-filtering the all-species sequence Parquet on `query_name`. Each subset is one rule, one Polars streaming sink:
 
 ```
-config/subsets/{subset}.query_names.txt            (one query_name per line; comments OK)
+results/projection/min{p}/subsets_def/{subset}.query_names.txt    (one query_name per line; comments OK)
         +
         ▼
 results/projection/min{p}/all_species_with_sequence.parquet
@@ -132,7 +132,69 @@ results/projection/min{p}/all_species_with_sequence.parquet
 results/projection/min{p}/subsets/{subset}.parquet
 ```
 
-Subsets are derived from human-side annotation overlaps (e.g. `bedtools intersect` of `results/bed/min{p}.bed.gz` with SCREEN cCREs, RefSeq CDS, etc.). The derivation step is intentionally out-of-pipeline so subsets can be added incrementally without re-running anything upstream — the projection cohort is canonical, subsets are just views over it.
+Derived subsets (with a Snakemake rule that produces the `query_names.txt` file) live under `results/.../subsets_def/`. The original PR-157 `subset_dataset` rule (which read from `config/subsets/...`) is preserved for hand-curated subsets that don't have a derivation rule; `subset_dataset_derived` takes precedence when both could match. Subsets pointing at the same `query_name` set are interchangeable; the derivation source is what differs.
+
+The current pipeline ships one derived subset:
+
+- **v2 — mRNA-TSS proximity.** `derive_subset_v2_tss_mrna` extracts protein-coding TSSes from Ensembl rel 115 GTF (via `bolinas.projection.tss.write_mrna_tss_band_bed`, which reuses `bolinas.data.utils.get_promoters_from_exons`), expands each to a `[TSS - tss_flank, TSS + tss_flank]` band (`tss_flank` defaults to 256 bp), and `bedtools intersect -u`s the human anchor BED against the merged band to keep windows touching any protein-coding TSS region.
+
+## HuggingFace datasets
+
+Two HF datasets per (pipeline, intervals) combination:
+
+| HF repo                              | pipeline | intervals | source Parquet                                                  |
+|---|---|---|---|
+| `bolinas-dna/zoonomia-v1-v1`         | v1       | v1        | `results/projection/min0.20/all_species_with_sequence.parquet`  |
+| `bolinas-dna/zoonomia-v1-v2`         | v1       | v2        | `results/projection/min0.20/subsets/v2.parquet`                 |
+
+**Two-axis versioning.** `pipeline_version` (in `config/config.yaml`) snapshots species set, conservation cutoff (`project_min_p`), alignment backend, and resize/length-filter params — bump it and re-run the projection. `intervals_versions` lists the post-projection subset definitions; bumps are cheap (one new derivation rule + cheap re-runs of `subset_dataset_derived` + sharding + upload).
+
+**Pipeline `v1` snapshot:**
+- 108 family-deduped Zoonomia 447 mammals (`config/species_zoonomia_447_family_dedup.tsv`)
+- `phyloP_447m`-conservation, `proportion_conserved >= 0.20`
+- halLiftover --noDupes against the 1.18 TiB Cactus HAL
+- midpoint-centered resize to exactly 255 bp; pre-resize length ∈ [128, 512]
+- source = hg38 Ensembl release 115
+
+**Intervals:**
+- `v1` — identity (every row of `all_species_with_sequence.parquet`)
+- `v2` — window overlaps `[TSS − 256, TSS + 256]` for any Ensembl protein_coding transcript (~5–15% of v1)
+
+**HF dataset schema** (single `train` split per repo; JSONL.zst-sharded at `data/train/shard_NNNN.jsonl.zst`):
+
+| column        | type | source                                              |
+|---|---|---|
+| `query_name`  | str  | human-window id (`win_<chrom>_<NNN>` from `windows.smk`) |
+| `species`     | str  | one of 108 mammals                                  |
+| `t_chrom`     | str  | UCSC `chr1`-style                                   |
+| `t_start`     | int  | 0-based half-open                                   |
+| `t_end`       | int  | 0-based half-open; `t_end - t_start == 255`         |
+| `t_strand`    | str  | `+` or `-`                                          |
+| `t_src_size`  | int  | target chromosome size                              |
+| `sequence`    | str  | exactly 255 bp; **strand-aware** (already RC'd if `t_strand == "-"`) |
+| `augmentation`| str  | `+` (original) or `-` (RC of `sequence`); only present when `add_rc: true` |
+
+**RC augmentation, shuffle, shard.** `prepare_training_shards` → `compress_shard` → `hf_upload_dataset`:
+
+- `add_rc: true` (default) doubles row count: each row gets a partner with the sequence reverse-complemented and `augmentation = "-"`. Vectorised in `bolinas.projection.dataset.reverse_complement_col` via Polars `str.replace_many`. Non-ACGT characters (N or other IUPAC ambiguity codes) are preserved unchanged — strict RC is only applied to ACGT.
+- `df.sample(fraction=1, shuffle=True, seed=42)` interleaves species so a model never sees blocks of 100 k consecutive `Mus_musculus` rows.
+- `n_shards: 64` (default) → 128 JSONL files (64 per dataset), each ~330 MB pre-compression. zstd-compressed in `compress_shard`, uploaded via `hf upload-large-folder`.
+
+**Bumping rules:**
+- Bump `pipeline_version` when ANY of: species TSV, `project_min_p`, alignment backend (rules in `project.smk`), resize / length-filter params changes. This invalidates all per-(pipeline, intervals) HF datasets and the projection itself must be re-run.
+- Bump `intervals_versions` (add a new entry) when you want a new subset definition. Cheap — only `subset_dataset_derived` + shard prep + upload re-run.
+
+**Run:**
+
+```bash
+# Local (dry-run only — actual upload needs the HF token cluster mount):
+uv run snakemake --profile workflow/profiles/default -n all_hf
+
+# Cloud (mounts ~/.cache/huggingface, ~30 min wall):
+sky launch -c zoonomia-upload sky/upload.yaml
+sky logs   zoonomia-upload
+sky down   zoonomia-upload          # at end of session
+```
 
 Scoring uses **pyBigWig directly** in a Snakemake `run:` block — no kentUtils binary chain. We tried `bigWigToBedGraph | awk threshold | bedGraphToBigWig` and `bigWigAverageOverBed`, but the bioconda kentUtils binaries refuse to read from stdin pipes (they need a regular file because they seek). Materialising the per-base bedGraph would cost ~30 GB temp disk for marginal speed.
 
@@ -224,11 +286,13 @@ workflow/envs/bioinformatics.yaml              # bedtools, kentUtils (faToTwoBit
 workflow/rules/
   common.smk                                   # imports + sanity checks
   genome.smk                                   # download_genome → 2bit → chrom_sizes → N-regions
-  download.smk                                 # phyloP bigWig
+  download.smk                                 # phyloP bigWig + Ensembl GTF
   windows.smk                                  # tile + N-filter (one rule)
   score.smk                                    # binarize + score
   filter.smk                                   # filtered BED per cutoff
-  project.smk                                  # cross-mammal halLiftover + filter + resize
+  project.smk                                  # cross-mammal halLiftover + filter + resize + sequence + subset
+  subsets.smk                                  # derive query_names lists for v2 subset; subset_dataset_derived override
+  dataset.smk                                  # RC augment + shuffle + shard + hf upload-large-folder
 scripts/
   calibrate_447m_threshold.py                  # one-off; uses src/bolinas/conservation/
   build_species_list.py                        # one-off; uses src/bolinas/projection/taxonomy
@@ -237,6 +301,7 @@ sky/
   run.yaml                                     # c6id.2xlarge — anchor windows
   calibrate.yaml                               # c6id.2xlarge — phyloP_447m calibration (one-off)
   project.yaml                                 # c6id.12xlarge — cross-mammal projection
+  upload.yaml                                  # r6i.8xlarge — HF dataset assembly + push (rule all_hf)
 ```
 
-Library code lives in `src/bolinas/conservation/` (anchor pipeline) and `src/bolinas/projection/` (projection step) — both testable; reused by their respective rules and one-off scripts. Tests in `tests/conservation/` and `tests/projection/` (40 + 20 = 60 unit tests).
+Library code lives in `src/bolinas/conservation/` (anchor pipeline) and `src/bolinas/projection/` (projection + tss + dataset modules) — both testable; reused by their respective rules and one-off scripts. Tests in `tests/conservation/` and `tests/projection/`.

--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -1,3 +1,7 @@
+# Ensembl release for the human reference + annotation. Both genome_url and
+# the GTF URL in download.smk are pinned to this release; the genome_url
+# string itself was inherited verbatim from PR #152 and isn't templated yet.
+ensembl_release: 115
 genome_url: "https://ftp.ensembl.org/pub/release-115/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
 
 # Bare Ensembl chrom names (1, 2, ..., X, Y). Bigwig queries internally

--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -46,3 +46,26 @@ pre_resize_max_len: 512
 # ZRS sanity check, ~5 min wall after staging. "full" runs all SPECIES × the
 # entire `min{project_min_p}.bed.gz`, ~5 h on c6id.12xlarge.
 tier: "full"
+
+# ===== HF dataset assembly (rule all_hf; sky/upload.yaml) =====
+# Pipeline version snapshot: bumps when species TSV, project_min_p,
+# alignment backend (project.smk), or resize/length params change.
+pipeline_version: "v1"
+
+# Intervals versions to push (one HF repo per entry).
+# v1 = identity (all post-projection windows)
+# v2 = mRNA-TSS proximity (window overlaps [TSS - tss_flank, TSS + tss_flank])
+intervals_versions: ["v1", "v2"]
+
+hf_owner: "bolinas-dna"
+
+# v2 subset: ± bp band around each mRNA TSS (Ensembl protein_coding biotype).
+# 256 bp matches the BOS+255 model context window.
+tss_flank: 256
+
+# Reverse-complement augmentation: doubles row count before shuffle/shard.
+add_rc: true
+
+# Shuffle + shard params (mirror training_dataset/dataset_creation defaults).
+n_shards: 64
+shuffle_seed: 42

--- a/snakemake/zoonomia_projection_dataset/sky/upload.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/upload.yaml
@@ -1,26 +1,17 @@
 name: zoonomia-projection-hf-upload
 
-# HF dataset assembly + upload for the cross-mammal projection corpus
-# (issue #149). Pulls the canonical
-# results/projection/min{p}/all_species_with_sequence.parquet from S3
-# (already produced by sky/project.yaml), derives subset definitions,
-# RC-augments + shuffles + shards into JSONL.zst, and pushes to HF Hub.
+# HF dataset assembly + upload (rule all_hf).
 
 resources:
     infra: aws/us-east-2
-    instance_type: r6i.8xlarge   # 32 vCPU, 256 GB RAM. RC-augmented v1
-                                 # peaks around ~20 GB in pandas/polars
-                                 # memory; 256 GB gives generous margin
-                                 # and matches the existing training_dataset
-                                 # upload YAML.
-    disk_size: 300               # ~12 GB Parquet pull + ~25 GB shards.
+    instance_type: r6i.8xlarge
+    disk_size: 300
     labels:
         project: dna
 
 workdir: .
 
-# The HF CLI reads the token from ~/.cache/huggingface/token. Same
-# pattern as snakemake/training_dataset/dataset_creation/sky/run_hf_upload_v30.yaml.
+# HF CLI reads the token from ~/.cache/huggingface/token.
 file_mounts:
     ~/.cache/huggingface: ~/.cache/huggingface
 

--- a/snakemake/zoonomia_projection_dataset/sky/upload.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/upload.yaml
@@ -1,0 +1,64 @@
+name: zoonomia-projection-hf-upload
+
+# HF dataset assembly + upload for the cross-mammal projection corpus
+# (issue #149). Pulls the canonical
+# results/projection/min{p}/all_species_with_sequence.parquet from S3
+# (already produced by sky/project.yaml), derives subset definitions,
+# RC-augments + shuffles + shards into JSONL.zst, and pushes to HF Hub.
+
+resources:
+    infra: aws/us-east-2
+    instance_type: r6i.8xlarge   # 32 vCPU, 256 GB RAM. RC-augmented v1
+                                 # peaks around ~20 GB in pandas/polars
+                                 # memory; 256 GB gives generous margin
+                                 # and matches the existing training_dataset
+                                 # upload YAML.
+    disk_size: 300               # ~12 GB Parquet pull + ~25 GB shards.
+    labels:
+        project: dna
+
+workdir: .
+
+# The HF CLI reads the token from ~/.cache/huggingface/token. Same
+# pattern as snakemake/training_dataset/dataset_creation/sky/run_hf_upload_v30.yaml.
+file_mounts:
+    ~/.cache/huggingface: ~/.cache/huggingface
+
+setup: |
+    set -euxo pipefail
+
+    if [ ! -d "$HOME/miniforge3" ]; then
+        curl -fsSL -o /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+        bash /tmp/miniforge.sh -b -p "$HOME/miniforge3"
+        rm /tmp/miniforge.sh
+    fi
+
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+
+    grep -q 'miniforge3/bin' "$HOME/.bashrc" || \
+        echo 'export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+
+    export PATH="$HOME/.local/bin:$PATH"
+    uv sync
+
+run: |
+    set -euxo pipefail
+
+    source "$HOME/miniforge3/etc/profile.d/conda.sh"
+    export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+    export CONDA_EXE="$HOME/miniforge3/bin/conda"
+
+    cd snakemake/zoonomia_projection_dataset
+
+    # Dry-run gate first — verify only HF-related rules are scheduled.
+    uv run snakemake --profile workflow/profiles/default \
+        --printshellcmds \
+        -n all_hf
+
+    # Real run.
+    uv run snakemake --profile workflow/profiles/default \
+        --printshellcmds \
+        --rerun-incomplete \
+        all_hf

--- a/snakemake/zoonomia_projection_dataset/workflow/Snakefile
+++ b/snakemake/zoonomia_projection_dataset/workflow/Snakefile
@@ -8,6 +8,8 @@ include: "rules/windows.smk"
 include: "rules/score.smk"
 include: "rules/filter.smk"
 include: "rules/project.smk"
+include: "rules/subsets.smk"
+include: "rules/dataset.smk"
 
 
 rule all:

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
@@ -1,0 +1,102 @@
+"""Training-shard assembly + HF upload (issue #149).
+
+Per (pipeline_version, intervals_version):
+    source Parquet
+        ↓ prepare_training_shards (RC augment + shuffle + shard, JSONL)
+    results/dataset/zoonomia-{p}-{iv}/data/train/{shard}.jsonl
+        ↓ compress_shard (zstd)
+    results/dataset/zoonomia-{p}-{iv}/data/train/{shard}.jsonl.zst
+        ↓ hf_upload_dataset (hf upload-large-folder, single train split)
+    HF: bolinas-dna/zoonomia-{p}-{iv}
+"""
+
+PIPELINE_VERSION = config["pipeline_version"]
+INTERVALS_VERSIONS = list(config["intervals_versions"])
+HF_OWNER = config["hf_owner"]
+ADD_RC = bool(config.get("add_rc", True))
+N_SHARDS = int(config.get("n_shards", 64))
+SHUFFLE_SEED = int(config.get("shuffle_seed", 42))
+assert N_SHARDS < 10_000  # zero-padding width below assumes 4 digits.
+SHARDS = [f"shard_{i:04d}" for i in range(N_SHARDS)]
+
+# intervals_version → source Parquet
+INTERVALS_SOURCES = {
+    "v1": f"results/projection/min{PROJECT_MIN_P}/all_species_with_sequence.parquet",
+    "v2": f"results/projection/min{PROJECT_MIN_P}/subsets/v2.parquet",
+}
+
+
+rule prepare_training_shards:
+    """Read source Parquet → RC augment → shuffle → shard to JSONL."""
+    input:
+        lambda wc: INTERVALS_SOURCES[wc.intervals_version],
+    output:
+        temp(
+            local(
+                expand(
+                    "results/dataset/zoonomia-{{pipeline_version}}-{{intervals_version}}/data/train/{shard}.jsonl",
+                    shard=SHARDS,
+                )
+            )
+        ),
+    threads: workflow.cores
+    resources:
+        mem_mb=120000,  # ~36 GB Parquet → ~70 GB after RC; ~2x in RAM.
+    run:
+        from bolinas.projection.dataset import prepare_shards
+
+        prepare_shards(
+            parquet_path=str(input[0]),
+            shard_paths=[str(p) for p in output],
+            add_rc=ADD_RC,
+            shuffle_seed=SHUFFLE_SEED,
+        )
+
+
+rule compress_shard:
+    input:
+        local("{anything}.jsonl"),
+    output:
+        local("{anything}.jsonl.zst"),
+    threads: 8
+    shell:
+        "zstd -T{threads} {input} -o {output}"
+
+
+rule hf_upload_dataset:
+    """Upload a dataset's compressed shard folder to HF Hub (single train split)."""
+    input:
+        local(
+            expand(
+                "results/dataset/zoonomia-{{pipeline_version}}-{{intervals_version}}/data/train/{shard}.jsonl.zst",
+                shard=SHARDS,
+            )
+        ),
+    output:
+        # Explicit `touch {output}` in shell because S3 default-storage
+        # doesn't auto-create touch() markers — same gotcha as the
+        # training_dataset hf_upload_training rule.
+        "results/upload.done/zoonomia-{pipeline_version}-{intervals_version}",
+    params:
+        repo=lambda wc: f"{HF_OWNER}/zoonomia-{wc.pipeline_version}-{wc.intervals_version}",
+        data_dir=lambda wc: f"results/dataset/zoonomia-{wc.pipeline_version}-{wc.intervals_version}",
+    wildcard_constraints:
+        pipeline_version=r"v\d+",
+        intervals_version=r"v\d+",
+    threads: workflow.cores
+    shell:
+        """
+        hf upload-large-folder {params.repo} --repo-type dataset {params.data_dir}
+        mkdir -p $(dirname {output})
+        touch {output}
+        """
+
+
+rule all_hf:
+    """Trigger HF push for every (PIPELINE_VERSION × INTERVALS_VERSIONS) combo."""
+    input:
+        expand(
+            "results/upload.done/zoonomia-{p}-{iv}",
+            p=[PIPELINE_VERSION],
+            iv=INTERVALS_VERSIONS,
+        ),

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
@@ -1,14 +1,4 @@
-"""Training-shard assembly + HF upload (issue #149).
-
-Per (pipeline_version, intervals_version):
-    source Parquet
-        ↓ prepare_training_shards (RC augment + shuffle + shard, JSONL)
-    results/dataset/zoonomia-{p}-{iv}/data/train/{shard}.jsonl
-        ↓ compress_shard (zstd)
-    results/dataset/zoonomia-{p}-{iv}/data/train/{shard}.jsonl.zst
-        ↓ hf_upload_dataset (hf upload-large-folder, single train split)
-    HF: bolinas-dna/zoonomia-{p}-{iv}
-"""
+"""Training-shard assembly + HF upload."""
 
 PIPELINE_VERSION = config["pipeline_version"]
 INTERVALS_VERSIONS = list(config["intervals_versions"])
@@ -19,7 +9,6 @@ SHUFFLE_SEED = int(config.get("shuffle_seed", 42))
 assert N_SHARDS < 10_000  # zero-padding width below assumes 4 digits.
 SHARDS = [f"shard_{i:04d}" for i in range(N_SHARDS)]
 
-# intervals_version → source Parquet
 INTERVALS_SOURCES = {
     "v1": f"results/projection/min{PROJECT_MIN_P}/all_species_with_sequence.parquet",
     "v2": f"results/projection/min{PROJECT_MIN_P}/subsets/v2.parquet",
@@ -41,7 +30,7 @@ rule prepare_training_shards:
         ),
     threads: workflow.cores
     resources:
-        mem_mb=120000,  # ~36 GB Parquet → ~70 GB after RC; ~2x in RAM.
+        mem_mb=120000,
     run:
         from bolinas.projection.dataset import prepare_shards
 
@@ -73,9 +62,7 @@ rule hf_upload_dataset:
             )
         ),
     output:
-        # Explicit `touch {output}` in shell because S3 default-storage
-        # doesn't auto-create touch() markers — same gotcha as the
-        # training_dataset hf_upload_training rule.
+        # Explicit `touch` in shell: S3 default-storage doesn't auto-create touch() markers.
         "results/upload.done/zoonomia-{pipeline_version}-{intervals_version}",
     params:
         repo=lambda wc: f"{HF_OWNER}/zoonomia-{wc.pipeline_version}-{wc.intervals_version}",

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/download.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/download.smk
@@ -17,14 +17,13 @@ rule download_bigwig:
 
 
 rule download_annotation:
-    """Ensembl release 115 GTF (matches genome_url release).
-
-    Used by ``derive_subset_v2_tss_mrna`` to extract protein_coding TSSes
-    for the v2 subset definition.
-    """
+    """Ensembl human GTF; release pinned by ``ensembl_release`` in config."""
     output:
-        "results/annotation/Homo_sapiens.GRCh38.115.gtf.gz",
+        f"results/annotation/Homo_sapiens.GRCh38.{config['ensembl_release']}.gtf.gz",
     params:
-        url="https://ftp.ensembl.org/pub/release-115/gtf/homo_sapiens/Homo_sapiens.GRCh38.115.gtf.gz",
+        url=(
+            f"https://ftp.ensembl.org/pub/release-{config['ensembl_release']}/gtf/"
+            f"homo_sapiens/Homo_sapiens.GRCh38.{config['ensembl_release']}.gtf.gz"
+        ),
     shell:
         "wget -q -O {output} {params.url}"

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/download.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/download.smk
@@ -14,3 +14,17 @@ rule download_bigwig:
         track="|".join(CONSERVATION_TRACKS),
     shell:
         "wget -q {params.url} -O {output}"
+
+
+rule download_annotation:
+    """Ensembl release 115 GTF (matches genome_url release).
+
+    Used by ``derive_subset_v2_tss_mrna`` to extract protein_coding TSSes
+    for the v2 subset definition.
+    """
+    output:
+        "results/annotation/Homo_sapiens.GRCh38.115.gtf.gz",
+    params:
+        url="https://ftp.ensembl.org/pub/release-115/gtf/homo_sapiens/Homo_sapiens.GRCh38.115.gtf.gz",
+    shell:
+        "wget -q -O {output} {params.url}"

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/subsets.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/subsets.smk
@@ -1,10 +1,4 @@
-"""Subset derivation for the zoonomia projection dataset (issue #149).
-
-v1 = identity (no derivation rule needed; v1 source is the
-all_species_with_sequence.parquet directly).
-v2 = mRNA-TSS proximity (window overlaps [TSS - tss_flank, TSS + tss_flank]
-     for any Ensembl protein_coding transcript).
-"""
+"""Subset derivation for the zoonomia projection dataset."""
 
 TSS_FLANK = int(config.get("tss_flank", 256))
 
@@ -25,8 +19,6 @@ rule derive_subset_v2_tss_mrna:
         from bolinas.projection.tss import write_mrna_tss_band_bed
 
         n_band = write_mrna_tss_band_bed(input.gtf, params.flank, output.band)
-        # Ensembl rel 115 has ~90k protein_coding transcripts; merged bands
-        # collapse closely-spaced TSSes — expect ~50k–80k merged intervals.
         assert n_band > 30_000, f"unexpectedly few mRNA TSS bands: {n_band}"
         shell(
             "bedtools intersect -u -a {input.bed} -b {output.band} "
@@ -37,9 +29,6 @@ rule derive_subset_v2_tss_mrna:
         assert kept > 0, "v2 subset is empty"
 
 
-# Override the existing PR-157 ``subset_dataset`` so derived subset
-# definitions live under ``results/.../subsets_def/`` (Snakemake outputs)
-# rather than ``config/subsets/`` (which is reserved for committed inputs).
 ruleorder: subset_dataset_derived > subset_dataset
 
 

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/subsets.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/subsets.smk
@@ -1,0 +1,57 @@
+"""Subset derivation for the zoonomia projection dataset (issue #149).
+
+v1 = identity (no derivation rule needed; v1 source is the
+all_species_with_sequence.parquet directly).
+v2 = mRNA-TSS proximity (window overlaps [TSS - tss_flank, TSS + tss_flank]
+     for any Ensembl protein_coding transcript).
+"""
+
+TSS_FLANK = int(config.get("tss_flank", 256))
+
+
+rule derive_subset_v2_tss_mrna:
+    """Generate v2 query_names: windows overlapping any mRNA TSS ± tss_flank."""
+    input:
+        gtf="results/annotation/Homo_sapiens.GRCh38.115.gtf.gz",
+        bed="results/bed/min{min_p}.bed.gz",
+    output:
+        band="results/projection/min{min_p}/subsets_def/v2_band.bed",
+        names="results/projection/min{min_p}/subsets_def/v2.query_names.txt",
+    params:
+        flank=TSS_FLANK,
+    conda:
+        "../envs/bioinformatics.yaml"
+    run:
+        from bolinas.projection.tss import write_mrna_tss_band_bed
+
+        n_band = write_mrna_tss_band_bed(input.gtf, params.flank, output.band)
+        # Ensembl rel 115 has ~90k protein_coding transcripts; merged bands
+        # collapse closely-spaced TSSes — expect ~50k–80k merged intervals.
+        assert n_band > 30_000, f"unexpectedly few mRNA TSS bands: {n_band}"
+        shell(
+            "bedtools intersect -u -a {input.bed} -b {output.band} "
+            "| cut -f4 > {output.names}"
+        )
+        with open(output.names) as fh:
+            kept = sum(1 for _ in fh)
+        assert kept > 0, "v2 subset is empty"
+
+
+# Override the existing PR-157 ``subset_dataset`` so derived subset
+# definitions live under ``results/.../subsets_def/`` (Snakemake outputs)
+# rather than ``config/subsets/`` (which is reserved for committed inputs).
+ruleorder: subset_dataset_derived > subset_dataset
+
+
+rule subset_dataset_derived:
+    """Lazy-filter all_species_with_sequence to a derived subset."""
+    input:
+        all_species="results/projection/min{min_p}/all_species_with_sequence.parquet",
+        names="results/projection/min{min_p}/subsets_def/{subset}.query_names.txt",
+    output:
+        "results/projection/min{min_p}/subsets/{subset}.parquet",
+    threads: 1
+    resources:
+        mem_mb=4000,
+    run:
+        filter_to_subset(input.all_species, input.names, output[0])

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/subsets.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/subsets.smk
@@ -6,7 +6,7 @@ TSS_FLANK = int(config.get("tss_flank", 256))
 rule derive_subset_v2_tss_mrna:
     """Generate v2 query_names: windows overlapping any mRNA TSS ± tss_flank."""
     input:
-        gtf="results/annotation/Homo_sapiens.GRCh38.115.gtf.gz",
+        gtf=f"results/annotation/Homo_sapiens.GRCh38.{config['ensembl_release']}.gtf.gz",
         bed="results/bed/min{min_p}.bed.gz",
     output:
         band="results/projection/min{min_p}/subsets_def/v2_band.bed",
@@ -41,6 +41,8 @@ rule subset_dataset_derived:
         "results/projection/min{min_p}/subsets/{subset}.parquet",
     threads: 1
     resources:
-        mem_mb=4000,
+        # filter_to_subset eagerly decodes the ~10 GB Parquet to ~25 GB in RAM
+        # (lazy sink_parquet path was buggy; see src/bolinas/projection/subset.py).
+        mem_mb=32000,
     run:
         filter_to_subset(input.all_species, input.names, output[0])

--- a/src/bolinas/projection/dataset.py
+++ b/src/bolinas/projection/dataset.py
@@ -1,19 +1,11 @@
-"""Training-shard prep for the zoonomia HF datasets (issue #149).
+"""Training-shard prep (RC augmentation, shuffle, shard to JSONL)."""
 
-Mirrors snakemake/training_dataset/dataset_creation pattern (RC augmentation,
-shuffle, shard) but vectorised in polars (much faster than the existing
-pandas + Bio.Seq path on the ~250 M-row v1 dataset).
-"""
-
-import json
 from pathlib import Path
 
 import polars as pl
 
-# DNA complement for ACGT (upper + lower). Anything else (N or other IUPAC
-# ambiguity codes — R, Y, S, W, K, M, B, D, H, V — is left as-is by
-# str.replace_many, which is fine for our training data; we only need
-# strict-RC behaviour on ACGT.
+from bolinas.data.utils import get_array_split_pairs
+
 _COMPLEMENT = {
     "A": "T",
     "T": "A",
@@ -27,13 +19,7 @@ _COMPLEMENT = {
 
 
 def reverse_complement_col(seq: pl.Expr) -> pl.Expr:
-    """Vectorised reverse-complement: complement via replace_many, then reverse.
-
-    Non-ACGT characters are preserved unchanged (replace_many leaves
-    unmapped chars alone). This is intentional and approximate for IUPAC
-    ambiguity codes; sequences in our pipeline are mostly ACGT after the
-    upstream N-region filter.
-    """
+    """Vectorised reverse-complement on ACGT only; other chars (N, IUPAC) pass through."""
     return seq.str.replace_many(_COMPLEMENT).str.reverse()
 
 
@@ -46,11 +32,10 @@ def prepare_shards(
     """Read source Parquet → optional RC augment → shuffle → shard to JSONL.
 
     Args:
-        parquet_path: source Parquet (e.g. all_species_with_sequence.parquet
-            or subsets/v2.parquet). Must include a ``sequence`` column.
+        parquet_path: source Parquet. Must include a ``sequence`` column.
         shard_paths: ordered list of N output JSONL paths. Row count is
             split evenly (np.array_split semantics).
-        add_rc: if True, prepend an ``augmentation`` column with values
+        add_rc: if True, append an ``augmentation`` column with values
             ``"+"`` (original) and ``"-"`` (reverse-complemented sequence).
             Total row count doubles.
         shuffle_seed: passed to ``df.sample(fraction=1, shuffle=True, seed=...)``
@@ -70,16 +55,8 @@ def prepare_shards(
 
     df = df.sample(fraction=1.0, shuffle=True, seed=shuffle_seed)
 
-    n_total = len(df)
-    n_shards = len(shard_paths)
-    base, rem = divmod(n_total, n_shards)
-    cur = 0
-    for i, path in enumerate(shard_paths):
-        size = base + (1 if i < rem else 0)
-        shard = df.slice(cur, size)
-        cur += size
+    for path, (start, end) in zip(
+        shard_paths, get_array_split_pairs(len(df), len(shard_paths))
+    ):
         Path(path).parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as fh:
-            for row in shard.iter_rows(named=True):
-                fh.write(json.dumps(row) + "\n")
-    assert cur == n_total
+        df.slice(start, end - start).write_ndjson(path)

--- a/src/bolinas/projection/dataset.py
+++ b/src/bolinas/projection/dataset.py
@@ -1,0 +1,85 @@
+"""Training-shard prep for the zoonomia HF datasets (issue #149).
+
+Mirrors snakemake/training_dataset/dataset_creation pattern (RC augmentation,
+shuffle, shard) but vectorised in polars (much faster than the existing
+pandas + Bio.Seq path on the ~250 M-row v1 dataset).
+"""
+
+import json
+from pathlib import Path
+
+import polars as pl
+
+# DNA complement for ACGT (upper + lower). Anything else (N or other IUPAC
+# ambiguity codes — R, Y, S, W, K, M, B, D, H, V — is left as-is by
+# str.replace_many, which is fine for our training data; we only need
+# strict-RC behaviour on ACGT.
+_COMPLEMENT = {
+    "A": "T",
+    "T": "A",
+    "C": "G",
+    "G": "C",
+    "a": "t",
+    "t": "a",
+    "c": "g",
+    "g": "c",
+}
+
+
+def reverse_complement_col(seq: pl.Expr) -> pl.Expr:
+    """Vectorised reverse-complement: complement via replace_many, then reverse.
+
+    Non-ACGT characters are preserved unchanged (replace_many leaves
+    unmapped chars alone). This is intentional and approximate for IUPAC
+    ambiguity codes; sequences in our pipeline are mostly ACGT after the
+    upstream N-region filter.
+    """
+    return seq.str.replace_many(_COMPLEMENT).str.reverse()
+
+
+def prepare_shards(
+    parquet_path: str | Path,
+    shard_paths: list[str],
+    add_rc: bool,
+    shuffle_seed: int,
+) -> None:
+    """Read source Parquet → optional RC augment → shuffle → shard to JSONL.
+
+    Args:
+        parquet_path: source Parquet (e.g. all_species_with_sequence.parquet
+            or subsets/v2.parquet). Must include a ``sequence`` column.
+        shard_paths: ordered list of N output JSONL paths. Row count is
+            split evenly (np.array_split semantics).
+        add_rc: if True, prepend an ``augmentation`` column with values
+            ``"+"`` (original) and ``"-"`` (reverse-complemented sequence).
+            Total row count doubles.
+        shuffle_seed: passed to ``df.sample(fraction=1, shuffle=True, seed=...)``
+            for cross-species interleaving.
+    """
+    assert len(shard_paths) > 0
+    df = pl.read_parquet(str(parquet_path))
+    assert "sequence" in df.columns, f"missing sequence column: {df.columns}"
+
+    if add_rc:
+        df_pos = df.with_columns(pl.lit("+").alias("augmentation"))
+        df_neg = df.with_columns(
+            reverse_complement_col(pl.col("sequence")).alias("sequence"),
+            pl.lit("-").alias("augmentation"),
+        )
+        df = pl.concat([df_pos, df_neg])
+
+    df = df.sample(fraction=1.0, shuffle=True, seed=shuffle_seed)
+
+    n_total = len(df)
+    n_shards = len(shard_paths)
+    base, rem = divmod(n_total, n_shards)
+    cur = 0
+    for i, path in enumerate(shard_paths):
+        size = base + (1 if i < rem else 0)
+        shard = df.slice(cur, size)
+        cur += size
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as fh:
+            for row in shard.iter_rows(named=True):
+                fh.write(json.dumps(row) + "\n")
+    assert cur == n_total

--- a/src/bolinas/projection/subset.py
+++ b/src/bolinas/projection/subset.py
@@ -59,8 +59,11 @@ def filter_to_subset(
     out = Path(out_parquet)
     out.parent.mkdir(parents=True, exist_ok=True)
 
-    (
-        pl.scan_parquet(str(all_species_parquet))
-        .filter(pl.col("query_name").is_in(keys))
-        .sink_parquet(str(out))
-    )
+    # Eager read+filter+write rather than scan+filter+sink_parquet:
+    # the lazy streaming engine on a ``query_name.is_in(keys)`` filter
+    # segfaults on the ~110 M-row all_species_with_sequence.parquet
+    # (polars 1.x bug); eager fits comfortably in RAM (~25 GB decoded
+    # from ~10 GB on disk) and runs in ~10 s on r6i.8xlarge.
+    df = pl.read_parquet(str(all_species_parquet))
+    df = df.filter(pl.col("query_name").is_in(keys))
+    df.write_parquet(str(out))

--- a/src/bolinas/projection/tss.py
+++ b/src/bolinas/projection/tss.py
@@ -1,8 +1,4 @@
-"""mRNA-TSS proximity band for the v2 subset (issue #149).
-
-Ensembl-specific: filters transcripts by ``transcript_biotype == "protein_coding"``
-(equivalent to mRNA in NCBI convention, where biotype is spelled ``"mRNA"``).
-"""
+"""mRNA-TSS proximity band for the v2 subset of the zoonomia projection dataset."""
 
 from pathlib import Path
 

--- a/src/bolinas/projection/tss.py
+++ b/src/bolinas/projection/tss.py
@@ -1,0 +1,55 @@
+"""mRNA-TSS proximity band for the v2 subset (issue #149).
+
+Ensembl-specific: filters transcripts by ``transcript_biotype == "protein_coding"``
+(equivalent to mRNA in NCBI convention, where biotype is spelled ``"mRNA"``).
+"""
+
+from pathlib import Path
+
+import polars as pl
+
+from bolinas.data.intervals import GenomicSet
+from bolinas.data.utils import get_promoters_from_exons, load_annotation
+
+
+def get_ensembl_protein_coding_exons(ann: pl.DataFrame) -> pl.DataFrame:
+    """Extract protein-coding (mRNA) exons from an Ensembl GTF DataFrame.
+
+    Args:
+        ann: Annotation DataFrame from ``bolinas.data.utils.load_annotation``.
+
+    Returns:
+        DataFrame with columns [chrom, start, end, strand, transcript_id]
+        containing exons of transcripts with biotype ``"protein_coding"``.
+    """
+    return (
+        ann.filter(pl.col("feature") == "exon")
+        .with_columns(
+            pl.col("attribute")
+            .str.extract(r'transcript_id "(.*?)"')
+            .alias("transcript_id"),
+            pl.col("attribute")
+            .str.extract(r'transcript_biotype "(.*?)"')
+            .alias("transcript_biotype"),
+        )
+        .filter(pl.col("transcript_biotype") == "protein_coding")
+        .select(["chrom", "start", "end", "strand", "transcript_id"])
+    )
+
+
+def write_mrna_tss_band_bed(
+    gtf_path: str | Path, flank: int, out_bed: str | Path
+) -> int:
+    """Compute [TSS − flank, TSS + flank] band over Ensembl protein-coding
+    transcripts; write merged BED. Returns row count of the written BED.
+    """
+    assert flank > 0, f"flank must be positive, got {flank}"
+    ann = load_annotation(str(gtf_path))
+    exons = get_ensembl_protein_coding_exons(ann)
+    assert len(exons) > 0, "no protein_coding exons found — wrong GTF flavor?"
+    band: GenomicSet = get_promoters_from_exons(
+        exons, n_upstream=flank, n_downstream=flank
+    )
+    band.write_bed(str(out_bed))
+    with open(out_bed) as fh:
+        return sum(1 for _ in fh)

--- a/tests/projection/test_dataset.py
+++ b/tests/projection/test_dataset.py
@@ -1,0 +1,178 @@
+"""Tests for ``bolinas.projection.dataset``."""
+
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from bolinas.projection.dataset import (
+    prepare_shards,
+    reverse_complement_col,
+)
+
+
+def _rc_via_expr(seq: str) -> str:
+    """Apply reverse_complement_col to a single string and return the result."""
+    df = pl.DataFrame({"s": [seq]})
+    return df.select(reverse_complement_col(pl.col("s")).alias("rc"))["rc"][0]
+
+
+def test_rc_basic_acgt() -> None:
+    assert _rc_via_expr("ACGT") == "ACGT"  # palindrome
+    assert _rc_via_expr("AAAA") == "TTTT"
+    assert _rc_via_expr("AAGCT") == "AGCTT"
+    assert _rc_via_expr("acgt") == "acgt"  # lowercase preserved
+    assert _rc_via_expr("Aa") == "tT"
+
+
+def test_rc_round_trip_acgt() -> None:
+    """rc(rc(seq)) == seq for ACGT strings."""
+    for seq in ["ACGT", "GATTACA", "CCCGGG", "ATATAT", "agctAGCT"]:
+        assert _rc_via_expr(_rc_via_expr(seq)) == seq
+
+
+def test_rc_preserves_non_acgt_chars() -> None:
+    """N and other IUPAC ambiguity chars are NOT strictly RC'd; they're left as-is.
+
+    This is the documented deviation from canonical RC. Asserting it
+    explicitly so the choice is loud.
+    """
+    # N self-pairs under canonical RC, so identity is "correct" by accident.
+    assert _rc_via_expr("ANT") == "ANT"
+    # R is NOT canonical-RC'd to Y; it's left as-is.
+    assert (
+        _rc_via_expr("AR") == "RT"
+    )  # complement(A)=T, R unchanged, then reverse → "RT"
+    # Multiple ambiguity chars preserved.
+    assert _rc_via_expr("ACRYT") == "AYRGT"  # rev: T,Y,R,C,A → comp: A,Y,R,G,T
+
+
+def _make_source_parquet(tmp_path: Path, n_rows: int = 100) -> Path:
+    """Build a tiny source Parquet matching all_species_with_sequence schema."""
+    df = pl.DataFrame(
+        {
+            "query_name": [f"win_1_{i:09d}" for i in range(n_rows)],
+            "species": [
+                "Mus_musculus" if i % 2 else "Bos_taurus" for i in range(n_rows)
+            ],
+            "t_chrom": ["chr1"] * n_rows,
+            "t_start": [1000 + i for i in range(n_rows)],
+            "t_end": [1000 + i + 255 for i in range(n_rows)],
+            "t_strand": ["+" if i % 3 else "-" for i in range(n_rows)],
+            "t_src_size": [200_000_000] * n_rows,
+            "sequence": ["ACGT" * 63 + "ACG" for _ in range(n_rows)],  # 255 bp
+        }
+    )
+    p = tmp_path / "src.parquet"
+    df.write_parquet(p)
+    return p
+
+
+def test_prepare_shards_no_rc(tmp_path: Path) -> None:
+    """add_rc=False: row count unchanged, no augmentation column."""
+    src = _make_source_parquet(tmp_path, n_rows=20)
+    shard_paths = [str(tmp_path / f"shard_{i:04d}.jsonl") for i in range(4)]
+    prepare_shards(src, shard_paths, add_rc=False, shuffle_seed=42)
+
+    rows: list[dict] = []
+    for p in shard_paths:
+        for line in Path(p).read_text().splitlines():
+            rows.append(json.loads(line))
+    assert len(rows) == 20
+    assert "augmentation" not in rows[0]
+    # All original query_names accounted for.
+    assert {r["query_name"] for r in rows} == {f"win_1_{i:09d}" for i in range(20)}
+
+
+def test_prepare_shards_with_rc_doubles_rows(tmp_path: Path) -> None:
+    """add_rc=True: row count doubles; both '+' and '-' augmentation present."""
+    src = _make_source_parquet(tmp_path, n_rows=10)
+    shard_paths = [str(tmp_path / f"shard_{i:04d}.jsonl") for i in range(4)]
+    prepare_shards(src, shard_paths, add_rc=True, shuffle_seed=42)
+
+    rows: list[dict] = []
+    for p in shard_paths:
+        for line in Path(p).read_text().splitlines():
+            rows.append(json.loads(line))
+    assert len(rows) == 20  # doubled
+    augs = [r["augmentation"] for r in rows]
+    assert sum(1 for a in augs if a == "+") == 10
+    assert sum(1 for a in augs if a == "-") == 10
+
+    # For each query_name, the '-' row's sequence is RC of the '+' row's.
+    by_qn_aug: dict[tuple[str, str], str] = {}
+    for r in rows:
+        by_qn_aug[(r["query_name"], r["augmentation"])] = r["sequence"]
+    qn = next(iter({r["query_name"] for r in rows}))
+    pos_seq = by_qn_aug[(qn, "+")]
+    neg_seq = by_qn_aug[(qn, "-")]
+    assert _rc_via_expr(pos_seq) == neg_seq
+
+
+def test_prepare_shards_balanced_sizes(tmp_path: Path) -> None:
+    """Shard sizes follow np.array_split semantics: |max - min| <= 1."""
+    src = _make_source_parquet(tmp_path, n_rows=23)  # 23 / 4 = 5,5,5,5,3 → 6,6,6,5
+    shard_paths = [str(tmp_path / f"shard_{i:04d}.jsonl") for i in range(4)]
+    prepare_shards(src, shard_paths, add_rc=False, shuffle_seed=42)
+
+    sizes = [sum(1 for _ in Path(p).read_text().splitlines()) for p in shard_paths]
+    assert sum(sizes) == 23
+    assert max(sizes) - min(sizes) <= 1
+
+
+def test_prepare_shards_reproducible_with_seed(tmp_path: Path) -> None:
+    """Same seed → identical shard contents in identical order."""
+    src = _make_source_parquet(tmp_path, n_rows=30)
+
+    out1 = [str(tmp_path / "a" / f"shard_{i:04d}.jsonl") for i in range(3)]
+    out2 = [str(tmp_path / "b" / f"shard_{i:04d}.jsonl") for i in range(3)]
+    prepare_shards(src, out1, add_rc=False, shuffle_seed=7)
+    prepare_shards(src, out2, add_rc=False, shuffle_seed=7)
+
+    for p1, p2 in zip(out1, out2):
+        assert Path(p1).read_text() == Path(p2).read_text()
+
+
+def test_prepare_shards_different_seed_changes_order(tmp_path: Path) -> None:
+    """Different seeds produce different orderings."""
+    src = _make_source_parquet(tmp_path, n_rows=30)
+    out1 = [str(tmp_path / "a" / f"shard_{i:04d}.jsonl") for i in range(3)]
+    out2 = [str(tmp_path / "b" / f"shard_{i:04d}.jsonl") for i in range(3)]
+    prepare_shards(src, out1, add_rc=False, shuffle_seed=7)
+    prepare_shards(src, out2, add_rc=False, shuffle_seed=8)
+
+    contents1 = "".join(Path(p).read_text() for p in out1)
+    contents2 = "".join(Path(p).read_text() for p in out2)
+    assert contents1 != contents2  # exceedingly unlikely to match with 30 rows
+
+
+def test_prepare_shards_missing_sequence_column_raises(tmp_path: Path) -> None:
+    """Source parquet without ``sequence`` column fires the assertion."""
+    df = pl.DataFrame({"query_name": ["x"], "species": ["A"]})
+    p = tmp_path / "bad.parquet"
+    df.write_parquet(p)
+    out = [str(tmp_path / "shard.jsonl")]
+    with pytest.raises(AssertionError, match="missing sequence column"):
+        prepare_shards(p, out, add_rc=False, shuffle_seed=42)
+
+
+def test_prepare_shards_preserves_all_columns(tmp_path: Path) -> None:
+    """The full all_species_with_sequence schema survives the JSONL round-trip."""
+    src = _make_source_parquet(tmp_path, n_rows=5)
+    shard_paths = [str(tmp_path / "shard.jsonl")]
+    prepare_shards(src, shard_paths, add_rc=False, shuffle_seed=42)
+
+    expected_cols = {
+        "query_name",
+        "species",
+        "t_chrom",
+        "t_start",
+        "t_end",
+        "t_strand",
+        "t_src_size",
+        "sequence",
+    }
+    line = Path(shard_paths[0]).read_text().splitlines()[0]
+    row = json.loads(line)
+    assert expected_cols.issubset(set(row.keys()))

--- a/tests/projection/test_tss.py
+++ b/tests/projection/test_tss.py
@@ -1,0 +1,244 @@
+"""Tests for ``bolinas.projection.tss``."""
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from bolinas.data.utils import load_annotation
+from bolinas.projection.tss import (
+    get_ensembl_protein_coding_exons,
+    write_mrna_tss_band_bed,
+)
+
+
+def _write_gtf(path: Path, rows: list[str]) -> None:
+    """Write a tiny Ensembl-format GTF (1-based, tab-separated)."""
+    path.write_text("\n".join(rows) + "\n")
+
+
+def _gtf_row(
+    chrom: str,
+    feature: str,
+    start_1based: int,
+    end_1based: int,
+    strand: str,
+    attribute: str,
+) -> str:
+    return (
+        f"{chrom}\tensembl\t{feature}\t{start_1based}\t{end_1based}"
+        f"\t.\t{strand}\t.\t{attribute}"
+    )
+
+
+def test_get_ensembl_protein_coding_exons_filters_biotype(tmp_path: Path) -> None:
+    """Only ``transcript_biotype == 'protein_coding'`` exons survive."""
+    gtf = tmp_path / "ann.gtf"
+    _write_gtf(
+        gtf,
+        [
+            # protein_coding mRNA: keep
+            _gtf_row(
+                "1",
+                "exon",
+                1001,
+                1100,
+                "+",
+                'transcript_id "ENST_pc"; transcript_biotype "protein_coding";',
+            ),
+            # lncRNA: drop
+            _gtf_row(
+                "1",
+                "exon",
+                2001,
+                2100,
+                "+",
+                'transcript_id "ENST_lnc"; transcript_biotype "lncRNA";',
+            ),
+            # processed_pseudogene: drop
+            _gtf_row(
+                "1",
+                "exon",
+                3001,
+                3100,
+                "+",
+                'transcript_id "ENST_psd"; transcript_biotype "processed_pseudogene";',
+            ),
+            # NCBI-style gbkey "mRNA" without transcript_biotype "protein_coding": drop
+            _gtf_row(
+                "1",
+                "exon",
+                4001,
+                4100,
+                "+",
+                'transcript_id "NM_xyz"; gbkey "mRNA";',
+            ),
+            # protein_coding on minus strand: keep
+            _gtf_row(
+                "2",
+                "exon",
+                5001,
+                5050,
+                "-",
+                'transcript_id "ENST_pc_minus"; transcript_biotype "protein_coding";',
+            ),
+            # transcript-level (not exon): drop
+            _gtf_row(
+                "1",
+                "transcript",
+                1001,
+                1100,
+                "+",
+                'transcript_id "ENST_pc"; transcript_biotype "protein_coding";',
+            ),
+        ],
+    )
+    ann = load_annotation(str(gtf))
+    exons = get_ensembl_protein_coding_exons(ann)
+
+    assert set(exons["transcript_id"]) == {"ENST_pc", "ENST_pc_minus"}
+    assert exons.columns == ["chrom", "start", "end", "strand", "transcript_id"]
+    # Coordinates should be 0-based (load_annotation does the conversion).
+    keep_pos = exons.filter(pl.col("transcript_id") == "ENST_pc").row(0, named=True)
+    assert keep_pos["start"] == 1000  # 1001 (1-based) → 1000 (0-based)
+    assert keep_pos["end"] == 1100
+    assert keep_pos["strand"] == "+"
+
+
+def test_write_mrna_tss_band_bed_symmetric_flank(tmp_path: Path) -> None:
+    """+ strand: band = [start - flank, start + flank]; − strand: [end - flank, end + flank]."""
+    gtf = tmp_path / "ann.gtf"
+    _write_gtf(
+        gtf,
+        [
+            # + strand: TSS at 5000 (1-based start) → 4999 (0-based)
+            _gtf_row(
+                "1",
+                "exon",
+                5000,
+                5500,
+                "+",
+                'transcript_id "T_plus"; transcript_biotype "protein_coding";',
+            ),
+            # − strand: TSS is the rightmost exon end (genomic).
+            # 1-based [3000, 4000] inclusive → 0-based [2999, 4000) → TSS at 4000.
+            _gtf_row(
+                "2",
+                "exon",
+                3000,
+                4000,
+                "-",
+                'transcript_id "T_minus"; transcript_biotype "protein_coding";',
+            ),
+        ],
+    )
+    out_bed = tmp_path / "band.bed"
+    n = write_mrna_tss_band_bed(gtf, flank=256, out_bed=out_bed)
+    assert n == 2
+
+    bed = pl.read_csv(
+        str(out_bed),
+        separator="\t",
+        has_header=False,
+        new_columns=["chrom", "start", "end"],
+        schema_overrides={"chrom": pl.Utf8},
+    )
+    by_chrom = {r["chrom"]: r for r in bed.iter_rows(named=True)}
+
+    # + strand: TSS=4999 → [4999 - 256, 4999 + 256] = [4743, 5255]
+    assert by_chrom["1"]["start"] == 4743
+    assert by_chrom["1"]["end"] == 5255
+    assert by_chrom["1"]["end"] - by_chrom["1"]["start"] == 512
+
+    # − strand: TSS=4000 → [4000 - 256, 4000 + 256] = [3744, 4256]
+    assert by_chrom["2"]["start"] == 3744
+    assert by_chrom["2"]["end"] == 4256
+    assert by_chrom["2"]["end"] - by_chrom["2"]["start"] == 512
+
+
+def test_write_mrna_tss_band_bed_merges_overlapping(tmp_path: Path) -> None:
+    """Two transcripts with overlapping ± flank bands collapse to one row."""
+    gtf = tmp_path / "ann.gtf"
+    _write_gtf(
+        gtf,
+        [
+            # TSS at 1000 (0-based): band [744, 1256]
+            _gtf_row(
+                "1",
+                "exon",
+                1001,
+                1500,
+                "+",
+                'transcript_id "T1"; transcript_biotype "protein_coding";',
+            ),
+            # TSS at 1100 (0-based): band [844, 1356] — overlaps T1's band
+            _gtf_row(
+                "1",
+                "exon",
+                1101,
+                1600,
+                "+",
+                'transcript_id "T2"; transcript_biotype "protein_coding";',
+            ),
+        ],
+    )
+    out_bed = tmp_path / "band.bed"
+    n = write_mrna_tss_band_bed(gtf, flank=256, out_bed=out_bed)
+    assert n == 1, "overlapping bands should merge"
+
+    bed = pl.read_csv(
+        str(out_bed),
+        separator="\t",
+        has_header=False,
+        new_columns=["chrom", "start", "end"],
+        schema_overrides={"chrom": pl.Utf8},
+    )
+    row = bed.row(0, named=True)
+    # Merged span = union of [744, 1256] and [844, 1356] = [744, 1356]
+    assert row["chrom"] == "1"
+    assert row["start"] == 744
+    assert row["end"] == 1356
+
+
+def test_write_mrna_tss_band_bed_empty_protein_coding_raises(tmp_path: Path) -> None:
+    """Annotation with no protein_coding exons fires the loud assertion."""
+    gtf = tmp_path / "ann.gtf"
+    _write_gtf(
+        gtf,
+        [
+            _gtf_row(
+                "1",
+                "exon",
+                1001,
+                1100,
+                "+",
+                'transcript_id "ENST_lnc"; transcript_biotype "lncRNA";',
+            ),
+        ],
+    )
+    out_bed = tmp_path / "band.bed"
+    with pytest.raises(AssertionError, match="no protein_coding exons"):
+        write_mrna_tss_band_bed(gtf, flank=256, out_bed=out_bed)
+
+
+def test_write_mrna_tss_band_bed_negative_flank_raises(tmp_path: Path) -> None:
+    """Negative or zero flank fires the loud assertion."""
+    gtf = tmp_path / "ann.gtf"
+    _write_gtf(
+        gtf,
+        [
+            _gtf_row(
+                "1",
+                "exon",
+                1001,
+                1100,
+                "+",
+                'transcript_id "T1"; transcript_biotype "protein_coding";',
+            ),
+        ],
+    )
+    out_bed = tmp_path / "band.bed"
+    with pytest.raises(AssertionError, match="flank must be positive"):
+        write_mrna_tss_band_bed(gtf, flank=0, out_bed=out_bed)
+    with pytest.raises(AssertionError, match="flank must be positive"):
+        write_mrna_tss_band_bed(gtf, flank=-1, out_bed=out_bed)


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes the v3 milestone of #149 by appending HF dataset assembly + push to `snakemake/zoonomia_projection_dataset/`. Builds on PR #157 (cross-mammal projection step) — no new pipeline directory.

## Summary

Two HF datasets per the issue:

| HF repo                          | rows in scope                                                  |
|---|---|
| `bolinas-dna/zoonomia-v1-v1`     | every row of `all_species_with_sequence.parquet`               |
| `bolinas-dna/zoonomia-v1-v2`     | windows where the human anchor overlaps `[TSS − 256, TSS + 256]` for any Ensembl `protein_coding` transcript |

Single `train` split each. Schema: `query_name, species, t_chrom, t_start, t_end, t_strand, t_src_size, sequence, augmentation` (`augmentation ∈ {+, -}` when `add_rc: true`). Shards: 64 × `data/train/shard_NNNN.jsonl.zst` per dataset.

## 2-axis versioning

```
bolinas-dna/zoonomia-{pipeline_version}-{intervals_version}
```

- **`pipeline_version`** snapshots species set, conservation cutoff (`project_min_p`), alignment backend, resize/length-filter params. Bump → re-run halLiftover.
- **`intervals_versions`** lists post-projection subset definitions. Bump → cheap (only `subset_dataset_derived` + shard prep + upload).

Both axes start at `v1`; intervals `v1` is identity, `v2` is mRNA-TSS proximity.

## What's new

**Library (testable):**
- `src/bolinas/projection/tss.py` — `get_ensembl_protein_coding_exons` (Ensembl uses `transcript_biotype "protein_coding"`; the existing `bolinas.data.utils.get_mrna_exons` matches `"mRNA"`, which is the NCBI spelling — Ensembl-flavoured helper kept here per CLAUDE.md "stay in scope" + "duplication beats premature abstraction"). `write_mrna_tss_band_bed` reuses `get_promoters_from_exons` for the symmetric ± flank expansion.
- `src/bolinas/projection/dataset.py` — vectorised polars RC (`str.replace_many` + `str.reverse`, ACGT only; non-ACGT preserved unchanged) and `prepare_shards` (RC augment + shuffle + JSONL shard, np.array_split-balanced sizes).

**Rules:**
- `download.smk`: `download_annotation` — Ensembl rel 115 GTF (matches `genome_url`).
- `subsets.smk`: `derive_subset_v2_tss_mrna` (writes `results/projection/min{p}/subsets_def/v2.query_names.txt` via `bolinas.projection.tss.write_mrna_tss_band_bed` + `bedtools intersect -u`) and `subset_dataset_derived` (overrides PR-157's `subset_dataset` so derived subset definitions live under `results/.../subsets_def/` rather than `config/subsets/`).
- `dataset.smk`: `prepare_training_shards` → `compress_shard` (zstd) → `hf_upload_dataset` (`hf upload-large-folder` to `bolinas-dna/zoonomia-{p}-{iv}` with `data/train/`-layout). `rule all_hf` expands over `(PIPELINE_VERSION × INTERVALS_VERSIONS)`.

**SkyPilot** (`sky/upload.yaml`): `r6i.8xlarge`, `us-east-2`, `project=dna`. Mounts `~/.cache/huggingface` for the HF token.

**Config**:

```yaml
pipeline_version: "v1"
intervals_versions: ["v1", "v2"]
hf_owner: "bolinas-dna"
tss_flank: 256
add_rc: true
n_shards: 64
shuffle_seed: 42
```

## Verification

- **15/15 unit tests pass**: `uv run pytest tests/projection/test_tss.py tests/projection/test_dataset.py`.
- **Ruff + ruff format + snakefmt clean**.
- **Snakemake dry-run for `all_hf`**: 136 jobs total. Only HF-related rules are scheduled — `download_annotation×1 + derive_subset_v2_tss_mrna×1 + subset_dataset_derived×1 + prepare_training_shards×2 + compress_shard×128 + hf_upload_dataset×2 + all_hf`. No re-runs of `project_one_species`, `extract_sequences`, `filter_bed`, etc.

## Test plan

- [x] Unit tests pass
- [x] Ruff / snakefmt clean
- [x] Snakemake dry-run shows no upstream re-runs
- [ ] Smoke HF push to a scratch repo (`--config hf_owner=gonzalobenegas intervals_versions='[\"v2\"]' n_shards=4`)
- [ ] Full launch on SkyPilot for both datasets
- [ ] Post-push HF check: `load_dataset(\"bolinas-dna/zoonomia-v1-v2\", split=\"train\", streaming=True)` materializes with expected schema