### PR TITLE
evals_v2: expand checkpoints + refresh mendelian leaderboard (#161)

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -41,11 +41,14 @@ results/
 
 - **Train split only.** Test is held out for the final-eval pass; train is
   the development split.
-- **Two context conventions are supported.** Per-model `window_size` config
-  field selects the number of DNA bases extracted (255 or 256). The
-  tokenizer loaded from each checkpoint handles BOS itself.
+- **Three context conventions are supported.** Per-model `window_size`
+  config field selects the number of DNA bases extracted. The tokenizer
+  loaded from each checkpoint handles BOS itself.
   - 255 = BOS-using runs (e.g. `exp136-proj_v30`, `exp166-p1B`).
-  - 256 = no-BOS runs (e.g. `exp55/58/59`).
+  - 256 = no-BOS runs at 256-token context (e.g. `exp55/58/59`).
+  - 512 = no-BOS runs trained at 512 bp context (e.g. `exp21` promoter-yolo).
+    Pair with a per-model `batch_size:` override to fit on an A10G; the
+    global default of 128 is tuned for 256-context.
 
 ## Setup
 
@@ -88,7 +91,7 @@ at `s3://oa-bolinas/snakemake/analysis/evals_v2/`.
 | `genome_path` | Canonical GRCh38 FASTA. fsspec URI (e.g. `s3://...`) or local path. The S3 path requires `--group genome-s3` at install time. |
 | `split` | `train` (or `test` once held-out eval is unlocked). |
 | `datasets` | List of `{name, score_column}`. |
-| `models` | List of `{name, window_size, ...}`. Each entry has exactly one of `gcs_path` (full GCS URI incl. `/hf/step-{N}`) or `hf_repo` (HuggingFace Hub repo ID). |
+| `models` | List of `{name, window_size, ...}`. Each entry has exactly one of `gcs_path` (full GCS URI incl. `/hf/step-{N}`) or `hf_repo` (HuggingFace Hub repo ID), plus two optional fields: `datasets: [...]` to restrict which `datasets` this checkpoint evaluates on (defaults to all), and `batch_size: N` to override the global `inference.batch_size` for this checkpoint (useful when context size differs from the global default's tuning). |
 | `inference.*` | Batch size, workers, `data_transform_on_the_fly`, `torch_compile`, `rc_avg` (FWD+RC averaging — doubles inference time). |
 
 ## Library

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -62,6 +62,21 @@ models:
     hf_repo: bolinas-dna/exp166-p1B-step-16398   # 1B zoonomia-v1-v1 generalist
     window_size: 255
 
+  # exp136 — enhancer-curation proj_v30, intermediate checkpoints (issue #136).
+  # Native Levanter checkpoints were saved at every num_train_steps // 3 step
+  # (CHECKPOINTS_PER_RUN = 3 in marin's exp136_enhancer_curation.py); the
+  # 3333/6666 intermediates were exported to HF after the fact (the original
+  # `hf/` only had step-9999 — see `exp136-proj_v30` entry above for that
+  # final checkpoint). Scoped to mendelian_traits for the convergence curve.
+  - name: exp136-proj_v30-step-3333
+    gcs_path: gs://marin-us-central1/checkpoints/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0/hf/step-3333
+    window_size: 255
+    datasets: [mendelian_traits]
+  - name: exp136-proj_v30-step-6666
+    gcs_path: gs://marin-us-central1/checkpoints/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0/hf/step-6666
+    window_size: 255
+    datasets: [mendelian_traits]
+
   # exp21 — animal-promoters-yolo (issue #21, wandb animal-promoters-yolo-r01-213a8e).
   # 512 bp context, no BOS. Scoped to mendelian_traits only: complex/eqtl signal
   # was weak in #21, and the matched-pair mendelian dataset is the one of

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -188,6 +188,11 @@ models:
     window_size: 512
     datasets: [mendelian_traits]
     batch_size: 64
+  - name: exp27-cds-yolo-step-34000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-cds-yolo-repeat-weight-0.01-r01-e8cb9b/hf/step-34000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
 
   # exp13 — promoter-cds-mixture-equal-r01-b67fd1 (50% promoter / 50% CDS).
   - name: exp13-mixture-equal-step-2000

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -79,7 +79,15 @@ models:
 
   # exp166 v0.1 — new generalist 1B run (separate from the older
   # `exp166-p1B` HF entry above which is the earlier step-16398 export).
-  # This is the final checkpoint of the c127da run that just finished.
+  # 3 HF-exported checkpoints from the c127da run: 10000, 20000, 27329 (final).
+  - name: exp166-v0.1-p1B-step-10000
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-exp166-v0.1-p1B-c127da/hf/step-10000
+    window_size: 255
+    datasets: [mendelian_traits]
+  - name: exp166-v0.1-p1B-step-20000
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-exp166-v0.1-p1B-c127da/hf/step-20000
+    window_size: 255
+    datasets: [mendelian_traits]
   - name: exp166-v0.1-p1B-step-27329
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-exp166-v0.1-p1B-c127da/hf/step-27329
     window_size: 255

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -66,53 +66,53 @@ models:
   # 512 bp context, no BOS. Scoped to mendelian_traits only: complex/eqtl signal
   # was weak in #21, and the matched-pair mendelian dataset is the one of
   # interest for tracking promoter-relevant convergence over training steps.
-  # batch_size: 32 is a conservative starting point for 512-context on A10G;
-  # bump up if `nvidia-smi` shows headroom.
+  # batch_size: 64 fits within A10G VRAM at 512-context (~32% VRAM at 32 →
+  # ~65% at 64); validated mid-run by nvidia-smi after the first compute_scores.
   - name: exp21-promoters-yolo-step-2000
     gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-2000
     window_size: 512
     datasets: [mendelian_traits]
-    batch_size: 32
+    batch_size: 64
   - name: exp21-promoters-yolo-step-6000
     gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-6000
     window_size: 512
     datasets: [mendelian_traits]
-    batch_size: 32
+    batch_size: 64
   - name: exp21-promoters-yolo-step-10000
     gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-10000
     window_size: 512
     datasets: [mendelian_traits]
-    batch_size: 32
+    batch_size: 64
   - name: exp21-promoters-yolo-step-12000
     gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-12000
     window_size: 512
     datasets: [mendelian_traits]
-    batch_size: 32
+    batch_size: 64
   - name: exp21-promoters-yolo-step-14000
     gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-14000
     window_size: 512
     datasets: [mendelian_traits]
-    batch_size: 32
+    batch_size: 64
   - name: exp21-promoters-yolo-step-16000
     gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-16000
     window_size: 512
     datasets: [mendelian_traits]
-    batch_size: 32
+    batch_size: 64
   - name: exp21-promoters-yolo-step-18000
     gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-18000
     window_size: 512
     datasets: [mendelian_traits]
-    batch_size: 32
+    batch_size: 64
   - name: exp21-promoters-yolo-step-20000
     gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-20000
     window_size: 512
     datasets: [mendelian_traits]
-    batch_size: 32
+    batch_size: 64
   - name: exp21-promoters-yolo-step-22000
     gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-22000
     window_size: 512
     datasets: [mendelian_traits]
-    batch_size: 32
+    batch_size: 64
 
 inference:
   batch_size: 128       # Was 64 with output_hidden_states=True keeping all

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -114,6 +114,124 @@ models:
     datasets: [mendelian_traits]
     batch_size: 64
 
+  # exp13/exp27 — promoter × CDS mixture sweep (issue #13). 4-way comparison
+  # of Qwen3-1.7B trained on: 100% promoters (exp21 above), 50/50 mix (exp13
+  # equal), 10/90 mix (exp13 proportional), 100% CDS (exp27 cds-yolo). All
+  # 512 bp context, no BOS. Step list 2000/6000/10000/14000/18000/22000 is
+  # the harmonized intersection that aligns with exp21's GCS ceiling; +26000
+  # added for the 3 runs that trained that far. mendelian_traits only.
+
+  # exp27 — animal-cds-yolo-repeat-weight-0.01-r01-e8cb9b (100% CDS).
+  - name: exp27-cds-yolo-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-cds-yolo-repeat-weight-0.01-r01-e8cb9b/hf/step-2000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp27-cds-yolo-step-6000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-cds-yolo-repeat-weight-0.01-r01-e8cb9b/hf/step-6000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp27-cds-yolo-step-10000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-cds-yolo-repeat-weight-0.01-r01-e8cb9b/hf/step-10000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp27-cds-yolo-step-14000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-cds-yolo-repeat-weight-0.01-r01-e8cb9b/hf/step-14000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp27-cds-yolo-step-18000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-cds-yolo-repeat-weight-0.01-r01-e8cb9b/hf/step-18000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp27-cds-yolo-step-22000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-cds-yolo-repeat-weight-0.01-r01-e8cb9b/hf/step-22000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp27-cds-yolo-step-26000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-cds-yolo-repeat-weight-0.01-r01-e8cb9b/hf/step-26000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+
+  # exp13 — promoter-cds-mixture-equal-r01-b67fd1 (50% promoter / 50% CDS).
+  - name: exp13-mixture-equal-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-equal-r01-b67fd1/hf/step-2000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-equal-step-6000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-equal-r01-b67fd1/hf/step-6000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-equal-step-10000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-equal-r01-b67fd1/hf/step-10000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-equal-step-14000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-equal-r01-b67fd1/hf/step-14000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-equal-step-18000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-equal-r01-b67fd1/hf/step-18000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-equal-step-22000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-equal-r01-b67fd1/hf/step-22000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-equal-step-26000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-equal-r01-b67fd1/hf/step-26000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+
+  # exp13 — promoter-cds-mixture-proportional-r01-6705f1 (10% promoter / 90% CDS).
+  - name: exp13-mixture-proportional-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-proportional-r01-6705f1/hf/step-2000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-proportional-step-6000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-proportional-r01-6705f1/hf/step-6000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-proportional-step-10000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-proportional-r01-6705f1/hf/step-10000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-proportional-step-14000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-proportional-r01-6705f1/hf/step-14000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-proportional-step-18000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-proportional-r01-6705f1/hf/step-18000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-proportional-step-22000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-proportional-r01-6705f1/hf/step-22000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+  - name: exp13-mixture-proportional-step-26000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-proportional-r01-6705f1/hf/step-26000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 64
+
 inference:
   batch_size: 128       # Was 64 with output_hidden_states=True keeping all
                         # 19+2 layers' activations alive (~2.6 GB at L=256,

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -77,6 +77,14 @@ models:
     window_size: 255
     datasets: [mendelian_traits]
 
+  # exp166 v0.1 — new generalist 1B run (separate from the older
+  # `exp166-p1B` HF entry above which is the earlier step-16398 export).
+  # This is the final checkpoint of the c127da run that just finished.
+  - name: exp166-v0.1-p1B-step-27329
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-exp166-v0.1-p1B-c127da/hf/step-27329
+    window_size: 255
+    datasets: [mendelian_traits]
+
   # exp21 — animal-promoters-yolo (issue #21, wandb animal-promoters-yolo-r01-213a8e).
   # 512 bp context, no BOS. Scoped to mendelian_traits only: complex/eqtl signal
   # was weak in #21, and the matched-pair mendelian dataset is the one of

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -28,6 +28,15 @@ datasets:
 # `window_size` is the number of DNA bases extracted per variant context.
 # 256 = old convention (no BOS, e.g. exp55/58/59).
 # 255 = new convention (BOS prepended, e.g. exp136 / exp166-p1B).
+# 512 = older 512-context runs trained without BOS (e.g. exp21 promoter-yolo);
+#       pair with a per-model `batch_size` override to fit on an A10G.
+#
+# Optional per-model fields:
+#   - `datasets: [name, …]`  Restrict evaluation to a subset of the configured
+#                            `datasets`. Omit to run on all of them.
+#   - `batch_size: N`        Override `inference.batch_size` for this checkpoint.
+#                            Useful when the global default is tuned for a
+#                            different context size.
 models:
   - name: exp55-mammals
     gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-mammals-r01-52f413/hf/step-16999
@@ -52,6 +61,58 @@ models:
   - name: exp166-p1B
     hf_repo: bolinas-dna/exp166-p1B-step-16398   # 1B zoonomia-v1-v1 generalist
     window_size: 255
+
+  # exp21 — animal-promoters-yolo (issue #21, wandb animal-promoters-yolo-r01-213a8e).
+  # 512 bp context, no BOS. Scoped to mendelian_traits only: complex/eqtl signal
+  # was weak in #21, and the matched-pair mendelian dataset is the one of
+  # interest for tracking promoter-relevant convergence over training steps.
+  # batch_size: 32 is a conservative starting point for 512-context on A10G;
+  # bump up if `nvidia-smi` shows headroom.
+  - name: exp21-promoters-yolo-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-2000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 32
+  - name: exp21-promoters-yolo-step-6000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-6000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 32
+  - name: exp21-promoters-yolo-step-10000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-10000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 32
+  - name: exp21-promoters-yolo-step-12000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-12000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 32
+  - name: exp21-promoters-yolo-step-14000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-14000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 32
+  - name: exp21-promoters-yolo-step-16000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-16000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 32
+  - name: exp21-promoters-yolo-step-18000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-18000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 32
+  - name: exp21-promoters-yolo-step-20000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-20000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 32
+  - name: exp21-promoters-yolo-step-22000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/animal-promoters-yolo-r01-213a8e/hf/step-22000
+    window_size: 512
+    datasets: [mendelian_traits]
+    batch_size: 32
 
 inference:
   batch_size: 128       # Was 64 with output_hidden_states=True keeping all

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -232,6 +232,278 @@ models:
     datasets: [mendelian_traits]
     batch_size: 64
 
+  # exp55/exp58 — promoters/CDS across evolutionary timescales (issues #55, #58).
+  # 256 bp context, no BOS (older convention; smaller models than exp21/13/27).
+  # Step list 1000/2000/3000/4000/5000/9000/13000/16999 (16999 is the final
+  # checkpoint — no step-17000). For exp55-mammals, exp58-mammals, exp58-animals
+  # the step-16999 slot is already covered by the existing single-step entries
+  # above (which have datasets: unset = all three eval datasets), so it's not
+  # duplicated here. Datasets scoped to mendelian_traits to mirror the issue
+  # plots; uses global inference.batch_size (128).
+
+  # exp55 humans — promoters trained on humans timescale (issue #55).
+  - name: exp55-humans-step-1000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-humans-r01-0fa9f3/hf/step-1000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-humans-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-humans-r01-0fa9f3/hf/step-2000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-humans-step-3000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-humans-r01-0fa9f3/hf/step-3000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-humans-step-4000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-humans-r01-0fa9f3/hf/step-4000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-humans-step-5000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-humans-r01-0fa9f3/hf/step-5000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-humans-step-9000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-humans-r01-0fa9f3/hf/step-9000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-humans-step-13000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-humans-r01-0fa9f3/hf/step-13000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-humans-step-16999
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-humans-r01-0fa9f3/hf/step-16999
+    window_size: 256
+    datasets: [mendelian_traits]
+
+  # exp55 primates — promoters trained on primates timescale (issue #55).
+  - name: exp55-primates-step-1000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-primates-r01-70b1a5/hf/step-1000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-primates-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-primates-r01-70b1a5/hf/step-2000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-primates-step-3000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-primates-r01-70b1a5/hf/step-3000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-primates-step-4000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-primates-r01-70b1a5/hf/step-4000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-primates-step-5000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-primates-r01-70b1a5/hf/step-5000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-primates-step-9000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-primates-r01-70b1a5/hf/step-9000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-primates-step-13000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-primates-r01-70b1a5/hf/step-13000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-primates-step-16999
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-primates-r01-70b1a5/hf/step-16999
+    window_size: 256
+    datasets: [mendelian_traits]
+
+  # exp55 mammals — promoters trained on mammals timescale (issue #55).
+  # step-16999 already covered by the existing `exp55-mammals` entry above.
+  - name: exp55-mammals-step-1000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-mammals-r01-52f413/hf/step-1000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-mammals-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-mammals-r01-52f413/hf/step-2000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-mammals-step-3000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-mammals-r01-52f413/hf/step-3000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-mammals-step-4000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-mammals-r01-52f413/hf/step-4000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-mammals-step-5000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-mammals-r01-52f413/hf/step-5000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-mammals-step-9000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-mammals-r01-52f413/hf/step-9000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-mammals-step-13000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-mammals-r01-52f413/hf/step-13000
+    window_size: 256
+    datasets: [mendelian_traits]
+
+  # exp55 vertebrates — promoters trained on vertebrates timescale (issue #55).
+  - name: exp55-vertebrates-step-1000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-vertebrates-r01-64b0da/hf/step-1000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-vertebrates-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-vertebrates-r01-64b0da/hf/step-2000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-vertebrates-step-3000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-vertebrates-r01-64b0da/hf/step-3000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-vertebrates-step-4000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-vertebrates-r01-64b0da/hf/step-4000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-vertebrates-step-5000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-vertebrates-r01-64b0da/hf/step-5000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-vertebrates-step-9000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-vertebrates-r01-64b0da/hf/step-9000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-vertebrates-step-13000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-vertebrates-r01-64b0da/hf/step-13000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-vertebrates-step-16999
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-vertebrates-r01-64b0da/hf/step-16999
+    window_size: 256
+    datasets: [mendelian_traits]
+
+  # exp55 animals — promoters trained on animals timescale (issue #55).
+  - name: exp55-animals-step-1000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-animals-r01-c5dd2f/hf/step-1000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-animals-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-animals-r01-c5dd2f/hf/step-2000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-animals-step-3000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-animals-r01-c5dd2f/hf/step-3000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-animals-step-4000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-animals-r01-c5dd2f/hf/step-4000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-animals-step-5000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-animals-r01-c5dd2f/hf/step-5000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-animals-step-9000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-animals-r01-c5dd2f/hf/step-9000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-animals-step-13000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-animals-r01-c5dd2f/hf/step-13000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp55-animals-step-16999
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp55-animals-r01-c5dd2f/hf/step-16999
+    window_size: 256
+    datasets: [mendelian_traits]
+
+  # exp58 mammals — CDS trained on mammals timescale (issue #58).
+  # step-16999 already covered by the existing `exp58-mammals` entry above.
+  - name: exp58-mammals-step-1000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-mammals-r01-23d451/hf/step-1000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-mammals-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-mammals-r01-23d451/hf/step-2000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-mammals-step-3000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-mammals-r01-23d451/hf/step-3000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-mammals-step-4000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-mammals-r01-23d451/hf/step-4000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-mammals-step-5000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-mammals-r01-23d451/hf/step-5000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-mammals-step-9000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-mammals-r01-23d451/hf/step-9000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-mammals-step-13000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-mammals-r01-23d451/hf/step-13000
+    window_size: 256
+    datasets: [mendelian_traits]
+
+  # exp58 vertebrates — CDS trained on vertebrates timescale (issue #58).
+  - name: exp58-vertebrates-step-1000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-vertebrates-r01-771c3a/hf/step-1000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-vertebrates-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-vertebrates-r01-771c3a/hf/step-2000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-vertebrates-step-3000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-vertebrates-r01-771c3a/hf/step-3000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-vertebrates-step-4000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-vertebrates-r01-771c3a/hf/step-4000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-vertebrates-step-5000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-vertebrates-r01-771c3a/hf/step-5000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-vertebrates-step-9000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-vertebrates-r01-771c3a/hf/step-9000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-vertebrates-step-13000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-vertebrates-r01-771c3a/hf/step-13000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-vertebrates-step-16999
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-vertebrates-r01-771c3a/hf/step-16999
+    window_size: 256
+    datasets: [mendelian_traits]
+
+  # exp58 animals — CDS trained on animals timescale (issue #58).
+  # step-16999 already covered by the existing `exp58-animals` entry above.
+  - name: exp58-animals-step-1000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-animals-r01-1e3682/hf/step-1000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-animals-step-2000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-animals-r01-1e3682/hf/step-2000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-animals-step-3000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-animals-r01-1e3682/hf/step-3000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-animals-step-4000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-animals-r01-1e3682/hf/step-4000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-animals-step-5000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-animals-r01-1e3682/hf/step-5000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-animals-step-9000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-animals-r01-1e3682/hf/step-9000
+    window_size: 256
+    datasets: [mendelian_traits]
+  - name: exp58-animals-step-13000
+    gcs_path: gs://marin-dna-us-central1/checkpoints/exp58-animals-r01-1e3682/hf/step-13000
+    window_size: 256
+    datasets: [mendelian_traits]
+
 inference:
   batch_size: 128       # Was 64 with output_hidden_states=True keeping all
                         # 19+2 layers' activations alive (~2.6 GB at L=256,

--- a/snakemake/analysis/evals_v2/workflow/Snakefile
+++ b/snakemake/analysis/evals_v2/workflow/Snakefile
@@ -13,8 +13,8 @@ include: "rules/metrics.smk"
 
 rule all:
     input:
-        expand(
-            "results/metrics/{model}/{dataset}.parquet",
-            model=[m["name"] for m in config["models"]],
-            dataset=[d["name"] for d in config["datasets"]],
-        ),
+        [
+            f"results/metrics/{m['name']}/{d}.parquet"
+            for m in config["models"]
+            for d in get_model_datasets(m["name"])
+        ],

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -29,9 +29,9 @@ def get_model_config(name):
 for _m in config["models"]:
     _has_gcs = "gcs_path" in _m
     _has_hf = "hf_repo" in _m
-    assert _has_gcs ^ _has_hf, (
-        f"model {_m['name']!r} must have exactly one of `gcs_path` or `hf_repo`"
-    )
+    assert (
+        _has_gcs ^ _has_hf
+    ), f"model {_m['name']!r} must have exactly one of `gcs_path` or `hf_repo`"
 
 
 # Wildcard alternations used across rules.
@@ -58,6 +58,10 @@ def get_model_datasets(model_name):
 
 def get_model_batch_size(model_name):
     """Per-model ``batch_size`` if set, else the global ``inference.batch_size``."""
-    return get_model_config(model_name).get(
+    bs = get_model_config(model_name).get(
         "batch_size", config["inference"]["batch_size"]
     )
+    assert (
+        isinstance(bs, int) and bs > 0
+    ), f"model {model_name!r} `batch_size` must be a positive int, got {bs!r}"
+    return bs

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -37,3 +37,27 @@ for _m in config["models"]:
 # Wildcard alternations used across rules.
 DATASETS = [d["name"] for d in config["datasets"]]
 MODELS = [m["name"] for m in config["models"]]
+
+
+def get_model_datasets(model_name):
+    """Datasets a given model is evaluated on.
+
+    Defaults to all configured datasets; a model entry may set
+    ``datasets: [name, …]`` to restrict evaluation to a subset.
+    """
+    cfg = get_model_config(model_name)
+    if "datasets" not in cfg:
+        return DATASETS
+    bad = [d for d in cfg["datasets"] if d not in DATASETS]
+    assert not bad, (
+        f"model {model_name!r} `datasets` references unknown names: {bad} "
+        f"(known: {DATASETS})"
+    )
+    return cfg["datasets"]
+
+
+def get_model_batch_size(model_name):
+    """Per-model ``batch_size`` if set, else the global ``inference.batch_size``."""
+    return get_model_config(model_name).get(
+        "batch_size", config["inference"]["batch_size"]
+    )

--- a/snakemake/analysis/evals_v2/workflow/rules/download.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/download.smk
@@ -22,15 +22,19 @@ rule download_model:
     wildcard_constraints:
         model="|".join(MODELS),
     params:
-        cfg=lambda wc: get_model_config(wc.model),
+        # Only the source URL/repo affects the download output. Other
+        # per-model fields (window_size, batch_size, datasets, …) don't,
+        # so they intentionally stay out of `params:` and won't trigger
+        # a re-download when tuned.
+        gcs_path=lambda wc: get_model_config(wc.model).get("gcs_path", ""),
+        hf_repo=lambda wc: get_model_config(wc.model).get("hf_repo", ""),
     run:
-        cfg = params.cfg
         out = output[0]
-        if "gcs_path" in cfg:
-            shell(f"mkdir -p {out} && gcloud storage cp -r '{cfg['gcs_path']}/*' {out}/")
-        elif "hf_repo" in cfg:
+        if params.gcs_path:
+            shell(f"mkdir -p {out} && gcloud storage cp -r '{params.gcs_path}/*' {out}/")
+        elif params.hf_repo:
             from huggingface_hub import snapshot_download
-            snapshot_download(repo_id=cfg["hf_repo"], local_dir=out)
+            snapshot_download(repo_id=params.hf_repo, local_dir=out)
         else:
             raise ValueError(
                 f"model {wildcards.model!r} needs `gcs_path` or `hf_repo`"

--- a/snakemake/analysis/evals_v2/workflow/rules/inference.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/inference.smk
@@ -17,6 +17,8 @@ rule compute_scores:
         # 255 for BOS-using checkpoints (e.g. exp136), 256 for older runs;
         # the tokenizer baked into each checkpoint handles BOS itself.
         window_size=lambda wc: get_model_config(wc.model)["window_size"],
+        # Per-model override; falls back to config["inference"]["batch_size"].
+        batch_size=lambda wc: get_model_batch_size(wc.model),
         hf_path=lambda wc: f"{config['input_hf_prefix']}_{wc.dataset}",
     threads: config["inference"]["num_workers"]
     run:
@@ -31,7 +33,7 @@ rule compute_scores:
             # no full download. Requires `--group genome-s3`.
             genome_path=config["genome_path"],
             context_size=params.window_size,
-            batch_size=config["inference"]["batch_size"],
+            batch_size=params.batch_size,
             num_workers=config["inference"]["num_workers"],
             data_transform_on_the_fly=config["inference"]["data_transform_on_the_fly"],
             torch_compile=config["inference"]["torch_compile"],

--- a/snakemake/analysis/evals_v2/workflow/rules/inference.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/inference.smk
@@ -16,12 +16,19 @@ rule compute_scores:
     params:
         # 255 for BOS-using checkpoints (e.g. exp136), 256 for older runs;
         # the tokenizer baked into each checkpoint handles BOS itself.
+        # NOTE: only output-affecting fields belong in `params:` — values
+        # here are tracked by snakemake's `params` rerun trigger. Execution-
+        # only knobs (e.g. batch_size) are read inside `run:` instead so
+        # tuning them doesn't force a re-run of finished work.
         window_size=lambda wc: get_model_config(wc.model)["window_size"],
-        # Per-model override; falls back to config["inference"]["batch_size"].
-        batch_size=lambda wc: get_model_batch_size(wc.model),
         hf_path=lambda wc: f"{config['input_hf_prefix']}_{wc.dataset}",
     threads: config["inference"]["num_workers"]
     run:
+        # batch_size is per-model but execution-only (numerics are batch-
+        # size-invariant modulo float-reduction noise), so we read it here
+        # rather than declare it as a snakemake param. See note in `params:`.
+        batch_size = get_model_batch_size(wildcards.model)
+
         ds = load_dataset(params.hf_path, split=config["split"]).to_pandas()
         for col in REQUIRED_VARIANT_COLUMNS:
             assert col in ds.columns, f"dataset missing column {col!r}"
@@ -33,7 +40,7 @@ rule compute_scores:
             # no full download. Requires `--group genome-s3`.
             genome_path=config["genome_path"],
             context_size=params.window_size,
-            batch_size=params.batch_size,
+            batch_size=batch_size,
             num_workers=config["inference"]["num_workers"],
             data_transform_on_the_fly=config["inference"]["data_transform_on_the_fly"],
             torch_compile=config["inference"]["torch_compile"],

--- a/snakemake/evals/scratch/leaderboard_gen.py
+++ b/snakemake/evals/scratch/leaderboard_gen.py
@@ -33,8 +33,11 @@ import json
 import re
 import subprocess
 from datetime import date
+from pathlib import Path
+from typing import NamedTuple
 
 import polars as pl
+import yaml
 
 from bolinas.pipelines.evals.gpn_star import GPN_STAR_MODELS, GPN_STAR_SCORE_COLUMN
 from bolinas.pipelines.evals.metrics import GLOBAL_SUBSET, MACRO_AVG_SUBSET
@@ -54,13 +57,113 @@ SCORE_TYPE = {
     "gpn_star": GPN_STAR_SCORE_COLUMN,
 }
 
-EVALS_V2_MODELS = [
-    ("exp55-mammals", "promoters, mammals"),
-    ("exp58-mammals", "CDS, mammals"),
-    ("exp58-animals", "CDS, animals"),
-    ("exp59-mammals", "downstream, mammals"),
-    ("exp136-proj_v30", "enhancers, mammals"),
-    ("exp166-p1B", "zoonomia, generalist, 1B"),
+
+class EvalsV2Method(NamedTuple):
+    """One row of the evals_v2 section of the leaderboard.
+
+    ``parquet`` is the model name as it appears under
+    ``s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics/{parquet}/{dataset}.parquet``
+    — same string as the ``name`` field in `snakemake/analysis/evals_v2/config/config.yaml`.
+
+    ``display`` is what's shown in the leaderboard ``method`` column. For the
+    legacy single-step entries it equals ``parquet``; for the newer per-step
+    entries (e.g. ``exp21-promoters-yolo-step-22000``) it's stripped to the
+    run's short name (``exp21-promoters-yolo``) — the step lives in the
+    Reproducibility section.
+
+    ``datasets`` are the datasets this entry has metrics for. Older entries
+    span all three; entries added with ``datasets: [mendelian_traits]`` in
+    the evals_v2 config only show up in the mendelian leaderboard.
+    """
+
+    parquet: str
+    display: str
+    comment: str | None
+    datasets: tuple[str, ...] = ("mendelian_traits", "complex_traits", "eqtl")
+
+
+EVALS_V2_MODELS: list[EvalsV2Method] = [
+    # Legacy single-step entries — evaluated on all 3 leaderboard datasets.
+    EvalsV2Method("exp55-mammals", "exp55-mammals", "promoters, mammals"),
+    EvalsV2Method("exp58-mammals", "exp58-mammals", "CDS, mammals"),
+    EvalsV2Method("exp58-animals", "exp58-animals", "CDS, animals"),
+    EvalsV2Method("exp59-mammals", "exp59-mammals", "downstream, mammals"),
+    EvalsV2Method("exp136-proj_v30", "exp136-proj_v30", "enhancers, mammals"),
+    # Older `exp166-p1B` (step-16398, HF) retained for #162/#172 only — its
+    # mendelian slot in #161 was replaced by `exp166-v0.1-p1B` (below) on
+    # 2026-05-16. Re-include here on complex/eqtl until v0.1 is also scored
+    # on those datasets.
+    EvalsV2Method(
+        "exp166-p1B",
+        "exp166-p1B",
+        "zoonomia, generalist, 1B",
+        datasets=("complex_traits", "eqtl"),
+    ),
+    # Convergence-style entries (final checkpoint only here per
+    # "last checkpoint per run" convention). All scored on mendelian only
+    # in the evals_v2 config, so they appear only in #161.
+    EvalsV2Method(
+        "exp21-promoters-yolo-step-22000",
+        "exp21-promoters-yolo",
+        "promoters, animals, 1.7B",
+        datasets=("mendelian_traits",),
+    ),
+    EvalsV2Method(
+        "exp13-mixture-equal-step-26000",
+        "exp13-mixture-equal",
+        "50/50 promoter+CDS, animals, 1.7B",
+        datasets=("mendelian_traits",),
+    ),
+    EvalsV2Method(
+        "exp13-mixture-proportional-step-26000",
+        "exp13-mixture-proportional",
+        "10/90 promoter+CDS, animals, 1.7B",
+        datasets=("mendelian_traits",),
+    ),
+    EvalsV2Method(
+        "exp27-cds-yolo-step-34000",
+        "exp27-cds-yolo",
+        "CDS, animals, 1.7B",
+        datasets=("mendelian_traits",),
+    ),
+    EvalsV2Method(
+        "exp55-humans-step-16999",
+        "exp55-humans",
+        "promoters, humans",
+        datasets=("mendelian_traits",),
+    ),
+    EvalsV2Method(
+        "exp55-primates-step-16999",
+        "exp55-primates",
+        "promoters, primates",
+        datasets=("mendelian_traits",),
+    ),
+    EvalsV2Method(
+        "exp55-vertebrates-step-16999",
+        "exp55-vertebrates",
+        "promoters, vertebrates",
+        datasets=("mendelian_traits",),
+    ),
+    EvalsV2Method(
+        "exp55-animals-step-16999",
+        "exp55-animals",
+        "promoters, animals",
+        datasets=("mendelian_traits",),
+    ),
+    EvalsV2Method(
+        "exp58-vertebrates-step-16999",
+        "exp58-vertebrates",
+        "CDS, vertebrates",
+        datasets=("mendelian_traits",),
+    ),
+    # Replaces the legacy `exp166-p1B` HF entry (step-16398) — that run has
+    # been superseded by this v0.1 c127da run at step-27329 (1.65× more steps).
+    EvalsV2Method(
+        "exp166-v0.1-p1B-step-27329",
+        "exp166-v0.1-p1B",
+        "zoonomia, generalist, 1B, v0.1",
+        datasets=("mendelian_traits",),
+    ),
 ]
 CONSERVATION_TRACKS = [
     "phastCons_100v",
@@ -116,15 +219,19 @@ def gather_methods(dataset: str) -> list[tuple[str, str | None, pl.DataFrame]]:
         )
         rows.append((f"`{track}`", None, df))
 
-    # 2. evals_v2 models
+    # 2. evals_v2 models — skip entries that weren't scored on this dataset
+    # (per-(model, dataset) inclusion). The legacy single-step entries cover
+    # all 3 datasets; convergence-style entries are mendelian-only.
     sct = SCORE_TYPE["evals_v2"][dataset]
-    for model, comment in EVALS_V2_MODELS:
+    for entry in EVALS_V2_MODELS:
+        if dataset not in entry.datasets:
+            continue
         df = pl.read_parquet(
-            f"{S3}/snakemake/analysis/evals_v2/results/metrics/{model}/{dataset}.parquet"
+            f"{S3}/snakemake/analysis/evals_v2/results/metrics/{entry.parquet}/{dataset}.parquet"
         )
         df = df.filter(pl.col("score_type") == sct).filter(pl.col("split") == SPLIT)
         df = df.select(["subset", "value", "se", "n_pairs"])
-        rows.append((f"`{model}`", comment, df))
+        rows.append((f"`{entry.display}`", entry.comment, df))
 
     # 3. alphagenome
     try:
@@ -397,6 +504,82 @@ def _update_glm_protocol(body: str) -> str:
     return body
 
 
+EVALS_V2_CONFIG = (
+    Path(__file__).resolve().parents[2] / "analysis/evals_v2/config/config.yaml"
+)
+
+
+def _load_evals_v2_sources() -> dict[str, str]:
+    """Map model `name` → its `gcs_path` (or `hf://<repo>` shorthand)
+    by reading `snakemake/analysis/evals_v2/config/config.yaml`. Single
+    source of truth for Reproducibility-section regeneration."""
+    cfg = yaml.safe_load(EVALS_V2_CONFIG.read_text())
+    sources: dict[str, str] = {}
+    for m in cfg["models"]:
+        if "gcs_path" in m:
+            sources[m["name"]] = m["gcs_path"]
+        elif "hf_repo" in m:
+            sources[m["name"]] = f"hf://{m['hf_repo']}"
+        else:
+            raise RuntimeError(f"model {m['name']!r} has neither gcs_path nor hf_repo")
+    return sources
+
+
+def _render_glm_repro_row(entry: "EvalsV2Method", source: str, dataset: str) -> str:
+    """One row of the Reproducibility table for an evals_v2 gLM entry."""
+    if source.startswith("gs://"):
+        m = re.search(r"checkpoints/([^/]+)/hf/step-(\d+)", source)
+        if m is None:
+            raise RuntimeError(
+                f"unexpected gcs_path shape for {entry.parquet}: {source}"
+            )
+        run_name, step = m.group(1), m.group(2)
+        source_md = f"`{source}`"
+        wandb_md = f"[run](https://wandb.ai/gonzalobenegas/marin/runs/{run_name})"
+    elif source.startswith("hf://"):
+        repo = source.removeprefix("hf://")
+        step_m = re.search(r"step-(\d+)", repo)
+        step = step_m.group(1) if step_m else "–"
+        source_md = f"HF Hub [`{repo}`](https://huggingface.co/{repo})"
+        wandb_md = "–"
+    else:
+        raise RuntimeError(f"unrecognized source URI for {entry.parquet}: {source!r}")
+    parquet = (
+        f"`s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics/"
+        f"{entry.parquet}/{dataset}.parquet`"
+    )
+    return f"| `{entry.display}` | {step} | {source_md} | {wandb_md} | {parquet} |"
+
+
+# The Repro section's gLM block = a contiguous run of rows starting with
+# `| \`exp...\` |`. We don't anchor on specific entry names so the regex
+# survives EVALS_V2_MODELS edits. (The conservation / GPN-Star / AlphaGenome
+# rows start with different method prefixes so they don't match.)
+REPRO_GLM_BLOCK_RE = re.compile(
+    r"(?P<block>(?:\| `exp[^`]+` \| [^\n]+\n)+)",
+    re.MULTILINE,
+)
+
+
+def _update_repro_glm_block(body: str, dataset: str) -> str:
+    """Regenerate the gLM rows of the Reproducibility table from
+    EVALS_V2_MODELS. Preserves the surrounding static rows (conservation,
+    GPN-Star, AlphaGenome) untouched."""
+    sources = _load_evals_v2_sources()
+    new_rows = [
+        _render_glm_repro_row(entry, sources[entry.parquet], dataset)
+        for entry in EVALS_V2_MODELS
+        if dataset in entry.datasets and entry.parquet in sources
+    ]
+    if not new_rows:
+        return body
+    new_block = "\n".join(new_rows) + "\n"
+    match = REPRO_GLM_BLOCK_RE.search(body)
+    if match is None:
+        raise RuntimeError("could not find gLM block in Reproducibility section")
+    return body[: match.start()] + new_block + body[match.end() :]
+
+
 def _bump_last_updated(body: str, today: str) -> str:
     return re.sub(
         r"\*\*Last updated:\*\* [0-9]{4}-[0-9]{2}-[0-9]{2}",
@@ -440,7 +623,21 @@ def patch_issue(dataset: str, table_md: str) -> None:
     new_body = _update_intro_paragraph(new_body, global_n, macro_k)
     new_body = _update_bold_rule(new_body)
     new_body = _update_glm_protocol(new_body)
+    new_body = _update_repro_glm_block(new_body, dataset)
     new_body = _bump_last_updated(new_body, str(date.today()))
+    if dataset == "mendelian_traits":
+        new_body = _prepend_changelog_entry(
+            new_body,
+            "- **2026-05-16** — added 10 evals_v2 gLM rows (final-checkpoint, "
+            "mendelian only): `exp21-promoters-yolo` (#21), "
+            "`exp13-mixture-equal` / `exp13-mixture-proportional` (#13), "
+            "`exp27-cds-yolo` (#27), `exp55-{humans, primates, vertebrates, "
+            "animals}` (#55, promoters across evolutionary timescales), "
+            "`exp58-vertebrates` (#58, CDS across timescales). Replaced "
+            "legacy `exp166-p1B` (step-16398) with `exp166-v0.1-p1B` "
+            "(step-27329, the c127da run that just finished — 1.65× more "
+            "steps; Global PA +0.65 pp, Macro Avg −2.76 pp vs the old).",
+        )
     new_body = _prepend_changelog_entry(
         new_body,
         "- **2026-05-14** — added `exp166-p1B` (1B zoonomia-v1-v1 generalist; "
@@ -493,7 +690,29 @@ def main() -> None:
         action="store_true",
         help="After printing, surgically PATCH the bodies of #161/#162/#172.",
     )
+    parser.add_argument(
+        "--patch-issue",
+        type=int,
+        action="append",
+        default=[],
+        metavar="N",
+        help=(
+            "PATCH a specific leaderboard issue (one of 161, 162, 172). "
+            "Repeatable. Useful when only some datasets' tables changed."
+        ),
+    )
     args = parser.parse_args()
+
+    issue_to_dataset = {n: ds for ds, n in DATASET_ISSUE.items()}
+    if args.patch_issues:
+        datasets_to_patch = list(DATASETS)
+    else:
+        bad = [n for n in args.patch_issue if n not in issue_to_dataset]
+        if bad:
+            parser.error(
+                f"--patch-issue must be one of {sorted(issue_to_dataset)}, got {bad}"
+            )
+        datasets_to_patch = [issue_to_dataset[n] for n in args.patch_issue]
 
     tables: dict[str, str] = {}
     for ds in DATASETS:
@@ -502,11 +721,11 @@ def main() -> None:
         print(table)
         tables[ds] = table
 
-    if args.patch_issues:
+    if datasets_to_patch:
         print("\n" + "#" * 70)
         print("# Patching GitHub issues")
         print("#" * 70)
-        for ds in DATASETS:
+        for ds in datasets_to_patch:
             patch_issue(ds, tables[ds])
 
 

--- a/snakemake/evals/scratch/leaderboard_gen.py
+++ b/snakemake/evals/scratch/leaderboard_gen.py
@@ -608,12 +608,19 @@ def _render_glm_repro_row(entry: "EvalsV2Method", source: str, dataset: str) -> 
     return f"| `{entry.display}` | {step} | {source_md} | {wandb_md} | {parquet} |"
 
 
-# The Repro section's gLM block = a contiguous run of rows starting with
-# `| \`exp...\` |`. We don't anchor on specific entry names so the regex
-# survives EVALS_V2_MODELS edits. (The conservation / GPN-Star / AlphaGenome
-# rows start with different method prefixes so they don't match.)
-REPRO_GLM_BLOCK_RE = re.compile(
-    r"(?P<block>(?:\| `exp[^`]+` \| [^\n]+\n)+)",
+# Stable HTML-comment anchors around the auto-regenerated gLM block.
+# GitHub-flavored markdown hides HTML comments in rendered output, so these
+# are invisible to readers but unmissable for the regex. On first run against
+# a body that pre-dates the anchors, we fall back to the legacy `exp`-prefix
+# regex and emit the anchors so future runs use the stable markers.
+REPRO_GLM_ANCHOR_START = "<!-- evals_v2-glm-rows:start -->"
+REPRO_GLM_ANCHOR_END = "<!-- evals_v2-glm-rows:end -->"
+REPRO_GLM_ANCHORED_RE = re.compile(
+    re.escape(REPRO_GLM_ANCHOR_START) + r"\n.*?\n" + re.escape(REPRO_GLM_ANCHOR_END),
+    re.DOTALL,
+)
+REPRO_GLM_LEGACY_RE = re.compile(
+    r"(?:\| `exp[^`]+` \| [^\n]+\n)+",
     re.MULTILINE,
 )
 
@@ -630,11 +637,23 @@ def _update_repro_glm_block(body: str, dataset: str) -> str:
     ]
     if not new_rows:
         return body
-    new_block = "\n".join(new_rows) + "\n"
-    match = REPRO_GLM_BLOCK_RE.search(body)
-    if match is None:
-        raise RuntimeError("could not find gLM block in Reproducibility section")
-    return body[: match.start()] + new_block + body[match.end() :]
+    anchored_block = (
+        REPRO_GLM_ANCHOR_START
+        + "\n"
+        + "\n".join(new_rows)
+        + "\n"
+        + REPRO_GLM_ANCHOR_END
+    )
+    if match := REPRO_GLM_ANCHORED_RE.search(body):
+        return body[: match.start()] + anchored_block + body[match.end() :]
+    # First-time migration: locate the existing exp-prefixed gLM block and
+    # replace it with the anchored version. Subsequent runs use anchors.
+    if match := REPRO_GLM_LEGACY_RE.search(body):
+        return body[: match.start()] + anchored_block + "\n" + body[match.end() :]
+    raise RuntimeError(
+        "could not find gLM block in Reproducibility section "
+        "(neither anchored nor legacy `exp`-prefixed rows matched)"
+    )
 
 
 def _bump_last_updated(body: str, today: str) -> str:
@@ -752,7 +771,25 @@ def patch_issue(dataset: str, table_md: str) -> None:
     print(f"  ↳ patched #{issue_number}.")
 
 
+def _check_evals_v2_consistency() -> None:
+    """Fail loud at script start if `EVALS_V2_MODELS` references a `parquet`
+    name that's not in the live evals_v2 config — catches drift between the
+    leaderboard's frozen list and the pipeline's source of truth (e.g. a
+    config rename without a corresponding update here)."""
+    sources = _load_evals_v2_sources()
+    missing = [
+        entry.parquet for entry in EVALS_V2_MODELS if entry.parquet not in sources
+    ]
+    if missing:
+        raise RuntimeError(
+            f"EVALS_V2_MODELS references parquet names not found in "
+            f"{EVALS_V2_CONFIG}: {missing}. Either add them to the config "
+            f"or remove them from EVALS_V2_MODELS."
+        )
+
+
 def main() -> None:
+    _check_evals_v2_consistency()
     parser = argparse.ArgumentParser()
     patch_group = parser.add_mutually_exclusive_group()
     patch_group.add_argument(

--- a/snakemake/evals/scratch/leaderboard_gen.py
+++ b/snakemake/evals/scratch/leaderboard_gen.py
@@ -192,6 +192,19 @@ DATASET_ISSUE = {
     "complex_traits": 162,
     "eqtl": 172,
 }
+
+# Which aggregate is the "headline" for each dataset — controls (a) the sort
+# axis (top of table = top method on this aggregate) and (b) which of the two
+# aggregate columns appears leftmost. Mendelian uses Macro Avg because the
+# variant composition is ~92% missense — a ClinVar annotator-history artifact,
+# not pathogenicity reality — so Global PA over-weights methods specialized
+# for protein-coding variant interpretation. Complex / eqtl have very different
+# subset compositions where the same bias doesn't apply, so they stay on Global.
+LEADING_AGGREGATE = {
+    "mendelian_traits": "macro",
+    "complex_traits": "global",
+    "eqtl": "global",
+}
 S3 = "s3://oa-bolinas"
 SPLIT = "train"
 N_MIN = 30
@@ -300,11 +313,13 @@ def build_table(dataset: str) -> str:
     # Pre-split each method once: per-subset rows + the two aggregate tuples.
     methods = [(method, comment, *_split_method(df)) for method, comment, df in rows]
 
-    # Sort by Global PA descending so the top of the table = current best
-    # method on the headline aggregate. Python's sort is stable, so methods
-    # tied on Global keep their insertion order (conservation → evals_v2 →
-    # AlphaGenome → GPN-Star).
-    methods.sort(key=lambda m: -m[3][0])
+    # Sort descending on the leading aggregate (Global for most datasets,
+    # Macro Avg for mendelian — see LEADING_AGGREGATE for the rationale).
+    # Python's sort is stable, so ties keep insertion order (conservation →
+    # evals_v2 → AlphaGenome → GPN-Star).
+    leading = LEADING_AGGREGATE[dataset]
+    sort_idx = 3 if leading == "global" else 4  # 3 = global tuple, 4 = macro tuple
+    methods.sort(key=lambda m: -m[sort_idx][0])
 
     subset_n: dict[str, int] = {}
     for _, _, per_sub, _, _ in methods:
@@ -333,20 +348,31 @@ def build_table(dataset: str) -> str:
     # Aggregate-column counts are constant across methods (same match_groups).
     _, _, _, (_, _, global_n), (_, _, macro_k) = methods[0]
 
-    header_cols = [
-        f"Global<br>(n={global_n})",
-        f"Macro Avg<br>({macro_k} subsets)",
-    ] + [f"{SUBSET_DISPLAY[s]}<br>(n={subset_n[s]})" for s in subsets]
+    # Column order: leading aggregate first, secondary aggregate after — so
+    # the leftmost cell of the top row matches the sort axis.
+    global_header = f"Global<br>(n={global_n})"
+    macro_header = f"Macro Avg<br>({macro_k} subsets)"
+    aggregate_headers = (
+        [macro_header, global_header]
+        if leading == "macro"
+        else [global_header, macro_header]
+    )
+    header_cols = aggregate_headers + [
+        f"{SUBSET_DISPLAY[s]}<br>(n={subset_n[s]})" for s in subsets
+    ]
     header = "| method | " + " | ".join(header_cols) + " |"
     sep = "|---|" + "|".join(["---"] * len(header_cols)) + "|"
     lines = [header, sep]
 
     for method, comment, _, (gv, gse, _), (mv, mse, _) in methods:
         label = method + (f" ({comment})" if comment else "")
-        cells = [
-            f"**{fmt(gv, gse)}**" if gv >= top_global - 0.01 else fmt(gv, gse),
-            f"**{fmt(mv, mse)}**" if mv >= top_macro - 0.01 else fmt(mv, mse),
-        ]
+        global_cell = f"**{fmt(gv, gse)}**" if gv >= top_global - 0.01 else fmt(gv, gse)
+        macro_cell = f"**{fmt(mv, mse)}**" if mv >= top_macro - 0.01 else fmt(mv, mse)
+        cells = (
+            [macro_cell, global_cell]
+            if leading == "macro"
+            else [global_cell, macro_cell]
+        )
         for s in subsets:
             if (method, s) not in cell_pa:
                 cells.append("—")
@@ -440,16 +466,38 @@ def _idempotent_replace(
     raise RuntimeError(f"could not locate {what}")
 
 
-def _update_intro_paragraph(body: str, global_n: int, macro_k: int) -> str:
-    new_intro = (
-        f"PairwiseAccuracy ± SE per method. Higher is better. Two leftmost "
-        f"columns aggregate across the per-subset cells: **Global** = PA "
-        f"across **all** matched pairs (n={global_n}), including any "
-        f"subsets below the threshold; **Macro Avg** = unweighted mean of "
-        f"per-subset PAs over the {macro_k} reported subsets. Subsets with "
-        f"`n_pairs < 30` are excluded from the per-subset columns by "
-        f"convention (held across leaderboard datasets in this repo)."
-    )
+def _update_intro_paragraph(
+    body: str, global_n: int, macro_k: int, dataset: str
+) -> str:
+    leading = LEADING_AGGREGATE[dataset]
+    if leading == "macro":
+        new_intro = (
+            f"PairwiseAccuracy ± SE per method. Higher is better. "
+            f"**Sorted by Macro Avg** for this dataset: the variant "
+            f"composition skews heavily toward missense (~92% of pairs) "
+            f"due to ClinVar annotator history, not pathogenicity reality, "
+            f"so Global PA over-weights methods specialized for "
+            f"protein-coding variant interpretation; Macro Avg gives equal "
+            f"weight to each consequence subset. Two leftmost columns "
+            f"aggregate across the per-subset cells: **Macro Avg** = "
+            f"unweighted mean of per-subset PAs over the {macro_k} "
+            f"reported subsets; **Global** = PA across **all** matched "
+            f"pairs (n={global_n}), including any subsets below the "
+            f"threshold. Subsets with `n_pairs < 30` are excluded from "
+            f"the per-subset columns by convention (held across "
+            f"leaderboard datasets in this repo)."
+        )
+    else:
+        new_intro = (
+            f"PairwiseAccuracy ± SE per method. Higher is better. Two "
+            f"leftmost columns aggregate across the per-subset cells: "
+            f"**Global** = PA across **all** matched pairs (n={global_n}), "
+            f"including any subsets below the threshold; **Macro Avg** = "
+            f"unweighted mean of per-subset PAs over the {macro_k} "
+            f"reported subsets. Subsets with `n_pairs < 30` are excluded "
+            f"from the per-subset columns by convention (held across "
+            f"leaderboard datasets in this repo)."
+        )
     old_variants = [
         # Mendelian / eqtl phrasing.
         "PairwiseAccuracy ± SE per consequence subset. Higher is better. "
@@ -460,6 +508,14 @@ def _update_intro_paragraph(body: str, global_n: int, macro_k: int) -> str:
         "Subsets with `n_pairs < 30` are excluded by convention (held across "
         "leaderboard datasets in this repo). Most consequence subsets in "
         "this dataset fall below that threshold — see Sizes for full breakdown.",
+        # Prior global-sort phrasing (in case we're switching from global → macro).
+        f"PairwiseAccuracy ± SE per method. Higher is better. Two leftmost "
+        f"columns aggregate across the per-subset cells: **Global** = PA "
+        f"across **all** matched pairs (n={global_n}), including any "
+        f"subsets below the threshold; **Macro Avg** = unweighted mean of "
+        f"per-subset PAs over the {macro_k} reported subsets. Subsets with "
+        f"`n_pairs < 30` are excluded from the per-subset columns by "
+        f"convention (held across leaderboard datasets in this repo).",
     ]
     return _idempotent_replace(body, old_variants, new_intro, "intro paragraph")
 
@@ -620,12 +676,24 @@ def patch_issue(dataset: str, table_md: str) -> None:
     macro_k = int(m_macro.group(1))
 
     new_body = _replace_table(body, table_md)
-    new_body = _update_intro_paragraph(new_body, global_n, macro_k)
+    new_body = _update_intro_paragraph(new_body, global_n, macro_k, dataset)
     new_body = _update_bold_rule(new_body)
     new_body = _update_glm_protocol(new_body)
     new_body = _update_repro_glm_block(new_body, dataset)
     new_body = _bump_last_updated(new_body, str(date.today()))
     if dataset == "mendelian_traits":
+        new_body = _prepend_changelog_entry(
+            new_body,
+            "- **2026-05-16** — sort axis switched from Global PA to "
+            "**Macro Avg** for this leaderboard only. Rationale: the "
+            "variant composition is ~92% missense (a ClinVar annotator-"
+            "history artifact, not pathogenicity reality), so Global PA "
+            "over-weights methods specialized for protein-coding variant "
+            "interpretation. Macro Avg gives equal weight to each "
+            "consequence subset. Column order updated so the leading "
+            "aggregate (Macro Avg) is leftmost. #162 / #172 continue to "
+            "sort by Global PA.",
+        )
         new_body = _prepend_changelog_entry(
             new_body,
             "- **2026-05-16** — added 10 evals_v2 gLM rows (final-checkpoint, "

--- a/snakemake/evals/scratch/leaderboard_gen.py
+++ b/snakemake/evals/scratch/leaderboard_gen.py
@@ -29,12 +29,13 @@ relying on manual paste.
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import re
 import subprocess
 from datetime import date
 from pathlib import Path
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 import polars as pl
 import yaml
@@ -89,10 +90,9 @@ EVALS_V2_MODELS: list[EvalsV2Method] = [
     EvalsV2Method("exp58-animals", "exp58-animals", "CDS, animals"),
     EvalsV2Method("exp59-mammals", "exp59-mammals", "downstream, mammals"),
     EvalsV2Method("exp136-proj_v30", "exp136-proj_v30", "enhancers, mammals"),
-    # Older `exp166-p1B` (step-16398, HF) retained for #162/#172 only — its
-    # mendelian slot in #161 was replaced by `exp166-v0.1-p1B` (below) on
-    # 2026-05-16. Re-include here on complex/eqtl until v0.1 is also scored
-    # on those datasets.
+    # Older `exp166-p1B` (step-16398, HF) retained for #162/#172 only —
+    # superseded by `exp166-v0.1-p1B` below on mendelian, but v0.1 hasn't
+    # been scored on complex/eqtl yet.
     EvalsV2Method(
         "exp166-p1B",
         "exp166-p1B",
@@ -156,8 +156,7 @@ EVALS_V2_MODELS: list[EvalsV2Method] = [
         "CDS, vertebrates",
         datasets=("mendelian_traits",),
     ),
-    # Replaces the legacy `exp166-p1B` HF entry (step-16398) — that run has
-    # been superseded by this v0.1 c127da run at step-27329 (1.65× more steps).
+    # Supersedes the legacy `exp166-p1B` HF entry (step-16398) on mendelian.
     EvalsV2Method(
         "exp166-v0.1-p1B-step-27329",
         "exp166-v0.1-p1B",
@@ -200,7 +199,8 @@ DATASET_ISSUE = {
 # not pathogenicity reality — so Global PA over-weights methods specialized
 # for protein-coding variant interpretation. Complex / eqtl have very different
 # subset compositions where the same bias doesn't apply, so they stay on Global.
-LEADING_AGGREGATE = {
+SortAxis = Literal["macro", "global"]
+LEADING_AGGREGATE: dict[str, SortAxis] = {
     "mendelian_traits": "macro",
     "complex_traits": "global",
     "eqtl": "global",
@@ -565,6 +565,7 @@ EVALS_V2_CONFIG = (
 )
 
 
+@functools.cache
 def _load_evals_v2_sources() -> dict[str, str]:
     """Map model `name` → its `gcs_path` (or `hf://<repo>` shorthand)
     by reading `snakemake/analysis/evals_v2/config/config.yaml`. Single
@@ -753,12 +754,13 @@ def patch_issue(dataset: str, table_md: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument(
+    patch_group = parser.add_mutually_exclusive_group()
+    patch_group.add_argument(
         "--patch-issues",
         action="store_true",
         help="After printing, surgically PATCH the bodies of #161/#162/#172.",
     )
-    parser.add_argument(
+    patch_group.add_argument(
         "--patch-issue",
         type=int,
         action="append",


### PR DESCRIPTION
## Summary

- **evals_v2 schema**: two new optional per-model fields — `datasets: [...]` (allow-list, defaults to all 3) and `batch_size: N` (per-checkpoint override of the global `inference.batch_size`). Existing entries untouched. Snakefile's `rule all` switches from `expand(models × datasets)` to a per-model list comprehension that honors the allow-list.
- **`params:` contract honored**: `batch_size` moved out of `compute_scores`' `params:` block into the `run:` body (it's execution-only — doesn't change outputs, so it shouldn't trigger snakemake's `params` rerun trigger). `download_model`'s params narrowed from the full cfg dict to just `gcs_path` / `hf_repo`. Net effect: tuning `batch_size` next time produces zero reruns.
- **+100 new checkpoint entries** spanning issues #21, #13, #27, #55, #58, #136, #166 — convergence-style step lists per run, mostly mendelian-only. Final-checkpoint table is in `snakemake/analysis/evals_v2/config/config.yaml`.
- **Leaderboard #161 refresh**: ran the new generator with `--patch-issue 161`. Added 10 new gLM rows (per "last-checkpoint per run"), replaced legacy `exp166-p1B` with the new `exp166-v0.1-p1B` (1.65× more training steps), and **switched the sort axis for #161 only** from Global PA → Macro Avg. Rationale: ~92% of mendelian pairs are missense (a ClinVar annotator-history artifact, not pathogenicity reality), so Global over-weights protein-coding specialists. Macro Avg gives equal weight to each consequence subset. Issues #162 and #172 are unchanged.
- **`leaderboard_gen.py` upgrades**: `EvalsV2Method` NamedTuple with per-(model, dataset) inclusion and display-name override; `--patch-issue N` (repeatable) for selective patching; `_update_repro_glm_block` auto-regenerates the gLM rows of the Reproducibility section from `evals_v2/config/config.yaml` (single source of truth for GCS paths and W&B run names); per-dataset `LEADING_AGGREGATE` controlling sort axis + leading-column position.

## Test plan
- [x] Local dry-run of evals_v2 confirms only newly-added entries' jobs are scheduled; option-(a) params fix means zero spurious reruns when `batch_size` is tuned.
- [x] Cluster dry-run on the live evals-v2 SkyPilot cluster (post `--cleanup-metadata`) reports "Nothing to be done" with default triggers.
- [x] All new checkpoints scored end-to-end on `mendelian_traits` (results in `s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics/`).
- [x] `leaderboard_gen.py` dry-runs all 3 datasets without error; `--patch-issue 161` PATCHes the issue body correctly.
- [x] Verified rendered #161 body: 26 rows, Macro Avg leftmost, sorted descending; intro paragraph + 2026-05-16 changelog entries present; Reproducibility section regenerated with all 15 gLM rows (incl. step + GCS path + W&B link).
- [x] `pre-commit run --files snakemake/evals/scratch/leaderboard_gen.py` passes (snakefmt skipped per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)