### PR TITLE
Dashboard CI: build on PRs as required status check

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -3,6 +3,11 @@ name: Dashboard
 # Builds the bolinas-dna leaderboard dashboard (Observable Framework site
 # under `dashboard/`) and deploys it to GitHub Pages.
 #
+# Runs on push to main *and* on pull requests against main, so the build
+# acts as a required status check before merge — same workflow, two
+# different entry points. The deploy job is gated to push-to-main only;
+# PR runs build + upload the artifact but never publish.
+#
 # Setup (one-time, by a repo admin):
 #   1. Settings → Pages → Source: "GitHub Actions".
 #   2. AWS S3 access for the data loaders via GitHub OIDC (no long-lived keys):
@@ -10,14 +15,22 @@ name: Dashboard
 #         * GitHub OIDC identity provider for `token.actions.githubusercontent.com`
 #           with audience `sts.amazonaws.com`.
 #         * IAM policy `BolinasDnaDashboardMetricsRead` granting `s3:GetObject`
-#           on `arn:aws:s3:::oa-bolinas/snakemake/analysis/evals_v2/results/metrics/*`.
-#         * IAM role `BolinasDnaDashboardCI` trusting
-#           `repo:Open-Athena/bolinas-dna:ref:refs/heads/main` (broaden the
-#           trust policy's `sub` condition to allow PRs/other branches if you
-#           want preview builds).
+#           on the four metric prefixes (one per eval pipeline):
+#             - `arn:aws:s3:::oa-bolinas/snakemake/analysis/evals_v2/results/metrics/*`
+#             - `arn:aws:s3:::oa-bolinas/snakemake/conservation_eval/results/*`
+#             - `arn:aws:s3:::oa-bolinas/snakemake/alphagenome_eval/results/metrics/*`
+#             - `arn:aws:s3:::oa-bolinas/snakemake/gpn_star_eval/results/metrics/*`
+#         * IAM role `BolinasDnaDashboardCI` trusting the OIDC provider on
+#           two `sub` claims (so PR runs from this repo can also assume the
+#           role and run a pre-merge build):
+#             - `repo:Open-Athena/bolinas-dna:ref:refs/heads/main`
+#             - `repo:Open-Athena/bolinas-dna:pull_request`
+#           Fork PRs carry a different sub (`repo:<fork>:pull_request`) and
+#           are denied — they can't grab AWS creds.
 #       - In the repo: set the `AWS_ROLE_ARN` Actions *variable* (Settings →
 #         Secrets and variables → Actions → Variables) to the role's ARN.
-#         The build step assumes that role via `aws-actions/configure-aws-credentials`.
+#       - Branch protection: Settings → Branches → require the
+#         "Dashboard / build" status check to pass on PRs against main.
 
 on:
   push:
@@ -29,13 +42,15 @@ on:
       - src/bolinas/pipelines/evals/metrics.py
       - src/bolinas/pipelines/evals/gpn_star.py
       - .github/workflows/dashboard.yml
+  pull_request:
+    paths:
+      - dashboard/**
+      - src/bolinas/pipelines/evals/leaderboard.py
+      - src/bolinas/pipelines/evals/models.py
+      - src/bolinas/pipelines/evals/metrics.py
+      - src/bolinas/pipelines/evals/gpn_star.py
+      - .github/workflows/dashboard.yml
   workflow_dispatch:
-
-# A single concurrent deploy at a time; cancel in-flight runs so we always
-# ship the latest commit.
-concurrency:
-  group: pages
-  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -89,7 +104,16 @@ jobs:
 
   deploy:
     needs: build
+    # Only publish on pushes to main. PR runs upload the artifact (which the
+    # build step does for free) but stop here without touching Pages.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # Single concurrent deploy at a time; cancel in-flight publishes so we
+    # always ship the latest commit. PR builds don't share this group, so
+    # they can run in parallel without interfering.
+    concurrency:
+      group: pages
+      cancel-in-progress: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

Makes the dashboard build a required pre-merge check instead of "merge and hope":

- **`pull_request:` trigger** added (same `paths:` filter as `push:`) → the workflow runs on every PR that touches `dashboard/` or the library it depends on. Build success/failure shows up as a PR check.
- **Deploy gated to main push only** via `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`. PR runs build + upload the Pages artifact (proves the artifact pipeline works) but never publish.
- **Concurrency moved from workflow-level → deploy job**. Was: `concurrency: { group: pages }` at the top, which would have a main push cancel an in-flight PR build through the shared group. Now Pages-serialization is scoped to the publish step where it matters; PR builds run in parallel.
- **Header comment updated** to (a) document the new trigger model, (b) list all four S3 metric prefixes the IAM policy needs to cover (the missing three caused the post-merge failure in #190).

## Required actions on your end (before this PR can pass its own check)

1. **Broaden the IAM role's trust policy** so PR runs can assume it. The current trust pins to `refs/heads/main` only — the PR's `Assume AWS role` step would fail without this.

   AWS Console → IAM → Roles → `BolinasDnaDashboardCI` → **Trust relationships** → **Edit**, replace the document with:

   ```json
   {
     "Version": "2012-10-17",
     "Statement": [{
       "Effect": "Allow",
       "Principal": {
         "Federated": "arn:aws:iam::836683583872:oidc-provider/token.actions.githubusercontent.com"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
         },
         "StringLike": {
           "token.actions.githubusercontent.com:sub": [
             "repo:Open-Athena/bolinas-dna:ref:refs/heads/main",
             "repo:Open-Athena/bolinas-dna:pull_request"
           ]
         }
       }
     }]
   }
   ```

   Note: PRs from **forks** carry a different sub (`repo:<fork-owner>/bolinas-dna:pull_request`) and stay denied. They can't grab AWS creds — that's the correct security default for OIDC.

2. **Enable branch protection** on `main`: Settings → Branches → "Add branch protection rule" → branch name pattern `main` → **Require status checks to pass before merging** → search and pick `build` (the job from the Dashboard workflow). Optionally also tick "Require branches to be up to date before merging" so a stale PR has to rebase if main moves.

## Test plan

- [x] Update IAM trust policy (step 1 above).
- [ ] First run of *this* PR's workflow then exercises the full pre-merge path: `pull_request` trigger fires → OIDC sub `repo:Open-Athena/bolinas-dna:pull_request` is accepted → build succeeds → no deploy.
- [ ] After merge: a `push` to main runs build + deploy; dashboard updates at `openathena.ai/bolinas-dna/`.

## Out of scope

- Fork-PR build support — would need either `pull_request_target` (security-fraught) or accepting that fork PRs can't reach AWS. Not needed today since contributors are org members.
