### PR TITLE
Add Eric's mix-v0.9 1B (uniform + uniform_to_upstream) to mendelian leaderboard

### DIFF
--- a/dashboard/models.yaml
+++ b/dashboard/models.yaml
@@ -320,6 +320,36 @@
     gcs: gs://marin-us-east5/checkpoints/dna-bolinas-exp166-v0.1-p1B-c127da/hf/step-27329
   datasets: [mendelian_traits, complex_traits]
 
+# Eric Czech's mix-v0.9 1B runs (Slack #bolinas, 2026-05-18). Headline
+# uniform-mixture run + continued-training upstream-weighted variant.
+- id: mix-v0.9-p1B-i0-uniform-step-25004
+  display: mix-v0.9-p1B-uniform
+  family: bolinas
+  description: mix v0.9, uniform mixture, 1B (52.4B tokens)
+  training:
+    data: bolinas_mix_v0.9_uniform
+    params: 1.0e9
+    window_size: 255
+    objective: CLM
+  wandb: https://wandb.ai/eric-czech/marin/runs/dna-bolinas-mix-v0.9-p1B-i0-uniform-2ba217
+  checkpoint:
+    gcs: gs://marin-us-east5/checkpoints/dna-bolinas-mix-v0.9-p1B-i0-uniform-2ba217/hf/step-25004
+  datasets: [mendelian_traits]
+
+- id: mix-v0.9-p1B-i16-upstream-step-8333
+  display: mix-v0.9-p1B-upstream_3.6
+  family: bolinas
+  description: mix v0.9, 40% upstream / 30% cds (continued from i0), 1B (17.5B tokens)
+  training:
+    data: bolinas_mix_v0.9_uniform_to_upstream_3.6
+    params: 1.0e9
+    window_size: 255
+    objective: CLM
+  wandb: https://wandb.ai/eric-czech/marin/runs/dna-bolinas-mix-v0.9-p1B-i16-uniform_to_upstream_3.6-07bc9c
+  checkpoint:
+    gcs: gs://marin-us-east5/checkpoints/dna-bolinas-mix-v0.9-p1B-i16-uniform_to_upstream_3.6-07bc9c/hf/step-8333
+  datasets: [mendelian_traits]
+
 # ---------------------------------------------------------------------------
 # External baselines (AlphaGenome, GPN-Star).
 # ---------------------------------------------------------------------------

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -104,6 +104,20 @@ models:
     window_size: 255
     datasets: [mendelian_traits, complex_traits]
 
+  # Eric's mix-v0.9 1B runs (Slack #bolinas, 2026-05-18). Qwen3-1B,
+  # 255 bp + BOS context. The i0-uniform run is the headline uniform-
+  # mixture baseline; the i16 run continues training from i0's final
+  # checkpoint with a 40% upstream / 30% downstream-cds mixture.
+  # Scoped to mendelian_traits to mirror exp166.
+  - name: mix-v0.9-p1B-i0-uniform-step-25004
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-mix-v0.9-p1B-i0-uniform-2ba217/hf/step-25004
+    window_size: 255
+    datasets: [mendelian_traits]
+  - name: mix-v0.9-p1B-i16-upstream-step-8333
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-mix-v0.9-p1B-i16-uniform_to_upstream_3.6-07bc9c/hf/step-8333
+    window_size: 255
+    datasets: [mendelian_traits]
+
   # exp21 — animal-promoters-yolo (issue #21, wandb animal-promoters-yolo-r01-213a8e).
   # 512 bp context, no BOS. Scoped to mendelian_traits only: complex signal
   # was weak in #21, and the matched-pair mendelian dataset is the one of


### PR DESCRIPTION
## Summary

Adds two of Eric Czech's 1B Qwen3 checkpoints ([Slack #bolinas, 2026-05-18](https://openathena.slack.com/archives/C0A7JN194MT/p1779113714092149?thread_ts=1779111759.134289&cid=C0A7JN194MT)) to the bolinas family on the mendelian_traits leaderboard:

- `mix-v0.9-p1B-i0-uniform-step-25004` — uniform mixture, 52.4B tokens
- `mix-v0.9-p1B-i16-upstream-step-8333` — 40% upstream / 30% downstream-cds, 17.5B tokens (continued from i0's final checkpoint)

Both are Qwen3-1B, 255 bp + BOS context. Scoped to `mendelian_traits` to mirror exp166. No HF mirror — eval direct from GCS (matches exp166 pattern).

## Results (mendelian_traits, global AUPRC, train split)

| Model | minus_llr_avg | SE | jsd_avg | SE |
|---|---|---|---|---|
| exp166-v0.1-p1B-step-27329 | 0.2726 | 0.0093 | 0.2606 | 0.0092 |
| mix-v0.9-p1B-i0-uniform-step-25004 | 0.3693 | 0.0109 | 0.3426 | 0.0108 |
| **mix-v0.9-p1B-i16-upstream-step-8333** | **0.3790** | 0.0108 | **0.3475** | 0.0107 |

Both new models jump ~+0.10 AUPRC over exp166 (existing 1B headline), well outside SE. i16-upstream is marginally ahead of i0-uniform.

## Test plan

- [x] Schema validates: `bolinas.pipelines.evals.models.load_models()` accepts both entries (`family: bolinas`, gcs checkpoint present, datasets ⊆ {mendelian_traits, complex_traits}).
- [x] Snakemake dry-run: only the 6 expected jobs (2× download_model + 2× compute_scores + 2× compute_metrics), no unrelated reruns.
- [x] SkyPilot parallel sweep on 2× g5.xlarge (us-east-2): both clusters succeeded; auto-down armed.
- [x] Both metrics parquets in S3 (`s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics/{model}/mendelian_traits.parquet`) with 66 rows × 9 cols and AUPRC values in (0, 1).
- [ ] Dashboard CI rebuilds on merge — the two new rows should appear in the bolinas family on the mendelian leaderboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)