### PR TITLE
Per-anchor region-type labels for v1 projected anchors

### DIFF
--- a/snakemake/zoonomia_projection_dataset/README.md
+++ b/snakemake/zoonomia_projection_dataset/README.md
@@ -265,6 +265,64 @@ uv run snakemake --profile workflow/profiles/default \
 uv run snakemake --profile workflow/profiles/default all_validation
 ```
 
+## Region-type annotation (`rule all_region_labels`)
+
+Each conservation-filtered anchor in `min{min_p}.bed.gz` is assigned **exactly one** of:
+
+```
+cds  >  utr3  >  ncrna_exon  >  tss_region_and_utr5  >  cre  >  background
+```
+
+(priority shown highest → lowest; ties broken by this order). The label is the highest-priority region with any overlap, **provided** the window's union-of-functional fraction is ≥ `region_label_functional_threshold` (default 0.20); otherwise the label is `background`.
+
+### Region definitions
+
+- **`cds`** — Ensembl r115 CDS (`get_cds`).
+- **`utr3`** — Ensembl r115 3' UTR derived from `transcript_biotype "protein_coding"` exons (`get_ensembl_3_prime_utr`).
+- **`ncrna_exon`** — every annotated exon that is **not** a protein-coding exon, i.e. `get_exons(ann) − get_ensembl_protein_coding_exons(ann)`. No biotype / quality filter: includes lncRNA, miRNA, snoRNA, pseudogenes, retained_intron, NMD, etc.
+- **`tss_region_and_utr5`** — `(TSS ± region_label_tss_radius bp over every annotated transcript) ∪ get_ensembl_5_prime_utr(ann)`. The union with the 5' UTR catches the long-tail UTRs that extend beyond the TSS band. One class (not two) because promoter and 5' UTR overlap by construction. Radius default 256 bp — see issue #42 for the empirical justification.
+- **`cre`** — ENCODE cCRE V4 `cre_class != "PLS"` (so: dELS, pELS, CA, CA-CTCF, CA-TF, CA-H3K4me3, TF, …) padded by `region_label_cre_flank` bp (default 500). PLS is **not** in `cre` because PLS-overlapping windows near a TSS are caught by `tss_region_and_utr5`; PLS isolated from any annotated TSS becomes `background`.
+- **`background`** — none of the above clear enough (intronic or intergenic).
+
+### Ensembl-only extractors
+
+All region extractors read **Ensembl** biotype vocabulary (`protein_coding`, `lncRNA`, `miRNA`, …). RefSeq-flavored helpers in `bolinas.data.utils` (`get_mrna_exons`, `get_5_prime_utr`, `get_3_prime_utr`, `get_ncrna_exons`, `get_promoters`) are **not** used and `build_region_beds` asserts the GTF carries `transcript_biotype "protein_coding"` to guard against silent vocabulary mismatch.
+
+### Pipeline
+
+```
+filtered/min{min_p}.bed.gz  (22.9M anchors after PR #152)
+GTF (Ensembl r115)
+cCRE V4 parquet (from validation.smk)        →  build_region_labels
+defined.bed (genome − N regions)                       ↓
+                                          region_labels/min{min_p}.parquet
+                                                       ↓
+                            region_label_composition       derive_subset_v3_region
+                                  ↓                                  ↓
+                         …composition.tsv          subsets_def/v3_<label>.query_names.txt
+```
+
+### Outputs
+
+- `results/human/intervals/region_labels/min{min_p}.parquet` — one row per input anchor with `name, chrom, start, end, label, functional_frac, cds_frac, utr3_frac, ncrna_exon_frac, tss_region_and_utr5_frac, cre_frac, gene_body_frac, intron_frac, intergenic_frac`.
+- `results/human/intervals/region_labels/min{min_p}.composition.tsv` — per-label counts, fractions of total, plus an explicit `background_intronic` / `background_intergenic` split (≥ 50% gene-body coverage = intronic).
+- `results/projection/min{min_p}/subsets_def/v3_<label>.query_names.txt` — one anchor name per line, ready to plug into the existing `subset_dataset_derived` rule. HF subset Parquets + upload rules are intentionally deferred to a follow-up PR.
+
+### Run
+
+```bash
+# Just the labels parquet (cheap if the GTF + cCRE are already on disk):
+uv run snakemake --profile workflow/profiles/default \
+    results/human/intervals/region_labels/min0.20.parquet
+
+# Everything (labels + composition TSV + per-label query_names lists):
+uv run snakemake --profile workflow/profiles/default all_region_labels
+```
+
+### Tuning
+
+Per-region fractions (`*_frac` columns) are emitted regardless of priority and threshold, so you can re-derive labels downstream by sweeping `region_label_functional_threshold` or `region_label_priority` without re-running the bedtools-style overlap pass.
+
 ## Run
 
 ```bash

--- a/snakemake/zoonomia_projection_dataset/README.md
+++ b/snakemake/zoonomia_projection_dataset/README.md
@@ -270,7 +270,7 @@ uv run snakemake --profile workflow/profiles/default all_validation
 Each conservation-filtered anchor in `min{min_p}.bed.gz` is assigned **exactly one** of:
 
 ```
-cds  >  utr3  >  ncrna_exon  >  tss_region_and_utr5  >  cre  >  background
+cds  >  utr3  >  ncrna_exon  >  tss_region_and_utr5  >  ccre_non_promoter  >  background
 ```
 
 (priority shown highest → lowest; ties broken by this order). The label is the highest-priority region with any overlap, **provided** the window's union-of-functional fraction is ≥ `region_label_functional_threshold` (default 0.20); otherwise the label is `background`.
@@ -281,7 +281,7 @@ cds  >  utr3  >  ncrna_exon  >  tss_region_and_utr5  >  cre  >  background
 - **`utr3`** — Ensembl r115 3' UTR derived from `transcript_biotype "protein_coding"` exons (`get_ensembl_3_prime_utr`).
 - **`ncrna_exon`** — every annotated exon that is **not** a protein-coding exon, i.e. `get_exons(ann) − get_ensembl_protein_coding_exons(ann)`. No biotype / quality filter: includes lncRNA, miRNA, snoRNA, pseudogenes, retained_intron, NMD, etc.
 - **`tss_region_and_utr5`** — `(TSS ± region_label_tss_radius bp over every annotated transcript) ∪ get_ensembl_5_prime_utr(ann)`. The union with the 5' UTR catches the long-tail UTRs that extend beyond the TSS band. One class (not two) because promoter and 5' UTR overlap by construction. Radius default 256 bp — see issue #42 for the empirical justification.
-- **`cre`** — ENCODE cCRE V4 `cre_class != "PLS"` (so: dELS, pELS, CA, CA-CTCF, CA-TF, CA-H3K4me3, TF, …) padded by `region_label_cre_flank` bp (default 500). PLS is **not** in `cre` because PLS-overlapping windows near a TSS are caught by `tss_region_and_utr5`; PLS isolated from any annotated TSS becomes `background`.
+- **`ccre_non_promoter`** — ENCODE cCRE V4 `cre_class != "PLS"` (so: dELS, pELS, CA, CA-CTCF, CA-TF, CA-H3K4me3, TF, …) padded by `region_label_ccre_flank` bp (default 500). PLS is **not** in `ccre_non_promoter` because PLS-overlapping windows near a TSS are caught by `tss_region_and_utr5`; PLS isolated from any annotated TSS becomes `background`. The "cCRE source-first, qualifier-second" naming makes it clear we're using ENCODE's catalog (cCRE) minus the promoter-like subset.
 - **`background`** — none of the above clear enough (intronic or intergenic).
 
 ### Ensembl-only extractors
@@ -304,7 +304,7 @@ defined.bed (genome − N regions)                       ↓
 
 ### Outputs
 
-- `results/human/intervals/region_labels/min{min_p}.parquet` — one row per input anchor with `name, chrom, start, end, label, functional_frac, cds_frac, utr3_frac, ncrna_exon_frac, tss_region_and_utr5_frac, cre_frac, gene_body_frac, intron_frac, intergenic_frac`.
+- `results/human/intervals/region_labels/min{min_p}.parquet` — one row per input anchor with `name, chrom, start, end, label, functional_frac, cds_frac, utr3_frac, ncrna_exon_frac, tss_region_and_utr5_frac, ccre_non_promoter_frac, gene_body_frac, intron_frac, intergenic_frac`.
 - `results/human/intervals/region_labels/min{min_p}.composition.tsv` — per-label counts, fractions of total, plus an explicit `background_intronic` / `background_intergenic` split (≥ 50% gene-body coverage = intronic).
 - `results/projection/min{min_p}/subsets_def/v3_<label>.query_names.txt` — one anchor name per line, ready to plug into the existing `subset_dataset_derived` rule. HF subset Parquets + upload rules are intentionally deferred to a follow-up PR.
 

--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -99,23 +99,24 @@ ccre_url: "https://downloads.wenglab.org/Registry-V4/GRCh38-cCREs.bed"
 
 # ===== Per-anchor region-type annotation (rule all_region_labels) =====
 # Labels every conservation-filtered anchor with exactly one of:
-#   cds  >  utr3  >  ncrna_exon  >  tss_region_and_utr5  >  cre  >  background
+#   cds  >  utr3  >  ncrna_exon  >  tss_region_and_utr5  >  ccre_non_promoter  >  background
 # tss_region_and_utr5 = (TSS ± tss_radius on *every* Ensembl transcript) ∪ 5' UTR
 # ncrna_exon          = get_exons(ann) − get_ensembl_protein_coding_exons(ann)
-# cre                 = ENCODE cCRE V4 with cre_class != "PLS" + cre_flank bp
+# ccre_non_promoter   = ENCODE cCRE V4 with cre_class != "PLS" + ccre_flank bp
+#                       (so: dELS, pELS, CA, CA-CTCF, CA-TF, CA-H3K4me3, TF)
 # A window's label is the highest-priority region with any overlap, provided
 # its union-of-functional fraction is >= functional_threshold; otherwise
 # background.
 region_label_tss_radius: 256              # bp each side of every Ensembl TSS
-region_label_cre_flank: 500               # bp each side of non-PLS cCRE
+region_label_ccre_flank: 500              # bp each side of non-PLS cCRE
 region_label_functional_threshold: 0.20   # ≥20% functional bases to escape background
 # Priority order for label assignment. tss_region_and_utr5 is intentionally
 # near the bottom — it's the broadest / most geographic class, so more
 # specific exonic features should win when they happen to overlap.
 region_label_priority:
-  ["cds", "utr3", "ncrna_exon", "tss_region_and_utr5", "cre"]
+  ["cds", "utr3", "ncrna_exon", "tss_region_and_utr5", "ccre_non_promoter"]
 # Per-region partition labels (one subset per label, plus background).
 # Emitted as subsets_def/<name>.query_names.txt — HF subset Parquets +
 # upload rules are intentionally deferred to a follow-up PR.
 region_label_subsets:
-  ["v3_cds", "v3_utr3", "v3_ncrna_exon", "v3_tss_region_and_utr5", "v3_cre", "v3_bg"]
+  ["v3_cds", "v3_utr3", "v3_ncrna_exon", "v3_tss_region_and_utr5", "v3_ccre_non_promoter", "v3_bg"]

--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -96,3 +96,26 @@ validation_tss_flank: 255
 validation_ncrna_biotypes:
   ["lncRNA", "miRNA", "snoRNA", "snRNA", "ribozyme", "scaRNA", "vault_RNA"]
 ccre_url: "https://downloads.wenglab.org/Registry-V4/GRCh38-cCREs.bed"
+
+# ===== Per-anchor region-type annotation (rule all_region_labels) =====
+# Labels every conservation-filtered anchor with exactly one of:
+#   cds  >  utr3  >  ncrna_exon  >  tss_region_and_utr5  >  cre  >  background
+# tss_region_and_utr5 = (TSS ± tss_radius on *every* Ensembl transcript) ∪ 5' UTR
+# ncrna_exon          = get_exons(ann) − get_ensembl_protein_coding_exons(ann)
+# cre                 = ENCODE cCRE V4 with cre_class != "PLS" + cre_flank bp
+# A window's label is the highest-priority region with any overlap, provided
+# its union-of-functional fraction is >= functional_threshold; otherwise
+# background.
+region_label_tss_radius: 256              # bp each side of every Ensembl TSS
+region_label_cre_flank: 500               # bp each side of non-PLS cCRE
+region_label_functional_threshold: 0.20   # ≥20% functional bases to escape background
+# Priority order for label assignment. tss_region_and_utr5 is intentionally
+# near the bottom — it's the broadest / most geographic class, so more
+# specific exonic features should win when they happen to overlap.
+region_label_priority:
+  ["cds", "utr3", "ncrna_exon", "tss_region_and_utr5", "cre"]
+# Per-region partition labels (one subset per label, plus background).
+# Emitted as subsets_def/<name>.query_names.txt — HF subset Parquets +
+# upload rules are intentionally deferred to a follow-up PR.
+region_label_subsets:
+  ["v3_cds", "v3_utr3", "v3_ncrna_exon", "v3_tss_region_and_utr5", "v3_cre", "v3_bg"]

--- a/snakemake/zoonomia_projection_dataset/sky/regions.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/regions.yaml
@@ -1,0 +1,82 @@
+name: zoonomia-regions
+
+# Per-anchor region-type annotation (rule all_region_labels).
+#
+# Produces, per conservation filter level (min0.10 and min0.20):
+#   - region_labels/min{min_p}.parquet         (per-anchor labels + frac_*)
+#   - region_labels/min{min_p}.composition.tsv (composition report)
+# And, for the project_min_p level only (min0.20):
+#   - subsets_def/v3_<label>.query_names.txt   (6 lists for the partition)
+#
+# Compute profile: c6id.4xlarge mirrors sky/validation.yaml. The bedtools
+# coverage step on 22.9M anchors × multiple region BEDs is mostly bound by
+# bioframe and is bound to <30 min wall. Memory: GTF parse + 5 region
+# unions; mem_mb=24000 in the rule covers it on a 32 GB box.
+#
+# Cluster pattern (memo: cloud_launch_conventions, sky_cluster_reuse):
+#   sky launch -c zoonomia-regions sky/regions.yaml
+#   sky exec   zoonomia-regions   sky/regions.yaml   # subsequent iterations
+#   sky down   zoonomia-regions                       # only at session end
+
+resources:
+    infra: aws/us-east-2
+    instance_type: c6id.4xlarge      # 16 vCPU, 32 GB RAM, 950 GB local NVMe
+    disk_size: 100
+    labels:
+        project: dna
+
+workdir: .
+
+setup: |
+    set -euxo pipefail
+
+    if [ ! -d "$HOME/miniforge3" ]; then
+        curl -fsSL -o /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+        bash /tmp/miniforge.sh -b -p "$HOME/miniforge3"
+        rm /tmp/miniforge.sh
+    fi
+
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+
+    grep -q 'miniforge3/bin' "$HOME/.bashrc" || \
+        echo 'export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+
+    export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+    uv sync
+
+run: |
+    set -euxo pipefail
+
+    source "$HOME/miniforge3/etc/profile.d/conda.sh"
+    export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+    export CONDA_EXE="$HOME/miniforge3/bin/conda"
+
+    cd snakemake/zoonomia_projection_dataset
+
+    # Clear any stale snakemake lockfile from a prior crash. Safe no-op on a
+    # clean working dir.
+    uv run snakemake --profile workflow/profiles/default --unlock || true
+
+    # Dry-run gate — verify only region_labels / composition / subset_def
+    # jobs are scheduled; everything else should be S3 no-ops.
+    uv run snakemake --profile workflow/profiles/default \
+        --printshellcmds \
+        --rerun-incomplete \
+        -n all_region_labels
+
+    # Real run.
+    uv run snakemake --profile workflow/profiles/default \
+        --use-conda \
+        --printshellcmds \
+        --rerun-incomplete \
+        all_region_labels
+
+    # Pull the composition TSV inline for quick eyeballing in `sky logs`.
+    echo
+    echo "===== composition (min0.20) ====="
+    cat results/human/intervals/region_labels/min0.20.composition.tsv
+    echo
+    echo "===== composition (min0.10) ====="
+    cat results/human/intervals/region_labels/min0.10.composition.tsv

--- a/snakemake/zoonomia_projection_dataset/sky/regions.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/regions.yaml
@@ -73,10 +73,11 @@ run: |
         --rerun-incomplete \
         all_region_labels
 
-    # Pull the composition TSV inline for quick eyeballing in `sky logs`.
+    # Pull the composition TSVs inline for quick eyeballing in `sky logs`.
+    # Snakemake prunes the local copy after S3 upload, so fetch from storage.
     echo
     echo "===== composition (min0.20) ====="
-    cat results/human/intervals/region_labels/min0.20.composition.tsv
+    aws s3 cp s3://oa-bolinas/snakemake/zoonomia_projection_dataset/results/human/intervals/region_labels/min0.20.composition.tsv -
     echo
     echo "===== composition (min0.10) ====="
-    cat results/human/intervals/region_labels/min0.10.composition.tsv
+    aws s3 cp s3://oa-bolinas/snakemake/zoonomia_projection_dataset/results/human/intervals/region_labels/min0.10.composition.tsv -

--- a/snakemake/zoonomia_projection_dataset/sky/regions.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/regions.yaml
@@ -73,11 +73,7 @@ run: |
         --rerun-incomplete \
         all_region_labels
 
-    # Pull the composition TSVs inline for quick eyeballing in `sky logs`.
-    # Snakemake prunes the local copy after S3 upload, so fetch from storage.
-    echo
-    echo "===== composition (min0.20) ====="
-    aws s3 cp s3://oa-bolinas/snakemake/zoonomia_projection_dataset/results/human/intervals/region_labels/min0.20.composition.tsv -
-    echo
-    echo "===== composition (min0.10) ====="
-    aws s3 cp s3://oa-bolinas/snakemake/zoonomia_projection_dataset/results/human/intervals/region_labels/min0.10.composition.tsv -
+    # Composition TSVs are uploaded to S3 by snakemake; fetch them from
+    # there for inspection (the cluster image doesn't ship awscli, and
+    # snakemake prunes the local copy after upload anyway):
+    #   aws s3 cp s3://oa-bolinas/snakemake/zoonomia_projection_dataset/results/human/intervals/region_labels/min0.20.composition.tsv -

--- a/snakemake/zoonomia_projection_dataset/workflow/Snakefile
+++ b/snakemake/zoonomia_projection_dataset/workflow/Snakefile
@@ -11,6 +11,7 @@ include: "rules/project.smk"
 include: "rules/subsets.smk"
 include: "rules/dataset.smk"
 include: "rules/validation.smk"
+include: "rules/regions.smk"
 
 
 rule all:

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/regions.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/regions.smk
@@ -1,7 +1,8 @@
 """Per-anchor region-type annotation.
 
 Labels every conservation-filtered human anchor (255 bp) with exactly one
-of ``cds``, ``utr3``, ``ncrna_exon``, ``tss_region_and_utr5``, ``cre``,
+of ``cds``, ``utr3``, ``ncrna_exon``, ``tss_region_and_utr5``,
+``ccre_non_promoter``,
 ``background``. Used to characterise the composition of the v1 training
 dataset and to emit per-label ``subsets_def/v3_*.query_names.txt`` lists
 that plug into the existing ``subset_dataset_derived`` machinery.
@@ -17,7 +18,7 @@ from bolinas.zoonomia_projection_dataset.region_labels import REGION_LABELS
 
 
 REGION_LABEL_TSS_RADIUS = int(config["region_label_tss_radius"])
-REGION_LABEL_CRE_FLANK = int(config["region_label_cre_flank"])
+REGION_LABEL_CCRE_FLANK = int(config["region_label_ccre_flank"])
 REGION_LABEL_FUNCTIONAL_THRESHOLD = float(
     config["region_label_functional_threshold"]
 )
@@ -50,7 +51,7 @@ rule build_region_labels:
         labels="results/human/intervals/region_labels/min{min_p}.parquet",
     params:
         tss_radius=REGION_LABEL_TSS_RADIUS,
-        cre_flank=REGION_LABEL_CRE_FLANK,
+        ccre_flank=REGION_LABEL_CCRE_FLANK,
         functional_threshold=REGION_LABEL_FUNCTIONAL_THRESHOLD,
         priority=REGION_LABEL_PRIORITY,
     resources:
@@ -70,7 +71,7 @@ rule build_region_labels:
             input.cre,
             defined,
             tss_radius=params.tss_radius,
-            cre_flank=params.cre_flank,
+            ccre_flank=params.ccre_flank,
         )
         df = label_windows(
             input.anchors,

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/regions.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/regions.smk
@@ -1,0 +1,191 @@
+"""Per-anchor region-type annotation.
+
+Labels every conservation-filtered human anchor (255 bp) with exactly one
+of ``cds``, ``utr3``, ``ncrna_exon``, ``tss_region_and_utr5``, ``cre``,
+``background``. Used to characterise the composition of the v1 training
+dataset and to emit per-label ``subsets_def/v3_*.query_names.txt`` lists
+that plug into the existing ``subset_dataset_derived`` machinery.
+
+Library code lives in ``bolinas.zoonomia_projection_dataset.region_labels``;
+``run:`` blocks here are thin glue + pipeline-level assertions.
+
+See plan and README "Region-type annotation" section for the priority /
+threshold / cCRE-flank semantics.
+"""
+
+from bolinas.zoonomia_projection_dataset.region_labels import REGION_LABELS
+
+
+REGION_LABEL_TSS_RADIUS = int(config["region_label_tss_radius"])
+REGION_LABEL_CRE_FLANK = int(config["region_label_cre_flank"])
+REGION_LABEL_FUNCTIONAL_THRESHOLD = float(
+    config["region_label_functional_threshold"]
+)
+REGION_LABEL_PRIORITY = list(config["region_label_priority"])
+REGION_LABEL_SUBSETS = list(config["region_label_subsets"])
+
+assert set(REGION_LABEL_PRIORITY) == set(REGION_LABELS), (
+    f"config['region_label_priority']={REGION_LABEL_PRIORITY} must be a "
+    f"permutation of REGION_LABELS={list(REGION_LABELS)}"
+)
+
+# Subset names are v3_<label>; cross-check against the priority list (+ bg).
+_EXPECTED_SUBSETS = {f"v3_{lbl}" for lbl in REGION_LABELS} | {"v3_bg"}
+assert set(REGION_LABEL_SUBSETS) == _EXPECTED_SUBSETS, (
+    f"config['region_label_subsets']={REGION_LABEL_SUBSETS} must equal "
+    f"{sorted(_EXPECTED_SUBSETS)}"
+)
+
+REGION_LABEL_SUBSET_RE = "|".join(REGION_LABEL_SUBSETS)
+
+
+rule build_region_labels:
+    """Annotate every anchor in min{min_p}.bed.gz with one region label."""
+    input:
+        anchors="results/human/intervals/filtered/min{min_p}.bed.gz",
+        gtf=f"results/annotation/Homo_sapiens.GRCh38.{config['ensembl_release']}.gtf.gz",
+        cre="results/human/intervals/cre/all.parquet",
+        defined="results/human/intervals/defined.bed",
+    output:
+        labels="results/human/intervals/region_labels/min{min_p}.parquet",
+    params:
+        tss_radius=REGION_LABEL_TSS_RADIUS,
+        cre_flank=REGION_LABEL_CRE_FLANK,
+        functional_threshold=REGION_LABEL_FUNCTIONAL_THRESHOLD,
+        priority=REGION_LABEL_PRIORITY,
+    resources:
+        # GTF parse + 5 region BEDs + bf.coverage over 22.9M anchors ×
+        # multiple region sets. Peaks around the union build; budget headroom.
+        mem_mb=24000,
+    run:
+        from bolinas.data.intervals import GenomicSet
+        from bolinas.zoonomia_projection_dataset.region_labels import (
+            build_region_beds,
+            label_windows,
+        )
+
+        defined = GenomicSet.read_bed(input.defined)
+        beds = build_region_beds(
+            input.gtf,
+            input.cre,
+            defined,
+            tss_radius=params.tss_radius,
+            cre_flank=params.cre_flank,
+        )
+        df = label_windows(
+            input.anchors,
+            beds,
+            functional_threshold=params.functional_threshold,
+            priority=params.priority,
+        )
+        # Partition invariant: every input window receives exactly one label.
+        n_in = sum(1 for _ in gzip.open(input.anchors, "rt"))
+        assert len(df) == n_in, (
+            f"label_windows lost rows: input={n_in}, output={len(df)}"
+        )
+        valid_labels = set(REGION_LABELS) | {"background"}
+        assert set(df["label"].unique().to_list()) <= valid_labels, (
+            f"unexpected labels: "
+            f"{set(df['label'].unique().to_list()) - valid_labels}"
+        )
+        df.write_parquet(output.labels)
+
+
+rule region_label_composition:
+    """Composition report: per-label counts + bg subsplit by gene-body coverage."""
+    input:
+        labels="results/human/intervals/region_labels/min{min_p}.parquet",
+    output:
+        tsv="results/human/intervals/region_labels/min{min_p}.composition.tsv",
+    run:
+        df = pl.read_parquet(input.labels)
+        n_total = len(df)
+
+        # Per-label counts and total bases.
+        by_label = (
+            df.group_by("label")
+            .agg(
+                pl.len().alias("n_windows"),
+                pl.col("functional_frac").mean().alias("mean_functional_frac"),
+                pl.col("gene_body_frac").mean().alias("mean_gene_body_frac"),
+                pl.col("intron_frac").mean().alias("mean_intron_frac"),
+                pl.col("intergenic_frac").mean().alias("mean_intergenic_frac"),
+            )
+            .with_columns(
+                (pl.col("n_windows") / n_total).alias("fraction_of_total")
+            )
+            .sort("label")
+        )
+
+        # Background subsplit: intronic (gene_body but not exon) vs intergenic.
+        bg = df.filter(pl.col("label") == "background")
+        n_bg = len(bg)
+        if n_bg > 0:
+            n_bg_intronic = bg.filter(pl.col("gene_body_frac") > 0.5).height
+            n_bg_intergenic = bg.filter(pl.col("gene_body_frac") <= 0.5).height
+        else:
+            n_bg_intronic = 0
+            n_bg_intergenic = 0
+        bg_split = pl.DataFrame(
+            {
+                "label": ["background_intronic", "background_intergenic"],
+                "n_windows": [n_bg_intronic, n_bg_intergenic],
+                "mean_functional_frac": [None, None],
+                "mean_gene_body_frac": [None, None],
+                "mean_intron_frac": [None, None],
+                "mean_intergenic_frac": [None, None],
+                "fraction_of_total": [
+                    n_bg_intronic / n_total if n_total else 0.0,
+                    n_bg_intergenic / n_total if n_total else 0.0,
+                ],
+            }
+        )
+
+        out = pl.concat([by_label, bg_split], how="diagonal_relaxed")
+        out.write_csv(output.tsv, separator="\t")
+
+
+def _label_for_subset(subset: str) -> str:
+    """Map ``v3_<label>`` → ``<label>`` (e.g. ``v3_bg`` → ``background``)."""
+    assert subset.startswith("v3_"), subset
+    stripped = subset[len("v3_") :]
+    return "background" if stripped == "bg" else stripped
+
+
+rule derive_subset_v3_region:
+    """Emit query_names for one region label."""
+    input:
+        labels="results/human/intervals/region_labels/min{min_p}.parquet",
+    output:
+        names="results/projection/min{min_p}/subsets_def/{subset}.query_names.txt",
+    wildcard_constraints:
+        subset=REGION_LABEL_SUBSET_RE,
+    run:
+        target = _label_for_subset(wildcards.subset)
+        df = pl.read_parquet(input.labels).filter(pl.col("label") == target)
+        # Guard against accidental empties (would silently produce a 0-row HF
+        # subset later); a label with zero anchors means a config/biology bug.
+        assert len(df) > 0, (
+            f"subset {wildcards.subset!r} (label {target!r}) is empty — "
+            f"is the GTF / cCRE / threshold correct?"
+        )
+        with open(output.names, "w") as fh:
+            for name in df["name"].to_list():
+                fh.write(f"{name}\n")
+
+
+rule all_region_labels:
+    """Aggregate target: composition TSV + all v3_<label> query_names lists."""
+    input:
+        expand(
+            "results/human/intervals/region_labels/min{min_p}.composition.tsv",
+            min_p=[
+                f"{f['min_proportion_conserved']:.2f}"
+                for f in config["filters"]
+            ],
+        ),
+        expand(
+            "results/projection/min{min_p}/subsets_def/{subset}.query_names.txt",
+            min_p=[f"{config['project_min_p']}"],
+            subset=REGION_LABEL_SUBSETS,
+        ),

--- a/src/bolinas/zoonomia_projection_dataset/region_labels.py
+++ b/src/bolinas/zoonomia_projection_dataset/region_labels.py
@@ -194,6 +194,13 @@ def _coverage_bp(windows: pd.DataFrame, region: pd.DataFrame) -> np.ndarray:
 
     Returns an array aligned to ``windows.index`` (caller must reset index
     before passing in). Empty ``region`` yields all zeros.
+
+    Caveat: ``bf.coverage`` resets its input DataFrame's index in place to
+    ``[0, 1, ...]`` (it sorts internally for the overlap join). We pass a
+    ``.copy()`` and capture ``sub.index`` *before* the call so each chrom
+    iteration writes coverage to the correct rows of ``out``. Without this,
+    the second-and-later chroms in the groupby loop silently corrupt
+    earlier chroms' values — the bug surfaces only on multi-chrom inputs.
     """
     assert windows.index.is_monotonic_increasing and windows.index[0] == 0, (
         "_coverage_bp requires reset_index() windows DataFrame"
@@ -206,8 +213,12 @@ def _coverage_bp(windows: pd.DataFrame, region: pd.DataFrame) -> np.ndarray:
         chrom_region = region_by_chrom.get(chrom)
         if chrom_region is None or len(chrom_region) == 0:
             continue
-        cov = bf.coverage(sub, chrom_region, return_input=False)["coverage"].to_numpy()
-        out[sub.index.to_numpy()] = cov
+        orig_idx = sub.index.to_numpy()  # Capture BEFORE bf.coverage mutates sub.index.
+        cov = (
+            bf.coverage(sub.copy(), chrom_region, return_input=False)["coverage"]
+            .to_numpy()
+        )
+        out[orig_idx] = cov
     return out
 
 

--- a/src/bolinas/zoonomia_projection_dataset/region_labels.py
+++ b/src/bolinas/zoonomia_projection_dataset/region_labels.py
@@ -1,0 +1,311 @@
+"""Per-anchor region-type annotation for the zoonomia projection dataset.
+
+Labels every conservation-filtered human anchor (255 bp) with exactly one of:
+
+    cds  >  utr3  >  ncrna_exon  >  tss_region_and_utr5  >  cre  >  background
+
+(see ``REGION_LABELS`` for the functional five; ``BACKGROUND`` covers the
+rest). The label is the highest-priority region with any overlap, *provided*
+the union-of-functional fraction over the window is ≥ ``functional_threshold``;
+otherwise the window is ``background``.
+
+All extractors are Ensembl-flavored: ``transcript_biotype "protein_coding"``,
+``"lncRNA"``, etc. RefSeq-flavored helpers in ``bolinas.data.utils``
+(``get_mrna_exons``, ``get_5_prime_utr``, ``get_3_prime_utr``,
+``get_ncrna_exons``, ``get_promoters``) must not be used here — they filter
+on RefSeq biotype vocabulary (``"mRNA"``, ``"lnc_RNA"``, ...). The
+``_assert_ensembl_gtf`` check at the top of ``build_region_beds`` guards
+against an accidental RefSeq GTF.
+"""
+
+from pathlib import Path
+
+import bioframe as bf
+import numpy as np
+import pandas as pd
+import polars as pl
+
+from bolinas.data.intervals import GenomicSet
+from bolinas.data.utils import (
+    get_cds,
+    get_exons,
+    get_promoters_from_exons,
+    load_annotation,
+)
+from bolinas.projection.tss import get_ensembl_protein_coding_exons
+from bolinas.zoonomia_projection_dataset.validation import (
+    get_ensembl_3_prime_utr,
+    get_ensembl_5_prime_utr,
+)
+
+# Functional region labels in canonical (default-priority) order.
+REGION_LABELS: tuple[str, ...] = (
+    "cds",
+    "utr3",
+    "ncrna_exon",
+    "tss_region_and_utr5",
+    "cre",
+)
+BACKGROUND_LABEL = "background"
+
+
+# ============================================================================
+# Ensembl-only extractors (no RefSeq fallback)
+# ============================================================================
+
+
+def get_ensembl_all_transcript_exons(ann: pl.DataFrame) -> pl.DataFrame:
+    """Every exon row carrying a transcript_id, no biotype filter.
+
+    Mirrors :func:`bolinas.projection.tss.get_ensembl_protein_coding_exons`
+    but drops the ``transcript_biotype == "protein_coding"`` filter — keeps
+    every annotated transcript (mRNA, lncRNA, miRNA, snoRNA, pseudogenes,
+    retained_intron, NMD, ...). Used to derive the TSS band for
+    ``tss_region_and_utr5``.
+
+    Returns ``[chrom, start, end, strand, transcript_id]`` — the shape
+    :func:`bolinas.data.utils.get_promoters_from_exons` expects.
+    """
+    return (
+        ann.filter(pl.col("feature") == "exon")
+        .with_columns(
+            pl.col("attribute")
+            .str.extract(r'transcript_id "(.*?)"')
+            .alias("transcript_id"),
+        )
+        .filter(pl.col("transcript_id").is_not_null())
+        .select(["chrom", "start", "end", "strand", "transcript_id"])
+    )
+
+
+def get_ensembl_gene_body(ann: pl.DataFrame) -> GenomicSet:
+    """Union of ``feature == "gene"`` spans (diagnostic only).
+
+    Used to compute ``gene_body_frac`` / ``intron_frac`` /
+    ``intergenic_frac`` columns. Does not feed the label.
+    """
+    return GenomicSet(ann.filter(pl.col("feature") == "gene"))
+
+
+def _assert_ensembl_gtf(ann: pl.DataFrame) -> None:
+    """Crash loudly if the GTF isn't Ensembl-flavored.
+
+    RefSeq GTFs use ``transcript_biotype "mRNA"``; Ensembl uses
+    ``"protein_coding"``. The extractors in this module *require* Ensembl
+    vocabulary — running them on a RefSeq GTF silently returns empty
+    ``cds`` / ``utr3`` / ``utr5`` sets without this check.
+    """
+    n_pc = (
+        ann.filter(pl.col("feature") == "transcript")
+        .filter(
+            pl.col("attribute").str.contains(
+                'transcript_biotype "protein_coding"', literal=True
+            )
+        )
+        .height
+    )
+    assert n_pc > 0, (
+        'no transcripts with transcript_biotype "protein_coding" — '
+        "this pipeline requires an Ensembl-flavored GTF. RefSeq uses "
+        'transcript_biotype "mRNA"; do not mix vocabularies.'
+    )
+
+
+# ============================================================================
+# Region BED construction
+# ============================================================================
+
+
+def build_region_beds(
+    ann_path: str | Path,
+    cre_parquet: str | Path,
+    defined: GenomicSet,
+    *,
+    tss_radius: int,
+    cre_flank: int,
+) -> dict[str, GenomicSet]:
+    """Build the 5 functional region BEDs + 2 diagnostic sets.
+
+    Every output GenomicSet is intersected with ``defined`` (genome minus
+    N regions) at the end, so per-window fractions never count bases that
+    fall in unsequenceable masked regions.
+
+    Args:
+        ann_path: Ensembl GTF (release pinned in the calling pipeline).
+        cre_parquet: ENCODE cCRE V4 parquet with ``chrom, start, end,
+            cre_class`` columns, produced by ``validation.smk:cre_process``.
+        defined: ``genome − N`` GenomicSet from ``windows.smk:undefined``.
+        tss_radius: ± bp around every transcript's TSS for the
+            ``tss_region_and_utr5`` class.
+        cre_flank: bp added on each side of every non-PLS cCRE.
+
+    Returns:
+        Dict with keys ``cds``, ``utr3``, ``ncrna_exon``,
+        ``tss_region_and_utr5``, ``cre`` (the five functional labels) plus
+        ``gene_body`` and ``all_exons`` (diagnostic, for
+        intron / intergenic decomposition).
+    """
+    ann = load_annotation(str(ann_path))
+    _assert_ensembl_gtf(ann)
+
+    cds = get_cds(ann)
+    utr3 = get_ensembl_3_prime_utr(ann)
+    utr5 = get_ensembl_5_prime_utr(ann)
+
+    pc_exons = GenomicSet(
+        get_ensembl_protein_coding_exons(ann).select(["chrom", "start", "end"])
+    )
+    all_exons = get_exons(ann)
+    ncrna_exon = all_exons - pc_exons
+
+    all_tx_exons = get_ensembl_all_transcript_exons(ann)
+    assert len(all_tx_exons) > 0, "GTF has no transcript-tagged exon rows"
+    tss_band = get_promoters_from_exons(
+        all_tx_exons, n_upstream=tss_radius, n_downstream=tss_radius
+    )
+    tss_region_and_utr5 = tss_band | utr5
+
+    cre_df = pl.read_parquet(cre_parquet).filter(pl.col("cre_class") != "PLS")
+    assert len(cre_df) > 0, (
+        f"no non-PLS cCREs in {cre_parquet} — wrong file or unexpected schema?"
+    )
+    cre = GenomicSet(cre_df.select(["chrom", "start", "end"])).add_flank(cre_flank)
+
+    gene_body = get_ensembl_gene_body(ann)
+
+    return {
+        "cds": cds & defined,
+        "utr3": utr3 & defined,
+        "ncrna_exon": ncrna_exon & defined,
+        "tss_region_and_utr5": tss_region_and_utr5 & defined,
+        "cre": cre & defined,
+        "gene_body": gene_body & defined,
+        "all_exons": all_exons & defined,
+    }
+
+
+# ============================================================================
+# Per-window labeling
+# ============================================================================
+
+
+def _coverage_bp(windows: pd.DataFrame, region: pd.DataFrame) -> np.ndarray:
+    """Per-window basepair coverage by ``region``, computed chrom-by-chrom.
+
+    Returns an array aligned to ``windows.index`` (caller must reset index
+    before passing in). Empty ``region`` yields all zeros.
+    """
+    assert windows.index.is_monotonic_increasing and windows.index[0] == 0, (
+        "_coverage_bp requires reset_index() windows DataFrame"
+    )
+    out = np.zeros(len(windows), dtype=np.int64)
+    if len(region) == 0:
+        return out
+    region_by_chrom = {chrom: sub for chrom, sub in region.groupby("chrom", sort=False)}
+    for chrom, sub in windows.groupby("chrom", sort=False):
+        chrom_region = region_by_chrom.get(chrom)
+        if chrom_region is None or len(chrom_region) == 0:
+            continue
+        cov = bf.coverage(sub, chrom_region, return_input=False)["coverage"].to_numpy()
+        out[sub.index.to_numpy()] = cov
+    return out
+
+
+def label_windows(
+    windows_bed: str | Path,
+    beds: dict[str, GenomicSet],
+    *,
+    functional_threshold: float,
+    priority: list[str],
+) -> pl.DataFrame:
+    """Label every window with one of ``REGION_LABELS`` or ``"background"``.
+
+    Args:
+        windows_bed: BED4 (chrom, start, end, name) of human anchors, e.g.
+            ``results/human/intervals/filtered/min0.20.bed.gz``. .gz auto-
+            detected by pandas.
+        beds: dict from :func:`build_region_beds` containing the 5
+            functional regions + ``gene_body`` + ``all_exons``.
+        functional_threshold: window's union-of-functional fraction must
+            be ≥ this to escape ``background``. Range [0, 1].
+        priority: ordering of functional labels for tie-breaking when a
+            window overlaps multiple regions. Must be a permutation of
+            ``REGION_LABELS``.
+
+    Returns:
+        Polars DataFrame with one row per input window and columns
+        ``name, chrom, start, end, label, functional_frac, cds_frac,
+        utr3_frac, ncrna_exon_frac, tss_region_and_utr5_frac, cre_frac,
+        gene_body_frac, intron_frac, intergenic_frac``.
+    """
+    assert 0.0 <= functional_threshold <= 1.0, functional_threshold
+    assert set(priority) == set(REGION_LABELS), (
+        f"priority {priority!r} must be a permutation of {list(REGION_LABELS)!r}"
+    )
+    missing_functional = set(REGION_LABELS) - set(beds.keys())
+    assert not missing_functional, f"beds missing functional keys: {missing_functional}"
+    for diag in ("gene_body", "all_exons"):
+        assert diag in beds, f"beds missing diagnostic key: {diag!r}"
+
+    windows = pd.read_csv(
+        str(windows_bed),
+        sep="\t",
+        header=None,
+        names=["chrom", "start", "end", "name"],
+        dtype={"chrom": str},
+    ).reset_index(drop=True)
+    sizes = (windows["end"] - windows["start"]).to_numpy()
+    assert (sizes > 0).all(), "non-positive window sizes"
+
+    coords = windows[["chrom", "start", "end"]]
+
+    # Per-region overlap fractions for the 5 functional labels.
+    frac: dict[str, np.ndarray] = {}
+    for label in REGION_LABELS:
+        cov_bp = _coverage_bp(coords, beds[label].to_pandas())
+        frac[label] = cov_bp / sizes
+
+    # Union of all 5 functional regions — basis for the threshold.
+    functional_union = beds[REGION_LABELS[0]]
+    for label in REGION_LABELS[1:]:
+        functional_union = functional_union | beds[label]
+    functional_frac = _coverage_bp(coords, functional_union.to_pandas()) / sizes
+
+    # Diagnostic: gene body, intron, intergenic.
+    gene_body_frac = _coverage_bp(coords, beds["gene_body"].to_pandas()) / sizes
+    exon_frac = _coverage_bp(coords, beds["all_exons"].to_pandas()) / sizes
+    intron_frac = np.clip(gene_body_frac - exon_frac, a_min=0.0, a_max=None)
+    intergenic_frac = np.clip(1.0 - gene_body_frac, a_min=0.0, a_max=None)
+
+    # Priority-walk: pick the first label in ``priority`` that has any overlap.
+    n = len(windows)
+    label_arr = np.full(n, BACKGROUND_LABEL, dtype=object)
+    is_functional = functional_frac >= functional_threshold
+    unassigned = is_functional.copy()
+    for label in priority:
+        pick = unassigned & (frac[label] > 0)
+        label_arr[pick] = label
+        unassigned &= ~pick
+        if not unassigned.any():
+            break
+    # Anything still unassigned among functional windows (functional_frac ≥
+    # threshold but no individual fraction > 0) cannot occur — the union is
+    # the union of these very same sets. Assert as an invariant.
+    assert not unassigned.any(), (
+        "labeler bug: window passed functional_threshold but no per-region frac > 0"
+    )
+
+    return pl.DataFrame(
+        {
+            "name": windows["name"].to_numpy(),
+            "chrom": windows["chrom"].to_numpy(),
+            "start": windows["start"].to_numpy(),
+            "end": windows["end"].to_numpy(),
+            "label": label_arr.astype(str),
+            "functional_frac": functional_frac,
+            **{f"{label}_frac": frac[label] for label in REGION_LABELS},
+            "gene_body_frac": gene_body_frac,
+            "intron_frac": intron_frac,
+            "intergenic_frac": intergenic_frac,
+        }
+    )

--- a/src/bolinas/zoonomia_projection_dataset/region_labels.py
+++ b/src/bolinas/zoonomia_projection_dataset/region_labels.py
@@ -2,12 +2,17 @@
 
 Labels every conservation-filtered human anchor (255 bp) with exactly one of:
 
-    cds  >  utr3  >  ncrna_exon  >  tss_region_and_utr5  >  cre  >  background
+    cds  >  utr3  >  ncrna_exon  >  tss_region_and_utr5  >  ccre_non_promoter  >  background
 
 (see ``REGION_LABELS`` for the functional five; ``BACKGROUND`` covers the
 rest). The label is the highest-priority region with any overlap, *provided*
 the union-of-functional fraction over the window is ≥ ``functional_threshold``;
 otherwise the window is ``background``.
+
+``ccre_non_promoter`` = every ENCODE cCRE V4 class **except** ``PLS``
+(so: dELS, pELS, CA, CA-CTCF, CA-TF, CA-H3K4me3, TF), extended by
+``ccre_flank`` bp on each side. PLS-overlapping windows near an annotated
+TSS are captured by ``tss_region_and_utr5`` instead.
 
 All extractors are Ensembl-flavored: ``transcript_biotype "protein_coding"``,
 ``"lncRNA"``, etc. RefSeq-flavored helpers in ``bolinas.data.utils``
@@ -44,7 +49,7 @@ REGION_LABELS: tuple[str, ...] = (
     "utr3",
     "ncrna_exon",
     "tss_region_and_utr5",
-    "cre",
+    "ccre_non_promoter",
 )
 BACKGROUND_LABEL = "background"
 
@@ -122,7 +127,7 @@ def build_region_beds(
     defined: GenomicSet,
     *,
     tss_radius: int,
-    cre_flank: int,
+    ccre_flank: int,
 ) -> dict[str, GenomicSet]:
     """Build the 5 functional region BEDs + 2 diagnostic sets.
 
@@ -137,13 +142,14 @@ def build_region_beds(
         defined: ``genome − N`` GenomicSet from ``windows.smk:undefined``.
         tss_radius: ± bp around every transcript's TSS for the
             ``tss_region_and_utr5`` class.
-        cre_flank: bp added on each side of every non-PLS cCRE.
+        ccre_flank: bp added on each side of every non-PLS cCRE before it
+            contributes to the ``ccre_non_promoter`` class.
 
     Returns:
         Dict with keys ``cds``, ``utr3``, ``ncrna_exon``,
-        ``tss_region_and_utr5``, ``cre`` (the five functional labels) plus
-        ``gene_body`` and ``all_exons`` (diagnostic, for
-        intron / intergenic decomposition).
+        ``tss_region_and_utr5``, ``ccre_non_promoter`` (the five
+        functional labels) plus ``gene_body`` and ``all_exons``
+        (diagnostic, for intron / intergenic decomposition).
     """
     ann = load_annotation(str(ann_path))
     _assert_ensembl_gtf(ann)
@@ -165,11 +171,13 @@ def build_region_beds(
     )
     tss_region_and_utr5 = tss_band | utr5
 
-    cre_df = pl.read_parquet(cre_parquet).filter(pl.col("cre_class") != "PLS")
-    assert len(cre_df) > 0, (
+    ccre_df = pl.read_parquet(cre_parquet).filter(pl.col("cre_class") != "PLS")
+    assert len(ccre_df) > 0, (
         f"no non-PLS cCREs in {cre_parquet} — wrong file or unexpected schema?"
     )
-    cre = GenomicSet(cre_df.select(["chrom", "start", "end"])).add_flank(cre_flank)
+    ccre_non_promoter = (
+        GenomicSet(ccre_df.select(["chrom", "start", "end"])).add_flank(ccre_flank)
+    )
 
     gene_body = get_ensembl_gene_body(ann)
 
@@ -178,7 +186,7 @@ def build_region_beds(
         "utr3": utr3 & defined,
         "ncrna_exon": ncrna_exon & defined,
         "tss_region_and_utr5": tss_region_and_utr5 & defined,
-        "cre": cre & defined,
+        "ccre_non_promoter": ccre_non_promoter & defined,
         "gene_body": gene_body & defined,
         "all_exons": all_exons & defined,
     }
@@ -246,8 +254,9 @@ def label_windows(
     Returns:
         Polars DataFrame with one row per input window and columns
         ``name, chrom, start, end, label, functional_frac, cds_frac,
-        utr3_frac, ncrna_exon_frac, tss_region_and_utr5_frac, cre_frac,
-        gene_body_frac, intron_frac, intergenic_frac``.
+        utr3_frac, ncrna_exon_frac, tss_region_and_utr5_frac,
+        ccre_non_promoter_frac, gene_body_frac, intron_frac,
+        intergenic_frac``.
     """
     assert 0.0 <= functional_threshold <= 1.0, functional_threshold
     assert set(priority) == set(REGION_LABELS), (

--- a/tests/zoonomia_projection_dataset/test_region_labels.py
+++ b/tests/zoonomia_projection_dataset/test_region_labels.py
@@ -1,0 +1,427 @@
+"""Tests for ``bolinas.zoonomia_projection_dataset.region_labels``.
+
+Builds a small synthetic Ensembl-flavored GTF + cCRE parquet covering every
+priority and threshold case from the plan, then asserts each 255 bp anchor
+gets the expected label and frac_* columns.
+"""
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from bolinas.data.intervals import GenomicSet
+from bolinas.zoonomia_projection_dataset.region_labels import (
+    BACKGROUND_LABEL,
+    REGION_LABELS,
+    build_region_beds,
+    label_windows,
+)
+
+# ============================================================================
+# Synthetic GTF / cCRE / windows
+# ============================================================================
+#
+# Chromosome "1" layout (0-based half-open everywhere):
+#
+#   Gene A — protein_coding, + strand
+#       exon1: 1000–1500   exon2: 4000–4600
+#       intron 1500–4000
+#       CDS  1300–1500 + 4000–4400
+#       =>  5' UTR 1000–1300, 3' UTR 4400–4600
+#       TSS = 1000, band 744–1256
+#
+#   Gene B — processed_pseudogene, + strand
+#       exon: 8000–8500     (no CDS; biotype != protein_coding)
+#       TSS = 8000, band 7744–8256
+#
+#   Gene C — lncRNA, + strand
+#       exon: 20000–20500
+#       TSS = 20000, band 19744–20256
+#
+#   Gene E — protein_coding, + strand, very long 5' UTR
+#       exon: 10000–12000
+#       CDS  11800–12000   =>  5' UTR 10000–11800 (1800 bp), no 3' UTR
+#       TSS = 10000, band 9744–10256
+#
+#   Gene D — protein_coding, - strand (isolated antisense gene)
+#       exon: 60000–60900
+#       CDS  60800–60900   =>  3' UTR 60000–60800, no 5' UTR
+#       TSS = 60900, band 60644–61156
+#
+#   Gene F — protein_coding, + strand (overlaps Gene D's 3' UTR)
+#       exon: 60500–60700
+#       CDS  60500–60700   =>  no UTR
+#       TSS = 60500, band 60244–60756
+#
+# cCREs (chrom 1):
+#       PLS    950–1050         (near Gene A TSS — excluded from `cre`)
+#       PLS    50000–50200      (isolated — excluded from `cre`)
+#       dELS   4100–4300        (inside Gene A CDS exon2; flanked 3600–4800)
+#       dELS   30000–30500      (intergenic; flanked 29500–31000)
+
+
+def _gtf_row(
+    chrom: str,
+    feature: str,
+    start_0based: int,
+    end_0based: int,
+    strand: str,
+    attrs: dict[str, str],
+) -> str:
+    """Build a single GTF row.
+
+    GTF uses 1-based inclusive starts; we accept 0-based half-open intervals
+    and convert to GTF (start+1; end unchanged numerically).
+    """
+    attr_str = " ".join(f'{k} "{v}";' for k, v in attrs.items())
+    return (
+        f"{chrom}\tsynth\t{feature}\t{start_0based + 1}\t{end_0based}\t"
+        f".\t{strand}\t.\t{attr_str}"
+    )
+
+
+def _ensembl_gtf_text() -> str:
+    rows: list[str] = []
+
+    def gene_block(
+        gene_id: str,
+        biotype: str,
+        strand: str,
+        start: int,
+        end: int,
+        exons: list[tuple[int, int]],
+        cds: list[tuple[int, int]] | None = None,
+    ) -> None:
+        tx_id = f"tx_{gene_id}"
+        gene_attrs = {"gene_id": gene_id, "gene_biotype": biotype}
+        tx_attrs = {
+            "gene_id": gene_id,
+            "transcript_id": tx_id,
+            "transcript_biotype": biotype,
+            "tag": "Ensembl_canonical",
+        }
+        rows.append(_gtf_row("1", "gene", start, end, strand, gene_attrs))
+        rows.append(_gtf_row("1", "transcript", start, end, strand, tx_attrs))
+        for ex_start, ex_end in exons:
+            rows.append(_gtf_row("1", "exon", ex_start, ex_end, strand, tx_attrs))
+        if cds is not None:
+            for cs_start, cs_end in cds:
+                rows.append(_gtf_row("1", "CDS", cs_start, cs_end, strand, tx_attrs))
+
+    # Gene A: PC, + strand, 2 exons + intron
+    gene_block(
+        "geneA",
+        "protein_coding",
+        "+",
+        start=1000,
+        end=4600,
+        exons=[(1000, 1500), (4000, 4600)],
+        cds=[(1300, 1500), (4000, 4400)],
+    )
+    # Gene B: pseudogene, + strand
+    gene_block(
+        "geneB",
+        "processed_pseudogene",
+        "+",
+        start=8000,
+        end=8500,
+        exons=[(8000, 8500)],
+        cds=None,
+    )
+    # Gene C: lncRNA, + strand
+    gene_block(
+        "geneC",
+        "lncRNA",
+        "+",
+        start=20000,
+        end=20500,
+        exons=[(20000, 20500)],
+        cds=None,
+    )
+    # Gene E: PC, + strand, long 5' UTR
+    gene_block(
+        "geneE",
+        "protein_coding",
+        "+",
+        start=10000,
+        end=12000,
+        exons=[(10000, 12000)],
+        cds=[(11800, 12000)],
+    )
+    # Gene D: PC, - strand
+    gene_block(
+        "geneD",
+        "protein_coding",
+        "-",
+        start=60000,
+        end=60900,
+        exons=[(60000, 60900)],
+        cds=[(60800, 60900)],
+    )
+    # Gene F: PC, + strand, CDS == exon (no UTR)
+    gene_block(
+        "geneF",
+        "protein_coding",
+        "+",
+        start=60500,
+        end=60700,
+        exons=[(60500, 60700)],
+        cds=[(60500, 60700)],
+    )
+    return "\n".join(rows) + "\n"
+
+
+def _write_synthetic_cre_parquet(path: Path) -> None:
+    pl.DataFrame(
+        {
+            "chrom": ["1", "1", "1", "1"],
+            "start": [950, 50000, 4100, 30000],
+            "end": [1050, 50200, 4300, 30500],
+            "cre_class": ["PLS", "PLS", "dELS", "dELS"],
+        }
+    ).write_parquet(path)
+
+
+# Window definitions: (name, start, end). All on chrom "1", 255 bp wide.
+_WINDOWS: list[tuple[str, int, int]] = [
+    ("w_cds100", 4050, 4305),
+    ("w_cds60_utr40", 1198, 1453),
+    ("w_cds10_intron90", 1474, 1729),
+    ("w_cds25_intron75", 1436, 1691),
+    ("w_cre_in_cds", 4100, 4355),
+    ("w_cre_intergenic", 30000, 30255),
+    ("w_utr3_antisense", 60244, 60499),
+    ("w_pls_at_tss", 950, 1205),
+    ("w_pls_isolated", 50000, 50255),
+    ("w_pseudogene", 8000, 8255),
+    ("w_long_utr5", 11000, 11255),
+]
+
+
+def _write_synthetic_windows_bed(path: Path) -> None:
+    with open(path, "w") as fh:
+        for name, start, end in _WINDOWS:
+            assert end - start == 255, f"{name} not 255 bp"
+            fh.write(f"1\t{start}\t{end}\t{name}\n")
+
+
+# ============================================================================
+# Pytest fixture
+# ============================================================================
+
+
+@pytest.fixture
+def synth(tmp_path):
+    gtf_path = tmp_path / "synth.gtf"
+    gtf_path.write_text(_ensembl_gtf_text())
+    cre_path = tmp_path / "cre.parquet"
+    _write_synthetic_cre_parquet(cre_path)
+    windows_path = tmp_path / "windows.bed"
+    _write_synthetic_windows_bed(windows_path)
+    # Whole-chrom defined region (no N gaps in the synthetic genome).
+    defined = GenomicSet(
+        pl.DataFrame({"chrom": ["1"], "start": [0], "end": [200_000]})
+    )
+    return {
+        "gtf": gtf_path,
+        "cre": cre_path,
+        "windows": windows_path,
+        "defined": defined,
+    }
+
+
+def _row(df: pl.DataFrame, name: str) -> dict:
+    matches = df.filter(pl.col("name") == name)
+    assert len(matches) == 1, f"window {name!r} not found in labels output"
+    return matches.row(0, named=True)
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+
+def test_priority_and_threshold_cases(synth):
+    beds = build_region_beds(
+        synth["gtf"], synth["cre"], synth["defined"],
+        tss_radius=256, cre_flank=500,
+    )
+    df = label_windows(
+        synth["windows"], beds,
+        functional_threshold=0.20, priority=list(REGION_LABELS),
+    )
+
+    # Window 100% in CDS
+    r = _row(df, "w_cds100")
+    assert r["label"] == "cds"
+    assert r["cds_frac"] == pytest.approx(1.0)
+    assert r["functional_frac"] == pytest.approx(1.0)
+
+    # 60% CDS + 40% 5' UTR — CDS wins by priority
+    r = _row(df, "w_cds60_utr40")
+    assert r["label"] == "cds"
+    assert r["cds_frac"] == pytest.approx(153 / 255)
+    assert r["tss_region_and_utr5_frac"] == pytest.approx(102 / 255)
+
+    # 10% CDS + 90% intron — below threshold => background
+    r = _row(df, "w_cds10_intron90")
+    assert r["label"] == BACKGROUND_LABEL
+    assert r["cds_frac"] == pytest.approx(26 / 255)
+    assert r["functional_frac"] == pytest.approx(26 / 255)
+    assert r["intron_frac"] == pytest.approx(229 / 255)
+
+    # 25% CDS + 75% intron — above threshold => cds
+    r = _row(df, "w_cds25_intron75")
+    assert r["label"] == "cds"
+    assert r["cds_frac"] == pytest.approx(64 / 255)
+    assert r["intron_frac"] == pytest.approx(191 / 255)
+
+    # cCRE entirely inside a CDS exon — exon wins over CRE
+    r = _row(df, "w_cre_in_cds")
+    assert r["label"] == "cds"
+    assert r["cds_frac"] == pytest.approx(1.0)
+    assert r["cre_frac"] == pytest.approx(1.0)
+
+    # cCRE in intergenic — no exon overlap, no TSS => cre
+    r = _row(df, "w_cre_intergenic")
+    assert r["label"] == "cre"
+    assert r["cre_frac"] == pytest.approx(1.0)
+
+    # Antisense TSS-band + 3' UTR overlap, no CDS — utr3 beats tss_region
+    r = _row(df, "w_utr3_antisense")
+    assert r["label"] == "utr3"
+    assert r["utr3_frac"] == pytest.approx(1.0)
+    assert r["tss_region_and_utr5_frac"] == pytest.approx(1.0)
+    assert r["cds_frac"] == pytest.approx(0.0)
+
+    # PLS sitting on a TSS — PLS excluded from cre, but TSS catches it
+    r = _row(df, "w_pls_at_tss")
+    assert r["label"] == "tss_region_and_utr5"
+    assert r["tss_region_and_utr5_frac"] == pytest.approx(1.0)
+    assert r["cre_frac"] == pytest.approx(0.0)
+    assert r["cds_frac"] == pytest.approx(0.0)
+
+    # PLS far from any TSS — nothing functional => background
+    r = _row(df, "w_pls_isolated")
+    assert r["label"] == BACKGROUND_LABEL
+    assert r["cre_frac"] == pytest.approx(0.0)
+    assert r["functional_frac"] == pytest.approx(0.0)
+
+    # Pseudogene exon only — broad ncrna_exon picks it up
+    r = _row(df, "w_pseudogene")
+    assert r["label"] == "ncrna_exon"
+    assert r["ncrna_exon_frac"] == pytest.approx(1.0)
+
+    # Long 5' UTR > 256 bp from TSS — still tss_region_and_utr5 via UTR union
+    r = _row(df, "w_long_utr5")
+    assert r["label"] == "tss_region_and_utr5"
+    assert r["tss_region_and_utr5_frac"] == pytest.approx(1.0)
+
+
+def test_partition_invariant(synth):
+    beds = build_region_beds(
+        synth["gtf"], synth["cre"], synth["defined"],
+        tss_radius=256, cre_flank=500,
+    )
+    df = label_windows(
+        synth["windows"], beds,
+        functional_threshold=0.20, priority=list(REGION_LABELS),
+    )
+    valid_labels = set(REGION_LABELS) | {BACKGROUND_LABEL}
+    assert set(df["label"].unique().to_list()) <= valid_labels
+    # Every window gets exactly one label — counts sum to total.
+    counts = df.group_by("label").len()
+    assert counts["len"].sum() == len(df) == len(_WINDOWS)
+
+
+def test_priority_permutation_changes_label_not_fracs(synth):
+    """Shuffling `priority` re-routes ambiguous windows but per-region
+    fracs (and functional_frac) must be unchanged."""
+    beds = build_region_beds(
+        synth["gtf"], synth["cre"], synth["defined"],
+        tss_radius=256, cre_flank=500,
+    )
+    default = label_windows(
+        synth["windows"], beds,
+        functional_threshold=0.20, priority=list(REGION_LABELS),
+    )
+    # Promote tss_region_and_utr5 above cds.
+    alt = label_windows(
+        synth["windows"], beds,
+        functional_threshold=0.20,
+        priority=[
+            "tss_region_and_utr5", "cds", "utr3", "ncrna_exon", "cre",
+        ],
+    )
+    # Frac columns unchanged
+    frac_cols = [c for c in default.columns if c.endswith("_frac")]
+    for col in frac_cols:
+        assert default[col].to_list() == alt[col].to_list(), (
+            f"{col} should be invariant to priority order"
+        )
+    # CDS-only window: cds beats tss-with-zero-overlap regardless
+    assert _row(alt, "w_cds100")["label"] == "cds"
+    # 60% CDS + 40% UTR5: now tss_region_and_utr5 wins (it overlaps)
+    assert _row(alt, "w_cds60_utr40")["label"] == "tss_region_and_utr5"
+
+
+def test_refseq_gtf_rejected(tmp_path):
+    """Synthetic RefSeq-style GTF (transcript_biotype "mRNA") must crash."""
+    refseq_rows = [
+        _gtf_row(
+            "1", "gene", 1000, 2000, "+",
+            {"gene_id": "geneA", "gene_biotype": "mRNA"},
+        ),
+        _gtf_row(
+            "1", "transcript", 1000, 2000, "+",
+            {"gene_id": "geneA", "transcript_id": "txA", "transcript_biotype": "mRNA"},
+        ),
+        _gtf_row(
+            "1", "exon", 1000, 2000, "+",
+            {"gene_id": "geneA", "transcript_id": "txA", "transcript_biotype": "mRNA"},
+        ),
+        _gtf_row(
+            "1", "CDS", 1200, 1800, "+",
+            {"gene_id": "geneA", "transcript_id": "txA", "transcript_biotype": "mRNA"},
+        ),
+    ]
+    refseq_path = tmp_path / "refseq.gtf"
+    refseq_path.write_text("\n".join(refseq_rows) + "\n")
+    cre_path = tmp_path / "cre.parquet"
+    pl.DataFrame(
+        {"chrom": ["1"], "start": [3000], "end": [3500], "cre_class": ["dELS"]}
+    ).write_parquet(cre_path)
+    defined = GenomicSet(
+        pl.DataFrame({"chrom": ["1"], "start": [0], "end": [10_000]})
+    )
+    with pytest.raises(AssertionError, match="protein_coding"):
+        build_region_beds(
+            refseq_path, cre_path, defined, tss_radius=256, cre_flank=500
+        )
+
+
+def test_threshold_validates_range(synth):
+    """functional_threshold must be in [0, 1]."""
+    beds = build_region_beds(
+        synth["gtf"], synth["cre"], synth["defined"],
+        tss_radius=256, cre_flank=500,
+    )
+    with pytest.raises(AssertionError):
+        label_windows(
+            synth["windows"], beds,
+            functional_threshold=1.5, priority=list(REGION_LABELS),
+        )
+
+
+def test_priority_must_be_permutation(synth):
+    beds = build_region_beds(
+        synth["gtf"], synth["cre"], synth["defined"],
+        tss_radius=256, cre_flank=500,
+    )
+    with pytest.raises(AssertionError, match="permutation"):
+        label_windows(
+            synth["windows"], beds,
+            functional_threshold=0.20,
+            priority=["cds", "utr3", "ncrna_exon"],  # missing two
+        )

--- a/tests/zoonomia_projection_dataset/test_region_labels.py
+++ b/tests/zoonomia_projection_dataset/test_region_labels.py
@@ -55,8 +55,8 @@ from bolinas.zoonomia_projection_dataset.region_labels import (
 #       TSS = 60500, band 60244–60756
 #
 # cCREs (chrom 1):
-#       PLS    950–1050         (near Gene A TSS — excluded from `cre`)
-#       PLS    50000–50200      (isolated — excluded from `cre`)
+#       PLS    950–1050         (near Gene A TSS — excluded from `ccre_non_promoter`)
+#       PLS    50000–50200      (isolated — excluded from `ccre_non_promoter`)
 #       dELS   4100–4300        (inside Gene A CDS exon2; flanked 3600–4800)
 #       dELS   30000–30500      (intergenic; flanked 29500–31000)
 
@@ -189,8 +189,8 @@ _WINDOWS: list[tuple[str, int, int]] = [
     ("w_cds60_utr40", 1198, 1453),
     ("w_cds10_intron90", 1474, 1729),
     ("w_cds25_intron75", 1436, 1691),
-    ("w_cre_in_cds", 4100, 4355),
-    ("w_cre_intergenic", 30000, 30255),
+    ("w_ccre_in_cds", 4100, 4355),
+    ("w_ccre_intergenic", 30000, 30255),
     ("w_utr3_antisense", 60244, 60499),
     ("w_pls_at_tss", 950, 1205),
     ("w_pls_isolated", 50000, 50255),
@@ -245,7 +245,7 @@ def _row(df: pl.DataFrame, name: str) -> dict:
 def test_priority_and_threshold_cases(synth):
     beds = build_region_beds(
         synth["gtf"], synth["cre"], synth["defined"],
-        tss_radius=256, cre_flank=500,
+        tss_radius=256, ccre_flank=500,
     )
     df = label_windows(
         synth["windows"], beds,
@@ -278,15 +278,15 @@ def test_priority_and_threshold_cases(synth):
     assert r["intron_frac"] == pytest.approx(191 / 255)
 
     # cCRE entirely inside a CDS exon — exon wins over CRE
-    r = _row(df, "w_cre_in_cds")
+    r = _row(df, "w_ccre_in_cds")
     assert r["label"] == "cds"
     assert r["cds_frac"] == pytest.approx(1.0)
-    assert r["cre_frac"] == pytest.approx(1.0)
+    assert r["ccre_non_promoter_frac"] == pytest.approx(1.0)
 
     # cCRE in intergenic — no exon overlap, no TSS => cre
-    r = _row(df, "w_cre_intergenic")
-    assert r["label"] == "cre"
-    assert r["cre_frac"] == pytest.approx(1.0)
+    r = _row(df, "w_ccre_intergenic")
+    assert r["label"] == "ccre_non_promoter"
+    assert r["ccre_non_promoter_frac"] == pytest.approx(1.0)
 
     # Antisense TSS-band + 3' UTR overlap, no CDS — utr3 beats tss_region
     r = _row(df, "w_utr3_antisense")
@@ -295,17 +295,17 @@ def test_priority_and_threshold_cases(synth):
     assert r["tss_region_and_utr5_frac"] == pytest.approx(1.0)
     assert r["cds_frac"] == pytest.approx(0.0)
 
-    # PLS sitting on a TSS — PLS excluded from cre, but TSS catches it
+    # PLS sitting on a TSS — PLS excluded from ccre_non_promoter, but TSS catches it
     r = _row(df, "w_pls_at_tss")
     assert r["label"] == "tss_region_and_utr5"
     assert r["tss_region_and_utr5_frac"] == pytest.approx(1.0)
-    assert r["cre_frac"] == pytest.approx(0.0)
+    assert r["ccre_non_promoter_frac"] == pytest.approx(0.0)
     assert r["cds_frac"] == pytest.approx(0.0)
 
     # PLS far from any TSS — nothing functional => background
     r = _row(df, "w_pls_isolated")
     assert r["label"] == BACKGROUND_LABEL
-    assert r["cre_frac"] == pytest.approx(0.0)
+    assert r["ccre_non_promoter_frac"] == pytest.approx(0.0)
     assert r["functional_frac"] == pytest.approx(0.0)
 
     # Pseudogene exon only — broad ncrna_exon picks it up
@@ -322,7 +322,7 @@ def test_priority_and_threshold_cases(synth):
 def test_partition_invariant(synth):
     beds = build_region_beds(
         synth["gtf"], synth["cre"], synth["defined"],
-        tss_radius=256, cre_flank=500,
+        tss_radius=256, ccre_flank=500,
     )
     df = label_windows(
         synth["windows"], beds,
@@ -340,7 +340,7 @@ def test_priority_permutation_changes_label_not_fracs(synth):
     fracs (and functional_frac) must be unchanged."""
     beds = build_region_beds(
         synth["gtf"], synth["cre"], synth["defined"],
-        tss_radius=256, cre_flank=500,
+        tss_radius=256, ccre_flank=500,
     )
     default = label_windows(
         synth["windows"], beds,
@@ -351,7 +351,7 @@ def test_priority_permutation_changes_label_not_fracs(synth):
         synth["windows"], beds,
         functional_threshold=0.20,
         priority=[
-            "tss_region_and_utr5", "cds", "utr3", "ncrna_exon", "cre",
+            "tss_region_and_utr5", "cds", "utr3", "ncrna_exon", "ccre_non_promoter",
         ],
     )
     # Frac columns unchanged
@@ -414,7 +414,7 @@ def test_multi_chrom_alignment(tmp_path):
     )
 
     beds = build_region_beds(
-        gtf_path, cre_path, defined, tss_radius=256, cre_flank=500,
+        gtf_path, cre_path, defined, tss_radius=256, ccre_flank=500,
     )
     df = label_windows(
         windows_bed, beds,
@@ -464,7 +464,7 @@ def test_refseq_gtf_rejected(tmp_path):
     )
     with pytest.raises(AssertionError, match="protein_coding"):
         build_region_beds(
-            refseq_path, cre_path, defined, tss_radius=256, cre_flank=500
+            refseq_path, cre_path, defined, tss_radius=256, ccre_flank=500
         )
 
 
@@ -472,7 +472,7 @@ def test_threshold_validates_range(synth):
     """functional_threshold must be in [0, 1]."""
     beds = build_region_beds(
         synth["gtf"], synth["cre"], synth["defined"],
-        tss_radius=256, cre_flank=500,
+        tss_radius=256, ccre_flank=500,
     )
     with pytest.raises(AssertionError):
         label_windows(
@@ -484,7 +484,7 @@ def test_threshold_validates_range(synth):
 def test_priority_must_be_permutation(synth):
     beds = build_region_beds(
         synth["gtf"], synth["cre"], synth["defined"],
-        tss_radius=256, cre_flank=500,
+        tss_radius=256, ccre_flank=500,
     )
     with pytest.raises(AssertionError, match="permutation"):
         label_windows(

--- a/tests/zoonomia_projection_dataset/test_region_labels.py
+++ b/tests/zoonomia_projection_dataset/test_region_labels.py
@@ -366,6 +366,73 @@ def test_priority_permutation_changes_label_not_fracs(synth):
     assert _row(alt, "w_cds60_utr40")["label"] == "tss_region_and_utr5"
 
 
+def test_multi_chrom_alignment(tmp_path):
+    """Regression: ``bf.coverage`` resets its input's index in place, so a
+    naive groupby-by-chrom labeler corrupts non-first-chrom alignments.
+    Build a 2-chrom Ensembl GTF and confirm chr-2 windows are labelled
+    correctly (not just chr-1).
+    """
+    # chr "1": one CDS at 1000–1500 (PC transcript).
+    # chr "2": one CDS at 8000–8500 (PC transcript).
+    rows: list[str] = []
+
+    def add_pc_gene(chrom: str, gene: str, start: int, end: int, cds: tuple[int, int]):
+        attrs_gene = {"gene_id": gene, "gene_biotype": "protein_coding"}
+        attrs_tx = {
+            "gene_id": gene,
+            "transcript_id": f"tx_{gene}",
+            "transcript_biotype": "protein_coding",
+            "tag": "Ensembl_canonical",
+        }
+        rows.append(_gtf_row(chrom, "gene", start, end, "+", attrs_gene))
+        rows.append(_gtf_row(chrom, "transcript", start, end, "+", attrs_tx))
+        rows.append(_gtf_row(chrom, "exon", start, end, "+", attrs_tx))
+        rows.append(_gtf_row(chrom, "CDS", cds[0], cds[1], "+", attrs_tx))
+
+    add_pc_gene("1", "geneA", 1000, 1500, cds=(1000, 1500))
+    add_pc_gene("2", "geneB", 8000, 8500, cds=(8000, 8500))
+    gtf_path = tmp_path / "two_chrom.gtf"
+    gtf_path.write_text("\n".join(rows) + "\n")
+
+    cre_path = tmp_path / "cre.parquet"
+    pl.DataFrame(
+        {"chrom": ["1"], "start": [50_000], "end": [50_500], "cre_class": ["dELS"]}
+    ).write_parquet(cre_path)
+
+    # Defined for both chroms.
+    defined = GenomicSet(
+        pl.DataFrame(
+            {"chrom": ["1", "2"], "start": [0, 0], "end": [100_000, 100_000]}
+        )
+    )
+
+    # Windows on BOTH chroms, each entirely in their chrom's CDS.
+    windows_bed = tmp_path / "windows.bed"
+    windows_bed.write_text(
+        "1\t1100\t1355\tw_chr1_cds\n"
+        "2\t8100\t8355\tw_chr2_cds\n"
+    )
+
+    beds = build_region_beds(
+        gtf_path, cre_path, defined, tss_radius=256, cre_flank=500,
+    )
+    df = label_windows(
+        windows_bed, beds,
+        functional_threshold=0.20, priority=list(REGION_LABELS),
+    )
+
+    # Both windows must be labelled `cds` with cds_frac == 1.0.
+    # Without the bf.coverage in-place mutation fix, the chr-2 window's
+    # coverage gets misaligned (written to the chr-1 row's position in `out`),
+    # and chr-2 is labelled `background` while chr-1 gets the wrong frac.
+    chr1 = _row(df, "w_chr1_cds")
+    chr2 = _row(df, "w_chr2_cds")
+    assert chr1["label"] == "cds", f"chr1 label={chr1['label']!r}"
+    assert chr1["cds_frac"] == pytest.approx(1.0), chr1
+    assert chr2["label"] == "cds", f"chr2 label={chr2['label']!r}"
+    assert chr2["cds_frac"] == pytest.approx(1.0), chr2
+
+
 def test_refseq_gtf_rejected(tmp_path):
     """Synthetic RefSeq-style GTF (transcript_biotype "mRNA") must crash."""
     refseq_rows = [


### PR DESCRIPTION
## Summary

Annotate every conservation-filtered human anchor (`results/human/intervals/filtered/min{min_p}.bed.gz`) with **exactly one** of:

```
cds  >  utr3  >  ncrna_exon  >  tss_region_and_utr5  >  ccre_non_promoter  >  background
```

(priority shown highest → lowest). The label is the highest-priority region with any overlap, **provided** the window's union-of-functional fraction is ≥ `region_label_functional_threshold` (default 0.20); otherwise `background`.

Motivation: characterise the composition of the v1 training set (`zoonomia-v1-v1`/-v1-v2), and enable per-label HF subsets (`zoonomia-v1-v3_cds`, …) as a follow-up. Plan was iterated in plan-mode before implementation.

### Region definitions (all Ensembl-flavored)

| Label                  | Source                                                                                                   |
| ---                    | ---                                                                                                      |
| `cds`                  | Ensembl r115 CDS (`get_cds`)                                                                             |
| `utr3`                 | `get_ensembl_3_prime_utr` (uses `transcript_biotype == "protein_coding"` exons)                          |
| `ncrna_exon`           | `get_exons(ann) - get_ensembl_protein_coding_exons(ann)` — all non-PC exons, no biotype/quality filter   |
| `tss_region_and_utr5`  | (TSS ± 256 bp over **every** annotated transcript) ∪ `get_ensembl_5_prime_utr`                            |
| `ccre_non_promoter`    | ENCODE cCRE V4 `cre_class != "PLS"` (dELS, pELS, CA, CA-CTCF, CA-TF, CA-H3K4me3, TF) + 500 bp flank      |
| `background`           | none of the above clear enough (intronic or intergenic)                                                  |

### Key design choices

- **One class `tss_region_and_utr5`** instead of separate `promoter` and `utr5` — promoters and 5' UTRs overlap by construction. Radius ± 256 bp matches v2's TSS-proximity band and sits in the core-promoter regime that issue #42 found beats wider bands.
- **`ccre_non_promoter` excludes PLS** because PLS-overlapping windows near a TSS are already captured by `tss_region_and_utr5`; conflating PLS into the class would double-count. Isolated PLS (no nearby annotated TSS) ⇒ `background`. The name is **source-first** (`ccre_`) and **qualifier-second** (`_non_promoter`) for clarity vs the older misleading `cre`.
- **Demoted `tss_region_and_utr5` in priority** (second-to-last) — it's the broadest / most geographic class, so more specific exonic features (`utr3`, `ncrna_exon`) should win when they overlap.
- **Threshold = 0.20** — a window with 25% functional bases passes; 10% does not. Configurable.
- **All extractors Ensembl-only** — RefSeq-flavored `bolinas.data.utils.get_mrna_exons` / `get_5_prime_utr` / `get_3_prime_utr` / `get_ncrna_exons` / `get_promoters` are intentionally **not** used (they filter on `"mRNA"` / `"lnc_RNA"` vocabulary). The labeler asserts the GTF carries `transcript_biotype "protein_coding"` to guard against silent vocabulary mismatch.

### Composition results

End-to-end on c6id.4xlarge, ~70 s wall.

**`min0.20` (the v1 dataset, 1,136,854 anchors)**:

| Label                   | Count     | Fraction of total |
| ---                     | ---:      | ---:              |
| `cds`                   | 402,393   | 35.40%            |
| `ccre_non_promoter`     | 468,131   | 41.18%            |
| `ncrna_exon`            | 93,064    | 8.19%             |
| `utr3`                  | 54,828    | 4.82%             |
| `tss_region_and_utr5`   | 40,823    | 3.59%             |
| `background`            | 77,615    | 6.83%             |
| ↳ background_intronic   | 54,141    | 4.76%             |
| ↳ background_intergenic | 23,474    | 2.06%             |

**`min0.10` (looser conservation filter, 1,947,760 anchors)**:

| Label                   | Count     | Fraction of total |
| ---                     | ---:      | ---:              |
| `cds`                   | 519,580   | 26.68%            |
| `ccre_non_promoter`     | 917,231   | 47.09%            |
| `ncrna_exon`            | 150,447   | 7.72%             |
| `utr3`                  | 88,747    | 4.56%             |
| `tss_region_and_utr5`   | 72,165    | 3.71%             |
| `background`            | 199,590   | 10.25%            |
| ↳ background_intronic   | 144,547   | 7.42%             |
| ↳ background_intergenic | 55,043    | 2.83%             |

### Background characterisation (`min0.20`)

**By `functional_frac` bin** (threshold = 0.20; below this is `background`):

| Bin                          | Count   | % of bg | % of total |
| ---                          | ---:    | ---:    | ---:       |
| **exactly 0 (pure)**         | 69,414  | 89.43%  | 6.11%      |
| (0, 0.05]                    | 1,344   | 1.73%   | 0.12%      |
| (0.05, 0.10]                 | 1,720   | 2.22%   | 0.15%      |
| (0.10, 0.15]                 | 2,171   | 2.80%   | 0.19%      |
| (0.15, 0.20]                 | 2,966   | 3.82%   | 0.26%      |

About **10.6% of background has some partial functional overlap**, and the count grows toward the threshold — lowering the threshold from 0.20 to 0.15 would reclaim ~3 k anchors; to 0.10 would reclaim ~5 k.

**Among the 8,201 partial-functional background anchors, dominant region:**

| Dominant region        | Count | % of partial bg | mean func_frac |
| ---                    | ---:  | ---:            | ---:           |
| `ccre_non_promoter`    | 4,032 | 49.16%          | 0.101          |
| `cds`                  | 3,096 | 37.75%          | 0.140          |
| `ncrna_exon`           | 766   | 9.34%           | 0.112          |
| `tss_region_and_utr5`  | 236   | 2.88%           | 0.112          |
| `utr3`                 | 71    | 0.87%           | 0.131          |

CDS-grazing background averages higher overlap (0.14) than cCRE-grazing (0.10) — when a background window touches CDS, it grazes it more, just below threshold.

**By gene-body location:**

| Subset                                | n      | % of bg | partial-functional within subset |
| ---                                   | ---:   | ---:    | ---:                              |
| intronic (`gene_body_frac > 0.5`)     | 54,141 | 69.76%  | 12.87%                            |
| intergenic (`gene_body_frac ≤ 0.5`)   | 23,474 | 30.24%  | 5.26%                             |

Intronic background is ~2.5× more likely to have partial functional overlap than intergenic.

### Conservation levels by label

Computed on an 8-chrom slice (~ 406 k anchors). Both metrics paint the same picture: **background is the least conserved** but the distributions overlap heavily.

**`proportion_conserved` (bases above phyloP_447m threshold 2.2162):**

| Label                  | p25   | p50   | p75   | mean  |
| ---                    | ---:  | ---:  | ---:  | ---:  |
| `cds`                  | 0.275 | 0.357 | 0.475 | 0.392 |
| `utr3`                 | 0.271 | 0.380 | 0.561 | 0.435 |
| `ncrna_exon`           | 0.263 | 0.361 | 0.514 | 0.405 |
| `tss_region_and_utr5`  | 0.255 | 0.337 | 0.471 | 0.385 |
| `ccre_non_promoter`    | 0.247 | 0.326 | 0.459 | 0.378 |
| **`background`**       | 0.235 | 0.298 | 0.408 | 0.344 |

**`mean_phyloP` (raw track average over the 255 bp window):**

| Label                  | p25   | p50   | p75   | mean  |
| ---                    | ---:  | ---:  | ---:  | ---:  |
| `utr3`                 | 1.387 | 1.923 | 2.842 | 2.261 |
| `cds`                  | 1.406 | 1.978 | 2.757 | 2.164 |
| `ncrna_exon`           | 1.210 | 1.731 | 2.688 | 2.029 |
| `tss_region_and_utr5`  | 1.264 | 1.691 | 2.391 | 1.967 |
| `ccre_non_promoter`    | 1.273 | 1.627 | 2.288 | 1.939 |
| **`background`**       | 1.241 | 1.513 | 2.014 | 1.744 |

`utr3` slightly edges out `cds` on mean phyloP (2.26 vs 2.16) — 3' UTRs in this set are highly constrained (miRNA targets, etc.). `background` median is only marginally below the functional classes (0.30 / 1.51 vs 0.33–0.38 / 1.51–1.98), and p75 of background (0.41 / 2.01) exceeds p25 of CDS (0.28 / 1.41) — many pure-background windows are as conserved as a typical CDS, just not on any annotated element. Good candidates for **conserved non-coding elements / UCEs / unannotated regulatory regions**.

> **Follow-up**: 255 bp windows dilute the core-element signal (UCEs are typically ~100–300 bp, motifs 6–15 bp). With tighter windows (e.g. 128 bp) or per-base / per-tile scoring inside the same window, the between-label spread on `mean_phyloP` would widen substantially. Tracked separately.

### Take-aways

- **~93% of conserved anchors are functional** by our labeler (`min0.20`). Conservation pre-filter is doing its job — most surviving anchors fall in CDS, cCRE-non-promoter, ncRNA exon, 3' UTR, or a TSS region.
- **`ccre_non_promoter` is the largest single category** (41% min0.20, 47% min0.10) — the 500 bp flank around every non-PLS cCRE absorbs a lot of conserved sequence.
- **`cds` is 35%** at min0.20 vs 27% at min0.10 — strict conservation enriches strongly for coding sequence, as expected.
- **Loosening 0.20 → 0.10** adds ~810 k anchors, ~73% of which are `ccre_non_promoter` and ~14% `background_intronic`. Coding sequence is already saturated at the strict cutoff.
- **`background` ≈ 7%** in `min0.20`, mostly intronic (~70%). 89% of background has *zero* functional overlap (true gene deserts or deep introns); the remaining 11% sits just below threshold.

### What's published

- `results/human/intervals/region_labels/min{min_p}.parquet` — one row per anchor with `name, chrom, start, end, label, functional_frac, cds_frac, utr3_frac, ncrna_exon_frac, tss_region_and_utr5_frac, ccre_non_promoter_frac, gene_body_frac, intron_frac, intergenic_frac`.
- `results/human/intervals/region_labels/min{min_p}.composition.tsv` — per-label counts + `background_intronic`/`background_intergenic` split.
- `results/projection/min{min_p}/subsets_def/v3_<label>.query_names.txt` — one anchor name per line for each of the 6 labels (`v3_cds`, `v3_utr3`, `v3_ncrna_exon`, `v3_tss_region_and_utr5`, `v3_ccre_non_promoter`, `v3_bg`). Plugs into the existing `subset_dataset_derived` rule.

**HF upload of `zoonomia-v1-v3_<label>` datasets is intentionally deferred to a follow-up PR** — this PR ships annotation + composition + query_names lists; the follow-up will wire `subset_dataset_derived` → `prepare_training_shards` → `hf_upload_dataset` for each label.

### Code changes

- **NEW** `src/bolinas/zoonomia_projection_dataset/region_labels.py` — Ensembl-flavored region builders (`build_region_beds`, `get_ensembl_all_transcript_exons`, `get_ensembl_gene_body`, `_assert_ensembl_gtf`) + `label_windows` per-anchor labeler (vectorised, chrom-by-chrom `bf.coverage`).
- **NEW** `snakemake/zoonomia_projection_dataset/workflow/rules/regions.smk` — `build_region_labels`, `region_label_composition`, `derive_subset_v3_region`, aggregate `all_region_labels`.
- **NEW** `snakemake/zoonomia_projection_dataset/sky/regions.yaml` — c6id.4xlarge launcher mirroring `sky/validation.yaml`.
- **NEW** `tests/zoonomia_projection_dataset/test_region_labels.py` — 7 unit tests on a synthetic Ensembl GTF + cCRE BED covering every priority/threshold case, a multi-chrom regression test (`test_multi_chrom_alignment`) for the `bf.coverage` in-place-index-mutation bug, and the RefSeq-GTF rejection guard.
- **EDIT** `config.yaml` — five new keys: `region_label_tss_radius`, `region_label_ccre_flank`, `region_label_functional_threshold`, `region_label_priority`, `region_label_subsets`.
- **EDIT** `Snakefile` — `include: "rules/regions.smk"`.
- **EDIT** `README.md` — new "Region-type annotation" section.

### Notable fixes during review

- **`bf.coverage` in-place index mutation bug** (commit a47f335). The chrom-by-chrom labeler was silently corrupting per-chrom alignments: `bf.coverage` resets its input DataFrame's index in place to `[0..N-1]` (sorts internally for the overlap join), and the groupby loop wrote later chroms' coverage values to earlier chroms' positions in the output array. The single-chrom synthetic test passed by coincidence (the reset matched positional layout). Fixed by capturing `sub.index` before the call and passing `sub.copy()`; added `test_multi_chrom_alignment` regression test. Pre-fix composition reported 92% `background` — post-fix is 7%, and the deep-dive analyses above were redone on the corrected data.
- **Label rename `cre` → `ccre_non_promoter`** (commit 4eda262). The old name was misleading: ENCODE's PLS (promoter-like) *is* a cCRE, so "cre" implied promoters were included. "Distal" / "enhancer" also don't fit (the class includes pELS, CA, CTCF). The new source-first / qualifier-second name is explicit. Same rename for `region_label_cre_flank` → `region_label_ccre_flank`.

## Test plan

- [x] 7 new unit tests pass (`uv run pytest tests/zoonomia_projection_dataset/test_region_labels.py`); full suite 49 tests pass.
- [x] Snakemake dry-run shows only the new region-label jobs plan to run (`-n all_region_labels` plans 11 jobs — no upstream rules re-run).
- [x] SkyPilot end-to-end run on c6id.4xlarge — both `min0.10` and `min0.20` composition TSVs produced; see "Composition results" above.
- [x] Multi-chrom regression test catches the bf.coverage bug (`test_multi_chrom_alignment`).
- [ ] Spot-check known loci with the labelled parquet (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
