### PR TITLE
Make GPN-Star a first-class leaderboard method

### DIFF
--- a/snakemake/evals/scratch/leaderboard_gen.py
+++ b/snakemake/evals/scratch/leaderboard_gen.py
@@ -4,6 +4,8 @@ Pulls per-(method, dataset, subset) PairwiseAccuracy + SE from S3:
   - conservation_eval: 7 conservation tracks
   - evals_v2: 5 model checkpoints
   - alphagenome_eval: AlphaGenome variant scorer
+  - gpn_star_eval: GPN-Star V/M/P (calibrated variants; predictions
+    scored externally by TraitGym)
 
 Combines into one table per dataset. n_pairs ≥ 30 cutoff for per-subset
 columns. Two aggregate columns are prepended:
@@ -12,6 +14,9 @@ columns. Two aggregate columns are prepended:
     row written by `compute_pairwise_metrics`.
   - Macro Avg: unweighted mean of per-subset PAs over n≥30 subsets. Sourced
     from the `_macro_avg_` row.
+
+Methods are sorted by `Global` PA descending so the best-overall method
+appears at the top of each table.
 
 Bolding rule (top method per column, plus any within 0.01 of the top) applies
 to every column including the aggregates.
@@ -30,6 +35,7 @@ from datetime import date
 
 import polars as pl
 
+from bolinas.evals.gpn_star import GPN_STAR_MODELS, GPN_STAR_SCORE_COLUMN
 from bolinas.evals.metrics import GLOBAL_SUBSET, MACRO_AVG_SUBSET
 
 # Per-dataset score_type per pipeline.
@@ -41,6 +47,10 @@ SCORE_TYPE = {
     },
     "conservation": "score",
     "alphagenome": "alphagenome_max_l2",
+    # GPN-Star ships with both calibrated and uncalibrated variants in the
+    # metrics parquet; the leaderboard renders the calibrated one (see
+    # `bolinas.evals.gpn_star.GPN_STAR_SCORE_COLUMN`).
+    "gpn_star": GPN_STAR_SCORE_COLUMN,
 }
 
 EVALS_V2_MODELS = [
@@ -132,6 +142,26 @@ def gather_methods(dataset: str) -> list[tuple[str, str | None, pl.DataFrame]]:
     except Exception as exc:  # noqa: BLE001
         print(f"  ! alphagenome metrics missing for {dataset}: {exc}")
 
+    # 4. gpn_star — calibrated variants only (uncalibrated numbers live in
+    # the #145 eval comment for reference). One row per model V/M/P.
+    try:
+        gs = pl.read_parquet(
+            f"{S3}/snakemake/gpn_star_eval/results/metrics/{dataset}.parquet"
+        )
+        gs = gs.filter(pl.col("score_type") == SCORE_TYPE["gpn_star"][dataset]).filter(
+            pl.col("split") == SPLIT
+        )
+        for model in GPN_STAR_MODELS:
+            df = gs.filter(pl.col("model") == f"GPN-Star-{model}").select(
+                ["subset", "value", "se", "n_pairs"]
+            )
+            assert df.height > 0, (
+                f"no GPN-Star-{model} rows for {dataset!r} in metrics parquet"
+            )
+            rows.append((f"`GPN-Star-{model}`", None, df))
+    except Exception as exc:  # noqa: BLE001
+        print(f"  ! gpn_star metrics missing for {dataset}: {exc}")
+
     return rows
 
 
@@ -158,6 +188,12 @@ def build_table(dataset: str) -> str:
     methods = [
         (method, comment, *_split_method(df)) for method, comment, df in rows
     ]
+
+    # Sort by Global PA descending so the top of the table = current best
+    # method on the headline aggregate. Python's sort is stable, so methods
+    # tied on Global keep their insertion order (conservation → evals_v2 →
+    # AlphaGenome → GPN-Star).
+    methods.sort(key=lambda m: -m[3][0])
 
     subset_n: dict[str, int] = {}
     for _, _, per_sub, _, _ in methods:
@@ -373,6 +409,21 @@ def patch_issue(dataset: str, table_md: str) -> None:
         f"{macro_k} subsets) aggregate columns. Implemented as new "
         f"`_global_` / `_macro_avg_` rows in `compute_pairwise_metrics` "
         f"(`src/bolinas/evals/metrics.py`); all 3 metric pipelines re-run.",
+    )
+    # GPN-Star addition + sort-by-Global change cycle. Hardcoded date so
+    # idempotency holds across future runs of this script.
+    calibrated = SCORE_TYPE["gpn_star"][dataset]
+    raw = calibrated.replace("_calibrated", "")
+    new_body = _prepend_changelog_entry(
+        new_body,
+        f"- **2026-05-13** — added `GPN-Star-V`, `GPN-Star-M`, `GPN-Star-P` "
+        f"(calibrated variants only; score column `{calibrated}`). Source "
+        f"predictions: [#145 comment](https://github.com/Open-Athena/bolinas-dna/issues/145#issuecomment-4444680280); "
+        f"evaluation + uncalibrated `{raw}` numbers: "
+        f"[#145 comment](https://github.com/Open-Athena/bolinas-dna/issues/145#issuecomment-4444856709). "
+        f"Pipeline = TraitGym at commit `05135727`. Existing rows re-sorted "
+        f"by `Global` PA descending (top of table = current best) — values "
+        f"unchanged.",
     )
 
     if new_body == body:

--- a/snakemake/evals/scratch/leaderboard_gen.py
+++ b/snakemake/evals/scratch/leaderboard_gen.py
@@ -143,11 +143,17 @@ def gather_methods(dataset: str) -> list[tuple[str, str | None, pl.DataFrame]]:
         print(f"  ! alphagenome metrics missing for {dataset}: {exc}")
 
     # 4. gpn_star — calibrated variants only (uncalibrated numbers live in
-    # the #145 eval comment for reference). One row per model V/M/P.
+    # the #145 eval comment for reference). One row per model V/M/P. Catch
+    # only the S3 read so a present-but-malformed parquet fails loud rather
+    # than getting silently treated as "metrics missing".
     try:
         gs = pl.read_parquet(
             f"{S3}/snakemake/gpn_star_eval/results/metrics/{dataset}.parquet"
         )
+    except Exception as exc:  # noqa: BLE001
+        print(f"  ! gpn_star metrics missing for {dataset}: {exc}")
+        gs = None
+    if gs is not None:
         gs = gs.filter(pl.col("score_type") == SCORE_TYPE["gpn_star"][dataset]).filter(
             pl.col("split") == SPLIT
         )
@@ -159,8 +165,6 @@ def gather_methods(dataset: str) -> list[tuple[str, str | None, pl.DataFrame]]:
                 f"no GPN-Star-{model} rows for {dataset!r} in metrics parquet"
             )
             rows.append((f"`GPN-Star-{model}`", None, df))
-    except Exception as exc:  # noqa: BLE001
-        print(f"  ! gpn_star metrics missing for {dataset}: {exc}")
 
     return rows
 
@@ -402,16 +406,18 @@ def patch_issue(dataset: str, table_md: str) -> None:
     new_body = _update_intro_paragraph(new_body, global_n, macro_k)
     new_body = _update_bold_rule(new_body)
     new_body = _bump_last_updated(new_body, str(date.today()))
+    # Hardcoded dates on changelog entries (matching the date the change
+    # actually landed) so re-runs of this script don't re-add the entry with
+    # today's date each time — idempotency relies on the entry text being
+    # stable across runs.
     new_body = _prepend_changelog_entry(
         new_body,
-        f"- **{date.today()}** — added `Global` (PA across all pairs, "
+        f"- **2026-05-12** — added `Global` (PA across all pairs, "
         f"n={global_n}) and `Macro Avg` (unweighted PA over n≥30 subsets, "
         f"{macro_k} subsets) aggregate columns. Implemented as new "
         f"`_global_` / `_macro_avg_` rows in `compute_pairwise_metrics` "
         f"(`src/bolinas/evals/metrics.py`); all 3 metric pipelines re-run.",
     )
-    # GPN-Star addition + sort-by-Global change cycle. Hardcoded date so
-    # idempotency holds across future runs of this script.
     calibrated = SCORE_TYPE["gpn_star"][dataset]
     raw = calibrated.replace("_calibrated", "")
     new_body = _prepend_changelog_entry(

--- a/snakemake/gpn_star_eval/README.md
+++ b/snakemake/gpn_star_eval/README.md
@@ -1,0 +1,96 @@
+# gpn_star_eval — GPN-Star V/M/P baseline on matched-pair eval datasets
+
+PairwiseAccuracy ± binomial SE for the three GPN-Star variants
+(V = vertebrate-100way, M = mammal-447way, P = primate-243way; all 200M params)
+on the matched-pair eval datasets ([#161 Mendelian](https://github.com/Open-Athena/bolinas-dna/issues/161),
+[#162 Complex traits](https://github.com/Open-Athena/bolinas-dna/issues/162),
+[#172 eQTL](https://github.com/Open-Athena/bolinas-dna/issues/172)).
+
+GPN-Star scoring runs in [songlab-cal/TraitGym](https://github.com/songlab-cal/TraitGym),
+not this repo. Predictions are pulled from a gist (commit pinned in
+`bolinas.evals.gpn_star.GPN_STAR_GIST_BASE`); see
+[#145 comment](https://github.com/Open-Athena/bolinas-dna/issues/145#issuecomment-4444680280)
+for the upstream definition. This pipeline is the align + aggregate step:
+load HF eval dataset, row-align with the predictions parquet, compute PA per
+subset.
+
+## What it does
+
+For each `dataset` in `config["datasets"]`:
+
+1. **Score** — for each of the 3 model variants, load the GPN-Star prediction
+   parquet (`predictions_url`), align row-by-row with the HF dataset's `train`
+   split, derive `minus_llr` and `minus_llr_calibrated` for the leaderboard
+   convention. Output: one long parquet per dataset, `model` column
+   distinguishing V / M / P.
+
+   Row alignment is asserted element-wise, no key-based merge — TraitGym's
+   `bolinas_pack_predictions` rule builds the predictions parquet by
+   horizontal-concat with HF row order, so a `split == "train"` filter is
+   sufficient.
+
+2. **Compute** PairwiseAccuracy ± SE per consequence subset on all 4 score
+   columns (`minus_llr`, `abs_llr`, `minus_llr_calibrated`,
+   `abs_llr_calibrated`). Output: metrics parquet keyed by
+   `(model, score_type, subset)`, plus the `_global_` / `_macro_avg_`
+   sentinel rows from `compute_pairwise_metrics` (n_min=30).
+
+Downstream consumers (e.g. `snakemake/evals/scratch/leaderboard_gen.py`)
+filter by `score_type` to pick the leaderboard-convention column:
+
+- **Mendelian:** `minus_llr_calibrated` (pathogenic ⇒ alt depleted under
+  purifying selection ⇒ negative LLR ⇒ positive `minus_llr`).
+- **Complex traits / eQTL:** `abs_llr_calibrated` (direction-agnostic
+  magnitude).
+
+## Outputs
+
+S3 bucket `s3://oa-bolinas/snakemake/gpn_star_eval/`:
+
+```
+results/
+├── scores/{dataset}.parquet    # 3 × N rows: variant cols + scores per model
+└── metrics/{dataset}.parquet   # PA per (model, score_type, subset)
+```
+
+## Conventions
+
+- **Train split only.** Test held out for the final-eval pass (matches the
+  other matched-pair pipelines in this repo).
+- **Calibration happens upstream.** `*_calibrated` columns are the producer's
+  pentanucleotide-context background-subtracted variant; see
+  [#145 comment](https://github.com/Open-Athena/bolinas-dna/issues/145#issuecomment-4444680280)
+  for the formula.
+- **Reverse-complement averaging happens upstream.** GPN-Star averages
+  forward + RC strand predictions. The `exp*` gLM rows in this repo's
+  leaderboards are forward-only — RC averaging is a planned addition.
+
+## Usage
+
+Pure CPU, ~10 seconds wallclock for all 3 datasets. Network: ~12 MB
+(downloads 9 prediction parquets from the pinned gist).
+
+```bash
+cd snakemake/gpn_star_eval
+
+# Dry-run to inspect the DAG.
+uv run snakemake -n
+
+# Real run — writes outputs to S3 per the default profile.
+uv run snakemake
+```
+
+No SkyPilot launch yaml — the workload is too small to be worth it.
+
+## Library
+
+Pipeline rules are thin glue around `bolinas.evals.gpn_star`:
+
+- `score_variants_gpn_star(hf_df, predictions, split)` — load + row-align
+  predictions, derive `minus_*` columns. Asserts row-count + key-order match.
+- `predictions_url(dataset, model)` — gist raw URL for one prediction parquet.
+- `GPN_STAR_MODELS`, `GPN_STAR_MODEL_INFO`, `GPN_STAR_SCORE_COLUMN` — metadata.
+
+Tests at [`tests/evals/test_gpn_star.py`](../../tests/evals/test_gpn_star.py)
+cover alignment, NaN detection, chrom-dtype handling, and the predictions-URL
+helper.

--- a/snakemake/gpn_star_eval/README.md
+++ b/snakemake/gpn_star_eval/README.md
@@ -67,8 +67,8 @@ results/
 
 ## Usage
 
-Pure CPU, ~10 seconds wallclock for all 3 datasets. Network: ~12 MB
-(downloads 9 prediction parquets from the pinned gist).
+Pure CPU, ~20 s wallclock for all 3 datasets. Network: ~12 MB (downloads
+9 prediction parquets from the pinned gist).
 
 ```bash
 cd snakemake/gpn_star_eval

--- a/snakemake/gpn_star_eval/config/config.yaml
+++ b/snakemake/gpn_star_eval/config/config.yaml
@@ -1,0 +1,25 @@
+input_hf_prefix: bolinas-dna/evals
+split: train
+
+datasets:
+  - mendelian_traits
+  - complex_traits
+  - eqtl
+
+# GPN-Star model variants (3 in current set). Model decoding lives in
+# `bolinas.evals.gpn_star.GPN_STAR_MODEL_INFO`; source URLs are derived via
+# `bolinas.evals.gpn_star.predictions_url`.
+models:
+  - V
+  - M
+  - P
+
+# Score columns evaluated against `compute_pairwise_metrics`. The 4 entries
+# below produce both the leaderboard-convention column (calibrated) and its
+# uncalibrated counterpart per dataset, so the same metrics parquet powers
+# both the live leaderboards and the #145 eval comment's parallel reporting.
+score_columns:
+  - minus_llr
+  - abs_llr
+  - minus_llr_calibrated
+  - abs_llr_calibrated

--- a/snakemake/gpn_star_eval/workflow/Snakefile
+++ b/snakemake/gpn_star_eval/workflow/Snakefile
@@ -1,0 +1,24 @@
+"""Snakemake workflow: GPN-Star (V/M/P) baseline on matched-pair eval datasets.
+
+Pulls externally-produced GPN-Star prediction parquets (songlab-cal/TraitGym
+`bolinas_pack_predictions` rule, pinned to a gist via
+``bolinas.evals.gpn_star.GPN_STAR_GIST_BASE``), row-aligns with the HF eval
+dataset's train split, computes PairwiseAccuracy ± SE per consequence subset.
+Train split only.
+"""
+
+
+configfile: "config/config.yaml"
+
+
+include: "rules/common.smk"
+include: "rules/score.smk"
+include: "rules/metrics.smk"
+
+
+rule all:
+    input:
+        expand(
+            "results/metrics/{dataset}.parquet",
+            dataset=DATASETS,
+        ),

--- a/snakemake/gpn_star_eval/workflow/profiles/default/config.yaml
+++ b/snakemake/gpn_star_eval/workflow/profiles/default/config.yaml
@@ -1,0 +1,3 @@
+default-storage-provider: s3
+default-storage-prefix: s3://oa-bolinas/snakemake/gpn_star_eval/
+cores: all

--- a/snakemake/gpn_star_eval/workflow/rules/common.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/common.smk
@@ -1,0 +1,17 @@
+"""Common imports + helpers for gpn_star_eval rules."""
+
+import pandas as pd
+from datasets import load_dataset
+
+from bolinas.evals.conservation import REQUIRED_VARIANT_COLUMNS
+from bolinas.evals.gpn_star import (
+    GPN_STAR_MODELS,
+    predictions_url,
+    score_variants_gpn_star,
+)
+from bolinas.evals.metrics import compute_pairwise_metrics
+
+
+DATASETS = config["datasets"]
+MODELS = config["models"]
+SCORE_COLUMNS = config["score_columns"]

--- a/snakemake/gpn_star_eval/workflow/rules/common.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/common.smk
@@ -4,11 +4,7 @@ import pandas as pd
 from datasets import load_dataset
 
 from bolinas.evals.conservation import REQUIRED_VARIANT_COLUMNS
-from bolinas.evals.gpn_star import (
-    GPN_STAR_MODELS,
-    predictions_url,
-    score_variants_gpn_star,
-)
+from bolinas.evals.gpn_star import predictions_url, score_variants_gpn_star
 from bolinas.evals.metrics import compute_pairwise_metrics
 
 

--- a/snakemake/gpn_star_eval/workflow/rules/metrics.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/metrics.smk
@@ -21,8 +21,15 @@ rule compute_metrics:
         for col in SCORE_COLUMNS:
             assert col in df.columns, f"input scores parquet missing column {col!r}"
 
+        expected_models = {f"GPN-Star-{m}" for m in MODELS}
+        assert set(df["model"].unique()) == expected_models, (
+            f"unexpected model set in scores parquet: "
+            f"{set(df['model'].unique())} vs {expected_models}"
+        )
+
         per_model = []
-        for model in sorted(df["model"].unique()):
+        for m in MODELS:
+            model = f"GPN-Star-{m}"
             sub = df[df["model"] == model]
             metrics = compute_pairwise_metrics(
                 dataset=sub[list(REQUIRED_VARIANT_COLUMNS)],

--- a/snakemake/gpn_star_eval/workflow/rules/metrics.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/metrics.smk
@@ -1,0 +1,44 @@
+"""Per-dataset PairwiseAccuracy ± SE on the 4 score columns × 3 models.
+
+Output schema (one row per ``(model, score_type, subset)``):
+``[score_type, subset, value, se, n_pairs, n_ties, model, dataset, split]``.
+Includes ``_global_`` and ``_macro_avg_`` sentinel subset rows from
+``compute_pairwise_metrics`` (n_min=30).
+"""
+
+
+rule compute_metrics:
+    input:
+        "results/scores/{dataset}.parquet",
+    output:
+        "results/metrics/{dataset}.parquet",
+    wildcard_constraints:
+        dataset="|".join(DATASETS),
+    run:
+        df = pd.read_parquet(input[0])
+        for col in REQUIRED_VARIANT_COLUMNS:
+            assert col in df.columns, f"input scores parquet missing column {col!r}"
+        for col in SCORE_COLUMNS:
+            assert col in df.columns, f"input scores parquet missing column {col!r}"
+
+        per_model = []
+        for model in sorted(df["model"].unique()):
+            sub = df[df["model"] == model]
+            metrics = compute_pairwise_metrics(
+                dataset=sub[list(REQUIRED_VARIANT_COLUMNS)],
+                scores=sub[SCORE_COLUMNS],
+                score_columns=SCORE_COLUMNS,
+                n_min=30,
+            )
+            metrics["model"] = model
+            per_model.append(metrics)
+
+        out = pd.concat(per_model, ignore_index=True)
+        out["dataset"] = wildcards.dataset
+        out["split"] = config["split"]
+        out.to_parquet(output[0], index=False)
+        print(
+            f"[gpn_star_eval] {wildcards.dataset}: {len(out)} metric rows "
+            f"({len(per_model)} models × {len(SCORE_COLUMNS)} score columns × "
+            f"per-subset rows incl. _global_ / _macro_avg_)"
+        )

--- a/snakemake/gpn_star_eval/workflow/rules/score.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/score.smk
@@ -1,0 +1,47 @@
+"""Per-dataset scoring: load HF + GPN-Star prediction parquets, align, write a
+combined long parquet with one row per (model, variant).
+
+Output schema:
+- REQUIRED_VARIANT_COLUMNS (chrom, pos, ref, alt, label, subset, match_group)
+- model: ``"GPN-Star-V" | "GPN-Star-M" | "GPN-Star-P"``
+- llr, abs_llr, llr_calibrated, abs_llr_calibrated (passthrough from
+  predictions parquet)
+- minus_llr, minus_llr_calibrated (derived: ``-llr`` / ``-llr_calibrated``
+  for the leaderboard convention)
+
+Total rows = ``len(MODELS) * n_variants_in_split``.
+"""
+
+
+rule score_variants:
+    output:
+        "results/scores/{dataset}.parquet",
+    wildcard_constraints:
+        dataset="|".join(DATASETS),
+    run:
+        hf_path = f"{config['input_hf_prefix']}_{wildcards.dataset}"
+        hf = load_dataset(hf_path, split=config["split"]).to_pandas()
+        for col in REQUIRED_VARIANT_COLUMNS:
+            assert col in hf.columns, f"HF dataset missing column {col!r}"
+
+        per_model = []
+        for model in MODELS:
+            url = predictions_url(wildcards.dataset, model)
+            preds = pd.read_parquet(url)
+            scores = score_variants_gpn_star(hf, preds, split=config["split"])
+            combined = pd.concat(
+                [
+                    hf[list(REQUIRED_VARIANT_COLUMNS)].reset_index(drop=True),
+                    scores.reset_index(drop=True),
+                ],
+                axis=1,
+            )
+            combined["model"] = f"GPN-Star-{model}"
+            per_model.append(combined)
+
+        out = pd.concat(per_model, ignore_index=True)
+        out.to_parquet(output[0], index=False)
+        print(
+            f"[gpn_star_eval] {wildcards.dataset}: {len(out)} rows "
+            f"({len(MODELS)} models × {len(hf)} variants)"
+        )

--- a/src/bolinas/evals/gpn_star.py
+++ b/src/bolinas/evals/gpn_star.py
@@ -1,0 +1,141 @@
+"""GPN-Star variant-effect scoring on the matched-pair eval datasets.
+
+GPN-Star scoring runs in a separate repo
+([songlab-cal/TraitGym](https://github.com/songlab-cal/TraitGym)), not here.
+The producer publishes prediction parquets to a gist (keyed by
+``(chrom, pos, ref, alt, split)`` with 4 score columns: ``llr``, ``abs_llr``,
+``llr_calibrated``, ``abs_llr_calibrated``). This module is the thin
+load + align layer used by ``snakemake/gpn_star_eval/`` to merge those
+predictions with the HF eval dataset and derive the leaderboard-convention
+``minus_*`` columns.
+
+Two upstream protocol notes (relevant when comparing against other
+leaderboard rows):
+
+- **Calibration.** ``*_calibrated`` columns are pentanucleotide-context
+  background subtracted by the producer:
+  ``llr_calibrated = llr − E[llr | 5-mer, mut]`` and similarly for ``|llr|``.
+  Definition pinned in
+  https://github.com/Open-Athena/bolinas-dna/issues/145#issuecomment-4444680280.
+- **Reverse-complement averaging.** GPN-Star averages predictions over
+  forward + reverse-complement strands. The other gLM rows in this repo's
+  leaderboards (``exp*``) are forward-only — RC averaging is a planned
+  addition.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+GPN_STAR_MODELS: tuple[str, ...] = ("V", "M", "P")
+
+# Per-variant model metadata: (filename suffix used by the producer,
+# human-readable MSA description). The suffix matches the parquet filename
+# convention in the source comment.
+GPN_STAR_MODEL_INFO: dict[str, tuple[str, str]] = {
+    "V": ("v100-200m", "vertebrate, 100-way MSA"),
+    "M": ("m447-200m", "mammal, 447-way MSA"),
+    "P": ("p243-200m", "primate, 243-way MSA"),
+}
+
+# Prediction parquets uploaded by the producer to a gist; pinned commit so the
+# raw URL is stable. Replace if the producer re-uploads.
+GPN_STAR_GIST_BASE: str = (
+    "https://gist.githubusercontent.com/gonzalobenegas/"
+    "facb982f19878b46f8bc4f7f4564416f/raw/"
+    "35bfb2fa160ae0d83811e024b777d429caae43d1"
+)
+
+# Per-dataset leaderboard score column. The calibrated variant is what each
+# leaderboard issue (#161 / #162 / #172) renders. The uncalibrated counterpart
+# is reported in #145 for context.
+GPN_STAR_SCORE_COLUMN: dict[str, str] = {
+    "mendelian_traits": "minus_llr_calibrated",
+    "complex_traits": "abs_llr_calibrated",
+    "eqtl": "abs_llr_calibrated",
+}
+
+
+def predictions_url(dataset: str, model: str) -> str:
+    """Return the gist raw URL for one GPN-Star prediction parquet."""
+    assert model in GPN_STAR_MODELS, f"unknown GPN-Star model {model!r}"
+    return f"{GPN_STAR_GIST_BASE}/bolinas_{dataset}.GPN-Star-{model}.parquet"
+
+
+def score_variants_gpn_star(
+    hf_df: pd.DataFrame,
+    predictions: pd.DataFrame,
+    split: str = "train",
+) -> pd.DataFrame:
+    """Align GPN-Star predictions with an HF eval dataset, row-by-row.
+
+    The producer (TraitGym ``bolinas_pack_predictions``) builds the prediction
+    parquet by horizontal-concatenating ``[chrom, pos, ref, alt, split]``
+    pulled from the HF dataset's ``train.parquet + test.parquet`` with the
+    GPN-Star feature parquet. So filtering ``predictions`` to one split
+    yields the same row order as ``load_dataset(..., split=split).to_pandas()``
+    — **no key-based merge is needed**, just an element-wise alignment assert.
+    If the assert fires, something has changed upstream and a silent merge
+    would mask it.
+
+    Args:
+        hf_df: HF eval dataset's train (or test) split as a pandas DataFrame.
+            Must include ``[chrom, pos, ref, alt]``.
+        predictions: Full GPN-Star prediction parquet (train + test rows).
+            Must include ``[chrom, pos, ref, alt, split, llr, abs_llr,
+            llr_calibrated, abs_llr_calibrated]``.
+        split: Which split of ``predictions`` to filter to. Default ``train``.
+
+    Returns:
+        DataFrame row-aligned with ``hf_df`` (same index order), columns
+        ``[llr, abs_llr, llr_calibrated, abs_llr_calibrated, minus_llr,
+        minus_llr_calibrated]``. The ``minus_*`` columns are ``-llr`` /
+        ``-llr_calibrated`` so positives (pathogenic / direction-of-effect)
+        score higher than negatives — the leaderboard convention for the
+        Mendelian benchmark. For Complex / eQTL the ``abs_*`` columns are
+        used directly.
+
+    Raises:
+        AssertionError on row-count mismatch, key-order mismatch, missing
+        columns, or NaN in any score column.
+    """
+    for col in ("chrom", "pos", "ref", "alt"):
+        assert col in hf_df.columns, f"hf_df missing column {col!r}"
+    for col in (
+        "chrom", "pos", "ref", "alt", "split",
+        "llr", "abs_llr", "llr_calibrated", "abs_llr_calibrated",
+    ):
+        assert col in predictions.columns, f"predictions missing column {col!r}"
+
+    pred_split = predictions[predictions["split"] == split].reset_index(drop=True)
+    hf_df = hf_df.reset_index(drop=True)
+
+    assert len(hf_df) == len(pred_split), (
+        f"row count mismatch: hf_df={len(hf_df)} vs "
+        f"predictions[{split}]={len(pred_split)}"
+    )
+
+    key_cols = ["chrom", "pos", "ref", "alt"]
+    hf_keys = hf_df[key_cols].copy()
+    hf_keys["chrom"] = hf_keys["chrom"].astype(str)
+    pred_keys = pred_split[key_cols].copy()
+    pred_keys["chrom"] = pred_keys["chrom"].astype(str)
+    eq = (hf_keys == pred_keys).all(axis=1)
+    if not eq.all():
+        bad_idx = int((~eq).idxmax())
+        raise AssertionError(
+            f"row alignment broken at index {bad_idx}:\n"
+            f"  hf:   {hf_keys.iloc[bad_idx].to_dict()}\n"
+            f"  pred: {pred_keys.iloc[bad_idx].to_dict()}"
+        )
+
+    raw_cols = ["llr", "abs_llr", "llr_calibrated", "abs_llr_calibrated"]
+    scores = pred_split[raw_cols].reset_index(drop=True).copy()
+    scores["minus_llr"] = -scores["llr"]
+    scores["minus_llr_calibrated"] = -scores["llr_calibrated"]
+
+    for col in scores.columns:
+        n_nan = int(scores[col].isna().sum())
+        assert n_nan == 0, f"score column {col!r} has {n_nan} NaN values"
+
+    return scores

--- a/tests/evals/test_gpn_star.py
+++ b/tests/evals/test_gpn_star.py
@@ -1,0 +1,196 @@
+"""Tests for ``bolinas.evals.gpn_star``."""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+
+from bolinas.evals.gpn_star import (
+    GPN_STAR_GIST_BASE,
+    GPN_STAR_MODELS,
+    GPN_STAR_MODEL_INFO,
+    GPN_STAR_SCORE_COLUMN,
+    predictions_url,
+    score_variants_gpn_star,
+)
+
+
+def _hf(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows)
+
+
+def _preds(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows)
+
+
+def test_score_variants_happy_path() -> None:
+    hf = _hf(
+        [
+            {"chrom": "1", "pos": 100, "ref": "A", "alt": "T"},
+            {"chrom": "1", "pos": 200, "ref": "G", "alt": "C"},
+        ]
+    )
+    preds = _preds(
+        [
+            # train rows, in HF order
+            {"chrom": "1", "pos": 100, "ref": "A", "alt": "T", "split": "train",
+             "llr": -2.0, "abs_llr": 2.0,
+             "llr_calibrated": -1.5, "abs_llr_calibrated": 0.5},
+            {"chrom": "1", "pos": 200, "ref": "G", "alt": "C", "split": "train",
+             "llr": 1.0, "abs_llr": 1.0,
+             "llr_calibrated": 0.7, "abs_llr_calibrated": -0.3},
+            # one test row to confirm filtering
+            {"chrom": "2", "pos": 99, "ref": "A", "alt": "G", "split": "test",
+             "llr": 0.0, "abs_llr": 0.0,
+             "llr_calibrated": 0.0, "abs_llr_calibrated": 0.0},
+        ]
+    )
+    out = score_variants_gpn_star(hf, preds, split="train")
+    assert list(out.columns) == [
+        "llr", "abs_llr", "llr_calibrated", "abs_llr_calibrated",
+        "minus_llr", "minus_llr_calibrated",
+    ]
+    assert out.shape == (2, 6)
+    # minus_* derived correctly
+    assert out["minus_llr"].tolist() == [2.0, -1.0]
+    assert out["minus_llr_calibrated"].tolist() == [1.5, -0.7]
+    # abs_* passed through unchanged (incl. the negative abs_llr_calibrated
+    # value, which is fine — calibration can push it below zero).
+    assert out["abs_llr_calibrated"].tolist() == [0.5, -0.3]
+
+
+def test_score_variants_row_count_mismatch() -> None:
+    hf = _hf([{"chrom": "1", "pos": 100, "ref": "A", "alt": "T"}])
+    preds = _preds(
+        [
+            {"chrom": "1", "pos": 100, "ref": "A", "alt": "T", "split": "train",
+             "llr": 0.0, "abs_llr": 0.0,
+             "llr_calibrated": 0.0, "abs_llr_calibrated": 0.0},
+            {"chrom": "1", "pos": 200, "ref": "G", "alt": "C", "split": "train",
+             "llr": 0.0, "abs_llr": 0.0,
+             "llr_calibrated": 0.0, "abs_llr_calibrated": 0.0},
+        ]
+    )
+    with pytest.raises(AssertionError, match="row count mismatch"):
+        score_variants_gpn_star(hf, preds, split="train")
+
+
+def test_score_variants_row_alignment_mismatch() -> None:
+    hf = _hf(
+        [
+            {"chrom": "1", "pos": 100, "ref": "A", "alt": "T"},
+            {"chrom": "1", "pos": 200, "ref": "G", "alt": "C"},
+        ]
+    )
+    preds = _preds(
+        [
+            {"chrom": "1", "pos": 100, "ref": "A", "alt": "T", "split": "train",
+             "llr": 0.0, "abs_llr": 0.0,
+             "llr_calibrated": 0.0, "abs_llr_calibrated": 0.0},
+            # pos 300 instead of 200 → alignment breaks at index 1
+            {"chrom": "1", "pos": 300, "ref": "G", "alt": "C", "split": "train",
+             "llr": 0.0, "abs_llr": 0.0,
+             "llr_calibrated": 0.0, "abs_llr_calibrated": 0.0},
+        ]
+    )
+    with pytest.raises(AssertionError, match="row alignment broken at index 1"):
+        score_variants_gpn_star(hf, preds, split="train")
+
+
+def test_score_variants_nan_score() -> None:
+    hf = _hf([{"chrom": "1", "pos": 100, "ref": "A", "alt": "T"}])
+    preds = _preds(
+        [
+            {"chrom": "1", "pos": 100, "ref": "A", "alt": "T", "split": "train",
+             "llr": math.nan, "abs_llr": 1.0,
+             "llr_calibrated": 0.0, "abs_llr_calibrated": 0.0},
+        ]
+    )
+    with pytest.raises(AssertionError, match="NaN"):
+        score_variants_gpn_star(hf, preds, split="train")
+
+
+def test_score_variants_chrom_dtype_string_vs_object() -> None:
+    """HF chrom may be pandas StringDtype while predictions has object/str;
+    both sides get cast to str inside, so the alignment assert should pass."""
+    hf = pd.DataFrame({
+        "chrom": pd.array(["1"], dtype="string"),
+        "pos": [100], "ref": ["A"], "alt": ["T"],
+    })
+    preds = pd.DataFrame({
+        "chrom": ["1"], "pos": [100], "ref": ["A"], "alt": ["T"],
+        "split": ["train"],
+        "llr": [-1.0], "abs_llr": [1.0],
+        "llr_calibrated": [-0.5], "abs_llr_calibrated": [0.5],
+    })
+    out = score_variants_gpn_star(hf, preds, split="train")
+    assert len(out) == 1
+    assert out["minus_llr"].iloc[0] == 1.0
+    assert out["minus_llr_calibrated"].iloc[0] == 0.5
+
+
+def test_score_variants_split_filter_test() -> None:
+    """``split`` arg controls which subset of predictions is used."""
+    hf = _hf([{"chrom": "X", "pos": 5, "ref": "T", "alt": "G"}])
+    preds = _preds(
+        [
+            {"chrom": "1", "pos": 1, "ref": "A", "alt": "C", "split": "train",
+             "llr": 0.0, "abs_llr": 0.0,
+             "llr_calibrated": 0.0, "abs_llr_calibrated": 0.0},
+            {"chrom": "X", "pos": 5, "ref": "T", "alt": "G", "split": "test",
+             "llr": -3.0, "abs_llr": 3.0,
+             "llr_calibrated": -2.5, "abs_llr_calibrated": 2.5},
+        ]
+    )
+    out = score_variants_gpn_star(hf, preds, split="test")
+    assert out["minus_llr"].iloc[0] == 3.0
+
+
+def test_score_variants_missing_hf_column() -> None:
+    hf = _hf([{"chrom": "1", "pos": 100, "ref": "A"}])  # no alt
+    preds = _preds(
+        [{"chrom": "1", "pos": 100, "ref": "A", "alt": "T", "split": "train",
+          "llr": 0.0, "abs_llr": 0.0,
+          "llr_calibrated": 0.0, "abs_llr_calibrated": 0.0}]
+    )
+    with pytest.raises(AssertionError, match="hf_df missing column 'alt'"):
+        score_variants_gpn_star(hf, preds, split="train")
+
+
+def test_score_variants_missing_pred_column() -> None:
+    hf = _hf([{"chrom": "1", "pos": 100, "ref": "A", "alt": "T"}])
+    preds = _preds([{"chrom": "1", "pos": 100, "ref": "A", "alt": "T",
+                     "split": "train", "llr": 0.0, "abs_llr": 0.0,
+                     "llr_calibrated": 0.0}])  # no abs_llr_calibrated
+    with pytest.raises(AssertionError, match="predictions missing column 'abs_llr_calibrated'"):
+        score_variants_gpn_star(hf, preds, split="train")
+
+
+def test_predictions_url_format() -> None:
+    assert predictions_url("mendelian_traits", "V") == (
+        f"{GPN_STAR_GIST_BASE}/bolinas_mendelian_traits.GPN-Star-V.parquet"
+    )
+    assert predictions_url("eqtl", "P") == (
+        f"{GPN_STAR_GIST_BASE}/bolinas_eqtl.GPN-Star-P.parquet"
+    )
+
+
+def test_predictions_url_unknown_model() -> None:
+    with pytest.raises(AssertionError, match="unknown GPN-Star model"):
+        predictions_url("mendelian_traits", "X")
+
+
+def test_score_column_per_dataset_convention() -> None:
+    # Mendelian uses signed (pathogenic ⇒ alt depleted under purifying selection).
+    assert GPN_STAR_SCORE_COLUMN["mendelian_traits"] == "minus_llr_calibrated"
+    # Complex / eQTL use magnitude (direction-agnostic; eQTLs can go either way).
+    assert GPN_STAR_SCORE_COLUMN["complex_traits"] == "abs_llr_calibrated"
+    assert GPN_STAR_SCORE_COLUMN["eqtl"] == "abs_llr_calibrated"
+    # No surprise datasets.
+    assert set(GPN_STAR_SCORE_COLUMN) == {"mendelian_traits", "complex_traits", "eqtl"}
+
+
+def test_model_info_keys_match_models_tuple() -> None:
+    assert set(GPN_STAR_MODEL_INFO) == set(GPN_STAR_MODELS)


### PR DESCRIPTION
## Summary

Wires GPN-Star V/M/P into the leaderboard regeneration path so the rows survive future `leaderboard_gen.py --patch-issues` runs (they wouldn't before — predictions are scored externally by [songlab-cal/TraitGym](https://github.com/songlab-cal/TraitGym), not by any bolinas pipeline).

Three new pieces:

1. **`bolinas.evals.gpn_star`** — load + row-align helper for the externally-produced prediction parquets. Pure functions, 12 unit tests.
2. **`snakemake/gpn_star_eval/`** — two-rule pipeline (score → metrics) mirroring `alphagenome_eval/`. Pulls 9 prediction parquets from the pinned gist, row-aligns with HF train split, computes PA ± SE per `(model, score_type, subset)`, writes to `s3://oa-bolinas/snakemake/gpn_star_eval/results/`. Pure CPU; ~20 s wallclock.
3. **`leaderboard_gen.py`** updates: 4th `gather_methods` block reading from the new S3 prefix, `build_table` sorts methods by `Global` PA descending, hardcoded GPN-Star changelog entry idempotent against the manually-applied 2026-05-13 entries.

Pipeline has already been run against S3; metrics parquets are live at `s3://oa-bolinas/snakemake/gpn_star_eval/results/metrics/{mendelian_traits,complex_traits,eqtl}.parquet`.

## Validation

- All 12 new tests pass (`tests/evals/test_gpn_star.py`).
- S3 metric values match my earlier scratch computation exactly (max float diff `0.00e+00` across all 60 comparable rows per dataset).
- Re-running `leaderboard_gen.py` (no patch) reproduces the current leaderboards verbatim for **Mendelian (#161)** and **eQTL (#172)**. For **Complex traits (#162)**, the regenerated table differs from the live body by one tied-row swap: `phyloP_470m` (raw Global `0.559397`) now correctly sorts above `phastCons_100v` (raw `0.558511`), where both round to `0.559` in display. My manual sort tied them on the displayed value — the regenerator uses the raw float, which is more correct. **Not auto-PATCHed**: a follow-up `gh api -X PATCH` (or `uv run python snakemake/evals/scratch/leaderboard_gen.py --patch-issues`) will apply the swap. Your call whether to push it; the metric values are identical, only the row order changes cosmetically.

## Test plan

- [ ] `uv run pytest tests/evals/test_gpn_star.py -v` — should pass 12/12.
- [ ] `cd snakemake/gpn_star_eval && uv run snakemake -n` — should plan 7 jobs (3 score + 3 metrics + all), no unrelated reruns.
- [ ] `uv run python snakemake/evals/scratch/leaderboard_gen.py` (no `--patch-issues`) — should print 3 tables matching the live leaderboards modulo the one tied-row swap in #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)