### PR TITLE
Bump biofoundation: fp32 log_softmax fix (Open-Athena/biofoundation#22)

### DIFF
--- a/snakemake/analysis/evals_v2/sky/run.yaml
+++ b/snakemake/analysis/evals_v2/sky/run.yaml
@@ -55,7 +55,7 @@ setup: |
     # Pin to the ADC we mounted; gcloud picks this up automatically.
     export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
 
-    uv sync
+    uv sync --frozen
 
     # Smoke-test GCS access so a bad ADC fails fast in setup, not in a rule.
     gcloud storage ls gs://marin-us-central1/checkpoints/ | head -3 >/dev/null

--- a/uv.lock
+++ b/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 [[package]]
 name = "biofoundation"
 version = "0.1.0"
-source = { git = "https://github.com/Open-Athena/biofoundation.git#df5bd4994ca4b2a5bbbc429ec7a592b08e5a22c3" }
+source = { git = "https://github.com/Open-Athena/biofoundation.git#81afbe5a1df5473de5b016e5b6f3a4a35bbc6078" }
 dependencies = [
     { name = "bioframe" },
     { name = "biopython" },


### PR DESCRIPTION
## Summary

- Bump `uv.lock` biofoundation pin from `df5bd49` → `81afbe5` to pick up [Open-Athena/biofoundation#22](https://github.com/Open-Athena/biofoundation/pull/22) (fp32 cast before `log_softmax` in `_logits_to_logprobs`). The previous pin compounded ~10⁻³ per-token bf16 rounding error across the sequence sum in CLM scoring.
- Tighten `evals_v2/sky/run.yaml` to `uv sync --frozen` so the cluster uses the locked dep versions instead of re-resolving against a different fork strategy.
- Re-scored all 5 gLM rows × 3 datasets (15 cells) on a fresh A10G SkyPilot cluster and refreshed leaderboards #161 / #162 / #172 in place (issue bodies via `gh api PATCH`, per the `leaderboards_are_issue_bodies` convention).

## What shifted on the leaderboards

Conservation tracks (`phyloP_*`, `phastCons_*`) and AlphaGenome **don't** flow through biofoundation, so those rows are bit-identical. Only the five `exp{55,58-m,58-a,59,136}` rows changed.

Pre-rerun sanity check on `exp136-proj_v30 × mendelian_traits` (8 subsets, n=9820 variants → 4910 matched pairs):

| metric | observed | PR #22 predicted |
|---|---|---|
| Pearson(`llr_pre`, `llr_post`) | 0.9997 | ~0.9996 |
| median \|Δllr\| | 0.025 | ~0.055 |
| worst \|Δllr\| | 0.139 | ~0.625 |
| matched-pair flip rate | 1.77 % (87/4910) | ~3.4 % (different model) |
| max \|ΔPA\| per subset (n≥30) | 0.013 | <1 pair/subset |
| max Δpairs per subset | 2 (out of 4495 missense) | ditto |

All 8 mendelian subsets stayed within 2·SE of their pre-fix value. Half the subsets had Δpairs = 0. Sweep on the remaining 14 cells (`exp{55,58-m,58-a,59} × {mendelian,complex,eqtl}` + `exp136 × {complex,eqtl}`) matched the same pattern — no ranking changes vs the conservation/AlphaGenome baselines.

## Out of scope

`scripts/evo2_eval/*` (TraitGym Mendelian via `compute_llr_clm`, LL-gap via `compute_ll_clm`) also flow through the patched `_logits_to_logprobs` and would shift under this pin — but they're not on the three leaderboards. Tracking as a separate task in agent memory.

## Test plan

- [x] `uv run --frozen pytest tests/ --ignore=<torch-importing dirs>` — 598 passed, 1 skipped (the 11 skips are pre-existing `libcudnn.so.9` not-installed errors on the CPU-only box and aren't related to this bump).
- [x] SkyPilot sanity check (`exp136-proj_v30 × mendelian_traits`) — shifts at or below PR predictions; ranking preserved.
- [x] Full 15-cell `evals_v2` sweep — all metrics parquets uploaded to `s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics/{model}/{dataset}.parquet` with 2026-05-12 timestamps.
- [x] Leaderboards #161 / #162 / #172 refreshed via `gh api PATCH`; new "Last updated" date and changelog entry; conservation/AlphaGenome rows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)