### PR TITLE
Dashboard: AVG-vs-FWD protocol comparisons + per-family comparison toggle

### DIFF
--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -24,9 +24,9 @@ export default {
     {
       name: "Protocols",
       pages: [
-        {name: "Bolinas (LLR vs JSD)", path: "/protocols/bolinas"},
-        {name: "Evo 2 (LLR vs JSD)", path: "/protocols/evo2"},
-        {name: "GPN-Star (cLLR vs LLR)", path: "/protocols/gpn-star"},
+        {name: "Bolinas", path: "/protocols/bolinas"},
+        {name: "Evo 2", path: "/protocols/evo2"},
+        {name: "GPN-Star", path: "/protocols/gpn-star"},
       ],
     },
     {name: "Models", path: "/models"},

--- a/dashboard/src/components/controls.js
+++ b/dashboard/src/components/controls.js
@@ -15,9 +15,12 @@ export const FAMILY_LABEL = {
   evo2: "Evo 2",
 };
 
-// Protocol options per family. Mirror of `PROTOCOLS` in
-// src/bolinas/pipelines/evals/leaderboard.py — keep in sync when adding
-// a protocol. Defaults match `DEFAULT_PROTOCOL`.
+// Leaderboard-visible protocol options per family. This is the subset of
+// `PROTOCOLS` (in src/bolinas/pipelines/evals/leaderboard.py) that the
+// leaderboards' `ProtocolPicker` exposes — additional protocols can live in
+// `PROTOCOLS` (e.g. `LLR-FWD`, `JSD-FWD` for the AVG-vs-FWD exploration on
+// the Protocols pages) without showing up as leaderboard toggles. Defaults
+// match `DEFAULT_PROTOCOL`.
 export const PROTOCOL_OPTIONS = {
   bolinas: ["LLR", "JSD"],
   gpn_star: ["cLLR", "LLR"],
@@ -141,6 +144,27 @@ export function DirectionPicker(protos, initialFrom, initialTo) {
   const pairs = [];
   for (const a of protos) for (const b of protos) if (a !== b) pairs.push([a, b]);
   let from = initialFrom, to = initialTo;
+  const node = html`<span class="lb-protocol-segmented"></span>`;
+  Object.defineProperty(node, "value", {get: () => ({from, to})});
+  function fire() { node.dispatchEvent(new Event("input", {bubbles: true})); }
+  function render() {
+    node.replaceChildren(...pairs.map(([a, b]) => html`<button
+      type="button"
+      class=${`lb-protocol-btn${from === a && to === b ? " active" : ""}`}
+      onclick=${() => { from = a; to = b; render(); fire(); }}
+    >${a} → ${b}</button>`));
+  }
+  render();
+  return node;
+}
+
+// Comparison picker: like `DirectionPicker`, but takes an explicit list of
+// `[from, to]` pairs instead of generating all permutations. Use this when
+// a page wants to surface only "default → alternative" directions (e.g.
+// `LLR → LLR-FWD` without the reverse) or when the set of pairs isn't the
+// full cross-product of a single protocol list. Value is `{from, to}`.
+export function ComparisonPicker(pairs, initialIdx = 0) {
+  let [from, to] = pairs[initialIdx];
   const node = html`<span class="lb-protocol-segmented"></span>`;
   Object.defineProperty(node, "value", {get: () => ({from, to})});
   function fire() { node.dispatchEvent(new Event("input", {bubbles: true})); }

--- a/dashboard/src/components/controls.js
+++ b/dashboard/src/components/controls.js
@@ -137,32 +137,9 @@ export function PillSelect(options, initial, formatter = (o) => o) {
   return node;
 }
 
-// "A → B" direction picker. Each option is an ordered pair of protocols;
-// the protocol-comparison heatmap renders `B PA − A PA` so cells read as
-// "improvement over A". Value is `{from, to}`.
-export function DirectionPicker(protos, initialFrom, initialTo) {
-  const pairs = [];
-  for (const a of protos) for (const b of protos) if (a !== b) pairs.push([a, b]);
-  let from = initialFrom, to = initialTo;
-  const node = html`<span class="lb-protocol-segmented"></span>`;
-  Object.defineProperty(node, "value", {get: () => ({from, to})});
-  function fire() { node.dispatchEvent(new Event("input", {bubbles: true})); }
-  function render() {
-    node.replaceChildren(...pairs.map(([a, b]) => html`<button
-      type="button"
-      class=${`lb-protocol-btn${from === a && to === b ? " active" : ""}`}
-      onclick=${() => { from = a; to = b; render(); fire(); }}
-    >${a} → ${b}</button>`));
-  }
-  render();
-  return node;
-}
-
-// Comparison picker: like `DirectionPicker`, but takes an explicit list of
-// `[from, to]` pairs instead of generating all permutations. Use this when
-// a page wants to surface only "default → alternative" directions (e.g.
-// `LLR → LLR-FWD` without the reverse) or when the set of pairs isn't the
-// full cross-product of a single protocol list. Value is `{from, to}`.
+// "A → B" comparison picker. Each `pairs` entry is an explicit `[from, to]`
+// pair; the protocol-comparison heatmap renders `to AUPRC − from AUPRC` so
+// cells read as "improvement over from". Value is `{from, to}`.
 export function ComparisonPicker(pairs, initialIdx = 0) {
   let [from, to] = pairs[initialIdx];
   const node = html`<span class="lb-protocol-segmented"></span>`;
@@ -172,7 +149,12 @@ export function ComparisonPicker(pairs, initialIdx = 0) {
     node.replaceChildren(...pairs.map(([a, b]) => html`<button
       type="button"
       class=${`lb-protocol-btn${from === a && to === b ? " active" : ""}`}
-      onclick=${() => { from = a; to = b; render(); fire(); }}
+      onclick=${() => {
+        if (from === a && to === b) return;
+        from = a; to = b;
+        render();
+        fire();
+      }}
     >${a} → ${b}</button>`));
   }
   render();

--- a/dashboard/src/protocols/bolinas.md
+++ b/dashboard/src/protocols/bolinas.md
@@ -93,24 +93,22 @@ for (const r of allRows) {
 }
 
 const deltaRows = [];
-if (baseline !== alternative) {
-  for (const cell of grouped.values()) {
-    const d = cell[baseline];
-    const a = cell[alternative];
-    if (!d || !a) continue;
-    deltaRows.push({
-      method_id: cell.method_id,
-      method_display: cell.method_display,
-      family: FAMILY,
-      protocol: alternative,
-      subset: cell.subset,
-      value: a.value - d.value,
-      se: 0,
-      n: d.n,
-      n_positives: d.n_positives,
-      dataset: dataset,
-    });
-  }
+for (const cell of grouped.values()) {
+  const d = cell[baseline];
+  const a = cell[alternative];
+  if (!d || !a) continue;
+  deltaRows.push({
+    method_id: cell.method_id,
+    method_display: cell.method_display,
+    family: FAMILY,
+    protocol: alternative,
+    subset: cell.subset,
+    value: a.value - d.value,
+    se: 0,
+    n: d.n,
+    n_positives: d.n_positives,
+    dataset: dataset,
+  });
 }
 ```
 

--- a/dashboard/src/protocols/bolinas.md
+++ b/dashboard/src/protocols/bolinas.md
@@ -11,12 +11,21 @@ const leaderboard = await FileAttachment("../data/leaderboard.parquet").parquet(
 const methods = await FileAttachment("../data/models.json").json();
 const datasets = await FileAttachment("../data/datasets.json").json();
 import {heatmap, colorLegend, leadingAggregateSubset, rowsFromLeaderboard} from "../components/heatmap.js";
-import {PillSelect, DirectionPicker, labeledRow} from "../components/controls.js";
+import {PillSelect, ComparisonPicker, labeledRow} from "../components/controls.js";
 ```
 
 ```js
 const FAMILY = "bolinas";
-const PROTOCOLS = ["LLR", "JSD"];
+// Each entry is `[baseline, alternative]`. The heatmap shows
+// `alternative − baseline`, so the default (leaderboard) protocol is the
+// `from` side and the variant being explored is the `to` side. LLR-FWD /
+// JSD-FWD aren't exposed in the leaderboards — see `PROTOCOL_OPTIONS` in
+// ../components/controls.js.
+const COMPARISONS = [
+  ["LLR", "JSD"],
+  ["LLR", "LLR-FWD"],
+  ["JSD", "JSD-FWD"],
+];
 const DATASETS = ["mendelian_traits", "complex_traits"];
 const DATASET_LABEL = {
   mendelian_traits: "Mendelian traits",
@@ -35,21 +44,21 @@ const dataset = view(
 ```
 
 ```js
-const direction = view(
+const comparison = view(
   labeledRow(
     "Compare",
-    DirectionPicker(PROTOCOLS, "LLR", "JSD"),
+    ComparisonPicker(COMPARISONS, 0),
     html`Cells show <b>right − left</b>, in pp.`,
   ),
 );
 ```
 
 ```js
-// `direction` from the cell above is the latest yielded value of the
+// `comparison` from the cell above is the latest yielded value of the
 // view's Generator — accessible only from a downstream cell, not from
 // the cell that calls `view(...)`. Split so `.from` / `.to` resolve.
-const baseline = direction.from;
-const alternative = direction.to;
+const baseline = comparison.from;
+const alternative = comparison.to;
 ```
 
 ```js
@@ -107,7 +116,13 @@ if (baseline !== alternative) {
 
 Each cell below is **${alternative} AUPRC − ${baseline} AUPRC**, in percentage points. Green = ${alternative} scores higher; red = the reverse; yellow = no meaningful change.
 
-Cells aggregate across the same matched groups the [${DATASET_LABEL[dataset]} leaderboard](../leaderboards/${dataset === "mendelian_traits" ? "mendelian" : "complex"}) uses — only the score column changes. See [About](../about) for the protocol definitions.
+**Protocol definitions** (each score is per-variant; transforms make higher = more variant-effect):
+
+- **LLR** — log-likelihood ratio of mutant vs. reference, averaged across forward and reverse-complement scores. Sign-flipped for Mendelian (`−LLR`) and absolute-valued for Complex (`|LLR|`). *Leaderboard default.*
+- **JSD** — per-position Jensen-Shannon divergence between the model's mutant and reference next-token distributions, averaged first across positions *downstream of the variant*, then across forward and reverse-complement scores.
+- **LLR-FWD / JSD-FWD** — same transforms applied to the forward strand only (no reverse-complement averaging). Surfaced here for strand-symmetry exploration; not used in the leaderboards.
+
+Cells aggregate across the same matched groups the [${DATASET_LABEL[dataset]} leaderboard](../leaderboards/${dataset === "mendelian_traits" ? "mendelian" : "complex"}) uses — only the score column changes.
 
 <style>
 :root { --observablehq-max-width: 1920px; }

--- a/dashboard/src/protocols/evo2.md
+++ b/dashboard/src/protocols/evo2.md
@@ -92,24 +92,22 @@ for (const r of allRows) {
 }
 
 const deltaRows = [];
-if (baseline !== alternative) {
-  for (const cell of grouped.values()) {
-    const d = cell[baseline];
-    const a = cell[alternative];
-    if (!d || !a) continue;
-    deltaRows.push({
-      method_id: cell.method_id,
-      method_display: cell.method_display,
-      family: FAMILY,
-      protocol: alternative,
-      subset: cell.subset,
-      value: a.value - d.value,
-      se: 0,
-      n: d.n,
-      n_positives: d.n_positives,
-      dataset: dataset,
-    });
-  }
+for (const cell of grouped.values()) {
+  const d = cell[baseline];
+  const a = cell[alternative];
+  if (!d || !a) continue;
+  deltaRows.push({
+    method_id: cell.method_id,
+    method_display: cell.method_display,
+    family: FAMILY,
+    protocol: alternative,
+    subset: cell.subset,
+    value: a.value - d.value,
+    se: 0,
+    n: d.n,
+    n_positives: d.n_positives,
+    dataset: dataset,
+  });
 }
 ```
 

--- a/dashboard/src/protocols/evo2.md
+++ b/dashboard/src/protocols/evo2.md
@@ -11,12 +11,21 @@ const leaderboard = await FileAttachment("../data/leaderboard.parquet").parquet(
 const methods = await FileAttachment("../data/models.json").json();
 const datasets = await FileAttachment("../data/datasets.json").json();
 import {heatmap, colorLegend, leadingAggregateSubset, rowsFromLeaderboard} from "../components/heatmap.js";
-import {PillSelect, DirectionPicker, labeledRow} from "../components/controls.js";
+import {PillSelect, ComparisonPicker, labeledRow} from "../components/controls.js";
 ```
 
 ```js
 const FAMILY = "evo2";
-const PROTOCOLS = ["LLR", "JSD"];
+// Each entry is `[baseline, alternative]`. The heatmap shows
+// `alternative − baseline`, so the default (leaderboard) protocol is the
+// `from` side and the variant being explored is the `to` side. LLR-FWD /
+// JSD-FWD aren't exposed in the leaderboards — see `PROTOCOL_OPTIONS` in
+// ../components/controls.js.
+const COMPARISONS = [
+  ["LLR", "JSD"],
+  ["LLR", "LLR-FWD"],
+  ["JSD", "JSD-FWD"],
+];
 const DATASETS = ["mendelian_traits"];
 const DATASET_LABEL = {
   mendelian_traits: "Mendelian traits",
@@ -34,21 +43,21 @@ const dataset = view(
 ```
 
 ```js
-const direction = view(
+const comparison = view(
   labeledRow(
     "Compare",
-    DirectionPicker(PROTOCOLS, "LLR", "JSD"),
+    ComparisonPicker(COMPARISONS, 0),
     html`Cells show <b>right − left</b>, in pp.`,
   ),
 );
 ```
 
 ```js
-// `direction` from the cell above is the latest yielded value of the
+// `comparison` from the cell above is the latest yielded value of the
 // view's Generator — accessible only from a downstream cell, not from
 // the cell that calls `view(...)`. Split so `.from` / `.to` resolve.
-const baseline = direction.from;
-const alternative = direction.to;
+const baseline = comparison.from;
+const alternative = comparison.to;
 ```
 
 ```js
@@ -106,7 +115,13 @@ if (baseline !== alternative) {
 
 Each cell below is **${alternative} AUPRC − ${baseline} AUPRC**, in percentage points. Green = ${alternative} scores higher; red = the reverse; yellow = no meaningful change.
 
-Cells aggregate across the same matched groups the [${DATASET_LABEL[dataset]} leaderboard](../leaderboards/${dataset === "mendelian_traits" ? "mendelian" : "complex"}) uses — only the score column changes. See [About](../about) for the protocol definitions.
+**Protocol definitions** (each score is per-variant; transforms make higher = more variant-effect):
+
+- **LLR** — log-likelihood ratio of mutant vs. reference, averaged across forward and reverse-complement scores. Sign-flipped (`−LLR`) so higher = more pathogenic. *Leaderboard default.*
+- **JSD** — per-position Jensen-Shannon divergence between the model's mutant and reference next-token distributions, averaged first across positions *downstream of the variant*, then across forward and reverse-complement scores.
+- **LLR-FWD / JSD-FWD** — same transforms applied to the forward strand only (no reverse-complement averaging). Surfaced here for strand-symmetry exploration; not used in the leaderboards.
+
+Cells aggregate across the same matched groups the [${DATASET_LABEL[dataset]} leaderboard](../leaderboards/${dataset === "mendelian_traits" ? "mendelian" : "complex"}) uses — only the score column changes.
 
 <style>
 :root { --observablehq-max-width: 1920px; }

--- a/dashboard/src/protocols/gpn-star.md
+++ b/dashboard/src/protocols/gpn-star.md
@@ -82,24 +82,22 @@ for (const r of allRows) {
 }
 
 const deltaRows = [];
-if (baseline !== alternative) {
-  for (const cell of grouped.values()) {
-    const d = cell[baseline];
-    const a = cell[alternative];
-    if (!d || !a) continue;
-    deltaRows.push({
-      method_id: cell.method_id,
-      method_display: cell.method_display,
-      family: FAMILY,
-      protocol: alternative,
-      subset: cell.subset,
-      value: a.value - d.value,
-      se: 0,
-      n: d.n,
-      n_positives: d.n_positives,
-      dataset: dataset,
-    });
-  }
+for (const cell of grouped.values()) {
+  const d = cell[baseline];
+  const a = cell[alternative];
+  if (!d || !a) continue;
+  deltaRows.push({
+    method_id: cell.method_id,
+    method_display: cell.method_display,
+    family: FAMILY,
+    protocol: alternative,
+    subset: cell.subset,
+    value: a.value - d.value,
+    se: 0,
+    n: d.n,
+    n_positives: d.n_positives,
+    dataset: dataset,
+  });
 }
 ```
 

--- a/dashboard/src/protocols/gpn-star.md
+++ b/dashboard/src/protocols/gpn-star.md
@@ -16,10 +16,8 @@ import {PillSelect, ComparisonPicker, labeledRow} from "../components/controls.j
 
 ```js
 const FAMILY = "gpn_star";
-// Each entry is `[baseline, alternative]`. The heatmap shows
-// `alternative − baseline`, so cells read as "raw LLR minus calibrated".
-// GPN-Star's metrics gist has no FWD/RC variants, so just one comparison
-// here — same shape as the bolinas / evo2 pages.
+// `[baseline, alternative]`; heatmap shows `alternative − baseline`. No
+// FWD/RC variants on this gist-sourced family, hence the single pair.
 const COMPARISONS = [["cLLR", "LLR"]];
 const DATASETS = ["mendelian_traits", "complex_traits"];
 const DATASET_LABEL = {

--- a/dashboard/src/protocols/gpn-star.md
+++ b/dashboard/src/protocols/gpn-star.md
@@ -11,12 +11,16 @@ const leaderboard = await FileAttachment("../data/leaderboard.parquet").parquet(
 const methods = await FileAttachment("../data/models.json").json();
 const datasets = await FileAttachment("../data/datasets.json").json();
 import {heatmap, colorLegend, leadingAggregateSubset, rowsFromLeaderboard} from "../components/heatmap.js";
-import {PillSelect, DirectionPicker, labeledRow} from "../components/controls.js";
+import {PillSelect, ComparisonPicker, labeledRow} from "../components/controls.js";
 ```
 
 ```js
 const FAMILY = "gpn_star";
-const PROTOCOLS = ["cLLR", "LLR"];
+// Each entry is `[baseline, alternative]`. The heatmap shows
+// `alternative − baseline`, so cells read as "raw LLR minus calibrated".
+// GPN-Star's metrics gist has no FWD/RC variants, so just one comparison
+// here — same shape as the bolinas / evo2 pages.
+const COMPARISONS = [["cLLR", "LLR"]];
 const DATASETS = ["mendelian_traits", "complex_traits"];
 const DATASET_LABEL = {
   mendelian_traits: "Mendelian traits",
@@ -35,21 +39,21 @@ const dataset = view(
 ```
 
 ```js
-const direction = view(
+const comparison = view(
   labeledRow(
     "Compare",
-    DirectionPicker(PROTOCOLS, "cLLR", "LLR"),
+    ComparisonPicker(COMPARISONS, 0),
     html`Cells show <b>right − left</b>, in pp.`,
   ),
 );
 ```
 
 ```js
-// `direction` from the cell above is the latest yielded value of the
+// `comparison` from the cell above is the latest yielded value of the
 // view's Generator — accessible only from a downstream cell, not from
 // the cell that calls `view(...)`. Split so `.from` / `.to` resolve.
-const baseline = direction.from;
-const alternative = direction.to;
+const baseline = comparison.from;
+const alternative = comparison.to;
 ```
 
 ```js
@@ -99,7 +103,12 @@ if (baseline !== alternative) {
 }
 ```
 
-Each cell below is **${alternative} AUPRC − ${baseline} AUPRC**, in percentage points. Green = ${alternative} scores higher than ${baseline}; red = the reverse. cLLR is the producer's recommended protocol on this leaderboard ([Benegas et al. #145](https://github.com/Open-Athena/bolinas-dna/issues/145)) — calibration subtracts pentanucleotide-context background, `llr_calibrated = llr − E[llr | 5-mer, mut]`.
+Each cell below is **${alternative} AUPRC − ${baseline} AUPRC**, in percentage points. Green = ${alternative} scores higher than ${baseline}; red = the reverse.
+
+**Protocol definitions:**
+
+- **cLLR** — calibrated log-likelihood ratio. Pentanucleotide-context background subtraction: `llr_calibrated = llr − E[llr | 5-mer, mut]`. The producer's recommended protocol on this leaderboard ([Benegas et al. #145](https://github.com/Open-Athena/bolinas-dna/issues/145)). *Leaderboard default.*
+- **LLR** — raw log-likelihood ratio of mutant vs. reference, without the pentanucleotide-context calibration.
 
 Same matched groups as the [${DATASET_LABEL[dataset]} leaderboard](../leaderboards/${dataset === "mendelian_traits" ? "mendelian" : "complex"}); only the `score_type` filter changes.
 

--- a/src/bolinas/pipelines/evals/leaderboard.py
+++ b/src/bolinas/pipelines/evals/leaderboard.py
@@ -74,8 +74,11 @@ EVO2_DATASET_SHORT: dict[str, str] = {
 PROTOCOLS: dict[str, dict[str, dict[str, str]]] = {
     "bolinas": {
         # Default LLR / JSD pick the FWD+RC `_avg` columns. The per-strand
-        # `_fwd` / `_rc` columns are also in the parquet for diagnostics
-        # but aren't exposed as separate protocols here.
+        # `_fwd` variants are surfaced on the dashboard's Protocols page
+        # for AVG-vs-FWD exploration; they're not exposed in the
+        # leaderboards' protocol toggle (see `PROTOCOL_OPTIONS` in
+        # `dashboard/src/components/controls.js`). The `_rc` columns are
+        # still in the parquet for diagnostics but aren't surfaced.
         "LLR": {
             "mendelian_traits": "minus_llr_avg",
             "complex_traits": "abs_llr_avg",
@@ -83,6 +86,14 @@ PROTOCOLS: dict[str, dict[str, dict[str, str]]] = {
         "JSD": {
             "mendelian_traits": "jsd_avg",
             "complex_traits": "jsd_avg",
+        },
+        "LLR-FWD": {
+            "mendelian_traits": "minus_llr_fwd",
+            "complex_traits": "abs_llr_fwd",
+        },
+        "JSD-FWD": {
+            "mendelian_traits": "jsd_fwd",
+            "complex_traits": "jsd_fwd",
         },
     },
     "conservation": {
@@ -108,6 +119,12 @@ PROTOCOLS: dict[str, dict[str, dict[str, str]]] = {
         },
         "JSD": {
             "mendelian_traits": "jsd_avg",
+        },
+        "LLR-FWD": {
+            "mendelian_traits": "minus_llr_fwd",
+        },
+        "JSD-FWD": {
+            "mendelian_traits": "jsd_fwd",
         },
     },
 }

--- a/tests/pipelines/evals/test_leaderboard.py
+++ b/tests/pipelines/evals/test_leaderboard.py
@@ -85,10 +85,18 @@ def test_default_protocol_keys_match_protocols():
 
 def test_score_type_for_returns_dataset_specific_column():
     # Bolinas family migrated to per-strand atoms + derived AVG under
-    # the AUPRC pipeline; default LLR/JSD pick the _avg variants.
+    # the AUPRC pipeline; default LLR/JSD pick the _avg variants. The
+    # per-strand _fwd variants are surfaced as LLR-FWD / JSD-FWD on the
+    # dashboard's Protocols pages (not in the leaderboards' protocol
+    # toggle — see PROTOCOL_OPTIONS in dashboard/src/components/controls.js).
     assert score_type_for("bolinas", "LLR", "mendelian_traits") == "minus_llr_avg"
     assert score_type_for("bolinas", "LLR", "complex_traits") == "abs_llr_avg"
     assert score_type_for("bolinas", "JSD", "mendelian_traits") == "jsd_avg"
+    assert score_type_for("bolinas", "LLR-FWD", "mendelian_traits") == "minus_llr_fwd"
+    assert score_type_for("bolinas", "LLR-FWD", "complex_traits") == "abs_llr_fwd"
+    assert score_type_for("bolinas", "JSD-FWD", "mendelian_traits") == "jsd_fwd"
+    assert score_type_for("evo2", "LLR-FWD", "mendelian_traits") == "minus_llr_fwd"
+    assert score_type_for("evo2", "JSD-FWD", "mendelian_traits") == "jsd_fwd"
     assert (
         score_type_for("gpn_star", "cLLR", "mendelian_traits") == "minus_llr_calibrated"
     )


### PR DESCRIPTION
## Summary

- Protocols pages now host **multiple comparisons per family**, picked via a single-direction toggle (default → alternative; drops the prior bidirectional clutter).
- `bolinas` and `evo2`: adds `LLR → LLR-FWD` and `JSD → JSD-FWD` next to the existing `LLR → JSD` toggle, exposing the AVG-vs-FWD strand comparison (per-strand `_fwd` columns from PR #195 / the Evo 2 post-hoc script were sitting unused in the parquets).
- `gpn-star`: keeps its single `cLLR → LLR` comparison; switches to the same `ComparisonPicker` for layout consistency.
- Each page documents its protocols inline (so readers don't chase definitions in the codebase). For bolinas/evo2 the JSD definition explicitly notes "averaged across positions downstream of the variant" (matches `down_jsd_mean` from issue #175 / `src/bolinas/pipelines/evals/inference.py:55-56`).
- `LLR-FWD` / `JSD-FWD` are **not** added to the leaderboards' protocol toggle — `PROTOCOL_OPTIONS` in `dashboard/src/components/controls.js` is unchanged, so the new protocols are protocol-comparison-only. The leaderboard.py `PROTOCOLS` dict now has 4 protocol keys per family but `DEFAULT_PROTOCOL` still picks `LLR`.

### Page-level changes

| File | Change |
| --- | --- |
| `src/bolinas/pipelines/evals/leaderboard.py` | +4 protocol entries (2 families × 2 protocols); refresh the docstring comment about `_fwd` / `_rc` |
| `dashboard/src/components/controls.js` | +1 component (`ComparisonPicker`); clarifies `PROTOCOL_OPTIONS` is the leaderboard-visible subset of `PROTOCOLS` |
| `dashboard/src/protocols/bolinas.md` | `DirectionPicker` → `ComparisonPicker` with 3 pairs; inline protocol definitions |
| `dashboard/src/protocols/evo2.md` | same |
| `dashboard/src/protocols/gpn-star.md` | `DirectionPicker` → `ComparisonPicker` with single `cLLR → LLR` pair; inline protocol definitions |
| `dashboard/observablehq.config.js` | Sidebar entries renamed to plain family names (`Bolinas`, `Evo 2`, `GPN-Star`) |

## Test plan

- [x] `uv run pytest -q --ignore=tests/pipelines/enhancer_classification --ignore=tests/pipelines/enhancer_segmentation` — 824 passed (skipped modules have a pre-existing `alphagenome_pytorch` import failure unrelated to this PR)
- [x] `SKIP=snakefmt uv run pre-commit run --all-files` — all hooks green (ruff, ruff-format, mypy, etc.)
- [x] `rm -rf dashboard/src/.observablehq/cache && AWS_REGION=us-east-2 npm run build` from `dashboard/` — all 8 pages render; verified `leaderboard.parquet` has `LLR-FWD` + `JSD-FWD` rows for bolinas (207 each) and evo2 (33 each), with conservation / alphagenome / gpn_star untouched
- [x] Live-spot-check on `npm run dev`: all 4 changed pages return 200; `ComparisonPicker` served at `/_import/components/controls.js`
- [x] Grep-confirmed `LLR-FWD` / `JSD-FWD` strings do **not** appear in `dist/leaderboards/*.html` (i.e. no leak into the leaderboard protocol toggle)
- [x] Visual interaction (toggling between comparisons / datasets on the live dev server) — not exercised by the agent; worth a quick local check before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)