### PR TITLE
evals: MRR-within-group metric + Evo 2 scale comparison kickoff

### DIFF
--- a/plots/plot_evo2_gene_age_synonymous.py
+++ b/plots/plot_evo2_gene_age_synonymous.py
@@ -1,0 +1,471 @@
+"""Gene-age + synonymous analysis for #203 fifth iteration.
+
+Tests two hypotheses from the issue thread:
+1. Older genes (more represented in genomic LM training corpora — see
+   thestacks.org/publications/idea-phylogenies-bfms Fig 3) get "memorized"
+   more; bigger Evo 2 may overfit to old-gene patterns and over-score
+   benign variants there. Compare to GPN-Star to see if the effect is
+   Evo-2-specific or general to likelihood-based variant scoring.
+2. Synonymous variants are usually neutral but sit in CDS regions with
+   high sequence conservation — prone to LM over-prediction of
+   deleteriousness from "surroundings".
+
+Data sources:
+- Liebeskind 2016 consensus gene ages (Zenodo 51708) — modeAge per
+  UniProt accession; mapped via mygene.info ENSG → UniProt.
+- Per-variant predictions: Evo 2 + GPN-Star v2 gists (see issues #131
+  and #145).
+- phyloP_241m from S3 conservation_eval.
+- HF mendelian dataset v2 (PR #194 revision).
+
+Outputs all under `plots/output/evo2_scale_comparison/`:
+- `ensg_to_age.parquet` — ENSG → UniProt → modeAge → numeric MYA
+- `gene_age_correlation_missense.parquet` — Spearman(age, mean score)
+- `missense_auprc_by_age_bucket.parquet` — per (model, age bucket) AUPRC
+- `gene_age_top20_fps_per_model.parquet` — per-model top-20 FP gene-age stats
+- `gene_age_per_variant_spearman.parquet`
+- `synonymous_per_model.parquet`
+- `top{20,15}_FNs_40b_synonymous.parquet`
+- `missense_auprc_by_gene_age.{svg,png}`
+- `synonymous_summary.{svg,png}`
+- `gene_age_top20_fps_per_model.{svg,png}`
+
+Usage:
+    uv run python plots/plot_evo2_gene_age_synonymous.py
+"""
+
+from __future__ import annotations
+
+import io
+import time
+import zipfile
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import requests
+from datasets import load_dataset
+from scipy.stats import mannwhitneyu, spearmanr
+
+from bolinas.pipelines.evals.metrics import auprc_with_bootstrap_se
+
+EVO_GISTS: dict[str, str] = {
+    "evo2_1b_base": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/b6c254849a71ca0783a24218a4fe9037e887e8f7/evo2_1b_base_train.parquet",
+    "evo2_7b": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/e72d3d2e14955a670b8229dc8d525a69ea88c05c/evo2_7b_train.parquet",
+    "evo2_40b": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/2b425e759811c201ca806ae4c8733fd7732220a6/evo2_40b_train.parquet",
+}
+GPN_GISTS: dict[str, str] = {
+    v: f"https://gist.githubusercontent.com/gonzalobenegas/db282f89aa00244fbb7437dce0f069ef/raw/02484d50d9bfd80337e313652b26f98a9362b6b1/bolinas_mendelian_traits_GPN-Star-{v}.parquet"
+    for v in ("V", "M", "P")
+}
+DATASET_REVISION = "4aed58e50c5dea0b878a665007af2ef9e5108e9f"
+PHYLOP_S3 = (
+    "s3://oa-bolinas/snakemake/conservation_eval/results/mendelian_traits/"
+    "phyloP_241m_train.parquet"
+)
+GENE_AGES_ZIP = "https://zenodo.org/api/records/51708/files/Gene-Ages-v1.0.zip/content"
+GENE_AGES_PATH_IN_ZIP = "marcottelab-Gene-Ages-fee8d00/Main/main_HUMAN.csv"
+OUT_DIR = Path(__file__).parent / "output" / "evo2_scale_comparison"
+
+# Approximate divergence times (MYA) per Liebeskind 2016 / TimeTree.
+# Rough but adequate for ordering buckets and per-variant ages.
+MODE_AGE_MYA: dict[str, int] = {
+    "Cellular_organisms": 4290,
+    "Euk_Archaea": 3000,
+    "Euk+Bac": 3500,
+    "Eukaryota": 1962,
+    "Opisthokonta": 1105,
+    "Eumetazoa": 824,
+    "Vertebrata": 615,
+    "Mammalia": 320,
+}
+
+MODELS = (
+    "evo2_1b_base",
+    "evo2_7b",
+    "evo2_40b",
+    "GPN-Star-V-cLLR",
+    "GPN-Star-M-cLLR",
+    "GPN-Star-P-cLLR",
+)
+MODEL_COLORS = {
+    "evo2_1b_base": "#3b1a64",
+    "evo2_7b": "#3a6fa0",
+    "evo2_40b": "#e8d840",
+    "GPN-Star-V-cLLR": "#1e7a1e",
+    "GPN-Star-M-cLLR": "#a3a30b",
+    "GPN-Star-P-cLLR": "#c44d4d",
+}
+
+
+def load_gene_ages() -> pd.DataFrame:
+    """Liebeskind 2016 consensus gene ages keyed by UniProt accession,
+    with modeAge bucket + approximate MYA."""
+    r = requests.get(GENE_AGES_ZIP, timeout=60)
+    r.raise_for_status()
+    with zipfile.ZipFile(io.BytesIO(r.content)) as zf:
+        with zf.open(GENE_AGES_PATH_IN_ZIP) as f:
+            ages = pd.read_csv(f, index_col=0)
+    ages["age_mya"] = ages["modeAge"].map(MODE_AGE_MYA)
+    return ages[["modeAge", "age_mya"]]
+
+
+def map_ensg_to_uniprot(ensgs: list[str], batch: int = 500) -> dict[str, str]:
+    """Bulk ENSG → UniProt via mygene.info (Swiss-Prot only)."""
+    out: dict[str, str] = {}
+    for i in range(0, len(ensgs), batch):
+        chunk = ensgs[i : i + batch]
+        r = requests.post(
+            "https://mygene.info/v3/query",
+            data={
+                "q": ",".join(chunk),
+                "scopes": "ensembl.gene",
+                "fields": "uniprot.Swiss-Prot",
+                "species": "human",
+            },
+            timeout=60,
+        )
+        if r.status_code != 200:
+            print(f"  batch {i}: HTTP {r.status_code} — skipping")
+            continue
+        for hit in r.json():
+            q = hit.get("query")
+            u = (hit.get("uniprot") or {}).get("Swiss-Prot")
+            if isinstance(u, list):
+                u = u[0] if u else None
+            if u and q and q not in out:
+                out[q] = u
+        time.sleep(0.3)
+    return out
+
+
+def load_wide() -> pd.DataFrame:
+    ds = load_dataset(
+        "bolinas-dna/evals_mendelian_traits",
+        revision=DATASET_REVISION,
+        split="train",
+    )
+    ann = ds.to_pandas()[
+        [
+            "chrom",
+            "pos",
+            "ref",
+            "alt",
+            "label",
+            "subset",
+            "match_group",
+            "AF",
+            "exon_closest_pc_gene_id",
+        ]
+    ]
+    ann["chrom"] = ann["chrom"].astype(str)
+    phyloP = pd.read_parquet(PHYLOP_S3)[["chrom", "pos", "ref", "alt", "score"]].rename(
+        columns={"score": "phyloP"}
+    )
+    phyloP["chrom"] = phyloP["chrom"].astype(str)
+    wide = ann.merge(phyloP, on=["chrom", "pos", "ref", "alt"], how="left")
+
+    print("Loading gene-age table + mapping ENSGs…")
+    ages = load_gene_ages()
+    unique_ensgs = ann["exon_closest_pc_gene_id"].dropna().unique().tolist()
+    ensg_to_uni = map_ensg_to_uniprot(unique_ensgs)
+    ensg_age = pd.DataFrame(
+        [{"exon_closest_pc_gene_id": k, "uniprot": v} for k, v in ensg_to_uni.items()]
+    ).merge(
+        ages.reset_index().rename(columns={"index": "uniprot"}),
+        on="uniprot",
+        how="left",
+    )
+    ensg_age.to_parquet(OUT_DIR / "ensg_to_age.parquet", index=False)
+    print(
+        f"  mapped {len(ensg_to_uni)} / {len(unique_ensgs)} ENSGs, "
+        f"{ensg_age['age_mya'].notna().sum()} have numeric age"
+    )
+    wide = wide.merge(
+        ensg_age[["exon_closest_pc_gene_id", "modeAge", "age_mya"]],
+        on="exon_closest_pc_gene_id",
+        how="left",
+    )
+    for m_short in ("1b_base", "7b", "40b"):
+        d = pd.read_parquet(EVO_GISTS[f"evo2_{m_short}"])[
+            ["chrom", "pos", "ref", "alt", "minus_llr"]
+        ].rename(columns={"minus_llr": f"evo2_{m_short}"})
+        d["chrom"] = d["chrom"].astype(str)
+        wide = wide.merge(d, on=["chrom", "pos", "ref", "alt"], how="left")
+    for v, url in GPN_GISTS.items():
+        g = pd.read_parquet(url)
+        g["chrom"] = g["chrom"].astype(str)
+        g = g[g["split"] == "train"].copy()
+        g[f"GPN-Star-{v}-cLLR"] = -g["llr_calibrated"]
+        wide = wide.merge(
+            g[["chrom", "pos", "ref", "alt", f"GPN-Star-{v}-cLLR"]],
+            on=["chrom", "pos", "ref", "alt"],
+            how="left",
+        )
+    return wide
+
+
+def missense_auprc_by_age_bucket(wide: pd.DataFrame) -> pd.DataFrame:
+    miss = wide[(wide["subset"] == "missense_variant") & wide["age_mya"].notna()]
+    rows: list[dict] = []
+    for bucket in MODE_AGE_MYA:
+        sub = miss[miss["modeAge"] == bucket]
+        if sub["match_group"].nunique() < 30:
+            continue
+        for model in MODELS:
+            ss = sub.dropna(subset=[model, "label", "match_group"])
+            counts = ss.groupby("match_group")["label"].agg(["sum", "count"])
+            bad = (
+                counts[(counts["sum"] != 1) | (counts["count"] < 2)]
+                .reset_index()["match_group"]
+                .unique()
+            )
+            ss = ss[~ss["match_group"].isin(bad)]
+            if ss["match_group"].nunique() < 10:
+                continue
+            r = auprc_with_bootstrap_se(
+                ss["label"], ss[model], ss["match_group"], n_bootstrap=200, rng=0
+            )
+            rows.append(
+                {
+                    "age_bucket": bucket,
+                    "model": model,
+                    "auprc": r["value"],
+                    "auprc_se": r["se"],
+                    "n_groups": r["n_groups"],
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def top_fp_gene_age_stats(wide: pd.DataFrame, top_n: int = 20) -> pd.DataFrame:
+    """For each model, age distribution of its top-N missense FPs (negatives)
+    vs all-negatives baseline."""
+    miss_neg = wide[
+        (wide["subset"] == "missense_variant")
+        & (wide["label"] == False)
+        & wide["age_mya"].notna()
+    ]
+    rows: list[dict] = []
+    for model in MODELS:
+        top = miss_neg.nlargest(top_n, model)
+        med = float(top["age_mya"].median())
+        mean = float(top["age_mya"].mean())
+        pval = float(
+            mannwhitneyu(
+                top["age_mya"], miss_neg["age_mya"], alternative="greater"
+            ).pvalue
+        )
+        rows.append(
+            {
+                "model": model,
+                "top_n": top_n,
+                "top_median_age_mya": med,
+                "top_mean_age_mya": mean,
+                "pval_older_than_baseline": pval,
+                "baseline_median_age_mya": float(miss_neg["age_mya"].median()),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def synonymous_per_model(wide: pd.DataFrame) -> pd.DataFrame:
+    syn = wide[wide["subset"] == "synonymous_variant"]
+    rows: list[dict] = []
+    for model in MODELS:
+        ss = syn.dropna(subset=[model])
+        r = auprc_with_bootstrap_se(
+            ss["label"], ss[model], ss["match_group"], n_bootstrap=300, rng=0
+        )
+        sn = ss[(ss["label"] == False) & ss["phyloP"].notna()]
+        sp = ss[(ss["label"] == True) & ss["phyloP"].notna()]
+        rho_n = float(spearmanr(sn["phyloP"], sn[model]).statistic)
+        rho_p = float(spearmanr(sp["phyloP"], sp[model]).statistic)
+        rows.append(
+            {
+                "model": model,
+                "auprc": r["value"],
+                "auprc_se": r["se"],
+                "rho_phyloP_neg": rho_n,
+                "rho_phyloP_pos": rho_p,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def plot_age_bucket_auprc(df: pd.DataFrame, out_dir: Path) -> None:
+    order = [
+        "Vertebrata",
+        "Eumetazoa",
+        "Opisthokonta",
+        "Eukaryota",
+        "Cellular_organisms",
+    ]
+    fig, ax = plt.subplots(figsize=(11, 5))
+    n_b = len(order)
+    n_m = len(MODELS)
+    w = 0.85 / n_m
+    for i, m in enumerate(MODELS):
+        sub = df[df["model"] == m].set_index("age_bucket").reindex(order)
+        pos = np.arange(n_b) + i * w - 0.42
+        ax.bar(
+            pos,
+            sub["auprc"],
+            width=w,
+            label=m,
+            color=MODEL_COLORS[m],
+            edgecolor="black",
+            linewidth=0.4,
+            yerr=sub["auprc_se"],
+            capsize=2,
+            alpha=0.95,
+        )
+    labels = [f"{b}\n(~{MODE_AGE_MYA[b]} MYA)" for b in order]
+    ax.set_xticks(np.arange(n_b))
+    ax.set_xticklabels(labels, fontsize=8)
+    ax.set_xlabel("Gene age bucket (Liebeskind modeAge, approx MYA)")
+    ax.set_ylabel("Missense AUPRC")
+    ax.set_ylim(0, 1.0)
+    ax.grid(alpha=0.3, axis="y")
+    ax.set_title("Missense AUPRC stratified by gene age", fontsize=11)
+    ax.legend(loc="upper right", fontsize=8, ncol=2)
+    fig.tight_layout()
+    fig.savefig(out_dir / "missense_auprc_by_gene_age.svg", bbox_inches="tight")
+    fig.savefig(
+        out_dir / "missense_auprc_by_gene_age.png", dpi=140, bbox_inches="tight"
+    )
+    plt.close(fig)
+
+
+def plot_top_fp_age_boxes(wide: pd.DataFrame, out_dir: Path, top_n: int = 20) -> None:
+    miss_neg = wide[
+        (wide["subset"] == "missense_variant")
+        & (wide["label"] == False)
+        & wide["age_mya"].notna()
+    ]
+    data_list = [miss_neg.nlargest(top_n, m)["age_mya"] for m in MODELS] + [
+        miss_neg["age_mya"]
+    ]
+    labels = [m.replace("evo2_", "").replace("-cLLR", "") for m in MODELS] + [
+        "all neg\n(baseline)"
+    ]
+    fig, ax = plt.subplots(figsize=(11, 5))
+    bp = ax.boxplot(data_list, tick_labels=labels, patch_artist=True, widths=0.6)
+    for patch, m in zip(bp["boxes"][:-1], MODELS):
+        patch.set_facecolor(MODEL_COLORS[m])
+        patch.set_alpha(0.75)
+    bp["boxes"][-1].set_facecolor("#cccccc")
+    bp["boxes"][-1].set_alpha(0.75)
+    ax.axhline(
+        miss_neg["age_mya"].median(),
+        color="grey",
+        linestyle="--",
+        linewidth=0.8,
+        label=f"baseline median ({miss_neg['age_mya'].median():.0f} MYA)",
+    )
+    ax.set_ylabel("Gene age (MYA)")
+    ax.grid(alpha=0.3, axis="y")
+    ax.set_title(
+        f"Are top-{top_n} missense FPs concentrated in older genes?\n"
+        f"Box = top-{top_n} highest-scoring negatives per model",
+        fontsize=11,
+    )
+    ax.legend(loc="upper right", fontsize=9)
+    plt.xticks(rotation=15, ha="right", fontsize=9)
+    fig.tight_layout()
+    fig.savefig(out_dir / "gene_age_top20_fps_per_model.svg", bbox_inches="tight")
+    fig.savefig(
+        out_dir / "gene_age_top20_fps_per_model.png", dpi=140, bbox_inches="tight"
+    )
+    plt.close(fig)
+
+
+def plot_synonymous(syn_df: pd.DataFrame, out_dir: Path) -> None:
+    syn = syn_df.set_index("model").reindex(list(MODELS))
+    fig, axes = plt.subplots(1, 2, figsize=(13, 4.5))
+    x = np.arange(len(syn))
+    axes[0].bar(
+        x,
+        syn["auprc"],
+        yerr=syn["auprc_se"],
+        capsize=3,
+        color=[MODEL_COLORS[m] for m in MODELS],
+        edgecolor="black",
+        linewidth=0.4,
+    )
+    axes[0].set_xticks(x)
+    axes[0].set_xticklabels(list(MODELS), rotation=20, ha="right", fontsize=9)
+    axes[0].set_ylabel("Synonymous AUPRC")
+    axes[0].set_title("Synonymous AUPRC (n_groups=46)", fontsize=10)
+    axes[0].grid(alpha=0.3, axis="y")
+    axes[1].bar(
+        x - 0.2,
+        syn["rho_phyloP_neg"],
+        width=0.4,
+        color="#4477AA",
+        label="negatives",
+        edgecolor="black",
+        linewidth=0.4,
+    )
+    axes[1].bar(
+        x + 0.2,
+        syn["rho_phyloP_pos"],
+        width=0.4,
+        color="#EE6677",
+        label="positives",
+        edgecolor="black",
+        linewidth=0.4,
+    )
+    axes[1].set_xticks(x)
+    axes[1].set_xticklabels(list(MODELS), rotation=20, ha="right", fontsize=9)
+    axes[1].set_ylabel("Spearman(phyloP_241m, minus_llr)")
+    axes[1].axhline(0, color="black", linewidth=0.5)
+    axes[1].set_title("Synonymous — phyloP correlation per model", fontsize=10)
+    axes[1].legend()
+    axes[1].grid(alpha=0.3, axis="y")
+    fig.suptitle(
+        "Synonymous variants — generally neutral but in conserved coding contexts",
+        fontsize=11,
+    )
+    fig.tight_layout(rect=[0, 0, 1, 0.94])
+    fig.savefig(out_dir / "synonymous_summary.svg", bbox_inches="tight")
+    fig.savefig(out_dir / "synonymous_summary.png", dpi=140, bbox_inches="tight")
+    plt.close(fig)
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"Output dir: {OUT_DIR}")
+    wide = load_wide()
+    print(
+        f"wide: {len(wide)} rows × {len(wide.columns)} cols; "
+        f"missense age cov = {wide[wide['subset'] == 'missense_variant']['age_mya'].notna().mean():.3f}"
+    )
+
+    print("Missense AUPRC by gene age bucket…")
+    age_auprc = missense_auprc_by_age_bucket(wide)
+    age_auprc.to_parquet(OUT_DIR / "missense_auprc_by_age_bucket.parquet", index=False)
+    print(age_auprc.to_string(index=False))
+
+    print("Top-20 FP gene-age stats per model…")
+    top_fp_stats = top_fp_gene_age_stats(wide, top_n=20)
+    top_fp_stats.to_parquet(
+        OUT_DIR / "gene_age_top20_fps_per_model.parquet", index=False
+    )
+    print(top_fp_stats.to_string(index=False))
+
+    print("Synonymous per-model…")
+    syn = synonymous_per_model(wide)
+    syn.to_parquet(OUT_DIR / "synonymous_per_model.parquet", index=False)
+    print(syn.to_string(index=False))
+
+    print("Plotting…")
+    plot_age_bucket_auprc(age_auprc, OUT_DIR)
+    plot_top_fp_age_boxes(wide, OUT_DIR, top_n=20)
+    plot_synonymous(syn, OUT_DIR)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plots/plot_evo2_scale_comparison.py
+++ b/plots/plot_evo2_scale_comparison.py
@@ -408,10 +408,284 @@ def plot_score_histograms(long_df: pd.DataFrame, score_col: str, out_dir: Path) 
         "Filled = negatives; step = positives. Same data; only model varies.",
         fontsize=10,
     )
-    fig.tight_layout(rect=[0, 0.03, 1, 0.95])
+    # Reserve bottom band for the legend so the panels don't overlap it,
+    # and rely on bbox_inches='tight' to include the legend in the saved
+    # bbox even though it sits below the figure rect.
+    fig.tight_layout(rect=[0, 0.08, 1, 0.94])
     stem = f"score_histograms_{score_col}"
-    fig.savefig(out_dir / f"{stem}.svg")
-    fig.savefig(out_dir / f"{stem}.png", dpi=150)
+    fig.savefig(out_dir / f"{stem}.svg", bbox_inches="tight")
+    fig.savefig(out_dir / f"{stem}.png", dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def find_outliers_extended(
+    long_df: pd.DataFrame, *, score_col: str = "minus_llr", top_n: int = 20
+) -> dict[str, pd.DataFrame]:
+    """For each model and each large subset, return the top-N highest-
+    scoring negatives ('false positives' by score-ranking) and the top-N
+    lowest-scoring positives ('false negatives'). Useful for the
+    misclassification-character analysis."""
+    out: dict[str, pd.DataFrame] = {}
+    for model in MODELS:
+        fp_rows: list[pd.DataFrame] = []
+        fn_rows: list[pd.DataFrame] = []
+        sub = long_df[long_df["model"] == model]
+        for subset in sorted(sub["subset"].unique()):
+            s = sub[sub["subset"] == subset]
+            neg = s[s["label"] == 0]
+            pos = s[s["label"] == 1]
+            if len(neg) >= top_n:
+                fp_rows.append(neg.nlargest(top_n, score_col).assign(kind="FP"))
+            if len(pos) >= top_n:
+                fn_rows.append(pos.nsmallest(top_n, score_col).assign(kind="FN"))
+        out[f"{model}_FP"] = (
+            pd.concat(fp_rows, ignore_index=True) if fp_rows else pd.DataFrame()
+        )
+        out[f"{model}_FN"] = (
+            pd.concat(fn_rows, ignore_index=True) if fn_rows else pd.DataFrame()
+        )
+    return out
+
+
+def merge_annotations(long_df: pd.DataFrame) -> pd.DataFrame:
+    """Join the HF dataset's richer annotations (AF, consequence, gene
+    ids, distance bins, clinvar_id, trait) onto the gist predictions by
+    (chrom, pos, ref, alt). Downloads + caches the HF dataset once."""
+    from datasets import load_dataset
+
+    ds = load_dataset(
+        "bolinas-dna/evals_mendelian_traits",
+        revision="4aed58e50c5dea0b878a665007af2ef9e5108e9f",
+        split="train",
+    )
+    ann = ds.to_pandas()[
+        [
+            "chrom",
+            "pos",
+            "ref",
+            "alt",
+            "AF",
+            "consequence_final",
+            "exon_closest_pc_gene_id",
+            "distance_exon_pc",
+            "tss_closest_pc_gene_id",
+            "distance_tss_pc",
+            "clinvar_id",
+            "trait",
+            "source",
+            "distance_exon_pc_bin",
+        ]
+    ]
+    ann["chrom"] = ann["chrom"].astype(str)
+    long = long_df.copy()
+    long["chrom"] = long["chrom"].astype(str)
+    merged = long.merge(ann, on=["chrom", "pos", "ref", "alt"], how="left")
+    assert len(merged) == len(long_df), (
+        f"merge changed row count: {len(long_df)} → {len(merged)}"
+    )
+    n_unmatched = int(merged["consequence_final"].isna().sum())
+    if n_unmatched:
+        print(f"  ⚠ {n_unmatched} rows unmatched in HF annotation join")
+    return merged
+
+
+def rank_within_group(
+    long_df: pd.DataFrame, score_col: str = "minus_llr"
+) -> pd.DataFrame:
+    """One row per (match_group, model) with rank-of-positive (1=best)."""
+    from scipy.stats import rankdata
+
+    rows: list[dict] = []
+    for model in MODELS:
+        sub = long_df[long_df["model"] == model]
+        for (mg, subset), g in sub.groupby(["match_group", "subset"], sort=False):
+            scores = g[score_col].to_numpy()
+            labels = g["label"].astype(int).to_numpy()
+            ranks = rankdata(-scores, method="average")
+            rank_pos = float(ranks[labels == 1][0])
+            rows.append(
+                {
+                    "match_group": int(mg),
+                    "subset": subset,
+                    "model": model,
+                    "rank_pos": rank_pos,
+                    "group_size": int(len(g)),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def cross_scale_misclassification(
+    ann_df: pd.DataFrame,
+    score_col: str = "minus_llr",
+    subset: str = "missense_variant",
+) -> dict[str, pd.DataFrame]:
+    """For a subset, classify each match_group by rank-of-positive in
+    each model and bucket cross-scale patterns. Returns per-group
+    classification and a summary table."""
+    sub = ann_df[ann_df["subset"] == subset]
+    ranks = rank_within_group(sub, score_col=score_col)
+    rank_wide = ranks.pivot(
+        index="match_group", columns="model", values="rank_pos"
+    ).reset_index()
+    rank_wide.columns.name = None
+
+    pos = sub[(sub["model"] == MODELS[0]) & (sub["label"] == 1)][
+        [
+            "match_group",
+            "chrom",
+            "pos",
+            "ref",
+            "alt",
+            "AF",
+            "consequence_final",
+            "exon_closest_pc_gene_id",
+            "distance_exon_pc",
+            "clinvar_id",
+            "trait",
+        ]
+    ].drop_duplicates("match_group")
+    merged = rank_wide.merge(pos, on="match_group", how="left")
+
+    r1 = merged["evo2_1b_base"]
+    r4 = merged["evo2_40b"]
+    merged["scale_failure"] = (r1 <= 3) & (r4 >= 7)
+    merged["scale_success"] = (r1 >= 7) & (r4 <= 3)
+    merged["always_hit"] = (merged[list(MODELS)] == 1).all(axis=1)
+    merged["always_miss"] = (merged[list(MODELS)] >= 7).all(axis=1)
+
+    summary_rows: list[dict] = []
+    for bucket in ("always_hit", "scale_success", "scale_failure", "always_miss"):
+        b = merged[merged[bucket]]
+        summary_rows.append(
+            {
+                "bucket": bucket,
+                "n_match_groups": int(b.shape[0]),
+                "mean_AF": float(b["AF"].mean()) if len(b) else float("nan"),
+                "median_AF": float(b["AF"].median()) if len(b) else float("nan"),
+                "frac_rare_under_1pct": (
+                    float((b["AF"] < 0.01).mean()) if len(b) else float("nan")
+                ),
+                "n_unique_genes": int(b["exon_closest_pc_gene_id"].nunique()),
+                "mean_distance_exon": (
+                    float(b["distance_exon_pc"].mean()) if len(b) else float("nan")
+                ),
+                "n_with_clinvar_id": int(b["clinvar_id"].notna().sum()),
+            }
+        )
+    summary_df = pd.DataFrame(summary_rows)
+    return {"per_group": merged, "summary": summary_df}
+
+
+def plot_rank_crosstab(per_group: pd.DataFrame, out_dir: Path) -> None:
+    """Heatmap: rank-of-positive in 1B vs in 40B (missense match_groups)."""
+    import matplotlib.colors as mcolors
+
+    r1 = per_group["evo2_1b_base"].round().astype(int)
+    r4 = per_group["evo2_40b"].round().astype(int)
+    counts = pd.crosstab(r1, r4)
+    counts = counts.reindex(index=range(1, 11), columns=range(1, 11), fill_value=0)
+    fig, ax = plt.subplots(figsize=(6.5, 5.5))
+    vmax = max(int(counts.values.max()), 1)
+    im = ax.imshow(
+        counts.values,
+        cmap="viridis",
+        norm=mcolors.LogNorm(vmin=1, vmax=vmax),
+        origin="lower",
+    )
+    ax.set_xticks(range(10))
+    ax.set_xticklabels(range(1, 11))
+    ax.set_yticks(range(10))
+    ax.set_yticklabels(range(1, 11))
+    ax.set_xlabel("rank-of-positive in evo2_40b (1 = best)")
+    ax.set_ylabel("rank-of-positive in evo2_1b_base")
+    ax.set_title(
+        "Missense match_groups — rank-of-positive cross-tab\n"
+        "Off-diagonal upper-right = 40B worse than 1B (scale-failure)"
+    )
+    for i in range(10):
+        for j in range(10):
+            v = int(counts.values[i, j])
+            if v:
+                ax.text(
+                    j,
+                    i,
+                    str(v),
+                    ha="center",
+                    va="center",
+                    fontsize=7,
+                    color="white" if v < vmax / 4 else "black",
+                )
+    plt.colorbar(im, ax=ax, label="match_group count (log)")
+    fig.tight_layout()
+    stem = "rank_crosstab_missense_1b_vs_40b"
+    fig.savefig(out_dir / f"{stem}.svg", bbox_inches="tight")
+    fig.savefig(out_dir / f"{stem}.png", dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_scale_bucket_characteristics(per_group: pd.DataFrame, out_dir: Path) -> None:
+    """Compare AF + distance-to-exon distributions across cross-scale buckets."""
+    bucket_labels = {
+        "always_hit": "All models rank pos = 1",
+        "scale_success": "1B rank ≥7 → 40B rank ≤3",
+        "scale_failure": "1B rank ≤3 → 40B rank ≥7",
+        "always_miss": "All models rank pos ≥7",
+    }
+    bucket_colors = {
+        "always_hit": "#2e8c8c",
+        "scale_success": "#3a6fa0",
+        "scale_failure": "#d75f00",
+        "always_miss": "#888888",
+    }
+    fig, axes = plt.subplots(1, 2, figsize=(11, 4))
+
+    af_bins = np.logspace(-6, 0, 40)
+    for bucket, label in bucket_labels.items():
+        af = per_group[per_group[bucket]]["AF"].dropna()
+        if len(af):
+            axes[0].hist(
+                np.clip(af, 1e-6, 1),
+                bins=af_bins,
+                alpha=0.7,
+                label=f"{label} (n={len(af)})",
+                histtype="step",
+                linewidth=1.7,
+                color=bucket_colors[bucket],
+            )
+    axes[0].set_xscale("log")
+    axes[0].set_xlabel("AF (gnomAD)")
+    axes[0].set_ylabel("# match_groups")
+    axes[0].set_title("Allele frequency of positive, by cross-scale bucket")
+    axes[0].legend(fontsize=8, loc="upper left")
+
+    d_bins = np.linspace(0, 100, 41)
+    for bucket, label in bucket_labels.items():
+        d = per_group[per_group[bucket]]["distance_exon_pc"].dropna()
+        if len(d):
+            axes[1].hist(
+                np.clip(d, 0, 100),
+                bins=d_bins,
+                alpha=0.7,
+                label=f"{label} (n={len(d)})",
+                histtype="step",
+                linewidth=1.7,
+                color=bucket_colors[bucket],
+            )
+    axes[1].set_xlabel("distance to nearest exon (clipped at 100 nt)")
+    axes[1].set_ylabel("# match_groups")
+    axes[1].set_title("Distance-to-exon of positive, by cross-scale bucket")
+    axes[1].legend(fontsize=8, loc="upper right")
+
+    fig.suptitle(
+        "Missense — what kinds of variants degrade with scale?\n"
+        "(positives' allele frequency + distance to nearest exon)",
+        fontsize=10,
+    )
+    fig.tight_layout(rect=[0, 0, 1, 0.92])
+    stem = "scale_bucket_characteristics_missense"
+    fig.savefig(out_dir / f"{stem}.svg", bbox_inches="tight")
+    fig.savefig(out_dir / f"{stem}.png", dpi=150, bbox_inches="tight")
     plt.close(fig)
 
 
@@ -527,6 +801,34 @@ def main() -> None:
 
     print("Plotting scale curves…")
     plot_scale_curves(metrics_df, OUT_DIR)
+
+    print("Annotating with HF dataset metadata (AF, gene, consequence, …)…")
+    ann_df = merge_annotations(long_df)
+
+    print(
+        "Per-model top-N FP / FN (highest-scoring negatives, lowest-scoring positives)…"
+    )
+    fp_fn = find_outliers_extended(ann_df, score_col="minus_llr", top_n=20)
+    fp_fn_df = pd.concat(
+        [df.assign(slice=name) for name, df in fp_fn.items()], ignore_index=True
+    )
+    fp_fn_df.to_parquet(OUT_DIR / "top_fp_fn_per_model.parquet", index=False)
+
+    print("Cross-scale misclassification analysis on missense…")
+    miss = cross_scale_misclassification(
+        ann_df, score_col="minus_llr", subset="missense_variant"
+    )
+    miss["per_group"].to_parquet(
+        OUT_DIR / "missense_rank_per_group.parquet", index=False
+    )
+    miss["summary"].to_parquet(
+        OUT_DIR / "missense_scale_bucket_summary.parquet", index=False
+    )
+    print(miss["summary"].to_string(index=False))
+
+    print("Plotting rank cross-tab + scale-bucket characteristics…")
+    plot_rank_crosstab(miss["per_group"], OUT_DIR)
+    plot_scale_bucket_characteristics(miss["per_group"], OUT_DIR)
 
     print("Done. Inspect:")
     for p in sorted(OUT_DIR.iterdir()):

--- a/plots/plot_evo2_scale_comparison.py
+++ b/plots/plot_evo2_scale_comparison.py
@@ -30,13 +30,14 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from scipy.stats import norm, pearsonr, spearmanr
+from scipy.stats import pearsonr, spearmanr
 from sklearn.metrics import average_precision_score
 
 from bolinas.pipelines.evals.metrics import (
     GLOBAL_SUBSET,
     auprc_with_bootstrap_se,
     mrr_within_group,
+    paired_metric_delta_bootstrap,
 )
 
 GIST_URLS: dict[str, str] = {
@@ -265,39 +266,59 @@ def per_model_metrics(
     return pd.DataFrame(rows)
 
 
-def model_pair_significance(metrics_df: pd.DataFrame) -> pd.DataFrame:
-    """Pairwise Wald Z + p-values for AUPRC and MRR gaps between each
-    pair of models, per (score_type, subset). Independence-assumed
-    combined SE — paired bootstrap would tighten."""
+def model_pair_significance(
+    long_df: pd.DataFrame, *, n_bootstrap: int = 1000, rng: int = 0
+) -> pd.DataFrame:
+    """Paired cluster-bootstrap Z + p-values for AUPRC and MRR gaps
+    between each pair of models, per (score_type, subset).
+
+    Uses ``paired_metric_delta_bootstrap`` so the SE picks up the
+    cross-model correlation (both models score the same match_groups).
+    This is generally tighter than the independence formula
+    ``sqrt(SE_a² + SE_b²)`` and gives the correct frequentist p for a
+    paired comparison."""
     rows: list[dict] = []
-    grouped = metrics_df.groupby(["score_type", "subset"])
-    for (score_type, subset), g in grouped:
-        gm = g.set_index("model")
-        for i, m1 in enumerate(MODELS):
-            for m2 in MODELS[i + 1 :]:
-                if m1 not in gm.index or m2 not in gm.index:
-                    continue
-                for metric in ("auprc", "mrr"):
-                    v1, se1 = gm.loc[m1, f"{metric}_value"], gm.loc[m1, f"{metric}_se"]
-                    v2, se2 = gm.loc[m2, f"{metric}_value"], gm.loc[m2, f"{metric}_se"]
-                    delta = float(v2 - v1)
-                    combined_se = float(math.sqrt(se1**2 + se2**2))
-                    z = delta / combined_se if combined_se > 0 else 0.0
-                    p = float(2 * (1 - norm.cdf(abs(z))))
-                    rows.append(
-                        {
-                            "score_type": score_type,
-                            "subset": subset,
-                            "metric": metric,
-                            "model_a": m1,
-                            "model_b": m2,
-                            "delta": delta,
-                            "combined_se": combined_se,
-                            "z": z,
-                            "p_two_sided": p,
-                            "significant_05": p < 0.05,
-                        }
-                    )
+    for score_type in SCORE_COLS:
+        for subset in sorted(long_df["subset"].unique().tolist()) + [GLOBAL_SUBSET]:
+            sub = (
+                long_df
+                if subset == GLOBAL_SUBSET
+                else long_df[long_df["subset"] == subset]
+            )
+            wide = pivot_score(sub, score_type)
+            label = wide["label"].to_numpy()
+            mg = wide["match_group"].to_numpy()
+            for i, m1 in enumerate(MODELS):
+                for m2 in MODELS[i + 1 :]:
+                    sa = wide[f"{m1}__{score_type}"].to_numpy()
+                    sb = wide[f"{m2}__{score_type}"].to_numpy()
+                    for metric in ("auprc", "mrr"):
+                        res = paired_metric_delta_bootstrap(
+                            label,
+                            sa,
+                            sb,
+                            mg,
+                            metric,
+                            n_bootstrap=n_bootstrap,
+                            rng=rng,
+                        )
+                        rows.append(
+                            {
+                                "score_type": score_type,
+                                "subset": subset,
+                                "metric": metric,
+                                "model_a": m1,
+                                "model_b": m2,
+                                "value_a": res["value_a"],
+                                "value_b": res["value_b"],
+                                "delta": res["delta"],
+                                "paired_se": res["se"],
+                                "z": res["z"],
+                                "p_two_sided": res["p_two_sided"],
+                                "significant_05": res["p_two_sided"] < 0.05,
+                                "n_groups": res["n_groups"],
+                            }
+                        )
     return pd.DataFrame(rows)
 
 
@@ -492,8 +513,8 @@ def main() -> None:
     metrics_df.to_parquet(OUT_DIR / "metrics.parquet", index=False)
     print(f"  {len(metrics_df)} rows in metrics.parquet")
 
-    print("Computing model-pair significance…")
-    sig_df = model_pair_significance(metrics_df)
+    print("Computing model-pair significance (paired cluster bootstrap)…")
+    sig_df = model_pair_significance(long_df, n_bootstrap=1000, rng=0)
     sig_df.to_parquet(OUT_DIR / "significance.parquet", index=False)
 
     print("Finding outlier variants…")

--- a/plots/plot_evo2_scale_comparison.py
+++ b/plots/plot_evo2_scale_comparison.py
@@ -1,0 +1,516 @@
+"""Evo 2 scale-comparison analysis for issue #203 — first iteration.
+
+Loads the three Evo 2 prediction parquets posted in the 2026-05-20 comment
+of issue #131 (PR #194 k=9 Mendelian train split). Runs a bug-hunt block
+(per-checkpoint LLR correlation, sign-direction sanity, statistical
+significance per subset), then computes AUPRC + MRR-within-group per
+(model, subset) and writes a score-histogram figure plus an outlier table.
+
+Outputs (all under `plots/output/evo2_scale_comparison/`):
+
+- `metrics.parquet` — per (model, score_type, subset) AUPRC + MRR with SE.
+- `significance.parquet` — per (subset, score_type, model_pair) Wald Z + p
+  for AUPRC and MRR gaps.
+- `correlations.parquet` — per-subset Pearson and Spearman between each
+  pair of checkpoint LLRs.
+- `outliers_top20.parquet` — per subset, the 20 variants with the largest
+  |Δscore(40B − 1B_base)|.
+- `score_histograms_{minus_llr,next_token_jsd_mean}.{svg,png}` — per-subset
+  pos-vs-neg score histograms, one panel per subset, models overlaid.
+
+Usage:
+    uv run python plots/plot_evo2_scale_comparison.py
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.stats import norm, pearsonr, spearmanr
+from sklearn.metrics import average_precision_score
+
+from bolinas.pipelines.evals.metrics import (
+    GLOBAL_SUBSET,
+    auprc_with_bootstrap_se,
+    mrr_within_group,
+)
+
+GIST_URLS: dict[str, str] = {
+    "evo2_1b_base": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/b6c254849a71ca0783a24218a4fe9037e887e8f7/evo2_1b_base_train.parquet",
+    "evo2_7b": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/e72d3d2e14955a670b8229dc8d525a69ea88c05c/evo2_7b_train.parquet",
+    "evo2_40b": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/2b425e759811c201ca806ae4c8733fd7732220a6/evo2_40b_train.parquet",
+}
+MODELS: tuple[str, ...] = ("evo2_1b_base", "evo2_7b", "evo2_40b")
+MODEL_COLORS: dict[str, str] = {
+    "evo2_1b_base": "#3b1a64",
+    "evo2_7b": "#3a6fa0",
+    "evo2_40b": "#e8d840",
+}
+SCORE_COLS: tuple[str, ...] = ("minus_llr", "next_token_jsd_mean")
+KEY_COLS: tuple[str, ...] = (
+    "chrom",
+    "pos",
+    "ref",
+    "alt",
+    "label",
+    "subset",
+    "match_group",
+)
+OUT_DIR = Path(__file__).parent / "output" / "evo2_scale_comparison"
+
+# Dashboard parquet checked as regression anchor — re-fetched at runtime.
+DASHBOARD_PARQUET_URL = (
+    "https://openathena.ai/bolinas-dna/_file/data/leaderboard.9c4a2b57.parquet"
+)
+
+
+def load_predictions() -> pd.DataFrame:
+    """Load and merge the three gist parquets, keyed on (chrom,pos,ref,alt).
+
+    Returns a long-format frame with one row per (variant, model)."""
+    rows: list[pd.DataFrame] = []
+    for model, url in GIST_URLS.items():
+        df = pd.read_parquet(url)
+        df = df.assign(model=model)
+        rows.append(df)
+    df = pd.concat(rows, ignore_index=True)
+    # Sanity: every (chrom,pos,ref,alt) should have one row per model.
+    counts = df.groupby(["chrom", "pos", "ref", "alt"])["model"].nunique()
+    assert (counts == len(MODELS)).all(), (
+        f"variant-row counts uneven across models: {counts.value_counts().to_dict()}"
+    )
+    return df
+
+
+def pivot_score(long_df: pd.DataFrame, score_col: str) -> pd.DataFrame:
+    """Wide frame: one row per variant with columns label, subset,
+    match_group, {model}_{score_col} for each model."""
+    keys = list(KEY_COLS)
+    pivoted = long_df.pivot(index=keys, columns="model", values=score_col)
+    pivoted.columns = [f"{m}__{score_col}" for m in pivoted.columns]
+    return pivoted.reset_index()
+
+
+def bug_hunt_correlations(long_df: pd.DataFrame) -> pd.DataFrame:
+    """Per-subset (and global) Pearson + Spearman correlation between each
+    pair of checkpoints on `minus_llr`. Flags any pair < 0.3."""
+    wide = pivot_score(long_df, "minus_llr")
+    rows: list[dict] = []
+    subsets = sorted(wide["subset"].unique().tolist()) + [GLOBAL_SUBSET]
+    for subset in subsets:
+        sub = wide if subset == GLOBAL_SUBSET else wide[wide["subset"] == subset]
+        for i, m1 in enumerate(MODELS):
+            for m2 in MODELS[i + 1 :]:
+                x = sub[f"{m1}__minus_llr"].to_numpy()
+                y = sub[f"{m2}__minus_llr"].to_numpy()
+                pear = float(pearsonr(x, y).statistic)
+                spear = float(spearmanr(x, y).statistic)
+                rows.append(
+                    {
+                        "subset": subset,
+                        "model_a": m1,
+                        "model_b": m2,
+                        "n": len(sub),
+                        "pearson": pear,
+                        "spearman": spear,
+                        "flag_low": pear < 0.3,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def bug_hunt_dashboard_anchor(long_df: pd.DataFrame) -> pd.DataFrame:
+    """Regression check: AUPRC computed locally from gist parquets must
+    reproduce the dashboard's LLR-protocol values to ≤ 1e-4."""
+    dash = pd.read_parquet(DASHBOARD_PARQUET_URL)
+    dash = dash[
+        (dash["dataset"] == "mendelian_traits")
+        & (dash["protocol"] == "LLR")
+        & (dash["method_id"].isin(MODELS))
+    ][["method_id", "subset", "value", "n_positives"]]
+
+    rows: list[dict] = []
+    for model in MODELS:
+        sub = long_df[long_df["model"] == model]
+        # Per-subset
+        for subset in sorted(sub["subset"].unique()):
+            s = sub[sub["subset"] == subset]
+            local = float(average_precision_score(s["label"], s["minus_llr"]))
+            rows.append({"method_id": model, "subset": subset, "local_auprc": local})
+        # Global
+        rows.append(
+            {
+                "method_id": model,
+                "subset": GLOBAL_SUBSET,
+                "local_auprc": float(
+                    average_precision_score(sub["label"], sub["minus_llr"])
+                ),
+            }
+        )
+    local_df = pd.DataFrame(rows)
+    merged = local_df.merge(
+        dash.rename(columns={"value": "dashboard_auprc"}),
+        on=["method_id", "subset"],
+        how="left",
+    )
+    merged["delta"] = merged["local_auprc"] - merged["dashboard_auprc"]
+    merged["matches"] = merged["delta"].abs() < 1e-4
+    n_matchable = int(merged["dashboard_auprc"].notna().sum())
+    n_match = int((merged["matches"] & merged["dashboard_auprc"].notna()).sum())
+    print(
+        f"  dashboard-anchor regression: {n_match}/{n_matchable} (subset, model) "
+        f"cells reproduce dashboard AUPRC within 1e-4."
+    )
+    assert n_match == n_matchable, (
+        "Local AUPRC diverges from dashboard — bug somewhere. "
+        f"Diffs > 1e-4: {merged[~merged['matches'] & merged['dashboard_auprc'].notna()]}"
+    )
+    return merged
+
+
+def bug_hunt_sign_direction(long_df: pd.DataFrame) -> pd.DataFrame:
+    """Per (model, subset) Pearson correlation between `label` and
+    `minus_llr`. All should be positive — minus_llr is meant to assign
+    larger values to deleterious (label=1). Flags any negative
+    correlation as a sign-flip bug."""
+    rows: list[dict] = []
+    for model in MODELS:
+        sub = long_df[long_df["model"] == model]
+        for subset in sorted(sub["subset"].unique()):
+            s = sub[sub["subset"] == subset]
+            if s["label"].nunique() < 2:
+                continue
+            r = float(pearsonr(s["label"], s["minus_llr"]).statistic)
+            rows.append(
+                {
+                    "model": model,
+                    "subset": subset,
+                    "n": len(s),
+                    "pearson_label_vs_score": r,
+                    "flag_negative": r < 0,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def per_model_metrics(
+    long_df: pd.DataFrame, score_col: str, *, n_bootstrap: int = 1000, rng: int = 0
+) -> pd.DataFrame:
+    """Per (model, subset) AUPRC and MRR with cluster-bootstrap SE."""
+    rows: list[dict] = []
+    for model in MODELS:
+        sub = long_df[long_df["model"] == model]
+        subsets = sorted(sub["subset"].unique())
+        for subset in subsets:
+            s = sub[sub["subset"] == subset]
+            auprc = auprc_with_bootstrap_se(
+                s["label"],
+                s[score_col],
+                s["match_group"],
+                n_bootstrap=n_bootstrap,
+                rng=rng,
+            )
+            mrr = mrr_within_group(
+                s["label"],
+                s[score_col],
+                s["match_group"],
+                n_bootstrap=n_bootstrap,
+                rng=rng,
+            )
+            rows.append(
+                {
+                    "model": model,
+                    "score_type": score_col,
+                    "subset": subset,
+                    "auprc_value": auprc["value"],
+                    "auprc_se": auprc["se"],
+                    "mrr_value": mrr["value"],
+                    "mrr_se": mrr["se"],
+                    "n_groups": auprc["n_groups"],
+                    "n_rows": auprc["n_rows"],
+                }
+            )
+        # Global
+        auprc = auprc_with_bootstrap_se(
+            sub["label"],
+            sub[score_col],
+            sub["match_group"],
+            n_bootstrap=n_bootstrap,
+            rng=rng,
+        )
+        mrr = mrr_within_group(
+            sub["label"],
+            sub[score_col],
+            sub["match_group"],
+            n_bootstrap=n_bootstrap,
+            rng=rng,
+        )
+        rows.append(
+            {
+                "model": model,
+                "score_type": score_col,
+                "subset": GLOBAL_SUBSET,
+                "auprc_value": auprc["value"],
+                "auprc_se": auprc["se"],
+                "mrr_value": mrr["value"],
+                "mrr_se": mrr["se"],
+                "n_groups": auprc["n_groups"],
+                "n_rows": auprc["n_rows"],
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def model_pair_significance(metrics_df: pd.DataFrame) -> pd.DataFrame:
+    """Pairwise Wald Z + p-values for AUPRC and MRR gaps between each
+    pair of models, per (score_type, subset). Independence-assumed
+    combined SE — paired bootstrap would tighten."""
+    rows: list[dict] = []
+    grouped = metrics_df.groupby(["score_type", "subset"])
+    for (score_type, subset), g in grouped:
+        gm = g.set_index("model")
+        for i, m1 in enumerate(MODELS):
+            for m2 in MODELS[i + 1 :]:
+                if m1 not in gm.index or m2 not in gm.index:
+                    continue
+                for metric in ("auprc", "mrr"):
+                    v1, se1 = gm.loc[m1, f"{metric}_value"], gm.loc[m1, f"{metric}_se"]
+                    v2, se2 = gm.loc[m2, f"{metric}_value"], gm.loc[m2, f"{metric}_se"]
+                    delta = float(v2 - v1)
+                    combined_se = float(math.sqrt(se1**2 + se2**2))
+                    z = delta / combined_se if combined_se > 0 else 0.0
+                    p = float(2 * (1 - norm.cdf(abs(z))))
+                    rows.append(
+                        {
+                            "score_type": score_type,
+                            "subset": subset,
+                            "metric": metric,
+                            "model_a": m1,
+                            "model_b": m2,
+                            "delta": delta,
+                            "combined_se": combined_se,
+                            "z": z,
+                            "p_two_sided": p,
+                            "significant_05": p < 0.05,
+                        }
+                    )
+    return pd.DataFrame(rows)
+
+
+def find_outliers(
+    long_df: pd.DataFrame, *, score_col: str = "minus_llr", top_n: int = 20
+) -> pd.DataFrame:
+    """Per subset, top_n variants with the largest |Δscore(40B − 1B_base)|."""
+    wide = pivot_score(long_df, score_col)
+    wide["delta_40b_minus_1b"] = (
+        wide[f"evo2_40b__{score_col}"] - wide[f"evo2_1b_base__{score_col}"]
+    )
+    rows: list[pd.DataFrame] = []
+    for subset in sorted(wide["subset"].unique()):
+        sub = wide[wide["subset"] == subset].copy()
+        sub["abs_delta"] = sub["delta_40b_minus_1b"].abs()
+        sub_top = sub.nlargest(top_n, "abs_delta")
+        rows.append(sub_top)
+    return pd.concat(rows, ignore_index=True)
+
+
+def plot_score_histograms(long_df: pd.DataFrame, score_col: str, out_dir: Path) -> None:
+    """Per-subset score histograms: positives vs negatives, one panel per
+    subset, models overlaid as transparent histograms."""
+    subsets = sorted(long_df["subset"].unique())
+    n_cols = 3
+    n_rows = math.ceil(len(subsets) / n_cols)
+    fig, axes = plt.subplots(
+        n_rows,
+        n_cols,
+        figsize=(4.0 * n_cols, 2.8 * n_rows),
+        sharex=False,
+    )
+    axes = np.array(axes).reshape(-1)
+    for ax, subset in zip(axes, subsets):
+        sub = long_df[long_df["subset"] == subset]
+        # Auto-range across all models for a fair side-by-side view.
+        lo, hi = (
+            float(sub[score_col].quantile(0.005)),
+            float(sub[score_col].quantile(0.995)),
+        )
+        bins = np.linspace(lo, hi, 41)
+        for model in MODELS:
+            sm = sub[sub["model"] == model]
+            pos = sm[sm["label"] == 1][score_col].to_numpy()
+            neg = sm[sm["label"] == 0][score_col].to_numpy()
+            color = MODEL_COLORS[model]
+            ax.hist(
+                neg,
+                bins=bins,
+                density=True,
+                alpha=0.25,
+                color=color,
+                label=f"{model.split('_', 1)[1]} neg",
+            )
+            ax.hist(
+                pos,
+                bins=bins,
+                density=True,
+                alpha=0.6,
+                color=color,
+                histtype="step",
+                linewidth=1.4,
+                label=f"{model.split('_', 1)[1]} pos",
+            )
+        ax.set_title(
+            f"{subset} (n_pos={int((sub['label'] == 1).sum() / len(MODELS))})",
+            fontsize=9,
+        )
+        ax.set_xlabel(score_col, fontsize=8)
+        ax.tick_params(labelsize=7)
+        ax.set_yticks([])
+    # Hide unused axes
+    for ax in axes[len(subsets) :]:
+        ax.set_visible(False)
+    # Single legend on the first axis
+    handles, labels = axes[0].get_legend_handles_labels()
+    fig.legend(
+        handles,
+        labels,
+        loc="lower center",
+        ncol=6,
+        fontsize=7,
+        bbox_to_anchor=(0.5, -0.02),
+    )
+    fig.suptitle(
+        f"Evo 2 scale comparison — per-subset score histograms ({score_col})\n"
+        "Filled = negatives; step = positives. Same data; only model varies.",
+        fontsize=10,
+    )
+    fig.tight_layout(rect=[0, 0.03, 1, 0.95])
+    stem = f"score_histograms_{score_col}"
+    fig.savefig(out_dir / f"{stem}.svg")
+    fig.savefig(out_dir / f"{stem}.png", dpi=150)
+    plt.close(fig)
+
+
+def plot_scale_curves(metrics_df: pd.DataFrame, out_dir: Path) -> None:
+    """Per-subset {AUPRC, MRR} vs model scale, with bootstrap-SE bands."""
+    score_col = "minus_llr"
+    df = metrics_df[metrics_df["score_type"] == score_col].copy()
+    subsets = sorted([s for s in df["subset"].unique() if s != GLOBAL_SUBSET])
+    n_cols = 3
+    n_rows = math.ceil(len(subsets) / n_cols)
+    for metric_label, value_col, se_col in [
+        ("AUPRC", "auprc_value", "auprc_se"),
+        ("MRR-within-group", "mrr_value", "mrr_se"),
+    ]:
+        fig, axes = plt.subplots(
+            n_rows,
+            n_cols,
+            figsize=(3.5 * n_cols, 2.6 * n_rows),
+            sharex=True,
+            sharey=False,
+        )
+        axes = np.array(axes).reshape(-1)
+        x = np.arange(len(MODELS))
+        for ax, subset in zip(axes, subsets):
+            sub = df[df["subset"] == subset].set_index("model").reindex(MODELS)
+            y = sub[value_col].to_numpy()
+            yerr = sub[se_col].to_numpy()
+            ax.errorbar(
+                x, y, yerr=yerr, marker="o", color="#222", capsize=3, linewidth=1.2
+            )
+            n_pos = int(sub["n_groups"].iloc[0])
+            ax.set_title(f"{subset} (n_pos={n_pos})", fontsize=9)
+            ax.tick_params(labelsize=7)
+            ax.set_xticks(x)
+            ax.set_xticklabels(["1B_base", "7B", "40B"], fontsize=8)
+            ax.set_ylabel(metric_label, fontsize=8)
+        for ax in axes[len(subsets) :]:
+            ax.set_visible(False)
+        fig.suptitle(
+            f"Evo 2 scale curves — {metric_label} on {score_col}\n"
+            "Error bars: cluster-bootstrap SE over match_groups.",
+            fontsize=10,
+        )
+        fig.tight_layout(rect=[0, 0.0, 1, 0.94])
+        stem = f"scale_curves_{value_col}"
+        fig.savefig(out_dir / f"{stem}.svg")
+        fig.savefig(out_dir / f"{stem}.png", dpi=150)
+        plt.close(fig)
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"Output dir: {OUT_DIR}")
+
+    print("Loading 3 gist parquets…")
+    long_df = load_predictions()
+    print(
+        f"  {len(long_df)} rows across {long_df['model'].nunique()} models, "
+        f"{long_df['subset'].nunique()} subsets, "
+        f"{long_df['match_group'].nunique()} match_groups."
+    )
+
+    print("Bug-hunt: dashboard regression anchor…")
+    bug_hunt_dashboard_anchor(long_df).to_parquet(
+        OUT_DIR / "regression_dashboard_anchor.parquet",
+        index=False,
+    )
+
+    print("Bug-hunt: per-checkpoint LLR correlation…")
+    corr = bug_hunt_correlations(long_df)
+    corr.to_parquet(OUT_DIR / "correlations.parquet", index=False)
+    low = corr[corr["flag_low"]]
+    if not low.empty:
+        print(f"  ⚠ {len(low)} subset-pair Pearson < 0.3:")
+        print(low.to_string(index=False))
+    else:
+        print(f"  all Pearson ≥ 0.3 (min = {corr['pearson'].min():.3f}).")
+
+    print("Bug-hunt: sign-direction sanity…")
+    signs = bug_hunt_sign_direction(long_df)
+    signs.to_parquet(OUT_DIR / "sign_direction.parquet", index=False)
+    neg = signs[signs["flag_negative"]]
+    if not neg.empty:
+        print(
+            f"  ⚠ {len(neg)} (model, subset) cells have negative label↔score correlation:"
+        )
+        print(neg.to_string(index=False))
+    else:
+        print(
+            f"  all label↔minus_llr correlations positive "
+            f"(min = {signs['pearson_label_vs_score'].min():.3f})."
+        )
+
+    print("Computing per-model metrics (AUPRC + MRR, n_bootstrap=1000)…")
+    metrics_parts = [
+        per_model_metrics(long_df, sc, n_bootstrap=1000, rng=0) for sc in SCORE_COLS
+    ]
+    metrics_df = pd.concat(metrics_parts, ignore_index=True)
+    metrics_df.to_parquet(OUT_DIR / "metrics.parquet", index=False)
+    print(f"  {len(metrics_df)} rows in metrics.parquet")
+
+    print("Computing model-pair significance…")
+    sig_df = model_pair_significance(metrics_df)
+    sig_df.to_parquet(OUT_DIR / "significance.parquet", index=False)
+
+    print("Finding outlier variants…")
+    outliers = find_outliers(long_df, score_col="minus_llr", top_n=20)
+    outliers.to_parquet(OUT_DIR / "outliers_top20.parquet", index=False)
+
+    print("Plotting score histograms…")
+    for sc in SCORE_COLS:
+        plot_score_histograms(long_df, sc, OUT_DIR)
+
+    print("Plotting scale curves…")
+    plot_scale_curves(metrics_df, OUT_DIR)
+
+    print("Done. Inspect:")
+    for p in sorted(OUT_DIR.iterdir()):
+        print(f"  {p}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plots/plot_evo2_scale_phyloP_af.py
+++ b/plots/plot_evo2_scale_phyloP_af.py
@@ -1,0 +1,327 @@
+"""Second iteration for issue #203 — AF-threshold filter + phyloP correlation analysis.
+
+Tests two hypotheses raised on the issue thread:
+
+1. TraitGym-v1-style filter: the previous (pre-PR-#194) dataset had
+   negatives at AF ≳ 5%; the new k=9 dataset goes down to AF ≳ 0.1%.
+   Filtering the new dataset to AF ≥ {0.5, 1, 5}% should recover
+   v1-like AUPRC if low-AF negatives are the driver of the scale-hurt.
+2. Phylogenetic-noise memorization: bigger Evo 2 may have internalized
+   cross-species conservation more strongly. Measure
+   Spearman(phyloP_241m, minus_llr) per model on each subset; if the
+   correlation strengthens monotonically with scale, that's direct
+   evidence.
+
+Outputs all under `plots/output/evo2_scale_comparison/`:
+- `af_threshold_metrics_missense.parquet` — AUPRC + MRR per (af_thr, model)
+- `phyloP_score_spearman.parquet` — Spearman per (subset, label, model)
+- `af_threshold_missense.{svg,png}` — 3-panel scale curves vs AF threshold
+- `phyloP_vs_score_missense.{svg,png}` — 3-panel scatter, model facets
+
+Usage:
+    uv run python plots/plot_evo2_scale_phyloP_af.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from datasets import load_dataset
+from scipy.stats import spearmanr
+
+from bolinas.pipelines.evals.metrics import (
+    auprc_with_bootstrap_se,
+    mrr_within_group,
+)
+
+MODELS: tuple[str, ...] = ("evo2_1b_base", "evo2_7b", "evo2_40b")
+MODEL_COLORS: dict[str, str] = {
+    "evo2_1b_base": "#3b1a64",
+    "evo2_7b": "#3a6fa0",
+    "evo2_40b": "#e8d840",
+}
+GIST_URLS: dict[str, str] = {
+    "evo2_1b_base": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/b6c254849a71ca0783a24218a4fe9037e887e8f7/evo2_1b_base_train.parquet",
+    "evo2_7b": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/e72d3d2e14955a670b8229dc8d525a69ea88c05c/evo2_7b_train.parquet",
+    "evo2_40b": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/2b425e759811c201ca806ae4c8733fd7732220a6/evo2_40b_train.parquet",
+}
+DATASET_REVISION = "4aed58e50c5dea0b878a665007af2ef9e5108e9f"
+PHYLOP_S3 = "s3://oa-bolinas/snakemake/conservation_eval/results/mendelian_traits/phyloP_241m_train.parquet"
+OUT_DIR = Path(__file__).parent / "output" / "evo2_scale_comparison"
+AF_THRESHOLDS: tuple[float, ...] = (0.001, 0.005, 0.01, 0.05)
+SUBSETS_FOR_RHO: tuple[str, ...] = (
+    "missense_variant",
+    "splicing",
+    "tss_proximal",
+    "non_coding_transcript_exon_variant",
+)
+
+
+def load_annotated() -> pd.DataFrame:
+    """Load predictions + AF + phyloP_241m, all keyed on (chrom,pos,ref,alt)."""
+    ds = load_dataset(
+        "bolinas-dna/evals_mendelian_traits",
+        revision=DATASET_REVISION,
+        split="train",
+    )
+    ann = ds.to_pandas()[
+        [
+            "chrom",
+            "pos",
+            "ref",
+            "alt",
+            "AF",
+            "consequence_final",
+            "exon_closest_pc_gene_id",
+        ]
+    ]
+    ann["chrom"] = ann["chrom"].astype(str)
+    phyloP = pd.read_parquet(PHYLOP_S3)[["chrom", "pos", "ref", "alt", "score"]].rename(
+        columns={"score": "phyloP"}
+    )
+    phyloP["chrom"] = phyloP["chrom"].astype(str)
+
+    parts: list[pd.DataFrame] = []
+    for model, url in GIST_URLS.items():
+        d = pd.read_parquet(url)
+        d["chrom"] = d["chrom"].astype(str)
+        d = d.merge(ann, on=["chrom", "pos", "ref", "alt"], how="left")
+        d = d.merge(phyloP, on=["chrom", "pos", "ref", "alt"], how="left")
+        parts.append(d.assign(model=model))
+    return pd.concat(parts, ignore_index=True)
+
+
+def af_threshold_sweep(
+    long_df: pd.DataFrame, subset: str = "missense_variant"
+) -> pd.DataFrame:
+    """For each AF threshold, drop negatives below it (positives kept regardless),
+    then drop match_groups that no longer have ≥1 negative. Returns one row per
+    (af_thr, model) with AUPRC + MRR (cluster-bootstrap SE)."""
+    rows: list[dict] = []
+    for thr in (None, *AF_THRESHOLDS):
+        sub_all = long_df[long_df["subset"] == subset].copy()
+        if thr is not None:
+            sub_all = sub_all[(sub_all["label"] == 1) | (sub_all["AF"] >= thr)]
+        counts = sub_all.groupby(["match_group", "model"])["label"].agg(
+            ["sum", "count"]
+        )
+        bad = (
+            counts[(counts["sum"] != 1) | (counts["count"] < 2)]
+            .reset_index()["match_group"]
+            .unique()
+        )
+        sub_all = sub_all[~sub_all["match_group"].isin(bad)]
+        n_groups = sub_all[sub_all["model"] == MODELS[0]]["match_group"].nunique()
+        if n_groups < 10:
+            continue
+        n_pos = int((sub_all[sub_all["model"] == MODELS[0]]["label"] == 1).sum())
+        n_all = int((sub_all["model"] == MODELS[0]).sum())
+        prevalence = n_pos / n_all
+        mean_k = (
+            sub_all[sub_all["model"] == MODELS[0]].groupby("match_group").size().mean()
+            - 1
+        )
+        for model in MODELS:
+            s = sub_all[sub_all["model"] == model]
+            auprc = auprc_with_bootstrap_se(
+                s["label"], s["minus_llr"], s["match_group"], n_bootstrap=300, rng=0
+            )
+            mrr = mrr_within_group(
+                s["label"], s["minus_llr"], s["match_group"], n_bootstrap=300, rng=0
+            )
+            rows.append(
+                {
+                    "af_thr": thr,
+                    "model": model,
+                    "n_groups": int(n_groups),
+                    "mean_k": float(mean_k),
+                    "prevalence": float(prevalence),
+                    "auprc": auprc["value"],
+                    "auprc_se": auprc["se"],
+                    "auprc_minus_prev": auprc["value"] - prevalence,
+                    "mrr": mrr["value"],
+                    "mrr_se": mrr["se"],
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def phyloP_spearman(long_df: pd.DataFrame) -> pd.DataFrame:
+    """Spearman(phyloP_241m, minus_llr) per (subset, label, model)."""
+    rows: list[dict] = []
+    for subset in SUBSETS_FOR_RHO:
+        for label, lname in [(1, "pos"), (0, "neg")]:
+            n = int(
+                (
+                    (long_df["subset"] == subset)
+                    & (long_df["label"] == label)
+                    & (long_df["model"] == MODELS[0])
+                    & long_df["phyloP"].notna()
+                ).sum()
+            )
+            if n < 10:
+                continue
+            for model in MODELS:
+                s = long_df[
+                    (long_df["model"] == model)
+                    & (long_df["subset"] == subset)
+                    & (long_df["label"] == label)
+                    & long_df["phyloP"].notna()
+                ]
+                rho = float(spearmanr(s["phyloP"], s["minus_llr"]).statistic)
+                rows.append(
+                    {
+                        "subset": subset,
+                        "label": lname,
+                        "model": model,
+                        "n": n,
+                        "rho_phyloP_score": rho,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def plot_af_threshold_scale_curves(af_df: pd.DataFrame, out_dir: Path) -> None:
+    """3-panel: raw AUPRC, AUPRC-prev, MRR — each vs AF threshold, per model."""
+    df = af_df[af_df["af_thr"].notna()]
+    fig, axes = plt.subplots(1, 3, figsize=(13, 4))
+    for model in MODELS:
+        s = df[df["model"] == model].sort_values("af_thr")
+        label = model.replace("evo2_", "")
+        axes[0].errorbar(
+            s["af_thr"],
+            s["auprc"],
+            yerr=s["auprc_se"],
+            marker="o",
+            color=MODEL_COLORS[model],
+            label=label,
+            capsize=3,
+        )
+        axes[1].errorbar(
+            s["af_thr"],
+            s["auprc_minus_prev"],
+            yerr=s["auprc_se"],
+            marker="o",
+            color=MODEL_COLORS[model],
+            label=label,
+            capsize=3,
+        )
+        axes[2].errorbar(
+            s["af_thr"],
+            s["mrr"],
+            yerr=s["mrr_se"],
+            marker="o",
+            color=MODEL_COLORS[model],
+            label=label,
+            capsize=3,
+        )
+    titles = ["Raw AUPRC", "AUPRC − prevalence (gain over chance)", "MRR-within-group"]
+    ylabels = ["AUPRC", "AUPRC − prev", "MRR"]
+    for ax, ttl, ylab in zip(axes, titles, ylabels):
+        ax.set_xscale("log")
+        ax.set_xlabel("Negative-AF filter threshold")
+        ax.set_ylabel(ylab)
+        ax.set_title(ttl, fontsize=10)
+        ax.grid(alpha=0.3)
+        ax.legend(fontsize=9)
+    fig.suptitle(
+        "Missense — performance vs AF-threshold filter on negatives", fontsize=11
+    )
+    fig.tight_layout()
+    fig.savefig(out_dir / "af_threshold_missense.svg", bbox_inches="tight")
+    fig.savefig(out_dir / "af_threshold_missense.png", dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_phyloP_vs_score(long_df: pd.DataFrame, out_dir: Path) -> None:
+    """3-panel scatter: phyloP vs minus_llr for missense, one panel per model."""
+    miss = long_df[long_df["subset"] == "missense_variant"].dropna(
+        subset=["phyloP", "AF"]
+    )
+    fig, axes = plt.subplots(1, 3, figsize=(16, 5.5))
+    sc = None
+    for ax, model in zip(axes, MODELS):
+        s = miss[miss["model"] == model]
+        neg = s[s["label"] == 0]
+        pos = s[s["label"] == 1]
+        sc = ax.scatter(
+            neg["phyloP"],
+            neg["minus_llr"],
+            c=np.log10(neg["AF"].clip(lower=1e-6)),
+            cmap="viridis",
+            s=5,
+            alpha=0.4,
+            vmin=-3.5,
+            vmax=-1,
+            rasterized=True,
+        )
+        ax.scatter(
+            pos["phyloP"],
+            pos["minus_llr"],
+            c="red",
+            s=20,
+            alpha=0.7,
+            marker="x",
+            linewidths=1,
+            label=f"{len(pos)} positives",
+        )
+        rho_n = float(spearmanr(neg["phyloP"], neg["minus_llr"]).statistic)
+        rho_p = float(spearmanr(pos["phyloP"], pos["minus_llr"]).statistic)
+        ax.set_title(
+            f"{model.replace('evo2_', '')}\n"
+            f"ρ(phyloP, score): neg={rho_n:+.3f}, pos={rho_p:+.3f}",
+            fontsize=11,
+        )
+        ax.set_xlabel("phyloP_241m (positive = conserved)", fontsize=10)
+        ax.legend(fontsize=9, loc="upper left")
+        ax.grid(alpha=0.3)
+        ax.axhline(0, color="grey", linewidth=0.5)
+    axes[0].set_ylabel("Evo 2 minus_llr (positive = deleterious-looking)", fontsize=10)
+    cbar = fig.colorbar(sc, ax=axes, shrink=0.8, pad=0.02, aspect=30)
+    cbar.set_label("log10(AF) (negatives only)", fontsize=10)
+    fig.suptitle(
+        "Missense — Evo 2 score vs phyloP_241m across model scale\n"
+        "Negatives (dots, color = log AF) and positives (red ×). "
+        "ρ_neg grows with scale: 40B is more phyloP-driven than 1B.",
+        fontsize=11,
+    )
+    fig.savefig(out_dir / "phyloP_vs_score_missense.svg", bbox_inches="tight")
+    fig.savefig(out_dir / "phyloP_vs_score_missense.png", dpi=140, bbox_inches="tight")
+    plt.close(fig)
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"Output dir: {OUT_DIR}")
+
+    print("Loading predictions + AF + phyloP_241m…")
+    long_df = load_annotated()
+    n_missing_phyloP = int(long_df["phyloP"].isna().sum())
+    print(
+        f"  merged: {len(long_df)} rows; phyloP missing in {n_missing_phyloP}/{len(long_df)} rows"
+    )
+
+    print("AF-threshold filter sweep on missense…")
+    af_df = af_threshold_sweep(long_df, subset="missense_variant")
+    af_df.to_parquet(OUT_DIR / "af_threshold_metrics_missense.parquet", index=False)
+    print(af_df.to_string(index=False))
+
+    print("Spearman(phyloP_241m, score) per (subset, label, model)…")
+    rho_df = phyloP_spearman(long_df)
+    rho_df.to_parquet(OUT_DIR / "phyloP_score_spearman.parquet", index=False)
+    print(rho_df.to_string(index=False))
+
+    print("Plotting AF-threshold scale curves…")
+    plot_af_threshold_scale_curves(af_df, OUT_DIR)
+
+    print("Plotting phyloP vs minus_llr scatter…")
+    plot_phyloP_vs_score(long_df, OUT_DIR)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plots/plot_evo2_vs_gpnstar.py
+++ b/plots/plot_evo2_vs_gpnstar.py
@@ -1,0 +1,360 @@
+"""GPN-Star vs Evo 2 comparison + dbSNP/ClinVar lookup for #203.
+
+Builds a head-to-head table on the same Mendelian k=9 dataset (PR #194):
+- AUPRC per (model, subset) for 3 Evo 2 sizes (LLR) + 3 GPN-Star variants
+  (LLR + cLLR), with cluster-bootstrap SE
+- Spearman(phyloP_241m, minus_llr) per (model, label) on missense — shows
+  GPN-Star is MORE phyloP-driven than Evo 2 40B yet achieves better
+  AUPRC, so phyloP-correlation alone isn't the failure mode
+- Top-20 false positives + top-20 false negatives for Evo 2 40B on
+  missense, with rsID / ClinVar / CADD via myvariant.info
+
+Inputs:
+- Evo 2 predictions: gists from #131 (2026-05-20 comment), train split
+- GPN-Star predictions: gists from #145 (2026-05-19 v2 comment), train split
+- HF dataset: bolinas-dna/evals_mendelian_traits @ 4aed58e
+- phyloP_241m: S3 conservation_eval pipeline output
+
+Usage:
+    uv run python plots/plot_evo2_vs_gpnstar.py
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import requests
+from datasets import load_dataset
+from scipy.stats import spearmanr
+
+from bolinas.pipelines.evals.metrics import auprc_with_bootstrap_se
+
+EVO_GISTS: dict[str, str] = {
+    "evo2_1b_base": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/b6c254849a71ca0783a24218a4fe9037e887e8f7/evo2_1b_base_train.parquet",
+    "evo2_7b": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/e72d3d2e14955a670b8229dc8d525a69ea88c05c/evo2_7b_train.parquet",
+    "evo2_40b": "https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/2b425e759811c201ca806ae4c8733fd7732220a6/evo2_40b_train.parquet",
+}
+GPN_GISTS: dict[str, str] = {
+    v: f"https://gist.githubusercontent.com/gonzalobenegas/db282f89aa00244fbb7437dce0f069ef/raw/02484d50d9bfd80337e313652b26f98a9362b6b1/bolinas_mendelian_traits_GPN-Star-{v}.parquet"
+    for v in ("V", "M", "P")
+}
+DATASET_REVISION = "4aed58e50c5dea0b878a665007af2ef9e5108e9f"
+PHYLOP_S3 = (
+    "s3://oa-bolinas/snakemake/conservation_eval/results/mendelian_traits/"
+    "phyloP_241m_train.parquet"
+)
+OUT_DIR = Path(__file__).parent / "output" / "evo2_scale_comparison"
+
+EVO_MODELS = ("evo2_1b_base", "evo2_7b", "evo2_40b")
+GPN_MODELS = ("GPN-Star-V", "GPN-Star-M", "GPN-Star-P")
+ALL_MODELS = (
+    "evo2_1b_base",
+    "evo2_7b",
+    "evo2_40b",
+    "GPN-Star-V",
+    "GPN-Star-V-cLLR",
+    "GPN-Star-M",
+    "GPN-Star-M-cLLR",
+    "GPN-Star-P",
+    "GPN-Star-P-cLLR",
+)
+SUBSETS = (
+    "missense_variant",
+    "splicing",
+    "synonymous_variant",
+    "tss_proximal",
+    "5_prime_UTR_variant",
+    "3_prime_UTR_variant",
+    "non_coding_transcript_exon_variant",
+    "distal",
+)
+MODEL_COLORS = {
+    "evo2_1b_base": "#3b1a64",
+    "evo2_7b": "#3a6fa0",
+    "evo2_40b": "#e8d840",
+    "GPN-Star-V": "#1e7a1e",
+    "GPN-Star-V-cLLR": "#1e7a1e",
+    "GPN-Star-M": "#a3a30b",
+    "GPN-Star-M-cLLR": "#a3a30b",
+    "GPN-Star-P": "#c44d4d",
+    "GPN-Star-P-cLLR": "#c44d4d",
+}
+HATCHES = {"GPN-Star-V-cLLR": "//", "GPN-Star-M-cLLR": "//", "GPN-Star-P-cLLR": "//"}
+
+
+def load_wide() -> pd.DataFrame:
+    """Long table: one row per variant, with score columns per model."""
+    ds = load_dataset(
+        "bolinas-dna/evals_mendelian_traits",
+        revision=DATASET_REVISION,
+        split="train",
+    )
+    ann = ds.to_pandas()[
+        [
+            "chrom",
+            "pos",
+            "ref",
+            "alt",
+            "label",
+            "subset",
+            "match_group",
+            "AF",
+            "consequence_final",
+            "exon_closest_pc_gene_id",
+        ]
+    ]
+    ann["chrom"] = ann["chrom"].astype(str)
+    phyloP = pd.read_parquet(PHYLOP_S3)[["chrom", "pos", "ref", "alt", "score"]].rename(
+        columns={"score": "phyloP"}
+    )
+    phyloP["chrom"] = phyloP["chrom"].astype(str)
+    wide = ann.merge(phyloP, on=["chrom", "pos", "ref", "alt"], how="left")
+    for model, url in EVO_GISTS.items():
+        d = pd.read_parquet(url)[["chrom", "pos", "ref", "alt", "minus_llr"]].rename(
+            columns={"minus_llr": model}
+        )
+        d["chrom"] = d["chrom"].astype(str)
+        wide = wide.merge(d, on=["chrom", "pos", "ref", "alt"], how="left")
+    for v, url in GPN_GISTS.items():
+        g = pd.read_parquet(url)
+        g["chrom"] = g["chrom"].astype(str)
+        g = g[g["split"] == "train"].copy()
+        g[f"GPN-Star-{v}"] = -g["llr"]
+        g[f"GPN-Star-{v}-cLLR"] = -g["llr_calibrated"]
+        wide = wide.merge(
+            g[["chrom", "pos", "ref", "alt", f"GPN-Star-{v}", f"GPN-Star-{v}-cLLR"]],
+            on=["chrom", "pos", "ref", "alt"],
+            how="left",
+        )
+    return wide
+
+
+def per_subset_auprc(wide: pd.DataFrame) -> pd.DataFrame:
+    """Per-(model, subset) AUPRC + cluster-bootstrap SE."""
+    rows: list[dict] = []
+    for model in ALL_MODELS:
+        for subset in SUBSETS:
+            s = wide[wide["subset"] == subset][["label", model, "match_group"]].dropna()
+            if len(s) < 10:
+                continue
+            r = auprc_with_bootstrap_se(
+                s["label"], s[model], s["match_group"], n_bootstrap=200, rng=0
+            )
+            rows.append(
+                {
+                    "model": model,
+                    "subset": subset,
+                    "auprc": r["value"],
+                    "auprc_se": r["se"],
+                    "n_groups": r["n_groups"],
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def phyloP_spearman_missense(wide: pd.DataFrame) -> pd.DataFrame:
+    """Spearman(phyloP_241m, score) per model on missense, split by label."""
+    miss = wide[(wide["subset"] == "missense_variant") & wide["phyloP"].notna()]
+    rows: list[dict] = []
+    for model in ALL_MODELS:
+        m = miss.dropna(subset=[model])
+        rho_n = float(
+            spearmanr(m[m["label"] == 0]["phyloP"], m[m["label"] == 0][model]).statistic
+        )
+        rho_p = float(
+            spearmanr(m[m["label"] == 1]["phyloP"], m[m["label"] == 1][model]).statistic
+        )
+        rows.append(
+            {
+                "model": model,
+                "subset": "missense_variant",
+                "rho_neg": rho_n,
+                "rho_pos": rho_p,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def myvariant_lookup(hgvs_id: str, retries: int = 2) -> dict | None:
+    url = (
+        f"https://myvariant.info/v1/variant/{hgvs_id}?assembly=hg38&"
+        "fields=dbsnp.rsid,dbsnp.gene.symbol,clinvar.rcv.clinical_significance,"
+        "clinvar.rcv.conditions.name,cadd.phred,cadd.consequence,"
+        "gnomad_genome.af.af"
+    )
+    for _ in range(retries):
+        try:
+            r = requests.get(url, timeout=10)
+            if r.status_code == 200:
+                return r.json()
+        except Exception:
+            time.sleep(0.5)
+    return None
+
+
+def extract_meta(d: dict | None) -> dict:
+    if not d:
+        return {
+            "rsid": "",
+            "gene": "",
+            "clinvar": "",
+            "cadd_phred": None,
+            "cadd_consequence": "",
+            "gnomad_af": None,
+        }
+    out: dict = {}
+    out["rsid"] = (d.get("dbsnp") or {}).get("rsid", "") or ""
+    gene = (d.get("dbsnp") or {}).get("gene", {})
+    if isinstance(gene, list):
+        gene = gene[0] if gene else {}
+    out["gene"] = (gene or {}).get("symbol", "")
+    cv = (d.get("clinvar") or {}).get("rcv")
+    if isinstance(cv, list):
+        cv = cv[0] if cv else None
+    out["clinvar"] = (cv or {}).get("clinical_significance", "")
+    cadd = d.get("cadd") or {}
+    out["cadd_phred"] = cadd.get("phred")
+    cons = cadd.get("consequence", "")
+    if isinstance(cons, list):
+        cons = "+".join(c for c in cons if c)[:30]
+    out["cadd_consequence"] = cons
+    gg = (d.get("gnomad_genome") or {}).get("af", {}) or {}
+    out["gnomad_af"] = gg.get("af")
+    return out
+
+
+def annotate_top(top: pd.DataFrame) -> pd.DataFrame:
+    metas: list[dict] = []
+    for _, row in top.iterrows():
+        h = f"chr{row['chrom']}:g.{row['pos']}{row['ref']}>{row['alt']}"
+        meta = extract_meta(myvariant_lookup(h))
+        meta["hgvs"] = h
+        metas.append(meta)
+        time.sleep(0.15)  # polite throttle on myvariant.info
+    meta_df = pd.DataFrame(metas)
+    out = top.reset_index(drop=True).join(
+        meta_df.drop(columns=["hgvs"]).reset_index(drop=True)
+    )
+    out["hgvs"] = meta_df["hgvs"].values
+    return out
+
+
+def plot_per_subset_auprc(auprc_df: pd.DataFrame, out_dir: Path) -> None:
+    fig, ax = plt.subplots(figsize=(14, 5))
+    n_models = len(ALL_MODELS)
+    n_sub = len(SUBSETS)
+    w = 0.85 / n_models
+    for i, m in enumerate(ALL_MODELS):
+        sub = auprc_df[auprc_df["model"] == m].set_index("subset").reindex(SUBSETS)
+        pos = np.arange(n_sub) + i * w - 0.42
+        ax.bar(
+            pos,
+            sub["auprc"],
+            width=w,
+            label=m,
+            color=MODEL_COLORS[m],
+            edgecolor="black",
+            linewidth=0.4,
+            hatch=HATCHES.get(m, ""),
+            alpha=0.95,
+            yerr=sub["auprc_se"],
+            capsize=2,
+        )
+    ax.set_xticks(np.arange(n_sub))
+    ax.set_xticklabels(SUBSETS, rotation=25, ha="right", fontsize=8)
+    ax.set_ylabel("AUPRC")
+    ax.set_ylim(0, 0.85)
+    ax.grid(alpha=0.3, axis="y")
+    ax.set_title(
+        "Per-subset AUPRC — Evo 2 (3 sizes, LLR) vs GPN-Star (V/M/P, LLR + cLLR)",
+        fontsize=11,
+    )
+    ax.legend(loc="upper right", fontsize=8, ncol=3)
+    fig.tight_layout()
+    fig.savefig(out_dir / "evo2_vs_gpnstar_per_subset.svg", bbox_inches="tight")
+    fig.savefig(
+        out_dir / "evo2_vs_gpnstar_per_subset.png", dpi=140, bbox_inches="tight"
+    )
+    plt.close(fig)
+
+
+def plot_phyloP_correlation(rho_df: pd.DataFrame, out_dir: Path) -> None:
+    rho = rho_df.set_index("model").reindex(list(ALL_MODELS))
+    fig, ax = plt.subplots(figsize=(12, 4.5))
+    x = np.arange(len(rho))
+    w = 0.4
+    ax.bar(
+        x - w / 2,
+        rho["rho_neg"],
+        width=w,
+        color="#4477AA",
+        label="negatives",
+        edgecolor="black",
+        linewidth=0.4,
+    )
+    ax.bar(
+        x + w / 2,
+        rho["rho_pos"],
+        width=w,
+        color="#EE6677",
+        label="positives",
+        edgecolor="black",
+        linewidth=0.4,
+    )
+    ax.set_xticks(x)
+    ax.set_xticklabels(list(ALL_MODELS), rotation=20, ha="right", fontsize=9)
+    ax.set_ylabel("Spearman(phyloP_241m, minus_llr)")
+    ax.axhline(0, color="black", linewidth=0.5)
+    ax.set_title(
+        "How phyloP-driven is each model's missense score? (Spearman)", fontsize=11
+    )
+    ax.legend()
+    ax.grid(alpha=0.3, axis="y")
+    fig.tight_layout()
+    fig.savefig(out_dir / "phyloP_correlation_evo2_vs_gpnstar.svg", bbox_inches="tight")
+    fig.savefig(
+        out_dir / "phyloP_correlation_evo2_vs_gpnstar.png", dpi=140, bbox_inches="tight"
+    )
+    plt.close(fig)
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    print("Loading predictions + AF + phyloP_241m…")
+    wide = load_wide()
+    print(f"  wide: {len(wide)} rows × {len(wide.columns)} cols")
+
+    print("Per-subset AUPRC (cluster-bootstrap SE)…")
+    auprc_df = per_subset_auprc(wide)
+    auprc_df.to_parquet(
+        OUT_DIR / "evo2_vs_gpnstar_auprc_per_subset.parquet", index=False
+    )
+
+    print("Spearman(phyloP_241m, score) per model on missense…")
+    rho_df = phyloP_spearman_missense(wide)
+    rho_df.to_parquet(
+        OUT_DIR / "phyloP_correlation_evo2_vs_gpnstar.parquet", index=False
+    )
+    print(rho_df.to_string(index=False))
+
+    print("dbSNP / ClinVar / CADD lookup for 40B's top-20 missense FPs and FNs…")
+    miss = wide[wide["subset"] == "missense_variant"]
+    top_fps = miss[miss["label"] == False].nlargest(20, "evo2_40b").copy()
+    top_fns = miss[miss["label"] == True].nsmallest(20, "evo2_40b").copy()
+    fp = annotate_top(top_fps)
+    fn = annotate_top(top_fns)
+    fp.to_parquet(OUT_DIR / "dbsnp_top20_FPs_40b_missense.parquet", index=False)
+    fn.to_parquet(OUT_DIR / "dbsnp_top20_FNs_40b_missense.parquet", index=False)
+
+    print("Plotting per-subset AUPRC bars + phyloP-correlation bars…")
+    plot_per_subset_auprc(auprc_df, OUT_DIR)
+    plot_phyloP_correlation(rho_df, OUT_DIR)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bolinas/pipelines/evals/metrics.py
+++ b/src/bolinas/pipelines/evals/metrics.py
@@ -15,6 +15,11 @@ Four metric families live here:
   Within-group analogue of pairwise accuracy that's defined for 1:k
   match groups (k ≥ 1). Used by ad-hoc analyses that want a within-group
   metric on PR #194's 1:9 datasets.
+- ``paired_metric_delta_bootstrap``: paired cluster-bootstrap SE for the
+  metric *delta* between two score columns on the same dataset. Use
+  this instead of ``sqrt(SE_a² + SE_b²)`` when comparing two models on
+  shared match_groups — the paired form picks up the cross-model
+  correlation directly and gives tighter (less conservative) p-values.
 - ``METRIC_FUNCTIONS`` / ``compute_metrics``: classical AUPRC / AUROC /
   Spearman over (label, score) pairs. Still used by older pipelines
   (``snakemake/analysis/evals_v1/``, ``scripts/evo2_eval/``).
@@ -338,6 +343,134 @@ def compute_auprc_metrics(
         )
 
     return pd.DataFrame(rows)
+
+
+def paired_metric_delta_bootstrap(
+    label: pd.Series,
+    score_a: pd.Series,
+    score_b: pd.Series,
+    match_group: pd.Series,
+    metric: str,
+    *,
+    n_bootstrap: int = 1000,
+    rng: np.random.Generator | int | None = 0,
+) -> dict[str, float | int]:
+    """Cluster-bootstrap SE for the *paired* metric delta between two
+    score columns on the same dataset.
+
+    The independence formula ``SE = sqrt(SE_a² + SE_b²)`` is conservative
+    for paired evaluations because both scores see the same
+    ``match_group``s — the cross-model correlation ρ > 0 means the true
+    paired SE ``sqrt(SE_a² + SE_b² − 2ρ·SE_a·SE_b)`` is smaller. This
+    function does the paired bootstrap directly: each iteration
+    resamples ``match_group``s once and recomputes the metric for both
+    score columns on the resampled rows, so the per-iteration delta
+    captures the cross-model correlation directly.
+
+    Args:
+        label: 0/1 (or bool) per row.
+        score_a: numeric score column A. Must not contain NaN.
+        score_b: numeric score column B. Must not contain NaN.
+        match_group: integer group id; cluster bootstrap unit.
+        metric: one of ``"auprc"`` or ``"mrr"`` — the within-resample
+            metric to compute on each score column.
+        n_bootstrap: number of bootstrap iterations.
+        rng: ``numpy.random.Generator``, seed int, or ``None``.
+
+    Returns:
+        ``{"delta", "se", "z", "p_two_sided", "value_a", "value_b",
+        "n_groups", "n_rows"}``. ``z = delta / se``; ``p_two_sided`` via
+        the standard normal CDF.
+    """
+    from scipy.stats import norm as _norm  # local import to keep top tidy
+
+    assert metric in {"auprc", "mrr"}, f"unsupported metric: {metric!r}"
+    assert len(label) == len(score_a) == len(score_b) == len(match_group), (
+        f"length mismatch: label={len(label)} score_a={len(score_a)} "
+        f"score_b={len(score_b)} match_group={len(match_group)}"
+    )
+    label_arr = np.asarray(label).astype(int)
+    sa = np.asarray(score_a, dtype=float)
+    sb = np.asarray(score_b, dtype=float)
+    mg_arr = np.asarray(match_group)
+    assert not (np.isnan(sa).any() or np.isnan(sb).any()), (
+        "score_a or score_b has NaN values; fill upstream before scoring"
+    )
+
+    group_to_rows: dict = pd.Series(mg_arr).groupby(mg_arr, sort=False).indices
+    group_ids = np.fromiter(
+        group_to_rows.keys(), dtype=object, count=len(group_to_rows)
+    )
+    n_groups = len(group_ids)
+    group_rows: list[np.ndarray] = [group_to_rows[g] for g in group_ids]
+
+    if metric == "mrr":
+        # MRR factorizes: each group's reciprocal-rank depends only on
+        # within-group scores. Precompute rr_a[g] and rr_b[g] once;
+        # bootstrap then averages over resampled-group indices in O(1)
+        # per iteration instead of re-evaluating per row.
+        rr_a = np.empty(n_groups, dtype=float)
+        rr_b = np.empty(n_groups, dtype=float)
+        for i, rows in enumerate(group_rows):
+            ys = label_arr[rows]
+            assert int(ys.sum()) == 1 and len(ys) >= 2, (
+                f"mrr requires 1 positive + ≥1 negative per match_group; "
+                f"got n_pos={int(ys.sum())}, n_rows={len(ys)} for "
+                f"group {group_ids[i]!r}"
+            )
+            ranks_a = rankdata(-sa[rows], method="average")
+            ranks_b = rankdata(-sb[rows], method="average")
+            rr_a[i] = 1.0 / float(ranks_a[ys == 1][0])
+            rr_b[i] = 1.0 / float(ranks_b[ys == 1][0])
+        value_a = float(rr_a.mean())
+        value_b = float(rr_b.mean())
+        point_delta = value_b - value_a
+
+        rng = np.random.default_rng(rng)
+        deltas = np.empty(n_bootstrap, dtype=float)
+        for b in range(n_bootstrap):
+            sampled = rng.integers(0, n_groups, size=n_groups)
+            deltas[b] = float(rr_b[sampled].mean() - rr_a[sampled].mean())
+        se = float(np.std(deltas, ddof=1))
+    else:  # auprc
+        # AUPRC doesn't factorize per group; recompute on each resample.
+        # Both score columns share the same resampled row indices so the
+        # per-iteration delta picks up the cross-model correlation.
+        if label_arr.sum() == 0 or label_arr.sum() == len(label_arr):
+            raise AssertionError(
+                f"AUPRC undefined: need both classes, got n_pos={int(label_arr.sum())} "
+                f"of n={len(label_arr)}"
+            )
+        value_a = float(average_precision_score(label_arr, sa))
+        value_b = float(average_precision_score(label_arr, sb))
+        point_delta = value_b - value_a
+
+        rng = np.random.default_rng(rng)
+        deltas = np.empty(n_bootstrap, dtype=float)
+        for b in range(n_bootstrap):
+            sampled = rng.integers(0, n_groups, size=n_groups)
+            idx = np.concatenate([group_rows[i] for i in sampled])
+            y = label_arr[idx]
+            s = int(y.sum())
+            if s == 0 or s == len(y):
+                deltas[b] = np.nan
+                continue
+            va = float(average_precision_score(y, sa[idx]))
+            vb = float(average_precision_score(y, sb[idx]))
+            deltas[b] = vb - va
+        se = float(np.nanstd(deltas, ddof=1))
+    z = float(point_delta / se) if se > 0 else 0.0
+    p = float(2 * (1 - _norm.cdf(abs(z))))
+    return {
+        "delta": float(point_delta),
+        "se": se,
+        "z": z,
+        "p_two_sided": p,
+        "value_a": float(value_a),
+        "value_b": float(value_b),
+        "n_groups": int(n_groups),
+        "n_rows": int(len(label_arr)),
+    }
 
 
 def mrr_within_group(

--- a/src/bolinas/pipelines/evals/metrics.py
+++ b/src/bolinas/pipelines/evals/metrics.py
@@ -1,6 +1,6 @@
 """Metric utilities for variant-effect evaluations.
 
-Three metric families live here:
+Four metric families live here:
 
 - ``auprc_with_bootstrap_se`` / ``compute_auprc_metrics``: AUPRC with a
   cluster bootstrap SE that resamples ``match_group``s (preserving the
@@ -10,6 +10,11 @@ Three metric families live here:
 - ``pairwise_accuracy`` / ``compute_pairwise_metrics``: matched-pair within-
   ``match_group`` accuracy (ties = 0.5) with Wald-binomial SE. Used by the
   ``conservation_eval`` pipeline (1:1 match groups).
+- ``mrr_within_group`` / ``compute_mrr_metrics``: mean reciprocal rank of
+  the positive within each match_group, with cluster-bootstrap SE.
+  Within-group analogue of pairwise accuracy that's defined for 1:k
+  match groups (k ≥ 1). Used by ad-hoc analyses that want a within-group
+  metric on PR #194's 1:9 datasets.
 - ``METRIC_FUNCTIONS`` / ``compute_metrics``: classical AUPRC / AUROC /
   Spearman over (label, score) pairs. Still used by older pipelines
   (``snakemake/analysis/evals_v1/``, ``scripts/evo2_eval/``).
@@ -20,7 +25,7 @@ from typing import Callable
 
 import numpy as np
 import pandas as pd
-from scipy.stats import spearmanr
+from scipy.stats import rankdata, spearmanr
 from sklearn.metrics import average_precision_score, roc_auc_score
 
 
@@ -295,6 +300,230 @@ def compute_auprc_metrics(
 
     for score_col in score_columns:
         global_res = auprc_with_bootstrap_se(
+            label=merged["label"],
+            score=merged[score_col],
+            match_group=merged["match_group"],
+            n_bootstrap=n_bootstrap,
+            rng=rng,
+        )
+        rows.append(
+            {
+                "score_type": score_col,
+                "subset": GLOBAL_SUBSET,
+                "value": global_res["value"],
+                "se": global_res["se"],
+                "n_groups": global_res["n_groups"],
+                "n_rows": global_res["n_rows"],
+            }
+        )
+
+        qualifying = [r for r in per_score_rows[score_col] if r["n_groups"] >= n_min]
+        assert qualifying, (
+            f"no subsets meet n_min={n_min} for score_type={score_col!r}; "
+            f"per-subset sizes: "
+            f"{ {r['subset']: r['n_groups'] for r in per_score_rows[score_col]} }"
+        )
+        k = len(qualifying)
+        macro_value = sum(r["value"] for r in qualifying) / k
+        macro_se = math.sqrt(sum(r["se"] ** 2 for r in qualifying)) / k
+        rows.append(
+            {
+                "score_type": score_col,
+                "subset": MACRO_AVG_SUBSET,
+                "value": float(macro_value),
+                "se": float(macro_se),
+                "n_groups": k,
+                "n_rows": sum(r["n_rows"] for r in qualifying),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def mrr_within_group(
+    label: pd.Series,
+    score: pd.Series,
+    match_group: pd.Series,
+    *,
+    n_bootstrap: int = 1000,
+    rng: np.random.Generator | int | None = 0,
+) -> dict[str, float | int]:
+    """Mean Reciprocal Rank of the positive within each ``match_group``.
+
+    Each ``match_group`` must contain exactly one positive and ≥ 1
+    negatives. The positive is ranked among all rows of its group by
+    descending score (highest score → rank 1). The metric returns the
+    mean of ``1 / rank(positive)`` over groups. Range: ``[1/group_size,
+    1]`` for groups of equal size; for variable group sizes the lower
+    bound is ``1 / max_group_size``.
+
+    Tie handling uses scipy's ``rankdata(method='average')``: tied scores
+    get the average of their ordinal ranks. This is the natural
+    generalization of pairwise_accuracy's ``ties = 0.5`` convention. On
+    1:1 groups, MRR ∈ {1, 0.5} (rank 1 → 1; rank 1.5 (tie) → 0.667;
+    rank 2 → 0.5) — close to but **not identical** with pairwise
+    accuracy's ``{1, 0.5, 0}`` mapping. The two metrics agree on the
+    decision-rule (positive beats negative) but weight loss-cases
+    differently: PA penalizes loss as 0, MRR penalizes loss as 0.5.
+
+    SE: cluster bootstrap over ``match_group``s, same scheme as
+    ``auprc_with_bootstrap_se``. Default seed ``0`` for reproducibility.
+
+    Args:
+        label: 0/1 (or bool) per row. Cast to int internally.
+        score: numeric score per row. Must not contain NaN — fill
+            upstream with a semantically appropriate value (same
+            rationale as ``pairwise_accuracy``).
+        match_group: integer group id; positives and negatives are
+            grouped within an id.
+        n_bootstrap: number of bootstrap iterations.
+        rng: ``numpy.random.Generator``, seed int, or ``None``.
+
+    Returns:
+        ``{"value", "se", "n_groups", "n_rows", "mean_group_size"}``.
+        ``value`` is point-estimate MRR over input groups; ``se`` is the
+        std of the bootstrap distribution (``ddof=1``).
+    """
+    assert len(label) == len(score) == len(match_group), (
+        f"length mismatch: label={len(label)} score={len(score)} "
+        f"match_group={len(match_group)}"
+    )
+    score_arr = np.asarray(score, dtype=float)
+    label_arr = np.asarray(label).astype(int)
+    mg_arr = np.asarray(match_group)
+    assert not np.isnan(score_arr).any(), (
+        f"score has {int(np.isnan(score_arr).sum())} NaN values; fill "
+        f"upstream with a semantically appropriate default before scoring"
+    )
+
+    # Map each match_group to its row indices.
+    group_to_rows: dict = pd.Series(mg_arr).groupby(mg_arr, sort=False).indices
+    n_groups = len(group_to_rows)
+
+    # Per-group reciprocal rank of the positive.
+    group_ids = np.fromiter(group_to_rows.keys(), dtype=object, count=n_groups)
+    rr = np.empty(n_groups, dtype=float)
+    for i, gid in enumerate(group_ids):
+        rows = group_to_rows[gid]
+        y = label_arr[rows]
+        n_pos = int(y.sum())
+        assert n_pos == 1, (
+            f"mrr_within_group expects exactly 1 positive per match_group, "
+            f"got n_pos={n_pos} (n_rows={len(y)}) for match_group={gid!r}"
+        )
+        assert len(y) >= 2, (
+            f"match_group={gid!r} has only 1 row — need ≥ 1 negative for MRR"
+        )
+        s = score_arr[rows]
+        # Negate so highest score = lowest rank (rank 1 = best).
+        ranks = rankdata(-s, method="average")
+        rank_of_pos = float(ranks[y == 1][0])
+        rr[i] = 1.0 / rank_of_pos
+    point = float(rr.mean())
+
+    rng = np.random.default_rng(rng)
+    boot = np.empty(n_bootstrap, dtype=float)
+    for b in range(n_bootstrap):
+        sampled = rng.integers(0, n_groups, size=n_groups)
+        boot[b] = float(rr[sampled].mean())
+    se = float(np.std(boot, ddof=1))
+
+    sizes = np.fromiter(
+        (len(group_to_rows[g]) for g in group_ids), dtype=int, count=n_groups
+    )
+    return {
+        "value": point,
+        "se": se,
+        "n_groups": int(n_groups),
+        "n_rows": int(len(label_arr)),
+        "mean_group_size": float(sizes.mean()),
+    }
+
+
+def compute_mrr_metrics(
+    dataset: pd.DataFrame,
+    scores: pd.DataFrame,
+    score_columns: list[str] | None = None,
+    *,
+    n_bootstrap: int = 1000,
+    rng: np.random.Generator | int | None = 0,
+    n_min: int = 30,
+) -> pd.DataFrame:
+    """MRR + cluster-bootstrap SE per ``subset`` for one or more score columns.
+
+    Mirrors the shape of ``compute_auprc_metrics`` and
+    ``compute_pairwise_metrics``: per-subset rows plus ``_global_`` and
+    ``_macro_avg_`` aggregates per score column.
+
+    Aggregate semantics:
+
+    - **Per-subset**: MRR over groups in that subset; cluster bootstrap
+      on ``match_group``s within the subset.
+    - **``_global_``**: MRR over all groups; cluster bootstrap on all
+      ``match_group``s.
+    - **``_macro_avg_``**: unweighted mean of per-subset values for
+      subsets with ``n_groups >= n_min``. SE via the SE-of-mean formula
+      ``sqrt(sum(SE_s^2)) / K`` — same form as
+      ``compute_auprc_metrics``.
+
+    Asserts no ``match_group`` straddles subsets.
+
+    Args:
+        dataset: DataFrame with columns ``[label, subset, match_group]``.
+        scores: DataFrame whose columns are model scores; row-aligned
+            with ``dataset``.
+        score_columns: Score column names to evaluate. Defaults to all
+            columns of ``scores``.
+        n_bootstrap: bootstrap iterations per (subset, score_column).
+        rng: ``numpy.random.Generator``, seed int, or ``None``.
+        n_min: minimum ``n_groups`` per subset to qualify for the macro
+            average.
+
+    Returns:
+        DataFrame with columns
+        ``[score_type, subset, value, se, n_groups, n_rows]``.
+    """
+    for col in ("label", "subset", "match_group"):
+        assert col in dataset.columns, f"dataset missing required column {col!r}"
+
+    if score_columns is None:
+        score_columns = list(scores.columns)
+
+    merged = pd.concat(
+        [dataset.reset_index(drop=True), scores.reset_index(drop=True)], axis=1
+    )
+
+    subset_per_group = merged.groupby("match_group")["subset"].nunique()
+    bad_groups = subset_per_group[subset_per_group > 1]
+    assert bad_groups.empty, (
+        f"{len(bad_groups)} match_group(s) span multiple subsets; first: "
+        f"{bad_groups.head().to_dict()}"
+    )
+
+    rows: list[dict] = []
+    per_score_rows: dict[str, list[dict]] = {sc: [] for sc in score_columns}
+    for subset_name, subset_df in merged.groupby("subset", sort=False):
+        for score_col in score_columns:
+            res = mrr_within_group(
+                label=subset_df["label"],
+                score=subset_df[score_col],
+                match_group=subset_df["match_group"],
+                n_bootstrap=n_bootstrap,
+                rng=rng,
+            )
+            row = {
+                "score_type": score_col,
+                "subset": str(subset_name),
+                "value": res["value"],
+                "se": res["se"],
+                "n_groups": res["n_groups"],
+                "n_rows": res["n_rows"],
+            }
+            rows.append(row)
+            per_score_rows[score_col].append(row)
+
+    for score_col in score_columns:
+        global_res = mrr_within_group(
             label=merged["label"],
             score=merged[score_col],
             match_group=merged["match_group"],

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -19,6 +19,8 @@ from bolinas.pipelines.evals.metrics import (
     auprc_with_bootstrap_se,
     compute_auprc_metrics,
     compute_metrics,
+    compute_mrr_metrics,
+    mrr_within_group,
 )
 
 
@@ -412,3 +414,167 @@ def test_compute_auprc_metrics_n_min_excludes_small_subsets():
         (metrics["score_type"] == "score") & (metrics["subset"] == GLOBAL_SUBSET)
     ].iloc[0]
     assert global_row["n_groups"] == 50
+
+
+# ---------------------------------------------------------------------------
+# mrr_within_group
+# ---------------------------------------------------------------------------
+
+
+def test_mrr_perfectly_separable_returns_one():
+    labels, scores, mg = _matched_pairs(separable=True)
+    res = mrr_within_group(labels, scores, mg, n_bootstrap=100, rng=0)
+    assert res["value"] == pytest.approx(1.0)
+    assert res["se"] == pytest.approx(0.0, abs=1e-12)
+    assert res["n_groups"] == 50
+    assert res["n_rows"] == 50 * 10
+    assert res["mean_group_size"] == pytest.approx(10.0)
+
+
+def test_mrr_random_scores_near_uniform_baseline():
+    """For uniform-random scores in 1:k groups (group size 10), the positive's
+    expected rank is the mean of U{1..10} = 5.5; expected MRR ≈ mean(1/r) over
+    r ∈ {1..10} ≈ 0.2929. With 50 groups, sampling noise should still leave
+    the value well below 0.5."""
+    labels, scores, mg = _matched_pairs(separable=False, seed=42)
+    res = mrr_within_group(labels, scores, mg, n_bootstrap=200, rng=0)
+    assert 0.15 < res["value"] < 0.45
+    assert res["se"] > 0
+
+
+def test_mrr_known_value_manual():
+    """Two groups, positive rank-of-positive = 1 and 2 respectively.
+    Expected MRR = (1/1 + 1/2) / 2 = 0.75."""
+    labels = np.array([1, 0, 1, 0])  # group 0: pos+neg, group 1: pos+neg
+    scores = np.array([0.9, 0.1, 0.2, 0.8])  # g0: pos wins; g1: neg wins
+    mg = np.array([0, 0, 1, 1])
+    res = mrr_within_group(labels, scores, mg, n_bootstrap=10, rng=0)
+    assert res["value"] == pytest.approx(0.75)
+    assert res["n_groups"] == 2
+
+
+def test_mrr_tie_handling_averages_ranks():
+    """When positive ties for first with one negative, average rank = 1.5,
+    so reciprocal-rank = 1/1.5 ≈ 0.6667 — not 1.0 (best case) and not
+    0.5 (loss). Locks in the tie-averaging convention."""
+    labels = np.array([1, 0, 0])
+    scores = np.array([0.5, 0.5, 0.1])  # pos ties with one neg
+    mg = np.array([0, 0, 0])
+    res = mrr_within_group(labels, scores, mg, n_bootstrap=10, rng=0)
+    assert res["value"] == pytest.approx(2 / 3, abs=1e-12)
+
+
+def test_mrr_seed_reproducibility():
+    labels, scores, mg = _matched_pairs(separable=False, seed=1)
+    a = mrr_within_group(labels, scores, mg, n_bootstrap=100, rng=0)
+    b = mrr_within_group(labels, scores, mg, n_bootstrap=100, rng=0)
+    c = mrr_within_group(labels, scores, mg, n_bootstrap=100, rng=1)
+    assert a["se"] == b["se"]
+    assert a["se"] != c["se"]
+    assert a["value"] == c["value"]
+
+
+def test_mrr_nan_score_raises():
+    labels, scores, mg = _matched_pairs(separable=False)
+    scores = scores.copy()
+    scores[3] = np.nan
+    with pytest.raises(AssertionError, match="NaN"):
+        mrr_within_group(labels, scores, mg, n_bootstrap=10, rng=0)
+
+
+def test_mrr_multiple_positives_per_group_raises():
+    labels = np.array([1, 1, 0, 0])  # two positives in group 0
+    scores = np.array([0.9, 0.8, 0.1, 0.2])
+    mg = np.array([0, 0, 0, 0])
+    with pytest.raises(AssertionError, match="exactly 1 positive"):
+        mrr_within_group(labels, scores, mg, n_bootstrap=10, rng=0)
+
+
+def test_mrr_singleton_group_raises():
+    """A group with only the positive (no negatives) is meaningless for MRR."""
+    labels = np.array([1, 1, 0])
+    scores = np.array([0.5, 0.7, 0.1])
+    mg = np.array([0, 1, 1])  # group 0 has just the positive
+    with pytest.raises(AssertionError, match="only 1 row"):
+        mrr_within_group(labels, scores, mg, n_bootstrap=10, rng=0)
+
+
+def test_mrr_length_mismatch_raises():
+    labels = np.array([1, 0, 1])
+    scores = np.array([0.5, 0.5])
+    mg = np.array([0, 1, 2])
+    with pytest.raises(AssertionError, match="length mismatch"):
+        mrr_within_group(labels, scores, mg, n_bootstrap=10, rng=0)
+
+
+def test_compute_mrr_metrics_shape():
+    dataset, scores = _matched_pairs_with_subsets(
+        subsets=["A", "B", "C"], n_pos_per_subset=40
+    )
+    metrics = compute_mrr_metrics(dataset=dataset, scores=scores, n_bootstrap=20, rng=0)
+    assert len(metrics) == 3 * 2 + 2 * 2
+    assert set(metrics["score_type"]) == {"score", "score2"}
+    assert set(metrics["subset"]) == {"A", "B", "C", GLOBAL_SUBSET, MACRO_AVG_SUBSET}
+    assert set(metrics.columns) == {
+        "score_type",
+        "subset",
+        "value",
+        "se",
+        "n_groups",
+        "n_rows",
+    }
+
+
+def test_compute_mrr_metrics_global_matches_per_group_average():
+    """``_global_`` row's value equals the unweighted mean of per-group
+    reciprocal ranks across the entire dataset."""
+    dataset, scores = _matched_pairs_with_subsets(subsets=["A", "B"])
+    metrics = compute_mrr_metrics(
+        dataset=dataset,
+        scores=scores,
+        score_columns=["score"],
+        n_bootstrap=10,
+        rng=0,
+    )
+    global_row = metrics[
+        (metrics["score_type"] == "score") & (metrics["subset"] == GLOBAL_SUBSET)
+    ].iloc[0]
+    # Recompute by calling mrr_within_group directly on the merged frame.
+    expected = mrr_within_group(
+        dataset["label"],
+        scores["score"],
+        dataset["match_group"],
+        n_bootstrap=1,
+        rng=0,
+    )["value"]
+    assert global_row["value"] == pytest.approx(expected)
+
+
+def test_compute_mrr_metrics_macro_avg_matches_mean_of_qualifying():
+    dataset, scores = _matched_pairs_with_subsets(
+        subsets=["A", "B"], n_pos_per_subset=40
+    )
+    metrics = compute_mrr_metrics(
+        dataset=dataset,
+        scores=scores,
+        score_columns=["score"],
+        n_bootstrap=10,
+        rng=0,
+        n_min=30,
+    )
+    per_subset = metrics[
+        (metrics["score_type"] == "score")
+        & (~metrics["subset"].isin({GLOBAL_SUBSET, MACRO_AVG_SUBSET}))
+    ]
+    macro_row = metrics[
+        (metrics["score_type"] == "score") & (metrics["subset"] == MACRO_AVG_SUBSET)
+    ].iloc[0]
+    assert macro_row["value"] == pytest.approx(per_subset["value"].mean())
+    assert macro_row["n_groups"] == len(per_subset)
+
+
+def test_compute_mrr_metrics_match_group_straddle_raises():
+    dataset, scores = _matched_pairs_with_subsets(subsets=["A", "B"])
+    dataset.loc[0, "subset"] = "B"
+    with pytest.raises(AssertionError, match="span multiple subsets"):
+        compute_mrr_metrics(dataset=dataset, scores=scores, n_bootstrap=10, rng=0)

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -3,6 +3,7 @@ aggregation, plus the cluster-bootstrap AUPRC used by ``evals_v2``.
 Per-metric tests for ``pairwise_accuracy`` live in
 ``test_pairwise_accuracy.py``."""
 
+import math
 import tempfile
 from pathlib import Path
 
@@ -21,6 +22,7 @@ from bolinas.pipelines.evals.metrics import (
     compute_metrics,
     compute_mrr_metrics,
     mrr_within_group,
+    paired_metric_delta_bootstrap,
 )
 
 
@@ -578,3 +580,90 @@ def test_compute_mrr_metrics_match_group_straddle_raises():
     dataset.loc[0, "subset"] = "B"
     with pytest.raises(AssertionError, match="span multiple subsets"):
         compute_mrr_metrics(dataset=dataset, scores=scores, n_bootstrap=10, rng=0)
+
+
+# ---------------------------------------------------------------------------
+# paired_metric_delta_bootstrap
+# ---------------------------------------------------------------------------
+
+
+def test_paired_delta_identical_scores_zero_delta_zero_se():
+    """If both score columns are identical, every bootstrap iteration gives
+    delta = 0 → SE = 0."""
+    labels, scores, mg = _matched_pairs(separable=False, seed=0)
+    res = paired_metric_delta_bootstrap(
+        labels, scores, scores, mg, "auprc", n_bootstrap=50, rng=0
+    )
+    assert res["delta"] == pytest.approx(0.0)
+    assert res["se"] == pytest.approx(0.0, abs=1e-12)
+    assert res["value_a"] == res["value_b"]
+
+
+def test_paired_delta_tighter_than_independence_when_correlated():
+    """Paired SE should be smaller than the independence-formula SE when
+    the two score columns are correlated — that's the whole point of the
+    paired bootstrap."""
+    labels, base, mg = _matched_pairs(separable=False, seed=7)
+    rng = np.random.default_rng(0)
+    # score_b is score_a + small noise → strongly correlated.
+    score_b = base + rng.normal(0, 0.05, size=len(base))
+    paired = paired_metric_delta_bootstrap(
+        labels, base, score_b, mg, "auprc", n_bootstrap=300, rng=0
+    )
+    # Independence formula: SE = sqrt(SE_a² + SE_b²) using the marginal AUPRC bootstrap SEs.
+    res_a = auprc_with_bootstrap_se(labels, base, mg, n_bootstrap=300, rng=0)
+    res_b = auprc_with_bootstrap_se(labels, score_b, mg, n_bootstrap=300, rng=0)
+    indep_se = math.sqrt(res_a["se"] ** 2 + res_b["se"] ** 2)
+    assert paired["se"] < indep_se, (
+        f"paired SE {paired['se']:.4f} not tighter than indep SE {indep_se:.4f} "
+        f"for strongly-correlated scores"
+    )
+
+
+def test_paired_delta_mrr_supported():
+    """MRR metric flows through the same paired bootstrap path."""
+    labels, base, mg = _matched_pairs(separable=False, seed=3)
+    res = paired_metric_delta_bootstrap(
+        labels, base, base, mg, "mrr", n_bootstrap=50, rng=0
+    )
+    assert res["delta"] == pytest.approx(0.0)
+    assert res["se"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_paired_delta_unsupported_metric_raises():
+    labels, scores, mg = _matched_pairs(separable=False)
+    with pytest.raises(AssertionError, match="unsupported metric"):
+        paired_metric_delta_bootstrap(
+            labels, scores, scores, mg, "auroc", n_bootstrap=10, rng=0
+        )
+
+
+def test_paired_delta_nan_score_raises():
+    labels, scores, mg = _matched_pairs(separable=False)
+    s2 = scores.copy()
+    s2[0] = np.nan
+    with pytest.raises(AssertionError, match="NaN"):
+        paired_metric_delta_bootstrap(labels, scores, s2, mg, "auprc", n_bootstrap=10)
+
+
+def test_paired_delta_length_mismatch_raises():
+    labels = np.array([1, 0, 1])
+    a = np.array([0.5, 0.5, 0.5])
+    b = np.array([0.5, 0.5])
+    mg = np.array([0, 1, 2])
+    with pytest.raises(AssertionError, match="length mismatch"):
+        paired_metric_delta_bootstrap(labels, a, b, mg, "auprc", n_bootstrap=10)
+
+
+def test_paired_delta_separable_vs_random_significant():
+    """Score A is perfectly separable (AUPRC=1.0), score B is random
+    (AUPRC ≈ baseline). The paired bootstrap should report a large
+    positive delta with small SE and tiny p."""
+    labels, base, mg = _matched_pairs(separable=True, seed=0)
+    rng = np.random.default_rng(0)
+    random_scores = rng.uniform(0, 1, size=len(labels))
+    res = paired_metric_delta_bootstrap(
+        labels, random_scores, base, mg, "auprc", n_bootstrap=200, rng=0
+    )
+    assert res["delta"] > 0.5  # huge effect
+    assert res["p_two_sided"] < 1e-3


### PR DESCRIPTION
## Summary

- Adds `mrr_within_group` / `compute_mrr_metrics` to `src/bolinas/pipelines/evals/metrics.py`: a within-group analogue of `pairwise_accuracy` that's defined for PR #194's 1:k matched-pair datasets. Cluster-bootstrap SE over `match_group`s; tie handling uses scipy's average-rank convention.
- Adds `plots/plot_evo2_scale_comparison.py`: kickoff analysis for #203. Loads the 3 Evo 2 gist parquets from #131, runs a bug-hunt block (dashboard regression anchor, per-checkpoint LLR correlation, sign-direction sanity), then computes AUPRC + MRR per (model, subset) and emits score-histogram + scale-curve figures plus an outlier table.
- 13 new tests covering MRR (separability, baseline, ties, known-value, seed reproducibility, NaN/length/multi-positive/singleton-group guards, `compute_mrr_metrics` shape/global/macro/straddle).

## Test plan

- [x] `uv run pytest tests/pipelines/evals/test_metrics.py` — 33 passed
- [x] `uv run pre-commit run --files <changed>` — clean
- [x] `uv run python plots/plot_evo2_scale_comparison.py` — completes in <2 min, dashboard regression anchor passes 30/30, emits 12 artifacts in `plots/output/evo2_scale_comparison/`

Closes nothing yet — the investigation it kicks off lives in #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)