### PR TITLE
alphagenome_eval: AUPRC + cluster-bootstrap SE, hf_revision pin, drop eqtl

### DIFF
--- a/dashboard/models.yaml
+++ b/dashboard/models.yaml
@@ -328,7 +328,7 @@
   display: AlphaGenome
   family: alphagenome
   description: variant scorer, API
-  datasets: [mendelian_traits, complex_traits, eqtl]
+  datasets: [mendelian_traits, complex_traits]
 
 - id: GPN-Star-V
   display: GPN-Star (V)

--- a/snakemake/alphagenome_eval/README.md
+++ b/snakemake/alphagenome_eval/README.md
@@ -1,12 +1,14 @@
 # alphagenome_eval — AlphaGenome baseline on matched-pair eval datasets
 
-PairwiseAccuracy ± binomial SE for [AlphaGenome](https://github.com/google-deepmind/alphagenome)
-on the new matched-pair eval datasets
-(`bolinas-dna/evals_mendelian_traits` and `bolinas-dna/evals_complex_traits`,
-PR #159). Provides issue [#154](https://github.com/Open-Athena/bolinas-dna/issues/154)'s
+AUPRC ± cluster-bootstrap SE (cluster = `match_group`) for
+[AlphaGenome](https://github.com/google-deepmind/alphagenome) on the
+matched-pair eval datasets `bolinas-dna/evals_mendelian_traits` and
+`bolinas-dna/evals_complex_traits` (1:k matched groups, PR #194 rebuild).
+Provides issue [#154](https://github.com/Open-Athena/bolinas-dna/issues/154)'s
 baseline row for the leaderboards in
 [#161](https://github.com/Open-Athena/bolinas-dna/issues/161) and
-[#162](https://github.com/Open-Athena/bolinas-dna/issues/162).
+[#162](https://github.com/Open-Athena/bolinas-dna/issues/162). The metric
+mirrors `snakemake/analysis/evals_v2/`'s post-PR-#195 schema.
 
 ## What it does
 
@@ -21,9 +23,13 @@ For each `dataset` in `config["datasets"]`:
    columns: `alphagenome_max_l2`. The full per-track table is preserved on S3
    so the aggregation protocol can change later (e.g. per-assay) without
    re-spending the API budget.
-3. **Compute** PairwiseAccuracy ± SE per consequence subset on
-   `alphagenome_max_l2`. Same column for both datasets — L2 is
-   direction-agnostic and fits both the mendelian and complex-trait protocols.
+3. **Compute** AUPRC ± cluster-bootstrap SE per consequence subset on
+   `alphagenome_max_l2`, with `match_group` as the cluster (resamples
+   groups, not rows, so SE reflects the 1:k matched structure). Same
+   column for both datasets — L2 is direction-agnostic and fits both the
+   mendelian and complex-trait protocols. Output includes per-subset
+   rows plus `_global_` (pooled) and `_macro_avg_` (mean of qualifying
+   subsets) aggregates.
 
 ## Outputs
 
@@ -33,7 +39,7 @@ S3 bucket `s3://oa-bolinas/snakemake/alphagenome_eval/`:
 results/
 ├── per_track_l2/{dataset}.parquet    # variant cols + per-track L2 columns
 ├── scores/{dataset}.parquet          # variant cols + alphagenome_max_l2
-└── metrics/{dataset}.parquet         # PairwiseAccuracy ± SE per subset
+└── metrics/{dataset}.parquet         # AUPRC ± cluster-bootstrap SE per subset
 ```
 
 ## Conventions
@@ -110,9 +116,11 @@ uv run snakemake
 | --- | --- |
 | `input_hf_prefix` | HF prefix for `f"{prefix}_{dataset}"`. |
 | `split` | `train` (test held out). |
-| `datasets` | List of dataset names. |
+| `datasets` | List of `{name, hf_revision}` entries. The SHA pins the HF commit consumed; bumping it forces a re-run via snakemake's `params:` hash (re-spends API budget). SHAs mirror `snakemake/analysis/evals_v2/config/config.yaml`. |
 | `num_workers` | Threads in the API ThreadPoolExecutor. Keep ≤ 4. |
 | `score_column` | Column name written by `aggregate_max` and consumed by `compute_metrics`. |
+| `n_bootstrap` | AUPRC cluster-bootstrap iterations per subset. |
+| `bootstrap_seed` | RNG seed for the bootstrap; bumping it re-triggers `compute_metrics`. |
 
 The 7 assays, the 1MB sequence length, and `L2_DIFF_LOG1P` aggregation type
 are **code constants** in `bolinas.evals.alphagenome`, not config.

--- a/snakemake/alphagenome_eval/config/config.yaml
+++ b/snakemake/alphagenome_eval/config/config.yaml
@@ -2,18 +2,29 @@ input_hf_prefix: bolinas-dna/evals
 split: train
 
 datasets:
-  - mendelian_traits
-  - complex_traits
-  - eqtl
+  # Per-dataset `hf_revision` pins the HF dataset commit consumed by
+  # this run. Bumping the SHA triggers re-execution via snakemake's
+  # `params:` hash. SHAs mirror evals_v2's pins (PR #194 k=9 rebuild).
+  - name: mendelian_traits
+    hf_revision: 4aed58e50c5dea0b878a665007af2ef9e5108e9f
+  - name: complex_traits
+    hf_revision: 22f86a89c65cb8f3007ac3cc2739f40efefa4340
 
 # AlphaGenome rate-limits — keep workers low (4 has been a safe ceiling).
 num_workers: 4
 
 # Single column written by `aggregate_max` and consumed by `compute_metrics`.
-# Direction-agnostic by construction (L2 of differences) — fits both
-# mendelian (pathogenic > benign) and complex (magnitude) leaderboards.
+# Direction-agnostic by construction (max over per-track L2 of delta-log1p)
+# — same column works for both mendelian (pathogenic > common) and complex
+# (magnitude) datasets, so no per-dataset score_protocol fan-out.
 score_column: alphagenome_max_l2
 
-# Smoke-test knob: keep only the first N matched pairs (= 2N rows). Override
-# via `--config subset_n_pairs=5`. Leave null in production runs.
+# AUPRC cluster-bootstrap params (cluster = `match_group`), mirroring
+# evals_v2. Bumping `bootstrap_seed` re-triggers `compute_metrics` via
+# snakemake's `params:` hash.
+n_bootstrap: 1000
+bootstrap_seed: 0
+
+# Smoke-test knob: keep only the first N matched groups. Override via
+# `--config subset_n_pairs=5`. Leave null in production runs.
 subset_n_pairs: null

--- a/snakemake/alphagenome_eval/workflow/rules/common.smk
+++ b/snakemake/alphagenome_eval/workflow/rules/common.smk
@@ -7,7 +7,14 @@ from datasets import load_dataset
 
 from bolinas.pipelines.evals.alphagenome import score_variants_alphagenome
 from bolinas.pipelines.evals.conservation import REQUIRED_VARIANT_COLUMNS
-from bolinas.pipelines.evals.metrics import compute_pairwise_metrics
+from bolinas.pipelines.evals.metrics import compute_auprc_metrics
 
 
-DATASETS = config["datasets"]
+def get_dataset_config(name):
+    for d in config["datasets"]:
+        if d["name"] == name:
+            return d
+    raise ValueError(f"dataset {name!r} not found in config")
+
+
+DATASETS = [d["name"] for d in config["datasets"]]

--- a/snakemake/alphagenome_eval/workflow/rules/metrics.smk
+++ b/snakemake/alphagenome_eval/workflow/rules/metrics.smk
@@ -1,4 +1,11 @@
-"""PairwiseAccuracy + binomial SE per (dataset)."""
+"""AUPRC + cluster-bootstrap SE per (dataset).
+
+Cluster = `match_group`; resamples groups (not rows) so the SE accounts
+for the 1:k matched structure. Output schema mirrors
+`bolinas.pipelines.evals.metrics.compute_auprc_metrics`:
+`[score_type, subset, value, se, n_groups, n_rows]` plus `_global_` and
+`_macro_avg_` aggregate rows per score_type.
+"""
 
 
 rule compute_metrics:
@@ -8,6 +15,9 @@ rule compute_metrics:
         "results/metrics/{dataset}.parquet",
     wildcard_constraints:
         dataset="|".join(DATASETS),
+    params:
+        n_bootstrap=config["n_bootstrap"],
+        bootstrap_seed=config["bootstrap_seed"],
     run:
         score_col = config["score_column"]
         df = pd.read_parquet(input[0])
@@ -17,10 +27,12 @@ rule compute_metrics:
             score_col in df.columns
         ), f"scores parquet missing score column {score_col!r}"
 
-        metrics = compute_pairwise_metrics(
+        metrics = compute_auprc_metrics(
             dataset=df[list(REQUIRED_VARIANT_COLUMNS)],
             scores=df[[score_col]],
             score_columns=[score_col],
+            n_bootstrap=params.n_bootstrap,
+            rng=params.bootstrap_seed,
         )
         metrics["dataset"] = wildcards.dataset
         metrics["split"] = config["split"]

--- a/snakemake/alphagenome_eval/workflow/rules/score.smk
+++ b/snakemake/alphagenome_eval/workflow/rules/score.smk
@@ -12,9 +12,17 @@ rule compute_per_track_l2:
     wildcard_constraints:
         dataset="|".join(DATASETS),
     threads: config["num_workers"]
+    params:
+        # Pin the HF dataset commit. Bumping it triggers rerun via the
+        # `params:` hash. `load_dataset(revision=…)` raises
+        # `RevisionNotFoundError` on an unknown SHA — no silent fallback
+        # to `main`.
+        hf_path=lambda wc: f"{config['input_hf_prefix']}_{wc.dataset}",
+        hf_revision=lambda wc: get_dataset_config(wc.dataset)["hf_revision"],
     run:
-        hf_path = f"{config['input_hf_prefix']}_{wildcards.dataset}"
-        ds = load_dataset(hf_path, split=config["split"]).to_pandas()
+        ds = load_dataset(
+            params.hf_path, split=config["split"], revision=params.hf_revision
+        ).to_pandas()
         for col in REQUIRED_VARIANT_COLUMNS:
             assert col in ds.columns, f"dataset missing column {col!r}"
 

--- a/src/bolinas/pipelines/evals/leaderboard.py
+++ b/src/bolinas/pipelines/evals/leaderboard.py
@@ -2,7 +2,7 @@
 
 Reads per-(method, dataset) metrics parquets emitted by the eval snakemake
 pipelines, filters by protocol / score-type, and emits one row per
-``(method, protocol, subset)`` for the dashboard. The bolinas and
+``(method, protocol, subset)`` for the dashboard. The bolinas,
 conservation, and alphagenome families emit AUPRC + cluster-bootstrap SE
 under the AUPRC migration (PRs #194/#195 for bolinas; the conservation_eval
 mirror for the seven phyloP / phastCons tracks; the alphagenome_eval mirror

--- a/src/bolinas/pipelines/evals/leaderboard.py
+++ b/src/bolinas/pipelines/evals/leaderboard.py
@@ -3,10 +3,11 @@
 Reads per-(method, dataset) metrics parquets emitted by the eval snakemake
 pipelines, filters by protocol / score-type, and emits one row per
 ``(method, protocol, subset)`` for the dashboard. The bolinas and
-conservation families emit AUPRC + cluster-bootstrap SE under the AUPRC
-migration (PRs #194/#195 for bolinas; the conservation_eval mirror for
-the seven phyloP / phastCons tracks); alphagenome, gpn_star, and evo2
-still emit PairwiseAccuracy + Wald-binomial SE.
+conservation, and alphagenome families emit AUPRC + cluster-bootstrap SE
+under the AUPRC migration (PRs #194/#195 for bolinas; the conservation_eval
+mirror for the seven phyloP / phastCons tracks; the alphagenome_eval mirror
+for the AlphaGenome max-L2 baseline); gpn_star and evo2 still emit
+PairwiseAccuracy + Wald-binomial SE.
 
   - ``snakemake/analysis/evals_v2/``  → one parquet per ``(model, dataset)``,
     filter by ``score_type`` + ``split``.
@@ -203,12 +204,12 @@ def fetch_method_metrics(
             f"{protocol!r} (score_type={score_type!r}) in {path}. The pipeline "
             f"may need to be re-run with this protocol included."
         )
-    # Schema bridge: bolinas + conservation migrated from PairwiseAccuracy
-    # (n_pairs/n_ties) to AUPRC (n_groups/n_rows). Map n_groups → n_pairs
-    # (semantically the bootstrap unit count for AUPRC, the pair count
-    # for PA), and fill n_ties with 0 — AUPRC has no ties. Alphagenome,
-    # gpn_star, and evo2 still emit the legacy PA schema.
-    if method.family in ("bolinas", "conservation"):
+    # Schema bridge: bolinas, conservation, and alphagenome migrated from
+    # PairwiseAccuracy (n_pairs/n_ties) to AUPRC (n_groups/n_rows). Map
+    # n_groups → n_pairs (semantically the bootstrap unit count for AUPRC,
+    # the pair count for PA), and fill n_ties with 0 — AUPRC has no ties.
+    # gpn_star and evo2 still emit the legacy PA schema.
+    if method.family in ("bolinas", "conservation", "alphagenome"):
         df = df.rename({"n_groups": "n_pairs"}).with_columns(
             pl.lit(0, dtype=pl.Int64).alias("n_ties")
         )


### PR DESCRIPTION
## Summary

- Mirrors `evals_v2`'s post-#195 schema for AlphaGenome on the PR #194 k=9 matched-pair datasets.
- `metrics.smk` swaps `compute_pairwise_metrics` → `compute_auprc_metrics` (cluster = `match_group`); output schema `[score_type, subset, value, se, n_groups, n_rows, dataset, split]`.
- `config.yaml` pins `hf_revision` per-dataset (SHAs match `evals_v2/config/config.yaml`), drops `eqtl`, and adds bootstrap knobs.
- `compute_per_track_l2` wires `hf_revision` through `params:` so a SHA bump re-triggers the rule via snakemake's params-hash.
- `leaderboard.py` extends the `n_groups → n_pairs` schema bridge to the `alphagenome` family; `dashboard/models.yaml` drops `eqtl` from AlphaGenome's `datasets:` list.

The dashboard `build`/`deploy` `if: false` gate stays off — `conservation`, `gpn_star`, and `evo2` still need their own AUPRC migrations before it can flip.

## Test plan

- [x] `uv run pytest tests/pipelines/evals/test_metrics.py tests/pipelines/evals/test_alphagenome.py` (26 passed, 1 skipped).
- [x] `cd snakemake/alphagenome_eval && uv run snakemake -n --forceall` plans the expected 7 jobs (`compute_per_track_l2`, `aggregate_max`, `compute_metrics` × 2 datasets + `all`).
- [x] `SKIP=snakefmt uv run pre-commit run --files …` clean on the 7 modified files.
- [ ] `sky launch snakemake/alphagenome_eval/sky/run.yaml -c alphagenome-eval --env ALPHA_GENOME_API_KEY` — re-scores all variants against the pinned k=9 SHAs and emits the new metrics parquet to S3. Subset smoke run via `--config subset_n_pairs=5` covers the new metric path before the full re-emit. *(Will re-spend API budget; existing per-track parquets were against k=1 variants.)*
- [ ] After the run lands, inspect `s3://oa-bolinas/snakemake/alphagenome_eval/results/metrics/{mendelian,complex}_traits.parquet`: schema `[score_type, subset, value, se, n_groups, n_rows, dataset, split]`, with `_global_` + `_macro_avg_` rows.
- [ ] `bolinas.pipelines.evals.leaderboard.fetch_method_metrics(AlphaGenome, "mendelian_traits")` returns rows with the bridged `n_pairs` (= `n_groups`) and `n_ties = 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)