### PR TITLE
PairwiseAccuracy metric + evals_v2 pipeline + matched-pair leaderboards

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -1,0 +1,90 @@
+# evals_v2 — gLM evaluation on matched-pair datasets
+
+PairwiseAccuracy ± binomial SE on the new matched-pair eval datasets
+(`bolinas-dna/evals_mendelian_traits` and `bolinas-dna/evals_complex_traits`,
+PR #159). Stripped-down successor to `evals_v1`: one metric, one split, no
+plotting, GCS-stored checkpoints.
+
+## What it does
+
+For each `model` × `dataset` in the config:
+
+1. **Download** the genome reference (GRCh38, Ensembl 113) and the model
+   checkpoint dir from GCS.
+2. **Score** every variant with `compute_variant_scores` (LLR + embedding
+   distances).
+3. **Compute** PairwiseAccuracy ± SE per consequence subset on the
+   dataset-appropriate score column:
+   - `mendelian_traits` → `minus_llr` (pathogenic > benign)
+   - `complex_traits` → `abs_llr` (magnitude)
+
+Outputs land in S3 at `s3://oa-bolinas/snakemake/analysis/evals_v2/results/`:
+
+```
+results/
+├── genome.fa.gz
+├── checkpoints/{model}/                         # cached HF model dir
+├── scores/{model}/{dataset}.parquet             # variant cols + LLR/embedding scores
+└── metrics/{model}/{dataset}.parquet            # PairwiseAccuracy ± SE per subset
+```
+
+## Conventions
+
+- **Train split only.** Test is held out for the final-eval pass; train is
+  the development split.
+- **Two context conventions are supported.** Per-model `window_size` config
+  field selects the number of DNA bases extracted (255 or 256). The
+  tokenizer loaded from each checkpoint handles BOS itself.
+  - 255 = BOS-using runs (e.g. `exp136-proj_v30`).
+  - 256 = no-BOS runs (e.g. `exp55/58/59`).
+
+## Setup
+
+GPU node (a small EC2 GPU is fine — these are ~0.6B-param models). On the
+node:
+
+```bash
+# Auth for GCS checkpoint pulls.
+gcloud auth application-default login
+
+# Verify gcloud is on PATH and AWS creds reach S3 (same setup as
+# snakemake/evals/ — see that pipeline's README).
+gcloud storage ls gs://marin-us-central1/checkpoints/ | head
+aws s3 ls s3://oa-bolinas/snakemake/analysis/evals_v2/ 2>&1 | head
+```
+
+## Usage
+
+```bash
+cd snakemake/analysis/evals_v2
+
+# Dry-run to inspect the DAG.
+uv run snakemake -n
+
+# Run.
+uv run snakemake
+```
+
+The default profile (`workflow/profiles/default/config.yaml`) uses S3 storage
+at `s3://oa-bolinas/snakemake/analysis/evals_v2/`.
+
+## Configuration (`config/config.yaml`)
+
+| Key | Purpose |
+| --- | --- |
+| `input_hf_prefix` | HF prefix for `f"{prefix}_{dataset.name}"`. |
+| `genome_url` | GRCh38 reference. |
+| `split` | `train` (or `test` once held-out eval is unlocked). |
+| `datasets` | List of `{name, score_column}`. |
+| `models` | List of `{name, gcs_path, window_size}`. `gcs_path` includes the `/hf/step-{N}` suffix. |
+| `inference.*` | Batch size, workers, `data_transform_on_the_fly`, `torch_compile`. |
+
+## Library
+
+Pipeline rules are thin glue around:
+
+- `bolinas.evals.inference.compute_variant_scores` — model + genome → score columns.
+- `bolinas.evals.metrics.compute_pairwise_metrics` — score column → PairwiseAccuracy ± SE per subset.
+
+No new library code is added by this pipeline; both functions are tested at
+`tests/evals/test_pairwise_accuracy.py` and elsewhere.

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -1,0 +1,50 @@
+# HuggingFace prefix for the matched-pair eval datasets. Each dataset is
+# loaded as f"{input_hf_prefix}_{dataset.name}".
+input_hf_prefix: bolinas-dna/evals
+
+# Genome reference for context extraction (GRCh38, Ensembl 113).
+genome_url: http://ftp.ensembl.org/pub/release-113/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
+
+# Train-only convention — the test split is held out for the final-eval pass.
+# All development / iteration uses train.
+split: train
+
+datasets:
+  - name: mendelian_traits
+    score_column: minus_llr   # pathogenic positives should score higher than gnomAD-common negatives
+  - name: complex_traits
+    score_column: abs_llr     # fine-mapped positives — magnitude regardless of direction
+
+# Model checkpoints. `gcs_path` is the full path to the specific checkpoint
+# directory (i.e. includes /hf/step-{N}). Pipeline copies its contents into
+# results/checkpoints/{name}/.
+#
+# `window_size` is the number of DNA bases extracted per variant context.
+# 256 = old convention (no BOS, e.g. exp55/58/59).
+# 255 = new convention (BOS prepended, e.g. exp136).
+models:
+  - name: exp55-mammals
+    gcs_path: gs://marin-us-central1/checkpoints/exp55-mammals-r01-52f413/hf/step-16999
+    window_size: 256
+
+  - name: exp58-mammals
+    gcs_path: gs://marin-us-central1/checkpoints/exp58-mammals-r01-23d451/hf/step-16999
+    window_size: 256
+
+  - name: exp58-animals
+    gcs_path: gs://marin-us-central1/checkpoints/exp58-animals-r01-1e3682/hf/step-16999
+    window_size: 256
+
+  - name: exp59-mammals
+    gcs_path: gs://marin-us-central1/checkpoints/exp59-mammals-r01-1d9235/hf/step-16999
+    window_size: 256
+
+  - name: exp136-proj_v30
+    gcs_path: gs://marin-us-central1/checkpoints/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0/hf/step-9999
+    window_size: 255   # 255 bp DNA + BOS = 256 total tokens
+
+inference:
+  batch_size: 512
+  num_workers: 4
+  data_transform_on_the_fly: true
+  torch_compile: false

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -39,12 +39,9 @@ models:
     gcs_path: gs://marin-dna-us-central1/checkpoints/exp59-mammals-r01-1d9235/hf/step-16999
     window_size: 256
 
-  # exp136 is commented out until biofoundation is patched to support
-  # window_size=255 (currently asserts even). Will re-enable once the
-  # library accepts odd windows. See conversation 2026-05-06.
-  # - name: exp136-proj_v30
-  #   gcs_path: gs://marin-us-central1/checkpoints/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0/hf/step-9999
-  #   window_size: 255   # 255 bp DNA + BOS = 256 total tokens
+  - name: exp136-proj_v30
+    gcs_path: gs://marin-us-central1/checkpoints/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0/hf/step-9999
+    window_size: 255   # 255 bp DNA + BOS = 256 total tokens
 
 inference:
   batch_size: 64        # OOMs at 512 on A10G (24 GB) for 0.6B Qwen3 + 256 tokens

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -47,7 +47,7 @@ models:
   #   window_size: 255   # 255 bp DNA + BOS = 256 total tokens
 
 inference:
-  batch_size: 512
+  batch_size: 64        # OOMs at 512 on A10G (24 GB) for 0.6B Qwen3 + 256 tokens
   num_workers: 4
   data_transform_on_the_fly: true
   torch_compile: false

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -39,9 +39,12 @@ models:
     gcs_path: gs://marin-dna-us-central1/checkpoints/exp59-mammals-r01-1d9235/hf/step-16999
     window_size: 256
 
-  - name: exp136-proj_v30
-    gcs_path: gs://marin-us-central1/checkpoints/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0/hf/step-9999
-    window_size: 255   # 255 bp DNA + BOS = 256 total tokens
+  # exp136 is commented out until biofoundation is patched to support
+  # window_size=255 (currently asserts even). Will re-enable once the
+  # library accepts odd windows. See conversation 2026-05-06.
+  # - name: exp136-proj_v30
+  #   gcs_path: gs://marin-us-central1/checkpoints/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0/hf/step-9999
+  #   window_size: 255   # 255 bp DNA + BOS = 256 total tokens
 
 inference:
   batch_size: 512

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -24,19 +24,19 @@ datasets:
 # 255 = new convention (BOS prepended, e.g. exp136).
 models:
   - name: exp55-mammals
-    gcs_path: gs://marin-us-central1/checkpoints/exp55-mammals-r01-52f413/hf/step-16999
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-mammals-r01-52f413/hf/step-16999
     window_size: 256
 
   - name: exp58-mammals
-    gcs_path: gs://marin-us-central1/checkpoints/exp58-mammals-r01-23d451/hf/step-16999
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-mammals-r01-23d451/hf/step-16999
     window_size: 256
 
   - name: exp58-animals
-    gcs_path: gs://marin-us-central1/checkpoints/exp58-animals-r01-1e3682/hf/step-16999
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-animals-r01-1e3682/hf/step-16999
     window_size: 256
 
   - name: exp59-mammals
-    gcs_path: gs://marin-us-central1/checkpoints/exp59-mammals-r01-1d9235/hf/step-16999
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp59-mammals-r01-1d9235/hf/step-16999
     window_size: 256
 
   - name: exp136-proj_v30

--- a/snakemake/analysis/evals_v2/sky/run.yaml
+++ b/snakemake/analysis/evals_v2/sky/run.yaml
@@ -17,7 +17,8 @@ name: evals-v2
 
 resources:
     infra: aws/us-east-2
-    accelerators: L4:1          # 24 GB Ada — bf16-capable; cheapest GPU that runs this workload
+    accelerators: A10G:1        # 24 GB Ampere — bf16-capable. Tried L4 (g6) first but its
+                                # AMI hits a getcwd() race during sky's runtime rsync.
     disk_size: 200
     labels:
         project: dna
@@ -60,6 +61,11 @@ run: |
 
     export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"
     export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
+
+    # HF Trainer auto-initializes wandb if it can find the package; without
+    # an API key on this fresh node it errors out. Disable wandb entirely
+    # since this is a non-training inference job.
+    export WANDB_DISABLED=true
 
     cd snakemake/analysis/evals_v2
 

--- a/snakemake/analysis/evals_v2/sky/run.yaml
+++ b/snakemake/analysis/evals_v2/sky/run.yaml
@@ -17,8 +17,9 @@ name: evals-v2
 
 resources:
     infra: aws/us-east-2
-    accelerators: A10G:1        # 24 GB Ampere — bf16-capable. Tried L4 (g6) first but its
-                                # AMI hits a getcwd() race during sky's runtime rsync.
+    accelerators: A10G:1        # 24 GB Ampere — bf16-capable. L4 (g6.xlarge) is
+                                # ~$0.21/hr cheaper and would also work; keeping A10G
+                                # because that's what we benchmarked batch_size=64 on.
     disk_size: 200
     labels:
         project: dna

--- a/snakemake/analysis/evals_v2/sky/run.yaml
+++ b/snakemake/analysis/evals_v2/sky/run.yaml
@@ -1,0 +1,69 @@
+# SkyPilot task: run the evals_v2 pipeline on a small GPU node.
+#
+# The pipeline pulls model checkpoints from `gs://marin-us-central1/...`,
+# scores variants on the matched-pair eval datasets, and computes
+# PairwiseAccuracy ± SE per (model, dataset). 5 models × 2 datasets = 10
+# inference runs, each ≤ 10K variants — fits on a single small GPU.
+#
+# Auth: the user's GCP application-default credentials are mounted from
+# ~/.config/gcloud/application_default_credentials.json. The setup step
+# installs the gcloud CLI so the pipeline's `gcloud storage cp -r` rule
+# works.
+#
+# Launch:
+#   sky launch snakemake/analysis/evals_v2/sky/run.yaml -c evals-v2
+
+name: evals-v2
+
+resources:
+    infra: aws/us-east-2
+    accelerators: L4:1          # 24 GB Ada — bf16-capable; cheapest GPU that runs this workload
+    disk_size: 200
+    labels:
+        project: dna
+
+workdir: .
+
+file_mounts:
+    # Application Default Credentials so `gcloud storage cp -r` can pull
+    # private GCS objects from gs://marin-us-central1/...
+    ~/.config/gcloud/application_default_credentials.json: ~/.config/gcloud/application_default_credentials.json
+
+setup: |
+    set -euxo pipefail
+
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+
+    # gcloud CLI for the pipeline's `download_model` shell rule.
+    if ! command -v gcloud >/dev/null 2>&1; then
+        curl -fsSL https://sdk.cloud.google.com > /tmp/gcloud-install.sh
+        bash /tmp/gcloud-install.sh --disable-prompts --install-dir="$HOME"
+    fi
+
+    grep -q 'google-cloud-sdk/bin' "$HOME/.bashrc" || \
+        echo 'export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+
+    export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"
+
+    # Pin to the ADC we mounted; gcloud picks this up automatically.
+    export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
+
+    uv sync
+
+    # Smoke-test GCS access so a bad ADC fails fast in setup, not in a rule.
+    gcloud storage ls gs://marin-us-central1/checkpoints/ | head -3 >/dev/null
+
+run: |
+    set -euxo pipefail
+
+    export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"
+    export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
+
+    cd snakemake/analysis/evals_v2
+
+    uv run --project ../../.. snakemake \
+        --profile workflow/profiles/default \
+        --printshellcmds \
+        --rerun-incomplete

--- a/snakemake/analysis/evals_v2/workflow/Snakefile
+++ b/snakemake/analysis/evals_v2/workflow/Snakefile
@@ -1,0 +1,20 @@
+"""Snakemake workflow: evaluate gLM checkpoints on matched-pair eval datasets
+with PairwiseAccuracy. Train split only (test held out)."""
+
+
+configfile: "config/config.yaml"
+
+
+include: "rules/common.smk"
+include: "rules/download.smk"
+include: "rules/inference.smk"
+include: "rules/metrics.smk"
+
+
+rule all:
+    input:
+        expand(
+            "results/metrics/{model}/{dataset}.parquet",
+            model=[m["name"] for m in config["models"]],
+            dataset=[d["name"] for d in config["datasets"]],
+        ),

--- a/snakemake/analysis/evals_v2/workflow/profiles/default/config.yaml
+++ b/snakemake/analysis/evals_v2/workflow/profiles/default/config.yaml
@@ -1,0 +1,3 @@
+default-storage-provider: s3
+default-storage-prefix: s3://oa-bolinas/snakemake/analysis/evals_v2/
+cores: all

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -1,0 +1,29 @@
+"""Common imports + helpers for evals_v2 rules."""
+
+from pathlib import Path
+
+import pandas as pd
+from datasets import load_dataset
+
+from bolinas.evals.conservation import REQUIRED_VARIANT_COLUMNS
+from bolinas.evals.inference import compute_variant_scores
+from bolinas.evals.metrics import compute_pairwise_metrics
+
+
+def get_dataset_config(name):
+    for d in config["datasets"]:
+        if d["name"] == name:
+            return d
+    raise ValueError(f"dataset {name!r} not found in config")
+
+
+def get_model_config(name):
+    for m in config["models"]:
+        if m["name"] == name:
+            return m
+    raise ValueError(f"model {name!r} not found in config")
+
+
+# Wildcard alternations used across rules.
+DATASETS = [d["name"] for d in config["datasets"]]
+MODELS = [m["name"] for m in config["models"]]

--- a/snakemake/analysis/evals_v2/workflow/rules/download.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/download.smk
@@ -13,14 +13,9 @@ rule download_genome:
 rule download_model:
     """Pull a specific checkpoint dir from GCS into results/checkpoints/{model}/.
 
-    `gcloud storage cp -r` insists on (a) the destination directory existing
-    and (b) nesting the source under it — so we mkdir first, then glob the
-    source's contents into {output} via `{gcs_path}/*` to flatten.
-
-    Auth: relies on `gcloud auth application-default login` (user-side) or
-    GCE/EC2 default credentials. We don't add the snakemake-gcs storage
-    plugin — a single shell rule keeps the pipeline simple and matches the
-    explicit-download style of `download_genome`.
+    The `mkdir` + glob is to flatten: `gcloud storage cp -r src dst` nests
+    src under dst, but the inference rule expects HF model files directly
+    under {output}. Auth uses application-default credentials.
     """
     output:
         directory("results/checkpoints/{model}"),

--- a/snakemake/analysis/evals_v2/workflow/rules/download.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/download.smk
@@ -1,0 +1,32 @@
+"""Download rules: reference genome + per-model checkpoint dirs from GCS."""
+
+
+rule download_genome:
+    output:
+        "results/genome.fa.gz",
+    params:
+        url=config["genome_url"],
+    shell:
+        "wget {params.url} -O {output}"
+
+
+rule download_model:
+    """Pull a specific checkpoint dir from GCS into results/checkpoints/{model}/.
+
+    The trailing slash on the source URL makes `gcloud storage cp -r` copy
+    the contents of the source dir into {output}, so HF model files land
+    directly at results/checkpoints/{model}/ (no extra step-N/ subdir).
+
+    Auth: relies on `gcloud auth application-default login` (user-side) or
+    GCE/EC2 default credentials. We don't add the snakemake-gcs storage
+    plugin — a single shell rule keeps the pipeline simple and matches the
+    explicit-download style of `download_genome`.
+    """
+    output:
+        directory("results/checkpoints/{model}"),
+    wildcard_constraints:
+        model="|".join(MODELS),
+    params:
+        gcs_path=lambda wc: get_model_config(wc.model)["gcs_path"],
+    shell:
+        "gcloud storage cp -r {params.gcs_path}/ {output}"

--- a/snakemake/analysis/evals_v2/workflow/rules/download.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/download.smk
@@ -13,9 +13,9 @@ rule download_genome:
 rule download_model:
     """Pull a specific checkpoint dir from GCS into results/checkpoints/{model}/.
 
-    The trailing slash on the source URL makes `gcloud storage cp -r` copy
-    the contents of the source dir into {output}, so HF model files land
-    directly at results/checkpoints/{model}/ (no extra step-N/ subdir).
+    `gcloud storage cp -r` insists on (a) the destination directory existing
+    and (b) nesting the source under it — so we mkdir first, then glob the
+    source's contents into {output} via `{gcs_path}/*` to flatten.
 
     Auth: relies on `gcloud auth application-default login` (user-side) or
     GCE/EC2 default credentials. We don't add the snakemake-gcs storage
@@ -29,4 +29,5 @@ rule download_model:
     params:
         gcs_path=lambda wc: get_model_config(wc.model)["gcs_path"],
     shell:
-        "gcloud storage cp -r {params.gcs_path}/ {output}"
+        "mkdir -p {output} && "
+        "gcloud storage cp -r '{params.gcs_path}/*' {output}/"

--- a/snakemake/analysis/evals_v2/workflow/rules/inference.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/inference.smk
@@ -1,0 +1,51 @@
+"""Compute LLR / abs(LLR) / embedding-distance scores per (model, dataset).
+
+GPU-bound: meant to run on a SkyPilot GPU node, not the local CPU box.
+"""
+
+
+rule compute_scores:
+    input:
+        genome="results/genome.fa.gz",
+        checkpoint="results/checkpoints/{model}",
+    output:
+        "results/scores/{model}/{dataset}.parquet",
+    wildcard_constraints:
+        model="|".join(MODELS),
+        dataset="|".join(DATASETS),
+    params:
+        # Number of DNA bases extracted per variant context. The model's
+        # tokenizer (loaded from the checkpoint) handles BOS itself, so this
+        # is 255 for BOS-using runs (e.g. exp136) and 256 for the older runs.
+        # We forward as ``context_size=`` because that's the parameter name
+        # in the existing library function.
+        window_size=lambda wc: get_model_config(wc.model)["window_size"],
+        hf_path=lambda wc: f"{config['input_hf_prefix']}_{wc.dataset}",
+    threads: config["inference"]["num_workers"]
+    run:
+        ds = load_dataset(params.hf_path, split=config["split"]).to_pandas()
+        for col in REQUIRED_VARIANT_COLUMNS:
+            assert col in ds.columns, f"dataset missing column {col!r}"
+
+        scores = compute_variant_scores(
+            checkpoint_path=input.checkpoint,
+            dataset=ds,
+            genome_path=input.genome,
+            context_size=params.window_size,
+            batch_size=config["inference"]["batch_size"],
+            num_workers=config["inference"]["num_workers"],
+            data_transform_on_the_fly=config["inference"]["data_transform_on_the_fly"],
+            torch_compile=config["inference"]["torch_compile"],
+        )
+        assert len(scores) == len(ds)
+
+        # Preserve all variant columns (chrom, pos, ref, alt, label, subset,
+        # match_group, …) alongside the score columns.
+        out = pd.concat(
+            [ds.reset_index(drop=True), scores.reset_index(drop=True)], axis=1
+        )
+        out.to_parquet(output[0], index=False)
+        print(
+            f"[evals_v2] {wildcards.model} {wildcards.dataset} "
+            f"({config['split']}): n={len(out)}"
+        )

--- a/snakemake/analysis/evals_v2/workflow/rules/inference.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/inference.smk
@@ -14,11 +14,8 @@ rule compute_scores:
         model="|".join(MODELS),
         dataset="|".join(DATASETS),
     params:
-        # Number of DNA bases extracted per variant context. The model's
-        # tokenizer (loaded from the checkpoint) handles BOS itself, so this
-        # is 255 for BOS-using runs (e.g. exp136) and 256 for the older runs.
-        # We forward as ``context_size=`` because that's the parameter name
-        # in the existing library function.
+        # 255 for BOS-using checkpoints (e.g. exp136), 256 for older runs;
+        # the tokenizer baked into each checkpoint handles BOS itself.
         window_size=lambda wc: get_model_config(wc.model)["window_size"],
         hf_path=lambda wc: f"{config['input_hf_prefix']}_{wc.dataset}",
     threads: config["inference"]["num_workers"]

--- a/snakemake/analysis/evals_v2/workflow/rules/metrics.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/metrics.smk
@@ -1,0 +1,37 @@
+"""Compute PairwiseAccuracy + binomial SE per (model, dataset).
+
+One rule, fired per (model, dataset) — no cross-model aggregation, no markdown
+rendering. The parquet is the deliverable.
+"""
+
+
+rule compute_metrics:
+    input:
+        "results/scores/{model}/{dataset}.parquet",
+    output:
+        "results/metrics/{model}/{dataset}.parquet",
+    wildcard_constraints:
+        model="|".join(MODELS),
+        dataset="|".join(DATASETS),
+    run:
+        score_col = get_dataset_config(wildcards.dataset)["score_column"]
+        df = pd.read_parquet(input[0])
+        for col in REQUIRED_VARIANT_COLUMNS:
+            assert col in df.columns, f"scores parquet missing column {col!r}"
+        assert score_col in df.columns, (
+            f"scores parquet missing score column {score_col!r}"
+        )
+
+        metrics = compute_pairwise_metrics(
+            dataset=df[list(REQUIRED_VARIANT_COLUMNS)],
+            scores=df[[score_col]],
+            score_columns=[score_col],
+        )
+        metrics["model"] = wildcards.model
+        metrics["dataset"] = wildcards.dataset
+        metrics["split"] = config["split"]
+        metrics.to_parquet(output[0], index=False)
+        print(
+            f"[evals_v2] {wildcards.model} {wildcards.dataset}: "
+            f"{len(metrics)} subset rows"
+        )

--- a/snakemake/conservation_eval/README.md
+++ b/snakemake/conservation_eval/README.md
@@ -1,14 +1,45 @@
 # Conservation scores baseline (issue #146)
 
-Per-variant conservation scores on TraitGym Mendelian v2 (`bolinas-dna/evals-traitgym_mendelian_v2`) as a classical baseline alongside model-based evals (e.g. Evo 2 in `scripts/evo2_eval/`, issue #131).
+Per-variant conservation scores on the matched-pair eval datasets produced by
+`snakemake/evals/` (PR #159):
+
+- `bolinas-dna/evals_mendelian_traits` — Mendelian-disease pathogenic SNVs vs
+  gnomAD common variants, 1:1 gene-matched.
+- `bolinas-dna/evals_complex_traits` — UKBB fine-mapped (PIP > 0.9) vs low-PIP
+  (< 0.01), 1:1 gene-matched.
+
+A classical baseline alongside model-based evals (e.g. Evo 2 in
+`scripts/evo2_eval/`).
 
 ## What it does
 
-For each split in `config["splits"]` (default `train` and `test`) and each track in `config["scores"]`:
+For each `dataset` in `config["datasets"]`, each `split` in `config["splits"]`
+(default `train` and `test`), and each `score` in `config["scores"]`:
 
 1. **Download** the bigWig from UCSC / Zoonomia (`results/conservation/{score}.bw`).
-2. **Score** each variant by single-base lookup at its 1-based `pos` (converted to pyBigWig's 0-based half-open `[pos-1, pos)`). NaN is preserved where the bigWig has no aligned data.
-3. **Aggregate** the scored parquets into one AUPRC table per split (`results/conservation_traitgym_v2/results_table_{split}.md`) plus a long-form `metrics_{split}.parquet`. The AUPRC table reports per-subset values plus an unweighted mean across subsets (macro-AUPRC) at the top — global AUPRC isn't shown because it's dominated by the largest subset (missense).
+2. **Score** each variant by single-base lookup at its 1-based `pos` (converted
+   to pyBigWig's 0-based half-open `[pos-1, pos)`). NaN is preserved where the
+   bigWig has no aligned data.
+3. **Aggregate** the scored parquets into one PairwiseAccuracy table per
+   `(dataset, split)` (`results/{dataset}/results_table_{split}.md`) plus a
+   long-form `metrics_{split}.parquet`.
+
+## Metric: PairwiseAccuracy ± SE
+
+The eval datasets are matched pairs: every positive variant has exactly one
+matched negative variant in the same `match_group`. We score this as a
+within-group classification:
+
+- For each `match_group`: +1 if the positive scores higher than the negative,
+  +0.5 on a tie, +0 otherwise.
+- Reported value = mean across pairs in the subset.
+- SE = `sqrt(value * (1 - value) / n_pairs)` (Wald binomial — adequate for the
+  hundreds-to-thousands of pairs per subset; ties contribute to `value` but
+  the SE form is unchanged).
+
+The markdown table reports per-subset rows (consequence groups: missense,
+distal, splicing, promoter, …) — no `global` or `mean` aggregate row, so each
+subset is read on its own terms.
 
 ## Tracks
 
@@ -26,16 +57,21 @@ URLs are owned by `bolinas.evals.conservation.CONSERVATION_TRACKS` (single sourc
 
 ## NaN handling
 
-NaN values arise when the bigWig has no alignment at a given locus (e.g. patches, alt contigs, or genuinely unalignable bases). We make a deliberate choice to **`fillna(0)`** before computing AUPRC:
+NaN values arise when the bigWig has no alignment at a given locus (e.g.
+patches, alt contigs, or genuinely unalignable bases). Before computing
+PairwiseAccuracy we **`fillna(0)`**:
 
 - For phyloP, **0 is semantically meaningful**: neither conserved nor accelerated.
 - For phastCons, **0 is also semantically meaningful**: non-conserved.
 
-This matches the choice in TraitGym's own `eval/workflow/rules/conservation.smk`. Some other benchmarks instead drop NaN variants from evaluation; we don't, for simplicity.
+This matches the choice in TraitGym's own `eval/workflow/rules/conservation.smk`.
 
-The per-variant parquets (`{score}_{split}.parquet`) preserve raw NaNs so you can apply a different policy without re-running scoring. Filling happens only at the aggregation stage.
+The per-variant parquets (`{score}_{split}.parquet`) preserve raw NaNs so you
+can apply a different policy without re-running scoring. Filling happens only
+at the aggregation stage.
 
-NaN counts are surfaced in `results_table_{split}.md` (per `(score, subset)`) so the size of the choice is visible.
+NaN counts are surfaced in `results_table_{split}.md` (per `(score, subset)`)
+so the size of the choice is visible.
 
 ## Usage
 
@@ -46,28 +82,36 @@ cd snakemake/conservation_eval
 uv run snakemake -n
 
 # Run locally (CPU-only — wall time is dominated by bigWig downloads;
-# the full 7-track set is ~50 GB total)
+# the full 7-track set is ~50 GB total). Use --cores to cap parallelism if
+# you're on a shared node.
 uv run snakemake
 ```
 
-The default profile (`workflow/profiles/default/config.yaml`) uses S3 storage at `s3://oa-bolinas/snakemake/conservation_eval/`. AWS credentials need S3 access — same setup as `snakemake/evals/` (see that pipeline's README for credentials).
+The default profile (`workflow/profiles/default/config.yaml`) uses S3 storage
+at `s3://oa-bolinas/snakemake/conservation_eval/`. AWS credentials need S3
+access — same setup as `snakemake/evals/`.
 
 ## Outputs
 
 ```
 results/
 ├── conservation/
-│   └── {score}.bw                         # one per track in config["scores"]
-└── conservation_traitgym_v2/
-    ├── {score}_{split}.parquet            # per-variant score (NaN preserved)
-    ├── metrics_{split}.parquet            # long-form metrics table
-    └── results_table_{split}.md           # markdown for issue follow-up
+│   └── {score}.bw                          # one per track in config["scores"]
+└── {dataset}/
+    ├── {score}_{split}.parquet             # per-variant score (NaN preserved)
+    ├── metrics_{split}.parquet             # long-form metrics table
+    └── results_table_{split}.md            # markdown report (PairwiseAccuracy ± SE)
 ```
+
+Each `metrics_{split}.parquet` has columns `[score_type, score_name, subset,
+value, se, n_pairs, n_ties, n_nan, n_total, split, dataset]`.
 
 ## Library
 
 Snakemake rules are thin glue around `bolinas.evals.conservation`:
-- `score_variants_at_positions(df, bw_path)` — bigWig lookup, NaN preserved.
-- `aggregate_traitgym_metrics(parquet_paths)` — `(metrics_df, markdown)`.
 
-Tests live at `tests/evals/test_conservation.py` (CPU-only, no real bigWig download).
+- `score_variants_at_positions(df, bw_path)` — bigWig lookup, NaN preserved.
+- `aggregate_conservation_metrics(parquet_paths)` — `(metrics_df, markdown)`.
+
+Tests live at `tests/evals/test_conservation.py` and
+`tests/evals/test_pairwise_accuracy.py` (CPU-only, no real bigWig download).

--- a/snakemake/conservation_eval/config/config.yaml
+++ b/snakemake/conservation_eval/config/config.yaml
@@ -1,5 +1,11 @@
-# TraitGym Mendelian v2 dataset on HuggingFace (produced by snakemake/evals/).
-dataset_hf_path: bolinas-dna/evals-traitgym_mendelian_v2
+# Matched-pair eval datasets on HuggingFace (produced by snakemake/evals/).
+# Each dataset is loaded as f"{input_hf_prefix}_{dataset}" — non-harness
+# variants only (the harness '_harness_255' versions are for sequence-based
+# models, not conservation-track lookups).
+input_hf_prefix: bolinas-dna/evals
+datasets:
+  - mendelian_traits
+  - complex_traits
 
 # Splits to score independently. Each produces its own markdown table.
 splits:

--- a/snakemake/conservation_eval/workflow/Snakefile
+++ b/snakemake/conservation_eval/workflow/Snakefile
@@ -9,6 +9,7 @@ include: "rules/score.smk"
 rule all:
     input:
         expand(
-            "results/conservation_traitgym_v2/results_table_{split}.md",
+            "results/{dataset}/results_table_{split}.md",
+            dataset=config["datasets"],
             split=config["splits"],
         ),

--- a/snakemake/conservation_eval/workflow/rules/common.smk
+++ b/snakemake/conservation_eval/workflow/rules/common.smk
@@ -7,15 +7,15 @@ from datasets import load_dataset
 from bolinas.evals.conservation import (
     CONSERVATION_TRACKS,
     REQUIRED_VARIANT_COLUMNS,
-    aggregate_traitgym_metrics,
+    aggregate_conservation_metrics,
     score_variants_at_positions,
 )
-from bolinas.evals.metrics import compute_metrics
 
 
 SCORES = config["scores"]
 SPLITS = config["splits"]
-DATASET_HF_PATH = config["dataset_hf_path"]
+DATASETS = config["datasets"]
+INPUT_HF_PREFIX = config["input_hf_prefix"]
 
 # Sanity-check up-front: every score listed in config must be a known track.
 _unknown = set(SCORES) - set(CONSERVATION_TRACKS)

--- a/snakemake/conservation_eval/workflow/rules/score.smk
+++ b/snakemake/conservation_eval/workflow/rules/score.smk
@@ -2,12 +2,14 @@ rule score_variants:
     input:
         bw="results/conservation/{score}.bw",
     output:
-        "results/conservation_traitgym_v2/{score}_{split}.parquet",
+        "results/{dataset}/{score}_{split}.parquet",
     wildcard_constraints:
         score="|".join(CONSERVATION_TRACKS),
         split="|".join(SPLITS),
+        dataset="|".join(DATASETS),
     run:
-        ds = load_dataset(DATASET_HF_PATH, split=wildcards.split).to_pandas()
+        hf_path = f"{INPUT_HF_PREFIX}_{wildcards.dataset}"
+        ds = load_dataset(hf_path, split=wildcards.split).to_pandas()
         for col in REQUIRED_VARIANT_COLUMNS:
             assert col in ds.columns, f"dataset missing column {col!r}"
 
@@ -18,8 +20,9 @@ rule score_variants:
         out["score"] = scores
         n_nan = int(out["score"].isna().sum())
         print(
-            f"[conservation_eval] {wildcards.score} {wildcards.split}: "
-            f"n={len(out)} n_nan={n_nan} ({100* n_nan/ len(out):.2f}%) "
+            f"[conservation_eval] {wildcards.dataset} {wildcards.score} "
+            f"{wildcards.split}: n={len(out)} n_nan={n_nan} "
+            f"({100 * n_nan / len(out):.2f}%) "
             f"score_min={out['score'].min():.3f} max={out['score'].max():.3f}"
         )
         out.to_parquet(output[0], index=False)
@@ -28,19 +31,21 @@ rule score_variants:
 rule aggregate_metrics:
     input:
         parquets=lambda wc: expand(
-            "results/conservation_traitgym_v2/{score}_{{split}}.parquet",
+            "results/{{dataset}}/{score}_{{split}}.parquet",
             score=SCORES,
         ),
     output:
-        metrics="results/conservation_traitgym_v2/metrics_{split}.parquet",
-        markdown="results/conservation_traitgym_v2/results_table_{split}.md",
+        metrics="results/{dataset}/metrics_{split}.parquet",
+        markdown="results/{dataset}/results_table_{split}.md",
     wildcard_constraints:
         split="|".join(SPLITS),
+        dataset="|".join(DATASETS),
     run:
         # input.parquets are S3-fetched local temp paths, in expand() order (= SCORES).
         parquet_paths = dict(zip(SCORES, input.parquets))
-        metrics, md = aggregate_traitgym_metrics(parquet_paths)
+        metrics, md = aggregate_conservation_metrics(parquet_paths)
         metrics["split"] = wildcards.split
+        metrics["dataset"] = wildcards.dataset
         metrics.to_parquet(output.metrics, index=False)
         Path(output.markdown).write_text(md)
         print(f"[conservation_eval] wrote {output.markdown}")

--- a/src/bolinas/evals/conservation.py
+++ b/src/bolinas/evals/conservation.py
@@ -229,9 +229,7 @@ def _build_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
         for s in score_names:
             v = val_pivot.loc[subset, s] if s in val_pivot.columns else float("nan")
             e = se_pivot.loc[subset, s] if s in se_pivot.columns else float("nan")
-            cells.append(
-                f"{v:.3f} ± {e:.3f}" if pd.notna(v) and pd.notna(e) else "—"
-            )
+            cells.append(f"{v:.3f} ± {e:.3f}" if pd.notna(v) and pd.notna(e) else "—")
         lines.append("| " + " | ".join([subset, str(n_pairs), *cells]) + " |")
 
     # NaN counts: per-subset rows ordered the same way as the metric table.

--- a/src/bolinas/evals/conservation.py
+++ b/src/bolinas/evals/conservation.py
@@ -1,7 +1,8 @@
 """Per-variant conservation scoring via UCSC bigWig tracks.
 
-Used by ``snakemake/conservation_eval/`` (issue #146) to score TraitGym
-Mendelian v2 variants with classical conservation tracks:
+Used by ``snakemake/conservation_eval/`` (issue #146) to score matched-pair
+variant-effect datasets (e.g. ``bolinas-dna/evals_mendelian_traits``,
+``bolinas-dna/evals_complex_traits``) with classical conservation tracks:
 
 - ``phyloP_100v``    — UCSC 100-vertebrate phyloP (multiz alignment)
 - ``phastCons_100v`` — UCSC 100-vertebrate phastCons (multiz alignment)
@@ -29,7 +30,7 @@ import numpy as np
 import pandas as pd
 import pyBigWig
 
-from bolinas.evals.metrics import compute_metrics
+from bolinas.evals.metrics import compute_pairwise_metrics
 
 
 CONSERVATION_TRACKS: dict[str, str] = {
@@ -52,8 +53,9 @@ CONSERVATION_TRACKS: dict[str, str] = {
 }
 
 
-# TraitGym variant columns the pipeline preserves end-to-end. Asserted by
-# the score and aggregate stages so a schema drift fails fast.
+# Variant columns the pipeline preserves end-to-end. Asserted by the score
+# and aggregate stages so a schema drift fails fast. ``match_group`` links
+# 1:1 matched positives and negatives produced by ``snakemake/evals/``.
 REQUIRED_VARIANT_COLUMNS: tuple[str, ...] = (
     "chrom",
     "pos",
@@ -61,6 +63,7 @@ REQUIRED_VARIANT_COLUMNS: tuple[str, ...] = (
     "alt",
     "label",
     "subset",
+    "match_group",
 )
 
 
@@ -113,20 +116,21 @@ def score_variants_at_positions(
     return scores
 
 
-def aggregate_traitgym_metrics(
+def aggregate_conservation_metrics(
     parquet_paths: dict[str, str | Path],
 ) -> tuple[pd.DataFrame, str]:
     """Aggregate per-score scored-variant parquets into a metrics DataFrame
     and a markdown report.
 
     Each input parquet is the output of ``score_variants_at_positions`` plus
-    the original TraitGym columns: must contain ``[chrom, pos, ref, alt,
-    label, subset, score]``. The ``score`` column may contain NaN (positions
-    with no alignment in the bigWig).
+    the matched-pair variant columns: must contain ``[chrom, pos, ref, alt,
+    label, subset, match_group, score]``. The ``score`` column may contain
+    NaN (positions with no alignment in the bigWig).
 
     For each score: NaN count is recorded per subset, then ``score`` is
     filled with 0 (semantically meaningful — see module docstring) before
-    AUPRC is computed via ``bolinas.evals.metrics.compute_metrics``.
+    PairwiseAccuracy + binomial SE is computed via
+    ``bolinas.evals.metrics.compute_pairwise_metrics``.
 
     Args:
         parquet_paths: mapping ``score_name -> parquet path``. Order is
@@ -134,7 +138,7 @@ def aggregate_traitgym_metrics(
 
     Returns:
         ``(metrics_df, markdown)`` where ``metrics_df`` has columns
-        ``[metric, score_type, score_name, subset, value, n_pos, n_neg,
+        ``[score_type, score_name, subset, value, se, n_pairs, n_ties,
         n_nan, n_total]``.
     """
     assert parquet_paths, "parquet_paths must be non-empty"
@@ -150,19 +154,15 @@ def aggregate_traitgym_metrics(
                 f"{parquet_paths[score_name]}: missing column {col!r}"
             )
 
-        # Count NaN per subset before filling; "global" matches compute_metrics'
-        # convention for the all-rows row.
+        # Count NaN per subset before filling.
         nan_per_subset = df.groupby("subset")["score"].apply(
             lambda s: int(s.isna().sum())
         )
-        nan_per_subset["global"] = int(df["score"].isna().sum())
         total_per_subset = df.groupby("subset").size().astype(int)
-        total_per_subset["global"] = len(df)
 
-        m = compute_metrics(
+        m = compute_pairwise_metrics(
             dataset=df[list(REQUIRED_VARIANT_COLUMNS)],
             scores=df[["score"]].fillna(0),
-            metrics=["AUPRC"],
             score_columns=["score"],
         )
         m["score_name"] = score_name
@@ -178,95 +178,84 @@ def aggregate_traitgym_metrics(
 def _build_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
     """Render the metrics DataFrame as a two-table markdown report.
 
-    AUPRC table: per-subset rows plus an unweighted ``mean`` row across
-    subsets at the top (macro-AUPRC). The ``global`` row is intentionally
-    excluded — it would be dominated by the largest subset (missense).
+    PairwiseAccuracy table: one row per ``subset`` (no ``global`` / ``mean``
+    aggregate row). Each cell is ``f"{value:.3f} ± {se:.3f}"``.
 
-    NaN-counts table: keeps the ``global`` row (it's a real total count,
-    not an aggregate of AUPRCs).
+    NaN-counts table: per-subset NaN counts plus per-subset n_total.
     """
-    auprc = metrics[metrics["metric"] == "AUPRC"].copy()
 
     def _pivot(values_col: str) -> pd.DataFrame:
-        return auprc.pivot_table(
+        return metrics.pivot_table(
             index="subset",
             columns="score_name",
             values=values_col,
             aggfunc="first",
         )
 
-    # Per-subset n_pos/n_neg/n_total from the first score (subset coverage
-    # is score-independent).
+    # Per-subset coverage (n_pairs / n_total / n_ties) from the first score —
+    # subset coverage is score-independent. n_ties varies per score, handled
+    # below in its own table column if we want to surface it.
     coverage = (
-        auprc[auprc["score_name"] == score_names[0]][
-            ["subset", "n_pos", "n_neg", "n_total"]
+        metrics[metrics["score_name"] == score_names[0]][
+            ["subset", "n_pairs", "n_total"]
         ]
         .drop_duplicates(subset="subset")
         .set_index("subset")
     )
 
-    pivot = _pivot("value")
+    val_pivot = _pivot("value")
+    se_pivot = _pivot("se")
     nan_pivot = _pivot("n_nan")
 
-    # Per-subset rows ordered by n_pos descending; "global" is excluded
-    # from the AUPRC table but kept for the NaN-counts table.
-    per_subset = [
-        s for s in coverage.sort_values("n_pos", ascending=False).index if s != "global"
-    ]
-    pivot_subsets = pivot.reindex(per_subset)
-
-    # Unweighted mean of per-subset AUPRCs (one value per score). NaN-skip
-    # so a missing subset value for one score doesn't take down the mean.
-    mean_row = pivot_subsets.mean(axis=0, skipna=True)
+    per_subset = list(coverage.sort_values("n_pairs", ascending=False).index)
 
     lines: list[str] = []
-    lines.append("### TraitGym Mendelian v2 — AUPRC")
+    lines.append("### Conservation — Pairwise Accuracy")
     lines.append("")
     lines.append(
-        "Per-subset AUPRC. The top `mean` row is the unweighted mean across "
-        "subsets (macro-AUPRC); each subset contributes equally regardless "
-        "of its size."
+        "Per-subset pairwise accuracy ± binomial SE. For each `match_group` "
+        "(1:1 matched positive and negative variants), the metric counts +1 "
+        "if the positive scores higher, +0.5 on a tie, +0 otherwise; the "
+        "table reports the mean across pairs and `sqrt(p*(1-p)/n)`."
     )
     lines.append("")
-    header = ["subset", "n_pos", "n_neg", *score_names]
+    header = ["subset", "n_pairs", *score_names]
     lines.append("| " + " | ".join(header) + " |")
     lines.append("| " + " | ".join(["---"] * len(header)) + " |")
 
-    mean_vals = [
-        f"{mean_row[s]:.3f}" if pd.notna(mean_row[s]) else "—" for s in score_names
-    ]
-    lines.append("| " + " | ".join(["mean", "—", "—", *mean_vals]) + " |")
-
     for subset in per_subset:
-        n_pos = int(coverage.loc[subset, "n_pos"])
-        n_neg = int(coverage.loc[subset, "n_neg"])
-        vals = [
-            f"{pivot.loc[subset, s]:.3f}" if pd.notna(pivot.loc[subset, s]) else "—"
-            for s in score_names
-        ]
-        lines.append("| " + " | ".join([subset, str(n_pos), str(n_neg), *vals]) + " |")
+        n_pairs = int(coverage.loc[subset, "n_pairs"])
+        cells: list[str] = []
+        for s in score_names:
+            v = val_pivot.loc[subset, s] if s in val_pivot.columns else float("nan")
+            e = se_pivot.loc[subset, s] if s in se_pivot.columns else float("nan")
+            cells.append(
+                f"{v:.3f} ± {e:.3f}" if pd.notna(v) and pd.notna(e) else "—"
+            )
+        lines.append("| " + " | ".join([subset, str(n_pairs), *cells]) + " |")
 
-    # NaN counts: keep the global row at the top, then per-subset rows.
-    nan_order = (["global"] if "global" in nan_pivot.index else []) + per_subset
-    nan_pivot_ordered = nan_pivot.reindex(nan_order)
-
+    # NaN counts: per-subset rows ordered the same way as the metric table.
     lines.append("")
     lines.append("### NaN counts")
     lines.append("")
     lines.append(
-        "NaN = no alignment at that locus in the bigWig. AUPRC above is computed "
-        "after `.fillna(0)`: 0 is semantically meaningful for both phyloP "
-        "(neither conserved nor accelerated) and phastCons (non-conserved)."
+        "NaN = no alignment at that locus in the bigWig. PairwiseAccuracy "
+        "above is computed after `.fillna(0)`: 0 is semantically meaningful "
+        "for both phyloP (neither conserved nor accelerated) and phastCons "
+        "(non-conserved)."
     )
     lines.append("")
     nan_header = ["subset", "n_total", *score_names]
     lines.append("| " + " | ".join(nan_header) + " |")
     lines.append("| " + " | ".join(["---"] * len(nan_header)) + " |")
-    for subset in nan_pivot_ordered.index:
-        n_total = (
-            int(coverage.loc[subset, "n_total"]) if subset in coverage.index else 0
-        )
-        vals = [str(int(nan_pivot_ordered.loc[subset, s])) for s in score_names]
+    for subset in per_subset:
+        n_total = int(coverage.loc[subset, "n_total"])
+        vals = [
+            str(int(nan_pivot.loc[subset, s]))
+            if s in nan_pivot.columns and pd.notna(nan_pivot.loc[subset, s])
+            else "0"
+            for s in score_names
+        ]
         lines.append("| " + " | ".join([subset, str(n_total), *vals]) + " |")
 
     return "\n".join(lines) + "\n"

--- a/src/bolinas/evals/metrics.py
+++ b/src/bolinas/evals/metrics.py
@@ -38,10 +38,13 @@ def pairwise_accuracy(
 
     Args:
         label: 0/1 (or bool) per row. Cast to int internally.
-        score: numeric score per row. NaN is allowed but the caller is
-            responsible for any fill policy (here ``NaN > NaN`` and
-            ``NaN == NaN`` are both False, so a NaN-vs-NaN pair would be
-            counted as a loss for the positive).
+        score: numeric score per row. **Must not contain NaN** — fill
+            upstream with a semantically appropriate value (the
+            ``conservation_eval`` pipeline does ``.fillna(0)``). Without
+            this rule, a NaN-vs-NaN pair would silently count as a loss
+            for the positive (since ``NaN > NaN`` and ``NaN == NaN`` are
+            both False) — that's exactly the kind of silent-corruption
+            risk we want to fail loud on.
         match_group: integer group id; positives and negatives are paired
             within a group.
 
@@ -57,6 +60,10 @@ def pairwise_accuracy(
     label_int = pd.Series(label).astype(int).reset_index(drop=True)
     score_arr = pd.Series(score).reset_index(drop=True)
     mg = pd.Series(match_group).reset_index(drop=True)
+    assert not score_arr.isna().any(), (
+        f"score has {int(score_arr.isna().sum())} NaN values; fill upstream "
+        f"with a semantically appropriate default before scoring"
+    )
 
     df = pd.DataFrame({"label": label_int, "score": score_arr, "match_group": mg})
 

--- a/src/bolinas/evals/metrics.py
+++ b/src/bolinas/evals/metrics.py
@@ -1,10 +1,23 @@
-"""Metric computation utilities for evaluating variant effect predictions."""
+"""Metric utilities for variant-effect evaluations.
 
+Two metric families live here:
+
+- ``pairwise_accuracy`` / ``compute_pairwise_metrics``: matched-pair within-
+  ``match_group`` accuracy (ties = 0.5) with Wald-binomial SE. Used by the
+  matched-pair eval datasets in ``snakemake/evals/`` and the
+  ``conservation_eval`` pipeline.
+- ``METRIC_FUNCTIONS`` / ``compute_metrics``: classical AUPRC / AUROC /
+  Spearman over (label, score) pairs. Still used by older pipelines
+  (``snakemake/analysis/evals_v1/``, ``scripts/evo2_eval/``).
+"""
+
+import math
 from typing import Callable
 
 import pandas as pd
 from scipy.stats import spearmanr
 from sklearn.metrics import average_precision_score, roc_auc_score
+
 
 METRIC_FUNCTIONS: dict[str, Callable[[pd.Series, pd.Series], float]] = {
     "AUPRC": lambda label, score: average_precision_score(label, score),
@@ -13,45 +26,162 @@ METRIC_FUNCTIONS: dict[str, Callable[[pd.Series, pd.Series], float]] = {
 }
 
 
+def pairwise_accuracy(
+    label: pd.Series,
+    score: pd.Series,
+    match_group: pd.Series,
+) -> dict[str, float | int]:
+    """Within-``match_group`` accuracy: fraction of pairs where the positive
+    scores higher than the negative (ties = 0.5).
+
+    Asserts each ``match_group`` has exactly one positive and one negative.
+
+    Args:
+        label: 0/1 (or bool) per row. Cast to int internally.
+        score: numeric score per row. NaN is allowed but the caller is
+            responsible for any fill policy (here ``NaN > NaN`` and
+            ``NaN == NaN`` are both False, so a NaN-vs-NaN pair would be
+            counted as a loss for the positive).
+        match_group: integer group id; positives and negatives are paired
+            within a group.
+
+    Returns:
+        ``{"value", "se", "n_pairs", "n_ties"}``. ``se`` is the Wald binomial
+        form ``sqrt(value * (1 - value) / n_pairs)``.
+    """
+    assert len(label) == len(score) == len(match_group), (
+        f"length mismatch: label={len(label)} score={len(score)} "
+        f"match_group={len(match_group)}"
+    )
+
+    label_int = pd.Series(label).astype(int).reset_index(drop=True)
+    score_arr = pd.Series(score).reset_index(drop=True)
+    mg = pd.Series(match_group).reset_index(drop=True)
+
+    df = pd.DataFrame({"label": label_int, "score": score_arr, "match_group": mg})
+
+    # Each group must have exactly 1 pos + 1 neg.
+    counts = df.groupby("match_group")["label"].agg(["sum", "count"])
+    bad = counts[(counts["sum"] != 1) | (counts["count"] != 2)]
+    assert bad.empty, (
+        f"pairwise_accuracy expects exactly 1 positive + 1 negative per "
+        f"match_group, got {len(bad)} bad groups; first: {bad.head().to_dict()}"
+    )
+
+    pos = df[df["label"] == 1].set_index("match_group")["score"].sort_index()
+    neg = df[df["label"] == 0].set_index("match_group")["score"].sort_index()
+    assert pos.index.equals(neg.index), "positive/negative match_group sets differ"
+
+    diff = pos.values - neg.values
+    n = len(diff)
+    wins = int((diff > 0).sum())
+    ties = int((diff == 0).sum())
+    value = (wins + 0.5 * ties) / n
+    se = math.sqrt(value * (1 - value) / n)
+    return {"value": float(value), "se": float(se), "n_pairs": int(n), "n_ties": ties}
+
+
+def compute_pairwise_metrics(
+    dataset: pd.DataFrame,
+    scores: pd.DataFrame,
+    score_columns: list[str] | None = None,
+) -> pd.DataFrame:
+    """Compute PairwiseAccuracy + SE per ``subset`` for one or more score columns.
+
+    Aligns ``dataset`` with ``scores`` by row index (assumes same order).
+    Stratifies by the ``subset`` column — one row per (subset, score_column).
+    Asserts no ``match_group`` straddles subsets.
+
+    Args:
+        dataset: DataFrame with columns ``[label, subset, match_group]`` (and
+            optionally other passthrough columns).
+        scores: DataFrame whose columns are the model scores; row-aligned with
+            ``dataset``.
+        score_columns: Score column names to evaluate. Defaults to all columns
+            of ``scores``.
+
+    Returns:
+        DataFrame with columns ``[score_type, subset, value, se, n_pairs,
+        n_ties]``. ``score_type`` is the column name from ``scores``.
+    """
+    for col in ("label", "subset", "match_group"):
+        assert col in dataset.columns, f"dataset missing required column {col!r}"
+
+    if score_columns is None:
+        score_columns = list(scores.columns)
+
+    merged = pd.concat(
+        [dataset.reset_index(drop=True), scores.reset_index(drop=True)], axis=1
+    )
+
+    # No match_group may straddle subsets — would silently double-count or
+    # drop pairs depending on filter order.
+    subset_per_group = merged.groupby("match_group")["subset"].nunique()
+    bad_groups = subset_per_group[subset_per_group > 1]
+    assert bad_groups.empty, (
+        f"{len(bad_groups)} match_group(s) span multiple subsets; first: "
+        f"{bad_groups.head().to_dict()}"
+    )
+
+    rows: list[dict] = []
+    for subset_name, subset_df in merged.groupby("subset", sort=False):
+        for score_col in score_columns:
+            res = pairwise_accuracy(
+                label=subset_df["label"],
+                score=subset_df[score_col],
+                match_group=subset_df["match_group"],
+            )
+            rows.append(
+                {
+                    "score_type": score_col,
+                    "subset": str(subset_name),
+                    "value": res["value"],
+                    "se": res["se"],
+                    "n_pairs": res["n_pairs"],
+                    "n_ties": res["n_ties"],
+                }
+            )
+    return pd.DataFrame(rows)
+
+
 def compute_metrics(
     dataset: pd.DataFrame,
     scores: pd.DataFrame,
     metrics: list[str],
     score_columns: list[str] | None = None,
 ) -> pd.DataFrame:
-    """Compute evaluation metrics for variant predictions.
+    """Compute classical (AUPRC/AUROC/Spearman) metrics for variant predictions.
 
-    Aligns dataset with scores by row index and computes specified metrics both
-    globally and on each subset (if dataset contains a 'subset' column). For datasets
-    with subsets, computes metrics on the full dataset (subset='global') and
-    on each individual subset.
+    Aligns ``dataset`` with ``scores`` by row index. For datasets with a
+    ``subset`` column, computes metrics on the full dataset (``subset='global'``)
+    and on each individual subset.
 
     Args:
-        dataset: DataFrame with columns [chrom, pos, ref, alt, label] and optionally [subset].
-        scores: DataFrame with columns [minus_llr, abs_llr, ...] aligned by index with dataset.
-        metrics: List of metric names to compute (e.g., ['AUPRC', 'AUROC']).
-        score_columns: List of score column names to evaluate. If None, uses ['minus_llr', 'abs_llr'].
+        dataset: DataFrame with ``[chrom, pos, ref, alt, label]`` and optionally
+            ``subset``.
+        scores: DataFrame whose columns are the model scores; row-aligned with
+            ``dataset``.
+        metrics: List of metric names from ``METRIC_FUNCTIONS``.
+        score_columns: Score column names to evaluate. Defaults to
+            ``['minus_llr', 'abs_llr']``.
 
     Returns:
-        DataFrame with columns [metric, score_type, subset, value].
-        Each row represents one metric computed on one score type for one subset.
+        DataFrame with columns ``[metric, score_type, subset, value, n_pos,
+        n_neg]``.
     """
     if score_columns is None:
         score_columns = ["minus_llr", "abs_llr"]
 
-    # Combine dataset and scores by index (assumes same order)
     merged = pd.concat(
         [dataset.reset_index(drop=True), scores.reset_index(drop=True)], axis=1
     )
 
-    # Build list of subsets to evaluate
     subsets_to_evaluate = [("global", merged)]
     if "subset" in merged.columns:
         for subset_name in merged["subset"].unique():
             subset_data = merged[merged["subset"] == subset_name]
             subsets_to_evaluate.append((subset_name, subset_data))
 
-    # Compute metrics for each subset
     results = []
     for subset_name, subset_data in subsets_to_evaluate:
         n_pos = int((subset_data["label"] == 1).sum())
@@ -70,7 +200,6 @@ def compute_metrics(
                         "n_neg": n_neg,
                     }
                 )
-
     return pd.DataFrame(results)
 
 
@@ -85,16 +214,14 @@ def aggregate_metrics(
         model_steps: List of model training steps corresponding to each file.
 
     Returns:
-        DataFrame with columns [step, dataset, metric, score_type, subset, value].
-        Sorted by step and dataset for easier analysis.
+        DataFrame with all per-file rows plus ``[step, dataset]`` columns,
+        sorted by step and dataset.
     """
     all_metrics = []
-
     for file_path, dataset_name, step in zip(metric_files, dataset_names, model_steps):
         df = pd.read_parquet(file_path)
         df["dataset"] = dataset_name
         df["step"] = int(step)
         all_metrics.append(df)
-
     result = pd.concat(all_metrics, ignore_index=True)
     return result.sort_values(["step", "dataset"]).reset_index(drop=True)

--- a/tests/evals/test_conservation.py
+++ b/tests/evals/test_conservation.py
@@ -139,9 +139,7 @@ def test_aggregate_conservation_metrics_nan_accounting(tmp_path):
     labels = [1, 0, 1, 0, 1, 0, 1, 0]
     subsets = ["A", "A", "A", "A", "B", "B", "B", "B"]
     match_groups = [0, 0, 1, 1, 2, 2, 3, 3]
-    p = _scored_parquet(
-        tmp_path, "phyloP_241m", scores, labels, subsets, match_groups
-    )
+    p = _scored_parquet(tmp_path, "phyloP_241m", scores, labels, subsets, match_groups)
 
     metrics, md = aggregate_conservation_metrics({"phyloP_241m": p})
 
@@ -225,9 +223,7 @@ def test_aggregate_conservation_metrics_no_global_or_mean_row(tmp_path):
     labels = [1, 0, 1, 0, 1, 0, 1, 0]
     subsets = ["A", "A", "A", "A", "B", "B", "B", "B"]
     match_groups = [0, 0, 1, 1, 2, 2, 3, 3]
-    p = _scored_parquet(
-        tmp_path, "score1", scores, labels, subsets, match_groups
-    )
+    p = _scored_parquet(tmp_path, "score1", scores, labels, subsets, match_groups)
 
     _, md = aggregate_conservation_metrics({"score1": p})
 
@@ -253,9 +249,7 @@ def test_aggregate_conservation_metrics_value_formatting(tmp_path):
     labels = [1, 0, 1, 0]
     subsets = ["A", "A", "A", "A"]
     match_groups = [0, 0, 1, 1]
-    p = _scored_parquet(
-        tmp_path, "score1", scores, labels, subsets, match_groups
-    )
+    p = _scored_parquet(tmp_path, "score1", scores, labels, subsets, match_groups)
     _, md = aggregate_conservation_metrics({"score1": p})
     assert "1.000 ± 0.000" in md
 

--- a/tests/evals/test_conservation.py
+++ b/tests/evals/test_conservation.py
@@ -7,7 +7,7 @@ import pytest
 
 from bolinas.evals.conservation import (
     CONSERVATION_TRACKS,
-    aggregate_traitgym_metrics,
+    aggregate_conservation_metrics,
     score_variants_at_positions,
 )
 
@@ -110,7 +110,7 @@ def test_score_variants_rejects_non_integer_pos(tmp_path):
         score_variants_at_positions(df, bw_path)
 
 
-def _scored_parquet(tmp_path, name, scores, labels, subsets):
+def _scored_parquet(tmp_path, name, scores, labels, subsets, match_groups):
     """Write a fake scored-variant parquet matching the score_variants output schema."""
     path = tmp_path / f"{name}.parquet"
     n = len(scores)
@@ -122,6 +122,7 @@ def _scored_parquet(tmp_path, name, scores, labels, subsets):
             "alt": ["T"] * n,
             "label": labels,
             "subset": subsets,
+            "match_group": match_groups,
             "score": scores,
         }
     )
@@ -129,135 +130,134 @@ def _scored_parquet(tmp_path, name, scores, labels, subsets):
     return path
 
 
-def test_aggregate_traitgym_metrics_nan_accounting(tmp_path):
-    """NaN counts should be correct per subset and globally; AUPRC computed
-    after fillna(0)."""
-    # 6 variants: 3 in subset_A, 3 in subset_B. Score column has 1 NaN
-    # in subset_A, 0 in subset_B.
-    scores = [0.9, np.nan, 0.1, 0.8, 0.2, 0.5]
-    labels = [1, 1, 0, 1, 0, 0]
-    subsets = ["A", "A", "A", "B", "B", "B"]
-    p = _scored_parquet(tmp_path, "phyloP_241m", scores, labels, subsets)
+def test_aggregate_conservation_metrics_nan_accounting(tmp_path):
+    """NaN counts should be correct per subset; PairwiseAccuracy computed
+    after fillna(0). 4 matched pairs across 2 subsets; subset A has 1 NaN."""
+    # 8 variants = 4 pairs. NaN in pos of group 0 -> after fillna(0) it's
+    # a loss for that pair (0 < 0.1).
+    scores = [np.nan, 0.1, 0.8, 0.2, 0.9, 0.1, 0.7, 0.3]
+    labels = [1, 0, 1, 0, 1, 0, 1, 0]
+    subsets = ["A", "A", "A", "A", "B", "B", "B", "B"]
+    match_groups = [0, 0, 1, 1, 2, 2, 3, 3]
+    p = _scored_parquet(
+        tmp_path, "phyloP_241m", scores, labels, subsets, match_groups
+    )
 
-    metrics, md = aggregate_traitgym_metrics({"phyloP_241m": p})
+    metrics, md = aggregate_conservation_metrics({"phyloP_241m": p})
 
     # Schema check.
     expected_cols = {
-        "metric",
         "score_type",
         "score_name",
         "subset",
         "value",
-        "n_pos",
-        "n_neg",
+        "se",
+        "n_pairs",
+        "n_ties",
         "n_nan",
         "n_total",
     }
     assert expected_cols.issubset(set(metrics.columns))
 
     # NaN accounting.
-    nan_global = metrics[
-        (metrics["score_name"] == "phyloP_241m") & (metrics["subset"] == "global")
-    ]["n_nan"].iloc[0]
     nan_a = metrics[
         (metrics["score_name"] == "phyloP_241m") & (metrics["subset"] == "A")
     ]["n_nan"].iloc[0]
     nan_b = metrics[
         (metrics["score_name"] == "phyloP_241m") & (metrics["subset"] == "B")
     ]["n_nan"].iloc[0]
-    assert nan_global == 1
     assert nan_a == 1
     assert nan_b == 0
 
     # Total counts.
-    tot_global = metrics[
-        (metrics["score_name"] == "phyloP_241m") & (metrics["subset"] == "global")
+    tot_a = metrics[
+        (metrics["score_name"] == "phyloP_241m") & (metrics["subset"] == "A")
     ]["n_total"].iloc[0]
-    assert tot_global == 6
+    assert tot_a == 4
 
-    # Markdown contains the AUPRC and NaN-count tables.
-    assert "AUPRC" in md
+    # Subset A: pair0 has NaN→0 vs 0.1 → loss; pair1 0.8 vs 0.2 → win. value = 0.5.
+    val_a = metrics[
+        (metrics["score_name"] == "phyloP_241m") & (metrics["subset"] == "A")
+    ]["value"].iloc[0]
+    assert val_a == 0.5
+    # Subset B: both pairs are wins. value = 1.0.
+    val_b = metrics[
+        (metrics["score_name"] == "phyloP_241m") & (metrics["subset"] == "B")
+    ]["value"].iloc[0]
+    assert val_b == 1.0
+
+    # Markdown contains the PairwiseAccuracy and NaN-count tables.
+    assert "Pairwise Accuracy" in md
     assert "NaN" in md
     assert "phyloP_241m" in md
 
 
-def test_aggregate_traitgym_metrics_multi_score_column_order(tmp_path):
+def test_aggregate_conservation_metrics_multi_score_column_order(tmp_path):
     """Markdown columns appear in the order of parquet_paths.keys()."""
-    scores = [0.5, 0.7, 0.3, 0.2]
-    labels = [1, 1, 0, 0]
+    scores = [0.7, 0.5, 0.3, 0.2]
+    labels = [1, 0, 1, 0]
     subsets = ["x", "x", "x", "x"]
+    match_groups = [0, 0, 1, 1]
     paths = {
         "phyloP_100v": _scored_parquet(
-            tmp_path, "phyloP_100v", scores, labels, subsets
+            tmp_path, "phyloP_100v", scores, labels, subsets, match_groups
         ),
         "phyloP_241m": _scored_parquet(
-            tmp_path, "phyloP_241m", scores, labels, subsets
+            tmp_path, "phyloP_241m", scores, labels, subsets, match_groups
         ),
         "phastCons_43p": _scored_parquet(
-            tmp_path, "phastCons_43p", scores, labels, subsets
+            tmp_path, "phastCons_43p", scores, labels, subsets, match_groups
         ),
     }
-    _, md = aggregate_traitgym_metrics(paths)
+    _, md = aggregate_conservation_metrics(paths)
 
-    # All three names appear; phyloP_100v comes before phyloP_241m (column order).
     pos_100v = md.find("phyloP_100v")
     pos_241m = md.find("phyloP_241m")
     pos_43p = md.find("phastCons_43p")
     assert 0 < pos_100v < pos_241m < pos_43p
 
 
-def test_aggregate_traitgym_metrics_mean_row_replaces_global(tmp_path):
-    """AUPRC table has a 'mean' row (unweighted across subsets) at the top
-    and *no* 'global' row. The NaN-counts table still includes global."""
-    # 8 variants, two subsets of size 4. The two subsets' AUPRCs differ,
-    # so unweighted mean ≠ global AUPRC and we can tell them apart.
-    # subset A: perfectly separable -> AUPRC = 1.0
-    # subset B: anti-correlated     -> AUPRC ≈ 0.4
-    scores = [0.9, 0.8, 0.2, 0.1, 0.1, 0.2, 0.8, 0.9]
-    labels = [1, 1, 0, 0, 1, 1, 0, 0]
+def test_aggregate_conservation_metrics_no_global_or_mean_row(tmp_path):
+    """PairwiseAccuracy table has only per-subset rows — no 'global' or
+    'mean' aggregate row (per user requirements)."""
+    # 8 variants = 4 pairs across 2 subsets.
+    scores = [0.9, 0.1, 0.8, 0.2, 0.7, 0.3, 0.6, 0.4]
+    labels = [1, 0, 1, 0, 1, 0, 1, 0]
     subsets = ["A", "A", "A", "A", "B", "B", "B", "B"]
-    p = _scored_parquet(tmp_path, "score1", scores, labels, subsets)
+    match_groups = [0, 0, 1, 1, 2, 2, 3, 3]
+    p = _scored_parquet(
+        tmp_path, "score1", scores, labels, subsets, match_groups
+    )
 
-    metrics, md = aggregate_traitgym_metrics({"score1": p})
+    _, md = aggregate_conservation_metrics({"score1": p})
 
     # Split markdown into the two tables.
-    auprc_section, nan_section = md.split("### NaN counts")
-    assert "AUPRC" in auprc_section
+    pa_section, nan_section = md.split("### NaN counts")
+    assert "Pairwise Accuracy" in pa_section
 
-    # AUPRC table: must have a 'mean' row, must NOT have a 'global' row.
-    auprc_rows = [
-        ln
-        for ln in auprc_section.splitlines()
-        if ln.startswith("| ") and "---" not in ln
+    pa_rows = [
+        ln for ln in pa_section.splitlines() if ln.startswith("| ") and "---" not in ln
     ]
     # First row is the header; data rows follow.
-    data_rows = auprc_rows[1:]
+    data_rows = pa_rows[1:]
     row_labels = [r.split("|")[1].strip() for r in data_rows]
-    assert "mean" in row_labels
     assert "global" not in row_labels
-    assert row_labels[0] == "mean", "mean row must be at the top of the AUPRC table"
+    assert "mean" not in row_labels
+    assert set(row_labels) == {"A", "B"}
 
-    # NaN-counts table: still has global.
-    nan_rows = [
-        ln for ln in nan_section.splitlines() if ln.startswith("| ") and "---" not in ln
-    ]
-    nan_data = nan_rows[1:]
-    nan_labels = [r.split("|")[1].strip() for r in nan_data]
-    assert "global" in nan_labels
 
-    # Mean value matches the unweighted mean of per-subset AUPRCs in metrics_df.
-    per_subset_auprc = metrics[
-        (metrics["metric"] == "AUPRC")
-        & (metrics["score_name"] == "score1")
-        & (metrics["subset"].isin(["A", "B"]))
-    ]["value"]
-    expected_mean = float(per_subset_auprc.mean())
-
-    mean_row_str = next(r for r in data_rows if r.split("|")[1].strip() == "mean")
-    # Cells: ['', 'mean', 'n_pos', 'n_neg', 'score1', '']
-    cells = [c.strip() for c in mean_row_str.split("|")]
-    rendered_mean = float(cells[4])
-    assert rendered_mean == pytest.approx(expected_mean, abs=1e-3)
+def test_aggregate_conservation_metrics_value_formatting(tmp_path):
+    """Cells in the markdown table follow the ``value ± se`` format."""
+    # 4 variants = 2 pairs in subset A. Both wins -> value=1.0, se=0.0.
+    scores = [0.9, 0.1, 0.8, 0.2]
+    labels = [1, 0, 1, 0]
+    subsets = ["A", "A", "A", "A"]
+    match_groups = [0, 0, 1, 1]
+    p = _scored_parquet(
+        tmp_path, "score1", scores, labels, subsets, match_groups
+    )
+    _, md = aggregate_conservation_metrics({"score1": p})
+    assert "1.000 ± 0.000" in md
 
 
 def test_score_variants_preserves_input_order(tmp_path):

--- a/tests/evals/test_metrics.py
+++ b/tests/evals/test_metrics.py
@@ -1,70 +1,66 @@
-"""Tests for metrics computation functions."""
+"""Tests for the classical (AUPRC/AUROC/Spearman) metrics API and cross-run
+aggregation. Per-metric tests for ``pairwise_accuracy`` live in
+``test_pairwise_accuracy.py``."""
+
+import tempfile
+from pathlib import Path
 
 import pandas as pd
 
-from bolinas.evals.metrics import METRIC_FUNCTIONS, aggregate_metrics, compute_metrics
+from bolinas.evals.metrics import (
+    METRIC_FUNCTIONS,
+    aggregate_metrics,
+    compute_metrics,
+)
 
 
 def test_metric_functions_auprc():
-    """Test AUPRC metric computation."""
     labels = pd.Series([1, 1, 0, 0, 1])
     scores = pd.Series([0.9, 0.8, 0.6, 0.3, 0.7])
-
     auprc = METRIC_FUNCTIONS["AUPRC"](labels, scores)
     assert 0.0 <= auprc <= 1.0
     assert isinstance(auprc, float)
 
 
 def test_metric_functions_auroc():
-    """Test AUROC metric computation."""
     labels = pd.Series([1, 1, 0, 0, 1])
     scores = pd.Series([0.9, 0.8, 0.6, 0.3, 0.7])
-
     auroc = METRIC_FUNCTIONS["AUROC"](labels, scores)
     assert 0.0 <= auroc <= 1.0
     assert isinstance(auroc, float)
 
 
 def test_metric_functions_spearman():
-    """Test Spearman correlation computation."""
     labels = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
     scores = pd.Series([1.1, 2.2, 2.9, 4.1, 5.0])
-
     spearman = METRIC_FUNCTIONS["Spearman"](labels, scores)
     assert -1.0 <= spearman <= 1.0
     assert isinstance(spearman, float)
 
 
 def test_compute_metrics_without_subsets():
-    """Test metric computation on dataset without subsets.
-
-    Should compute metrics globally only, for each score type.
-    """
     dataset = pd.DataFrame(
         {
-            "chrom": ["chr1", "chr1", "chr1", "chr1", "chr1"],
+            "chrom": ["chr1"] * 5,
             "pos": [100, 200, 300, 400, 500],
             "ref": ["A", "C", "G", "T", "A"],
             "alt": ["T", "G", "A", "C", "G"],
             "label": [1, 1, 0, 0, 1],
         }
     )
-
     scores = pd.DataFrame(
         {
             "minus_llr": [0.9, 0.8, 0.6, 0.3, 0.7],
             "abs_llr": [0.9, 0.8, 0.6, 0.3, 0.7],
         }
     )
-
     metrics = compute_metrics(
         dataset=dataset,
         scores=scores,
         metrics=["AUPRC", "AUROC"],
         score_columns=["minus_llr", "abs_llr"],
     )
-
-    # Should have 2 metrics * 2 score types = 4 rows
+    # 2 metrics * 2 score types = 4 rows
     assert len(metrics) == 4
     assert set(metrics["metric"]) == {"AUPRC", "AUROC"}
     assert set(metrics["score_type"]) == {"minus_llr", "abs_llr"}
@@ -73,13 +69,9 @@ def test_compute_metrics_without_subsets():
 
 
 def test_compute_metrics_with_subsets():
-    """Test metric computation on dataset with subsets.
-
-    Should compute metrics globally and for each subset.
-    """
     dataset = pd.DataFrame(
         {
-            "chrom": ["chr1", "chr1", "chr1", "chr1", "chr1", "chr1"],
+            "chrom": ["chr1"] * 6,
             "pos": [100, 200, 300, 400, 500, 600],
             "ref": ["A", "C", "G", "T", "A", "C"],
             "alt": ["T", "G", "A", "C", "G", "T"],
@@ -87,79 +79,24 @@ def test_compute_metrics_with_subsets():
             "subset": ["5UTR", "5UTR", "3UTR", "3UTR", "5UTR", "3UTR"],
         }
     )
-
     scores = pd.DataFrame(
         {
             "minus_llr": [0.9, 0.8, 0.6, 0.3, 0.7, 0.4],
             "abs_llr": [0.9, 0.8, 0.6, 0.3, 0.7, 0.4],
         }
     )
-
     metrics = compute_metrics(
         dataset=dataset,
         scores=scores,
         metrics=["AUPRC"],
         score_columns=["minus_llr"],
     )
-
-    # Should have 1 metric * 1 score type * 3 subsets (global, 5UTR, 3UTR) = 3 rows
+    # 1 metric * 1 score type * 3 subsets (global, 5UTR, 3UTR) = 3 rows
     assert len(metrics) == 3
     assert set(metrics["subset"]) == {"global", "5UTR", "3UTR"}
-    assert all(metrics["metric"] == "AUPRC")
-    assert all(metrics["score_type"] == "minus_llr")
-    assert all(metrics["value"].notna())
-
-
-def test_aggregate_metrics():
-    """Test aggregating metrics from multiple files."""
-    # Create temporary parquet files
-    import tempfile
-    from pathlib import Path
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmpdir = Path(tmpdir)
-
-        # Create metric files
-        metrics1 = pd.DataFrame(
-            {
-                "metric": ["AUPRC", "AUROC"],
-                "score_type": ["llr_minus", "llr_minus"],
-                "subset": ["global", "global"],
-                "value": [0.85, 0.80],
-            }
-        )
-        metrics1.to_parquet(tmpdir / "metrics1.parquet")
-
-        metrics2 = pd.DataFrame(
-            {
-                "metric": ["AUPRC", "AUROC"],
-                "score_type": ["llr_minus", "llr_minus"],
-                "subset": ["global", "global"],
-                "value": [0.90, 0.85],
-            }
-        )
-        metrics2.to_parquet(tmpdir / "metrics2.parquet")
-
-        # Aggregate
-        result = aggregate_metrics(
-            metric_files=[
-                str(tmpdir / "metrics1.parquet"),
-                str(tmpdir / "metrics2.parquet"),
-            ],
-            dataset_names=["dataset1", "dataset1"],
-            model_steps=["10000", "20000"],
-        )
-
-        # Should have 4 rows (2 metrics * 2 steps)
-        assert len(result) == 4
-        assert set(result["step"]) == {10000, 20000}
-        assert set(result["dataset"]) == {"dataset1"}
-        assert set(result["metric"]) == {"AUPRC", "AUROC"}
-        assert all(result["value"].notna())
 
 
 def test_compute_metrics_default_score_columns():
-    """Test that compute_metrics uses default score columns when not specified."""
     dataset = pd.DataFrame(
         {
             "chrom": ["chr1"],
@@ -169,15 +106,49 @@ def test_compute_metrics_default_score_columns():
             "label": [1],
         }
     )
-
-    scores = pd.DataFrame(
-        {
-            "minus_llr": [0.9],
-            "abs_llr": [0.9],
-        }
-    )
-
+    scores = pd.DataFrame({"minus_llr": [0.9], "abs_llr": [0.9]})
     metrics = compute_metrics(dataset=dataset, scores=scores, metrics=["AUPRC"])
-
-    # Should use default score_columns=['minus_llr', 'abs_llr']
     assert set(metrics["score_type"]) == {"minus_llr", "abs_llr"}
+
+
+def test_aggregate_metrics():
+    """Aggregating metrics from multiple files annotates each row with
+    ``step`` and ``dataset`` and concatenates."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        m1 = pd.DataFrame(
+            {
+                "score_type": ["score", "score"],
+                "subset": ["A", "B"],
+                "value": [0.9, 0.7],
+                "se": [0.05, 0.10],
+                "n_pairs": [100, 50],
+                "n_ties": [0, 2],
+            }
+        )
+        m1.to_parquet(tmpdir / "m1.parquet")
+
+        m2 = pd.DataFrame(
+            {
+                "score_type": ["score", "score"],
+                "subset": ["A", "B"],
+                "value": [0.85, 0.65],
+                "se": [0.06, 0.11],
+                "n_pairs": [100, 50],
+                "n_ties": [1, 2],
+            }
+        )
+        m2.to_parquet(tmpdir / "m2.parquet")
+
+        result = aggregate_metrics(
+            metric_files=[str(tmpdir / "m1.parquet"), str(tmpdir / "m2.parquet")],
+            dataset_names=["dataset1", "dataset1"],
+            model_steps=["10000", "20000"],
+        )
+
+        assert len(result) == 4
+        assert set(result["step"]) == {10000, 20000}
+        assert set(result["dataset"]) == {"dataset1"}
+        assert set(result["subset"]) == {"A", "B"}
+        assert all(result["value"].notna())

--- a/tests/evals/test_pairwise_accuracy.py
+++ b/tests/evals/test_pairwise_accuracy.py
@@ -1,0 +1,216 @@
+"""Tests for the pairwise-accuracy metric (matched-pair within-group)."""
+
+import math
+
+import pandas as pd
+import pytest
+
+from bolinas.evals.metrics import compute_pairwise_metrics, pairwise_accuracy
+
+
+# ---- pairwise_accuracy ----------------------------------------------------
+
+
+def _frame(label, score, match_group):
+    return (
+        pd.Series(label),
+        pd.Series(score, dtype=float),
+        pd.Series(match_group),
+    )
+
+
+def test_pairwise_accuracy_all_wins():
+    label, score, mg = _frame([1, 0, 1, 0], [0.9, 0.1, 0.8, 0.2], [0, 0, 1, 1])
+    res = pairwise_accuracy(label, score, mg)
+    assert res["value"] == 1.0
+    assert res["se"] == 0.0
+    assert res["n_pairs"] == 2
+    assert res["n_ties"] == 0
+
+
+def test_pairwise_accuracy_all_losses():
+    label, score, mg = _frame([1, 0, 1, 0], [0.1, 0.9, 0.2, 0.8], [0, 0, 1, 1])
+    res = pairwise_accuracy(label, score, mg)
+    assert res["value"] == 0.0
+    assert res["se"] == 0.0
+    assert res["n_pairs"] == 2
+    assert res["n_ties"] == 0
+
+
+def test_pairwise_accuracy_fifty_fifty():
+    # 4 pairs: 2 wins, 2 losses.
+    label = [1, 0, 1, 0, 1, 0, 1, 0]
+    score = [0.9, 0.1, 0.1, 0.9, 0.8, 0.2, 0.2, 0.8]
+    mg = [0, 0, 1, 1, 2, 2, 3, 3]
+    res = pairwise_accuracy(*_frame(label, score, mg))
+    assert res["value"] == 0.5
+    assert res["se"] == pytest.approx(math.sqrt(0.25 / 4))
+    assert res["n_pairs"] == 4
+    assert res["n_ties"] == 0
+
+
+def test_pairwise_accuracy_pure_ties():
+    label = [1, 0, 1, 0, 1, 0]
+    score = [0.5, 0.5, 0.7, 0.7, 0.0, 0.0]
+    mg = [0, 0, 1, 1, 2, 2]
+    res = pairwise_accuracy(*_frame(label, score, mg))
+    assert res["value"] == 0.5  # ties counted as 0.5
+    assert res["n_pairs"] == 3
+    assert res["n_ties"] == 3
+    assert res["se"] == pytest.approx(math.sqrt(0.5 * 0.5 / 3))
+
+
+def test_pairwise_accuracy_mixed_wins_and_ties():
+    # 4 pairs: 2 wins, 1 tie, 1 loss => value = (2 + 0.5*1) / 4 = 0.625
+    label = [1, 0, 1, 0, 1, 0, 1, 0]
+    score = [0.9, 0.1, 0.5, 0.5, 0.8, 0.2, 0.1, 0.9]
+    mg = [0, 0, 1, 1, 2, 2, 3, 3]
+    res = pairwise_accuracy(*_frame(label, score, mg))
+    expected = (2 + 0.5) / 4
+    assert res["value"] == pytest.approx(expected)
+    assert res["se"] == pytest.approx(math.sqrt(expected * (1 - expected) / 4))
+    assert res["n_pairs"] == 4
+    assert res["n_ties"] == 1
+
+
+def test_pairwise_accuracy_handles_bool_label():
+    label = [True, False, True, False]
+    score = [0.9, 0.1, 0.8, 0.2]
+    mg = [0, 0, 1, 1]
+    res = pairwise_accuracy(*_frame(label, score, mg))
+    assert res["value"] == 1.0
+    assert res["n_pairs"] == 2
+
+
+def test_pairwise_accuracy_se_decreases_with_n():
+    """SE for 50/50 must shrink as 1/sqrt(n)."""
+    se_small = pairwise_accuracy(*_frame([1, 0, 1, 0], [1, 0, 0, 1], [0, 0, 1, 1]))[
+        "se"
+    ]
+    n_big = 100
+    label = [1, 0] * n_big
+    score = ([1, 0] * (n_big // 2)) + ([0, 1] * (n_big // 2))
+    mg = [i for i in range(n_big) for _ in range(2)]
+    se_big = pairwise_accuracy(*_frame(label, score, mg))["se"]
+    assert se_big < se_small
+
+
+def test_pairwise_accuracy_rejects_extra_positive_in_group():
+    # match_group 0 has 2 positives, 1 negative.
+    label = [1, 1, 0, 1, 0]
+    score = [0.9, 0.5, 0.1, 0.8, 0.2]
+    mg = [0, 0, 0, 1, 1]
+    with pytest.raises(AssertionError, match="exactly 1 positive"):
+        pairwise_accuracy(*_frame(label, score, mg))
+
+
+def test_pairwise_accuracy_rejects_missing_negative_in_group():
+    # match_group 1 has only a positive.
+    label = [1, 0, 1]
+    score = [0.9, 0.1, 0.8]
+    mg = [0, 0, 1]
+    with pytest.raises(AssertionError, match="exactly 1 positive"):
+        pairwise_accuracy(*_frame(label, score, mg))
+
+
+def test_pairwise_accuracy_rejects_length_mismatch():
+    with pytest.raises(AssertionError, match="length mismatch"):
+        pairwise_accuracy(
+            pd.Series([1, 0, 1, 0]),
+            pd.Series([0.9, 0.1, 0.8]),
+            pd.Series([0, 0, 1, 1]),
+        )
+
+
+# ---- compute_pairwise_metrics --------------------------------------------
+
+
+def test_compute_pairwise_metrics_per_subset():
+    """Stratifies by ``subset`` and returns one row per (subset, score)."""
+    dataset = pd.DataFrame(
+        {
+            "label": [1, 0, 1, 0, 1, 0, 1, 0],
+            "subset": ["A", "A", "A", "A", "B", "B", "B", "B"],
+            "match_group": [0, 0, 1, 1, 2, 2, 3, 3],
+        }
+    )
+    # Subset A: both pairs are wins -> 1.0
+    # Subset B: one win, one loss -> 0.5
+    scores = pd.DataFrame(
+        {
+            "score": [0.9, 0.1, 0.8, 0.2, 0.9, 0.1, 0.1, 0.9],
+        }
+    )
+    metrics = compute_pairwise_metrics(
+        dataset=dataset, scores=scores, score_columns=["score"]
+    )
+    assert set(metrics.columns) == {
+        "score_type",
+        "subset",
+        "value",
+        "se",
+        "n_pairs",
+        "n_ties",
+    }
+    assert len(metrics) == 2  # 2 subsets x 1 score_column
+    by_subset = metrics.set_index("subset")["value"]
+    assert by_subset["A"] == 1.0
+    assert by_subset["B"] == 0.5
+
+
+def test_compute_pairwise_metrics_multi_score_columns():
+    dataset = pd.DataFrame(
+        {
+            "label": [1, 0, 1, 0],
+            "subset": ["A", "A", "A", "A"],
+            "match_group": [0, 0, 1, 1],
+        }
+    )
+    scores = pd.DataFrame(
+        {
+            "score_a": [0.9, 0.1, 0.8, 0.2],  # all wins -> 1.0
+            "score_b": [0.1, 0.9, 0.2, 0.8],  # all losses -> 0.0
+        }
+    )
+    metrics = compute_pairwise_metrics(dataset=dataset, scores=scores)
+    by_score = metrics.set_index("score_type")["value"]
+    assert by_score["score_a"] == 1.0
+    assert by_score["score_b"] == 0.0
+
+
+def test_compute_pairwise_metrics_rejects_subset_straddle():
+    """A match_group spanning two subsets is a silent-corruption risk."""
+    dataset = pd.DataFrame(
+        {
+            "label": [1, 0, 1, 0],
+            "subset": ["A", "B", "A", "A"],  # group 0 straddles A/B
+            "match_group": [0, 0, 1, 1],
+        }
+    )
+    scores = pd.DataFrame({"score": [0.9, 0.1, 0.8, 0.2]})
+    with pytest.raises(AssertionError, match="span multiple subsets"):
+        compute_pairwise_metrics(
+            dataset=dataset, scores=scores, score_columns=["score"]
+        )
+
+
+def test_compute_pairwise_metrics_default_score_columns():
+    dataset = pd.DataFrame(
+        {
+            "label": [1, 0],
+            "subset": ["A", "A"],
+            "match_group": [0, 0],
+        }
+    )
+    scores = pd.DataFrame({"foo": [0.9, 0.1], "bar": [0.1, 0.9]})
+    metrics = compute_pairwise_metrics(dataset=dataset, scores=scores)
+    assert set(metrics["score_type"]) == {"foo", "bar"}
+
+
+def test_compute_pairwise_metrics_requires_match_group_column():
+    dataset = pd.DataFrame({"label": [1, 0], "subset": ["A", "A"]})
+    scores = pd.DataFrame({"score": [0.9, 0.1]})
+    with pytest.raises(AssertionError, match="match_group"):
+        compute_pairwise_metrics(
+            dataset=dataset, scores=scores, score_columns=["score"]
+        )

--- a/tests/evals/test_pairwise_accuracy.py
+++ b/tests/evals/test_pairwise_accuracy.py
@@ -122,6 +122,16 @@ def test_pairwise_accuracy_rejects_length_mismatch():
         )
 
 
+def test_pairwise_accuracy_rejects_nan_score():
+    """NaN in score is a silent-corruption risk (NaN > NaN and NaN == NaN both
+    False -> NaN-vs-NaN silently counts as a loss). Caller must fill upstream."""
+    label = [1, 0, 1, 0]
+    score = [float("nan"), 0.1, 0.8, 0.2]
+    mg = [0, 0, 1, 1]
+    with pytest.raises(AssertionError, match="NaN"):
+        pairwise_accuracy(*_frame(label, score, mg))
+
+
 # ---- compute_pairwise_metrics --------------------------------------------
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ wheels = [
 [[package]]
 name = "biofoundation"
 version = "0.1.0"
-source = { git = "https://github.com/Open-Athena/biofoundation.git#66cf4d46fd8b53d9c39446a4278f7b24ccf7fc40" }
+source = { git = "https://github.com/Open-Athena/biofoundation.git#df5bd4994ca4b2a5bbbc429ec7a592b08e5a22c3" }
 dependencies = [
     { name = "bioframe" },
     { name = "biopython" },


### PR DESCRIPTION
## Summary

- New **PairwiseAccuracy ± SE** metric for matched-pair eval datasets (`evals_mendelian_traits`, `evals_complex_traits`, PR #159), with binomial Wald SE. Covers conservation tracks and gLM checkpoints.
- **`snakemake/conservation_eval/`** rewired off the legacy `evals-traitgym_mendelian_v2` onto the new matched-pair datasets, with PairwiseAccuracy reporting.
- **`snakemake/analysis/evals_v2/`** new pipeline: GCS-stored gLM checkpoints, GPU SkyPilot YAML, PairwiseAccuracy per (model, dataset). Stripped-down successor to `evals_v1` — one metric, one split (train/val), no plotting.
- Train/val split convention: only `train` is touched during development; `test` held out for the final-eval pass.
- biofoundation pin bumped to `df5bd49` to pick up odd-`window_size` support ([Open-Athena/biofoundation#20](https://github.com/Open-Athena/biofoundation/pull/20), originally filed as [#19](https://github.com/Open-Athena/biofoundation/issues/19) from this work).
- Pinned leaderboard issues created and populated:
  - [#161 — Leaderboard: Mendelian traits](https://github.com/Open-Athena/bolinas-dna/issues/161)
  - [#162 — Leaderboard: Complex traits](https://github.com/Open-Athena/bolinas-dna/issues/162)

## Result highlights (train/val, all on S3)

- 7 conservation tracks + 5 gLMs (#55-mammals, #58-mammals, #58-animals, #59-mammals, #136-proj_v30) scored on both datasets.
- **`exp136-proj_v30` tops every method on Mendelian-distal at PairwiseAccuracy = 0.722 ± 0.053** — beats best conservation track (`phyloP_470m`, 0.688) and best other gLM (`exp55-mammals`, 0.528). Consistent with issue #136's distal AUPRC = 0.382 story.
- Conservation tracks dominate Missense/Splicing as expected (`phyloP_100v` 0.849 on Missense). gLMs win where their training corpus aligns: `exp58-mammals` for Splicing, `exp55-mammals` for 5' UTR / Promoter, `exp136-proj_v30` for Distal.

## Test plan

- [x] `uv run pytest tests/evals/` — 128 tests pass (13 new `test_pairwise_accuracy.py` cases).
- [x] `cd snakemake/conservation_eval && uv run snakemake -n` — DAG sane.
- [x] Conservation pipeline ran end-to-end on both datasets × both splits → S3.
- [x] `cd snakemake/analysis/evals_v2 && uv run snakemake -n` — DAG sane (27 jobs).
- [x] evals_v2 pipeline ran end-to-end on SkyPilot A10G for 5 models × 2 datasets → S3.
- [x] Leaderboard issues #161 / #162 reflect the metrics from these S3 outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)