### PR TITLE
evals_v1: GCS checkpoint support + full TraitGym Mendelian benchmark eval

### DIFF
--- a/snakemake/analysis/evals_v1/README.md
+++ b/snakemake/analysis/evals_v1/README.md
@@ -34,13 +34,23 @@ You need AWS credentials with S3 access:
 
 Edit `config/config.yaml` to specify:
 
-1. **Models to evaluate**: Specify training runs with base paths, context size, and checkpoint steps
+1. **Models to evaluate**: Specify training runs with **either** a local
+   `base_path` **or** a `gcs_path` (parent of `step-{N}/`), plus context
+   size and the steps to score:
    ```yaml
    models:
+     # Local checkpoint (legacy convention — typically EFS):
      - name: gpn_promoter
        base_path: /path/to/training/run
        context_size: 512
        steps: [10000, 20000, 50000, 100000]
+
+     # GCS checkpoint (new) — pulled by `download_model_step` from
+     # rules/download.smk. `context_size: 255` if the tokenizer prepends BOS.
+     - name: exp136-proj_v30
+       gcs_path: gs://marin-us-central1/checkpoints/.../hf
+       context_size: 255
+       steps: [9999]
    ```
 
 2. **Datasets**: Evaluation datasets from HuggingFace
@@ -50,6 +60,14 @@ Edit `config/config.yaml` to specify:
        hf_path: gonzalobenegas/bolinas_evals-traitgym_mendelian
        split: test
        metrics: [AUPRC, AUROC]
+
+     # Full TraitGym Mendelian benchmark (3380 vars). `train+test` of our
+     # derivative covers the same coordinates as `songlab/omim_traitgym`'s
+     # canonical test split and keeps the per-subset annotations.
+     - name: traitgym_mendelian_full
+       hf_path: gonzalobenegas/bolinas_evals-traitgym_mendelian
+       split: train+test
+       metrics: [AUPRC]
    ```
 
 3. **Inference settings**: Performance tuning (doesn't affect output, won't trigger recomputation)
@@ -73,6 +91,15 @@ Run the complete pipeline:
 
 ```bash
 uv run snakemake
+```
+
+For GPU-bound inference on `gcs_path`-backed checkpoints, use the SkyPilot
+launcher (mirrors `evals_v2/sky/run.yaml`):
+
+```bash
+sky launch snakemake/analysis/evals_v1/sky/run.yaml -c evals-v1
+# subsequent runs (cluster reuse):
+sky exec evals-v1 snakemake/analysis/evals_v1/sky/run.yaml
 ```
 
 Run specific targets:

--- a/snakemake/analysis/evals_v1/config/config.yaml
+++ b/snakemake/analysis/evals_v1/config/config.yaml
@@ -600,14 +600,10 @@ models:
       - 7000
       - 9999
 
-  # GCS-backed entry: pulled from the marin checkpoint bucket via
-  # `download_model_step` (see workflow/rules/download.smk). `gcs_path` is
-  # the parent of `step-{N}/` — same semantics as `base_path`. Using the
-  # same exp136 checkpoint as evals_v2; `context_size: 255` because the
-  # tokenizer prepends BOS (255 bp DNA + BOS = 256 tokens).
   - name: exp136-proj_v30
+    # `gcs_path` is the parent of `step-{N}/` (same semantics as `base_path`).
     gcs_path: gs://marin-us-central1/checkpoints/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0/hf
-    context_size: 255
+    context_size: 255  # 255 bp DNA + BOS = 256 tokens
     steps:
       - 9999
 
@@ -620,10 +616,9 @@ datasets:
     metrics:
       - AUPRC
 
-  # Full TraitGym Mendelian benchmark — 3380 variants. `train+test` of our
-  # derivative is the same coordinate set as `songlab/omim_traitgym` test
-  # (the canonical TraitGym leaderboard split). Use this entry for
-  # final-eval comparisons against the v1 baselines.
+  # `train+test` covers the same 3380 coords as `songlab/omim_traitgym` test
+  # (the canonical TraitGym leaderboard split); the existing `traitgym_mendelian`
+  # entry above uses split=train (a 2640-coord dev subset).
   - name: traitgym_mendelian_full
     hf_path: gonzalobenegas/bolinas_evals-traitgym_mendelian
     split: train+test

--- a/snakemake/analysis/evals_v1/config/config.yaml
+++ b/snakemake/analysis/evals_v1/config/config.yaml
@@ -600,12 +600,33 @@ models:
       - 7000
       - 9999
 
+  # GCS-backed entry: pulled from the marin checkpoint bucket via
+  # `download_model_step` (see workflow/rules/download.smk). `gcs_path` is
+  # the parent of `step-{N}/` — same semantics as `base_path`. Using the
+  # same exp136 checkpoint as evals_v2; `context_size: 255` because the
+  # tokenizer prepends BOS (255 bp DNA + BOS = 256 tokens).
+  - name: exp136-proj_v30
+    gcs_path: gs://marin-us-central1/checkpoints/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0/hf
+    context_size: 255
+    steps:
+      - 9999
+
 # Evaluation datasets from HuggingFace
 # Each dataset should have been created by the snakemake/evals pipeline
 datasets:
   - name: traitgym_mendelian
     hf_path: gonzalobenegas/bolinas_evals-traitgym_mendelian
     split: train
+    metrics:
+      - AUPRC
+
+  # Full TraitGym Mendelian benchmark — 3380 variants. `train+test` of our
+  # derivative is the same coordinate set as `songlab/omim_traitgym` test
+  # (the canonical TraitGym leaderboard split). Use this entry for
+  # final-eval comparisons against the v1 baselines.
+  - name: traitgym_mendelian_full
+    hf_path: gonzalobenegas/bolinas_evals-traitgym_mendelian
+    split: train+test
     metrics:
       - AUPRC
 
@@ -656,6 +677,7 @@ baselines:
   # Mapping from our dataset names to original TraitGym dataset paths
   dataset_mapping:
     traitgym_mendelian: songlab/omim_traitgym
+    traitgym_mendelian_full: songlab/omim_traitgym
     traitgym_complex: songlab/ukb_finemapped_nc_traitgym
     clinvar_missense: songlab/clinvar_vs_benign
     gwas_missense: songlab/ukb_finemapped_coding
@@ -671,6 +693,44 @@ score_types:
 # Each plot can filter which models and which (dataset, subset) combinations to include
 # Each dataset_subset can specify its own score_type
 custom_plots:
+  - name: exp136_proj_v30_traitgym_mendelian_full
+    title: "exp136 proj_v30 — full TraitGym Mendelian benchmark (3380 vars)"
+    models:
+      - model: exp136-proj_v30
+        title: "proj_v30 (0.6B, enhancer-curated)"
+    n_cols: 3
+    dataset_subsets:
+      - dataset: traitgym_mendelian_full
+        subset: nonexonic_AND_distal
+        score_type: minus_llr
+        include_baselines: true
+        title: "Distal (analogue of v2 distal)"
+      - dataset: traitgym_mendelian_full
+        subset: nonexonic_AND_proximal
+        score_type: minus_llr
+        include_baselines: true
+        title: "Promoter"
+      - dataset: traitgym_mendelian_full
+        subset: 5_prime_UTR_variant
+        score_type: minus_llr
+        include_baselines: true
+        title: "5' UTR"
+      - dataset: traitgym_mendelian_full
+        subset: 3_prime_UTR_variant
+        score_type: minus_llr
+        include_baselines: true
+        title: "3' UTR"
+      - dataset: traitgym_mendelian_full
+        subset: non_coding_transcript_exon_variant
+        score_type: minus_llr
+        include_baselines: true
+        title: "ncRNA"
+      - dataset: traitgym_mendelian_full
+        subset: global
+        score_type: minus_llr
+        include_baselines: true
+        title: "Global"
+
   - name: promoters_yolo
     title: "Promoters YOLO run (Qwen 1.7B)"
     models:

--- a/snakemake/analysis/evals_v1/sky/run.yaml
+++ b/snakemake/analysis/evals_v1/sky/run.yaml
@@ -1,27 +1,15 @@
-# SkyPilot task: run the evals_v1 pipeline on a small GPU node.
+# Launch: sky launch snakemake/analysis/evals_v1/sky/run.yaml -c evals-v1
 #
-# The pipeline pulls model checkpoints from `gs://marin-us-central1/...`
-# (for `gcs_path`-backed entries) or expects them at a local `base_path`,
-# scores variants on the configured eval datasets, and computes per-subset
-# AUPRC/AUROC metrics. Used for the full TraitGym Mendelian benchmark eval
-# of `exp136-proj_v30` (issue #136 follow-up: v1 distal AUPRC vs the GPN-Star
-# / Evo 2 baselines).
-#
-# Auth: the user's GCP application-default credentials are mounted from
-# ~/.config/gcloud/application_default_credentials.json. The setup step
-# installs the gcloud CLI so the pipeline's `gcloud storage cp -r` rule
-# works.
-#
-# Launch:
-#   sky launch snakemake/analysis/evals_v1/sky/run.yaml -c evals-v1
+# Auth: GCP application-default credentials are mounted from
+# ~/.config/gcloud/application_default_credentials.json so the pipeline's
+# `gcloud storage cp -r` rule can pull private GCS checkpoints.
 
 name: evals-v1
 
 resources:
     infra: aws/us-east-2
-    accelerators: A10G:1        # 24 GB Ampere — same hardware evals_v2 was
-                                # benchmarked on (batch_size 64 fits 0.6B Qwen3
-                                # at 256 tokens).
+    accelerators: A10G:1        # matches the evals_v2 hardware (batch_size 64
+                                # fits 0.6B Qwen3 at 256 tokens).
     disk_size: 200
     labels:
         project: dna
@@ -29,8 +17,6 @@ resources:
 workdir: .
 
 file_mounts:
-    # Application Default Credentials so `gcloud storage cp -r` can pull
-    # private GCS objects from gs://marin-us-central1/...
     ~/.config/gcloud/application_default_credentials.json: ~/.config/gcloud/application_default_credentials.json
 
 setup: |
@@ -40,7 +26,6 @@ setup: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
     fi
 
-    # gcloud CLI for the pipeline's `download_model_step` shell rule.
     if ! command -v gcloud >/dev/null 2>&1; then
         curl -fsSL https://sdk.cloud.google.com > /tmp/gcloud-install.sh
         bash /tmp/gcloud-install.sh --disable-prompts --install-dir="$HOME"
@@ -50,13 +35,11 @@ setup: |
         echo 'export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
 
     export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"
-
-    # Pin to the ADC we mounted; gcloud picks this up automatically.
     export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
 
     uv sync
 
-    # Smoke-test GCS access so a bad ADC fails fast in setup, not in a rule.
+    # Fail fast on bad ADC, not deep inside a Snakemake rule.
     gcloud storage ls gs://marin-us-central1/checkpoints/ | head -3 >/dev/null
 
 run: |
@@ -65,17 +48,12 @@ run: |
     export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"
     export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
 
-    # HF Trainer auto-initializes wandb if it can find the package; without
-    # an API key on this fresh node it errors out. Disable wandb entirely
-    # since this is a non-training inference job.
+    # HF Trainer auto-inits wandb if the package is importable; without an
+    # API key on a fresh node it errors out. Disable for inference-only jobs.
     export WANDB_DISABLED=true
 
     cd snakemake/analysis/evals_v1
 
-    # Default target is the new exp136 plot, which transitively requires
-    # the proj_v30 scores + metrics + baseline metrics on the full
-    # benchmark. Override on the CLI with `sky exec evals-v1 --env
-    # SNAKEMAKE_TARGET=...` to evaluate a different subset of rule all.
     TARGET="${SNAKEMAKE_TARGET:-results/plots/custom_comparison/exp136_proj_v30_traitgym_mendelian_full.svg}"
 
     uv run --project ../../.. snakemake \

--- a/snakemake/analysis/evals_v1/sky/run.yaml
+++ b/snakemake/analysis/evals_v1/sky/run.yaml
@@ -1,0 +1,85 @@
+# SkyPilot task: run the evals_v1 pipeline on a small GPU node.
+#
+# The pipeline pulls model checkpoints from `gs://marin-us-central1/...`
+# (for `gcs_path`-backed entries) or expects them at a local `base_path`,
+# scores variants on the configured eval datasets, and computes per-subset
+# AUPRC/AUROC metrics. Used for the full TraitGym Mendelian benchmark eval
+# of `exp136-proj_v30` (issue #136 follow-up: v1 distal AUPRC vs the GPN-Star
+# / Evo 2 baselines).
+#
+# Auth: the user's GCP application-default credentials are mounted from
+# ~/.config/gcloud/application_default_credentials.json. The setup step
+# installs the gcloud CLI so the pipeline's `gcloud storage cp -r` rule
+# works.
+#
+# Launch:
+#   sky launch snakemake/analysis/evals_v1/sky/run.yaml -c evals-v1
+
+name: evals-v1
+
+resources:
+    infra: aws/us-east-2
+    accelerators: A10G:1        # 24 GB Ampere — same hardware evals_v2 was
+                                # benchmarked on (batch_size 64 fits 0.6B Qwen3
+                                # at 256 tokens).
+    disk_size: 200
+    labels:
+        project: dna
+
+workdir: .
+
+file_mounts:
+    # Application Default Credentials so `gcloud storage cp -r` can pull
+    # private GCS objects from gs://marin-us-central1/...
+    ~/.config/gcloud/application_default_credentials.json: ~/.config/gcloud/application_default_credentials.json
+
+setup: |
+    set -euxo pipefail
+
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+
+    # gcloud CLI for the pipeline's `download_model_step` shell rule.
+    if ! command -v gcloud >/dev/null 2>&1; then
+        curl -fsSL https://sdk.cloud.google.com > /tmp/gcloud-install.sh
+        bash /tmp/gcloud-install.sh --disable-prompts --install-dir="$HOME"
+    fi
+
+    grep -q 'google-cloud-sdk/bin' "$HOME/.bashrc" || \
+        echo 'export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+
+    export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"
+
+    # Pin to the ADC we mounted; gcloud picks this up automatically.
+    export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
+
+    uv sync
+
+    # Smoke-test GCS access so a bad ADC fails fast in setup, not in a rule.
+    gcloud storage ls gs://marin-us-central1/checkpoints/ | head -3 >/dev/null
+
+run: |
+    set -euxo pipefail
+
+    export PATH="$HOME/google-cloud-sdk/bin:$HOME/.local/bin:$PATH"
+    export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
+
+    # HF Trainer auto-initializes wandb if it can find the package; without
+    # an API key on this fresh node it errors out. Disable wandb entirely
+    # since this is a non-training inference job.
+    export WANDB_DISABLED=true
+
+    cd snakemake/analysis/evals_v1
+
+    # Default target is the new exp136 plot, which transitively requires
+    # the proj_v30 scores + metrics + baseline metrics on the full
+    # benchmark. Override on the CLI with `sky exec evals-v1 --env
+    # SNAKEMAKE_TARGET=...` to evaluate a different subset of rule all.
+    TARGET="${SNAKEMAKE_TARGET:-results/plots/custom_comparison/exp136_proj_v30_traitgym_mendelian_full.svg}"
+
+    uv run --project ../../.. snakemake \
+        --profile workflow/profiles/default \
+        --printshellcmds \
+        --rerun-incomplete \
+        "$TARGET"

--- a/snakemake/analysis/evals_v1/workflow/Snakefile
+++ b/snakemake/analysis/evals_v1/workflow/Snakefile
@@ -109,6 +109,7 @@ def get_baseline_input_files(plot_name: str) -> list[str]:
 
 # Include rule files
 include: "rules/common.smk"
+include: "rules/download.smk"
 include: "rules/inference.smk"
 include: "rules/metrics.smk"
 include: "rules/plots.smk"

--- a/snakemake/analysis/evals_v1/workflow/rules/download.smk
+++ b/snakemake/analysis/evals_v1/workflow/rules/download.smk
@@ -1,0 +1,27 @@
+"""Per-step GCS download for `gcs_path`-backed model entries.
+
+Mirrors the `evals_v2` pattern (``evals_v2/workflow/rules/download.smk``).
+The `compute_scores` rule depends on this output for entries that specify
+`gcs_path` in `config/config.yaml`; legacy `base_path` entries still resolve
+the local checkpoint without a download step.
+"""
+
+GCS_MODELS = [m["name"] for m in config["models"] if "gcs_path" in m]
+
+
+rule download_model_step:
+    """Pull `{gcs_path}/step-{step}/` into `results/checkpoints/{model}/step-{step}/`.
+
+    `gcloud storage cp -r src dst` nests src under dst, so we glob with `/*`
+    to land HF model files directly under the output directory. Auth uses
+    application-default credentials.
+    """
+    output:
+        directory("results/checkpoints/{model}/step-{step}"),
+    wildcard_constraints:
+        model="|".join(GCS_MODELS) if GCS_MODELS else "(?!)",
+    params:
+        gcs_path=lambda wc: get_model_config(wc.model)["gcs_path"],
+    shell:
+        "mkdir -p {output} && "
+        "gcloud storage cp -r '{params.gcs_path}/step-{wildcards.step}/*' {output}/"

--- a/snakemake/analysis/evals_v1/workflow/rules/download.smk
+++ b/snakemake/analysis/evals_v1/workflow/rules/download.smk
@@ -1,27 +1,19 @@
-"""Per-step GCS download for `gcs_path`-backed model entries.
-
-Mirrors the `evals_v2` pattern (``evals_v2/workflow/rules/download.smk``).
-The `compute_scores` rule depends on this output for entries that specify
-`gcs_path` in `config/config.yaml`; legacy `base_path` entries still resolve
-the local checkpoint without a download step.
-"""
+"""Per-step GCS download for `gcs_path`-backed model entries."""
 
 GCS_MODELS = [m["name"] for m in config["models"] if "gcs_path" in m]
 
 
-rule download_model_step:
-    """Pull `{gcs_path}/step-{step}/` into `results/checkpoints/{model}/step-{step}/`.
+if GCS_MODELS:
 
-    `gcloud storage cp -r src dst` nests src under dst, so we glob with `/*`
-    to land HF model files directly under the output directory. Auth uses
-    application-default credentials.
-    """
-    output:
-        directory("results/checkpoints/{model}/step-{step}"),
-    wildcard_constraints:
-        model="|".join(GCS_MODELS) if GCS_MODELS else "(?!)",
-    params:
-        gcs_path=lambda wc: get_model_config(wc.model)["gcs_path"],
-    shell:
-        "mkdir -p {output} && "
-        "gcloud storage cp -r '{params.gcs_path}/step-{wildcards.step}/*' {output}/"
+    rule download_model_step:
+        output:
+            directory("results/checkpoints/{model}/step-{step}"),
+        wildcard_constraints:
+            model="|".join(GCS_MODELS),
+        params:
+            gcs_path=lambda wc: get_model_config(wc.model)["gcs_path"],
+        # `gcloud cp -r src dst` nests src under dst, so glob with /* to land
+        # HF model files directly under {output}.
+        shell:
+            "mkdir -p {output} && "
+            "gcloud storage cp -r '{params.gcs_path}/step-{wildcards.step}/*' {output}/"

--- a/snakemake/analysis/evals_v1/workflow/rules/inference.smk
+++ b/snakemake/analysis/evals_v1/workflow/rules/inference.smk
@@ -1,13 +1,26 @@
 """Inference rules for computing LLR scores on evaluation datasets."""
 
 
+def _checkpoint_input(wildcards):
+    """Per-(model, step) checkpoint dependency.
+
+    For `gcs_path`-backed entries we depend on the local download from
+    `download.smk`; legacy `base_path` entries return [] (no Snakemake
+    dependency) and the run block resolves the path directly.
+    """
+    cfg = get_model_config(wildcards.model)
+    if "gcs_path" in cfg:
+        return f"results/checkpoints/{wildcards.model}/step-{wildcards.step}"
+    return []
+
+
 rule compute_scores:
     input:
         genome="results/genome.fa.gz",
+        checkpoint=_checkpoint_input,
     output:
         "results/scores/{dataset}/{model}/{step}.parquet",
     params:
-        model_base_path=lambda wildcards: get_model_config(wildcards.model)["base_path"],
         model_context_size=lambda wildcards: get_model_config(wildcards.model)[
             "context_size"
         ],
@@ -15,10 +28,13 @@ rule compute_scores:
             "hf_path"
         ],
         dataset_split=lambda wildcards: get_dataset_config(wildcards.dataset)["split"],
-        step=lambda wildcards: wildcards.step,
     threads: config["inference"]["num_workers"]
     run:
-        checkpoint_path = f"{params.model_base_path}/step-{params.step}"
+        cfg = get_model_config(wildcards.model)
+        if "gcs_path" in cfg:
+            checkpoint_path = input.checkpoint
+        else:
+            checkpoint_path = f"{cfg['base_path']}/step-{wildcards.step}"
 
         hf_dataset = load_dataset(params.dataset_hf_path, split=params.dataset_split)
         dataset = hf_dataset.to_pandas()

--- a/snakemake/analysis/evals_v1/workflow/rules/inference.smk
+++ b/snakemake/analysis/evals_v1/workflow/rules/inference.smk
@@ -2,12 +2,7 @@
 
 
 def _checkpoint_input(wildcards):
-    """Per-(model, step) checkpoint dependency.
-
-    For `gcs_path`-backed entries we depend on the local download from
-    `download.smk`; legacy `base_path` entries return [] (no Snakemake
-    dependency) and the run block resolves the path directly.
-    """
+    """Local download dir for `gcs_path` entries; `[]` (no input) for `base_path` entries."""
     cfg = get_model_config(wildcards.model)
     if "gcs_path" in cfg:
         return f"results/checkpoints/{wildcards.model}/step-{wildcards.step}"


### PR DESCRIPTION
## Summary

- Adds `gcs_path` schema option to `evals_v1` model entries (mirrors the `evals_v2` download pattern via a new `download_model_step` rule). Legacy `base_path` entries continue to work unchanged — the dependency wiring uses an input function that returns `[]` for those entries, so existing scores in S3 aren't invalidated.
- Adds `traitgym_mendelian_full` dataset entry (`split: train+test`) covering the canonical 3380-variant TraitGym Mendelian benchmark — same coordinate set as `songlab/omim_traitgym`'s test split, but with our `subset` column preserved for the per-subset breakdown.
- Wires up `exp136-proj_v30` (best checkpoint per #136) for the v1 follow-up — issue #136 reported v2 distal AUPRC 0.382; this lets us produce the v1 distal (`nonexonic_AND_distal`) AUPRC alongside the existing GPN-Star / Evo 2 baselines.
- Adds a SkyPilot launcher at `snakemake/analysis/evals_v1/sky/run.yaml` (A10G in `aws/us-east-2`, `project=dna`), mirroring `evals_v2/sky/run.yaml`.

## Test plan

- [x] `uv run pytest` — 135 passed, 1 skipped, no new failures
- [x] `uv run snakemake -n` (full target) — only 15 jobs scheduled, all scoped to the new model + new dataset (no unrelated reruns)
- [x] Pre-commit (snakefmt) passes
- [ ] SkyPilot launch — A10G GPU, end-to-end run on `traitgym_mendelian_full` (in progress on cluster `evals-v1`)
- [ ] Sanity check the resulting scores parquet (3380 rows, no NaN in `minus_llr`)
- [ ] Compare distal AUPRC vs baselines and post on issue #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)