### PR TITLE
plots: add exp13/21/27/59 recipes (post-#194 evals_v2)

### DIFF
--- a/plots/exp13_promoter_cds_mixture.py
+++ b/plots/exp13_promoter_cds_mixture.py
@@ -22,37 +22,45 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 import matplotlib.pyplot as plt
 import polars as pl
 
-# arm_key → (checkpoint-prefix used in S3 path, label, color, step list).
-# Step lists are the per-run checkpoints that exist on S3; differ across arms.
-ARMS: dict[str, dict[str, object]] = {
-    "promoter_100": {
-        "prefix": "exp21-promoters-yolo",
-        "label": "100% promoter (exp21)",
-        "color": "#1f77b4",
-        "steps": (2000, 6000, 10000, 12000, 14000, 16000, 18000, 20000, 22000),
-    },
-    "mixture_equal": {
-        "prefix": "exp13-mixture-equal",
-        "label": "50/50 mix (exp13 equal)",
-        "color": "#2ca02c",
-        "steps": (2000, 6000, 10000, 14000, 18000, 22000, 26000),
-    },
-    "mixture_proportional": {
-        "prefix": "exp13-mixture-proportional",
-        "label": "10/90 mix (exp13 proportional)",
-        "color": "#ff7f0e",
-        "steps": (2000, 6000, 10000, 14000, 18000, 22000, 26000),
-    },
-    "cds_100": {
-        "prefix": "exp27-cds-yolo",
-        "label": "100% CDS (exp27)",
-        "color": "#d62728",
-        "steps": (2000, 6000, 10000, 14000, 18000, 22000, 26000, 34000),
-    },
+
+class Arm(NamedTuple):
+    prefix: str
+    label: str
+    color: str
+    steps: tuple[int, ...]
+
+
+# Per-run checkpoint step lists differ across arms.
+ARMS: dict[str, Arm] = {
+    "promoter_100": Arm(
+        prefix="exp21-promoters-yolo",
+        label="100% promoter (exp21)",
+        color="#1f77b4",
+        steps=(2000, 6000, 10000, 12000, 14000, 16000, 18000, 20000, 22000),
+    ),
+    "mixture_equal": Arm(
+        prefix="exp13-mixture-equal",
+        label="50/50 mix (exp13 equal)",
+        color="#2ca02c",
+        steps=(2000, 6000, 10000, 14000, 18000, 22000, 26000),
+    ),
+    "mixture_proportional": Arm(
+        prefix="exp13-mixture-proportional",
+        label="10/90 mix (exp13 proportional)",
+        color="#ff7f0e",
+        steps=(2000, 6000, 10000, 14000, 18000, 22000, 26000),
+    ),
+    "cds_100": Arm(
+        prefix="exp27-cds-yolo",
+        label="100% CDS (exp27)",
+        color="#d62728",
+        steps=(2000, 6000, 10000, 14000, 18000, 22000, 26000, 34000),
+    ),
 }
 SUBSETS: tuple[str, ...] = (
     "tss_proximal",
@@ -62,7 +70,7 @@ SUBSETS: tuple[str, ...] = (
     "splicing",
 )
 SUBSET_LABELS: dict[str, str] = {
-    "tss_proximal": "TSS-proximal",
+    "tss_proximal": "Promoter",
     "5_prime_UTR_variant": "5' UTR",
     "missense_variant": "Missense",
     "synonymous_variant": "Synonymous",
@@ -77,13 +85,10 @@ OUT_STEM = "exp13_promoter_cds_mixture_auprc"
 def load_all() -> pl.DataFrame:
     parts: list[pl.DataFrame] = []
     missing: list[str] = []
-    total = 0
-    for arm_key, cfg in ARMS.items():
-        prefix = cfg["prefix"]
-        steps: tuple[int, ...] = cfg["steps"]  # type: ignore[assignment]
-        for step in steps:
-            total += 1
-            uri = f"{S3_BASE}/{prefix}-step-{step}/mendelian_traits.parquet"
+    total = sum(len(arm.steps) for arm in ARMS.values())
+    for arm_key, arm in ARMS.items():
+        for step in arm.steps:
+            uri = f"{S3_BASE}/{arm.prefix}-step-{step}/mendelian_traits.parquet"
             try:
                 df = pl.read_parquet(uri)
             except Exception as exc:
@@ -101,7 +106,7 @@ def load_all() -> pl.DataFrame:
             + "\n".join(missing),
             file=sys.stderr,
         )
-    assert parts, "no parquets loaded"
+    assert parts, "no parquets loaded — has the sweep started?"
     return pl.concat(parts)
 
 
@@ -128,7 +133,7 @@ def main() -> None:
         head = sub.row(0, named=True)
         n_groups = int(head["n_groups"])
         n_rows = int(head["n_rows"])
-        for arm_key, cfg in ARMS.items():
+        for arm_key, arm in ARMS.items():
             arm_df = sub.filter(pl.col("arm") == arm_key).sort("step")
             if arm_df.is_empty():
                 continue
@@ -136,8 +141,8 @@ def main() -> None:
                 arm_df["step"].to_numpy(),
                 arm_df["value"].to_numpy(),
                 marker="o",
-                color=cfg["color"],
-                label=cfg["label"],
+                color=arm.color,
+                label=arm.label,
                 linewidth=1.5,
                 markersize=5,
             )

--- a/plots/exp13_promoter_cds_mixture.py
+++ b/plots/exp13_promoter_cds_mixture.py
@@ -124,7 +124,7 @@ def main() -> None:
     n_panels = len(SUBSETS)
     fig, axes = plt.subplots(1, n_panels, figsize=(4.5 * n_panels, 4), sharex=True)
     fig.suptitle(
-        "Exp13 Promoter × CDS Mixture Sweep — Qwen 1B, 512 bp",
+        "Exp13 Promoter × CDS Mixture Sweep — Qwen3 1B, 512 bp",
         y=1.02,
     )
 

--- a/plots/exp13_promoter_cds_mixture.py
+++ b/plots/exp13_promoter_cds_mixture.py
@@ -1,0 +1,163 @@
+"""Plot minus_llr_avg AUPRC vs training step for the exp13 promoter × CDS
+mixture sweep, as a 4-way comparison:
+
+  - 100% promoter   (exp21-promoters-yolo-r01)        — promoter reference
+  - 50/50  mix      (exp13-mixture-equal-r01)         — balanced mixing
+  - 10/90  mix      (exp13-mixture-proportional-r01)  — proportional mixing
+  - 100% CDS        (exp27-cds-yolo-r01)              — CDS reference
+
+All arms are Qwen3 1B at 512 bp context. Panels span both region types so
+the mixture effect is visible on each side: tss_proximal + 5' UTR
+(promoter side) and missense + synonymous + splicing (CDS side).
+
+Reads metrics parquets directly from S3, no local download needed. Writes
+both SVG (the artifact to upload to GitHub) and PNG (local-iteration
+format) into `plots/output/exp13_promoter_cds_mixture/`.
+
+Usage:
+    uv run python plots/exp13_promoter_cds_mixture.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import polars as pl
+
+# arm_key → (checkpoint-prefix used in S3 path, label, color, step list).
+# Step lists are the per-run checkpoints that exist on S3; differ across arms.
+ARMS: dict[str, dict[str, object]] = {
+    "promoter_100": {
+        "prefix": "exp21-promoters-yolo",
+        "label": "100% promoter (exp21)",
+        "color": "#1f77b4",
+        "steps": (2000, 6000, 10000, 12000, 14000, 16000, 18000, 20000, 22000),
+    },
+    "mixture_equal": {
+        "prefix": "exp13-mixture-equal",
+        "label": "50/50 mix (exp13 equal)",
+        "color": "#2ca02c",
+        "steps": (2000, 6000, 10000, 14000, 18000, 22000, 26000),
+    },
+    "mixture_proportional": {
+        "prefix": "exp13-mixture-proportional",
+        "label": "10/90 mix (exp13 proportional)",
+        "color": "#ff7f0e",
+        "steps": (2000, 6000, 10000, 14000, 18000, 22000, 26000),
+    },
+    "cds_100": {
+        "prefix": "exp27-cds-yolo",
+        "label": "100% CDS (exp27)",
+        "color": "#d62728",
+        "steps": (2000, 6000, 10000, 14000, 18000, 22000, 26000, 34000),
+    },
+}
+SUBSETS: tuple[str, ...] = (
+    "tss_proximal",
+    "5_prime_UTR_variant",
+    "missense_variant",
+    "synonymous_variant",
+    "splicing",
+)
+SUBSET_LABELS: dict[str, str] = {
+    "tss_proximal": "TSS-proximal",
+    "5_prime_UTR_variant": "5' UTR",
+    "missense_variant": "Missense",
+    "synonymous_variant": "Synonymous",
+    "splicing": "Splicing",
+}
+S3_BASE = "s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics"
+SCORE_TYPE = "minus_llr_avg"
+OUT_DIR = Path(__file__).parent / "output" / Path(__file__).stem
+OUT_STEM = "exp13_promoter_cds_mixture_auprc"
+
+
+def load_all() -> pl.DataFrame:
+    parts: list[pl.DataFrame] = []
+    missing: list[str] = []
+    total = 0
+    for arm_key, cfg in ARMS.items():
+        prefix = cfg["prefix"]
+        steps: tuple[int, ...] = cfg["steps"]  # type: ignore[assignment]
+        for step in steps:
+            total += 1
+            uri = f"{S3_BASE}/{prefix}-step-{step}/mendelian_traits.parquet"
+            try:
+                df = pl.read_parquet(uri)
+            except Exception as exc:
+                missing.append(f"  {arm_key} step-{step}: {exc}")
+                continue
+            parts.append(
+                df.with_columns(
+                    pl.lit(arm_key).alias("arm"),
+                    pl.lit(step).alias("step"),
+                )
+            )
+    if missing:
+        print(
+            f"WARNING: {len(missing)} of {total} parquets unreadable:\n"
+            + "\n".join(missing),
+            file=sys.stderr,
+        )
+    assert parts, "no parquets loaded"
+    return pl.concat(parts)
+
+
+def main() -> None:
+    all_df = load_all()
+    df = all_df.filter(
+        (pl.col("score_type") == SCORE_TYPE) & (pl.col("subset").is_in(SUBSETS))
+    )
+    assert not df.is_empty(), (
+        f"empty after filtering on {SCORE_TYPE} + {SUBSETS}; "
+        f"got score_types={sorted(all_df['score_type'].unique().to_list())}, "
+        f"subsets={sorted(all_df['subset'].unique().to_list())}"
+    )
+
+    n_panels = len(SUBSETS)
+    fig, axes = plt.subplots(1, n_panels, figsize=(4.5 * n_panels, 4), sharex=True)
+    fig.suptitle(
+        "Exp13 Promoter × CDS Mixture Sweep — Qwen 1B, 512 bp",
+        y=1.02,
+    )
+
+    for ax, subset in zip(axes, SUBSETS):
+        sub = df.filter(pl.col("subset") == subset)
+        head = sub.row(0, named=True)
+        n_groups = int(head["n_groups"])
+        n_rows = int(head["n_rows"])
+        for arm_key, cfg in ARMS.items():
+            arm_df = sub.filter(pl.col("arm") == arm_key).sort("step")
+            if arm_df.is_empty():
+                continue
+            ax.plot(
+                arm_df["step"].to_numpy(),
+                arm_df["value"].to_numpy(),
+                marker="o",
+                color=cfg["color"],
+                label=cfg["label"],
+                linewidth=1.5,
+                markersize=5,
+            )
+        ax.set_title(f"{SUBSET_LABELS[subset]}\n(n={n_groups} vs. {n_rows - n_groups})")
+        ax.set_xlabel("Training Step")
+        ax.set_ylabel("AUPRC")
+        ax.grid(False)
+        for spine in ("top", "right"):
+            ax.spines[spine].set_visible(False)
+
+    axes[-1].legend(
+        loc="center left", bbox_to_anchor=(1.02, 0.5), title="Model", frameon=False
+    )
+    plt.tight_layout()
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    for ext in ("svg", "png"):
+        out = OUT_DIR / f"{OUT_STEM}.{ext}"
+        plt.savefig(out, dpi=150, bbox_inches="tight")
+        print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plots/exp21_promoters_yolo.py
+++ b/plots/exp21_promoters_yolo.py
@@ -64,7 +64,9 @@ def main() -> None:
         f"subsets={sorted(all_df['subset'].unique().to_list())}"
     )
 
-    fig, axes = plt.subplots(1, len(SUBSETS), figsize=(4.5 * len(SUBSETS), 4), sharex=True)
+    fig, axes = plt.subplots(
+        1, len(SUBSETS), figsize=(4.5 * len(SUBSETS), 4), sharex=True
+    )
     fig.suptitle("Exp21 Promoters YOLO — convergence on promoter subsets", y=1.02)
 
     for ax, subset in zip(axes, SUBSETS):

--- a/plots/exp21_promoters_yolo.py
+++ b/plots/exp21_promoters_yolo.py
@@ -18,12 +18,11 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import polars as pl
 
-ARM_LABEL = "exp21 — 100% animal promoters (1B, 512 bp)"
 ARM_COLOR = "#1f77b4"
 STEPS: tuple[int, ...] = (2000, 6000, 10000, 12000, 14000, 16000, 18000, 20000, 22000)
 SUBSETS: tuple[str, ...] = ("tss_proximal", "5_prime_UTR_variant")
 SUBSET_LABELS: dict[str, str] = {
-    "tss_proximal": "TSS-proximal (promoter)",
+    "tss_proximal": "Promoter",
     "5_prime_UTR_variant": "5' UTR",
 }
 S3_BASE = "s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics"
@@ -67,7 +66,7 @@ def main() -> None:
     fig, axes = plt.subplots(
         1, len(SUBSETS), figsize=(4.5 * len(SUBSETS), 4), sharex=True
     )
-    fig.suptitle("Exp21 Promoters YOLO — convergence on promoter subsets", y=1.02)
+    fig.suptitle("Exp21 — 100% animal promoters, Qwen3 1B, 512 bp", y=1.02)
 
     for ax, subset in zip(axes, SUBSETS):
         sub = df.filter(pl.col("subset") == subset).sort("step")
@@ -79,7 +78,6 @@ def main() -> None:
             sub["value"].to_numpy(),
             marker="o",
             color=ARM_COLOR,
-            label=ARM_LABEL,
             linewidth=1.5,
             markersize=5,
         )
@@ -90,9 +88,6 @@ def main() -> None:
         for spine in ("top", "right"):
             ax.spines[spine].set_visible(False)
 
-    axes[-1].legend(
-        loc="center left", bbox_to_anchor=(1.02, 0.5), title="Model", frameon=False
-    )
     plt.tight_layout()
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     for ext in ("svg", "png"):

--- a/plots/exp21_promoters_yolo.py
+++ b/plots/exp21_promoters_yolo.py
@@ -1,0 +1,105 @@
+"""Plot minus_llr_avg AUPRC vs training step for exp21 (animal-promoters-yolo,
+1B Qwen3, 512 bp context), on three mendelian subsets: tss_proximal +
+5' UTR (the promoter-relevant target regions the model trained on) plus
+missense as a CDS off-target sanity panel.
+
+Reads metrics parquets directly from S3, no local download needed. Writes
+both SVG (the artifact to upload to GitHub) and PNG (local-iteration
+format) into `plots/output/exp21_promoters_yolo/`.
+
+Usage:
+    uv run python plots/exp21_promoters_yolo.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import polars as pl
+
+ARM_LABEL = "exp21 — 100% animal promoters (1B, 512 bp)"
+ARM_COLOR = "#1f77b4"
+STEPS: tuple[int, ...] = (2000, 6000, 10000, 12000, 14000, 16000, 18000, 20000, 22000)
+SUBSETS: tuple[str, ...] = ("tss_proximal", "5_prime_UTR_variant", "missense_variant")
+SUBSET_LABELS: dict[str, str] = {
+    "tss_proximal": "TSS-proximal (promoter)",
+    "5_prime_UTR_variant": "5' UTR",
+    "missense_variant": "Missense (off-target)",
+}
+S3_BASE = "s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics"
+SCORE_TYPE = "minus_llr_avg"
+OUT_DIR = Path(__file__).parent / "output" / Path(__file__).stem
+OUT_STEM = "exp21_promoters_yolo_auprc"
+
+
+def load_all() -> pl.DataFrame:
+    parts: list[pl.DataFrame] = []
+    missing: list[str] = []
+    for step in STEPS:
+        uri = f"{S3_BASE}/exp21-promoters-yolo-step-{step}/mendelian_traits.parquet"
+        try:
+            df = pl.read_parquet(uri)
+        except Exception as exc:
+            missing.append(f"  step-{step}: {exc}")
+            continue
+        parts.append(df.with_columns(pl.lit(step).alias("step")))
+    if missing:
+        print(
+            f"WARNING: {len(missing)} of {len(STEPS)} parquets unreadable:\n"
+            + "\n".join(missing),
+            file=sys.stderr,
+        )
+    assert parts, "no parquets loaded — has the sweep started?"
+    return pl.concat(parts)
+
+
+def main() -> None:
+    all_df = load_all()
+    df = all_df.filter(
+        (pl.col("score_type") == SCORE_TYPE) & (pl.col("subset").is_in(SUBSETS))
+    )
+    assert not df.is_empty(), (
+        f"empty after filtering on {SCORE_TYPE} + {SUBSETS}; "
+        f"got score_types={sorted(all_df['score_type'].unique().to_list())}, "
+        f"subsets={sorted(all_df['subset'].unique().to_list())}"
+    )
+
+    fig, axes = plt.subplots(1, 3, figsize=(13.5, 4), sharex=True)
+    fig.suptitle("Exp21 Promoters YOLO — convergence on mendelian subsets", y=1.02)
+
+    for ax, subset in zip(axes, SUBSETS):
+        sub = df.filter(pl.col("subset") == subset).sort("step")
+        head = sub.row(0, named=True)
+        n_groups = int(head["n_groups"])
+        n_rows = int(head["n_rows"])
+        ax.plot(
+            sub["step"].to_numpy(),
+            sub["value"].to_numpy(),
+            marker="o",
+            color=ARM_COLOR,
+            label=ARM_LABEL,
+            linewidth=1.5,
+            markersize=5,
+        )
+        ax.set_title(f"{SUBSET_LABELS[subset]}\n(n={n_groups} vs. {n_rows - n_groups})")
+        ax.set_xlabel("Training Step")
+        ax.set_ylabel("AUPRC")
+        ax.grid(False)
+        for spine in ("top", "right"):
+            ax.spines[spine].set_visible(False)
+
+    axes[-1].legend(
+        loc="center left", bbox_to_anchor=(1.02, 0.5), title="Model", frameon=False
+    )
+    plt.tight_layout()
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    for ext in ("svg", "png"):
+        out = OUT_DIR / f"{OUT_STEM}.{ext}"
+        plt.savefig(out, dpi=150, bbox_inches="tight")
+        print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plots/exp21_promoters_yolo.py
+++ b/plots/exp21_promoters_yolo.py
@@ -1,7 +1,6 @@
 """Plot minus_llr_avg AUPRC vs training step for exp21 (animal-promoters-yolo,
-1B Qwen3, 512 bp context), on three mendelian subsets: tss_proximal +
-5' UTR (the promoter-relevant target regions the model trained on) plus
-missense as a CDS off-target sanity panel.
+1B Qwen3, 512 bp context), on the two promoter-relevant mendelian subsets:
+tss_proximal + 5' UTR.
 
 Reads metrics parquets directly from S3, no local download needed. Writes
 both SVG (the artifact to upload to GitHub) and PNG (local-iteration
@@ -22,11 +21,10 @@ import polars as pl
 ARM_LABEL = "exp21 — 100% animal promoters (1B, 512 bp)"
 ARM_COLOR = "#1f77b4"
 STEPS: tuple[int, ...] = (2000, 6000, 10000, 12000, 14000, 16000, 18000, 20000, 22000)
-SUBSETS: tuple[str, ...] = ("tss_proximal", "5_prime_UTR_variant", "missense_variant")
+SUBSETS: tuple[str, ...] = ("tss_proximal", "5_prime_UTR_variant")
 SUBSET_LABELS: dict[str, str] = {
     "tss_proximal": "TSS-proximal (promoter)",
     "5_prime_UTR_variant": "5' UTR",
-    "missense_variant": "Missense (off-target)",
 }
 S3_BASE = "s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics"
 SCORE_TYPE = "minus_llr_avg"
@@ -66,8 +64,8 @@ def main() -> None:
         f"subsets={sorted(all_df['subset'].unique().to_list())}"
     )
 
-    fig, axes = plt.subplots(1, 3, figsize=(13.5, 4), sharex=True)
-    fig.suptitle("Exp21 Promoters YOLO — convergence on mendelian subsets", y=1.02)
+    fig, axes = plt.subplots(1, len(SUBSETS), figsize=(4.5 * len(SUBSETS), 4), sharex=True)
+    fig.suptitle("Exp21 Promoters YOLO — convergence on promoter subsets", y=1.02)
 
     for ax, subset in zip(axes, SUBSETS):
         sub = df.filter(pl.col("subset") == subset).sort("step")

--- a/plots/exp27_cds_yolo.py
+++ b/plots/exp27_cds_yolo.py
@@ -66,7 +66,9 @@ def main() -> None:
         f"subsets={sorted(all_df['subset'].unique().to_list())}"
     )
 
-    fig, axes = plt.subplots(1, len(SUBSETS), figsize=(4.5 * len(SUBSETS), 4), sharex=True)
+    fig, axes = plt.subplots(
+        1, len(SUBSETS), figsize=(4.5 * len(SUBSETS), 4), sharex=True
+    )
     fig.suptitle("Exp27 — 100% animal CDS, Qwen3 1B, 512 bp", y=1.02)
 
     for ax, subset in zip(axes, SUBSETS):

--- a/plots/exp27_cds_yolo.py
+++ b/plots/exp27_cds_yolo.py
@@ -20,7 +20,6 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import polars as pl
 
-ARM_LABEL = "exp27 — 100% animal CDS (1B, 512 bp)"
 ARM_COLOR = "#d62728"
 STEPS: tuple[int, ...] = (2000, 6000, 10000, 14000, 18000, 22000, 26000, 34000)
 SUBSETS: tuple[str, ...] = ("missense_variant", "synonymous_variant", "splicing")
@@ -67,8 +66,8 @@ def main() -> None:
         f"subsets={sorted(all_df['subset'].unique().to_list())}"
     )
 
-    fig, axes = plt.subplots(1, 3, figsize=(13.5, 4), sharex=True)
-    fig.suptitle("Exp27 CDS YOLO — convergence on mendelian CDS subsets", y=1.02)
+    fig, axes = plt.subplots(1, len(SUBSETS), figsize=(4.5 * len(SUBSETS), 4), sharex=True)
+    fig.suptitle("Exp27 — 100% animal CDS, Qwen3 1B, 512 bp", y=1.02)
 
     for ax, subset in zip(axes, SUBSETS):
         sub = df.filter(pl.col("subset") == subset).sort("step")
@@ -80,7 +79,6 @@ def main() -> None:
             sub["value"].to_numpy(),
             marker="o",
             color=ARM_COLOR,
-            label=ARM_LABEL,
             linewidth=1.5,
             markersize=5,
         )
@@ -91,9 +89,6 @@ def main() -> None:
         for spine in ("top", "right"):
             ax.spines[spine].set_visible(False)
 
-    axes[-1].legend(
-        loc="center left", bbox_to_anchor=(1.02, 0.5), title="Model", frameon=False
-    )
     plt.tight_layout()
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     for ext in ("svg", "png"):

--- a/plots/exp27_cds_yolo.py
+++ b/plots/exp27_cds_yolo.py
@@ -1,0 +1,106 @@
+"""Plot minus_llr_avg AUPRC vs training step for exp27 (animal-cds-yolo,
+1B Qwen3, 512 bp context), on three mendelian CDS subsets: missense +
+synonymous + splicing. Mirrors the exp58 panel set so exp27 (100% CDS,
+no evolutionary-timescale sweep) can be compared side-by-side with the
+exp58 multi-timescale runs.
+
+Reads metrics parquets directly from S3, no local download needed. Writes
+both SVG (the artifact to upload to GitHub) and PNG (local-iteration
+format) into `plots/output/exp27_cds_yolo/`.
+
+Usage:
+    uv run python plots/exp27_cds_yolo.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import polars as pl
+
+ARM_LABEL = "exp27 — 100% animal CDS (1B, 512 bp)"
+ARM_COLOR = "#d62728"
+STEPS: tuple[int, ...] = (2000, 6000, 10000, 14000, 18000, 22000, 26000, 34000)
+SUBSETS: tuple[str, ...] = ("missense_variant", "synonymous_variant", "splicing")
+SUBSET_LABELS: dict[str, str] = {
+    "missense_variant": "Missense",
+    "synonymous_variant": "Synonymous",
+    "splicing": "Splicing",
+}
+S3_BASE = "s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics"
+SCORE_TYPE = "minus_llr_avg"
+OUT_DIR = Path(__file__).parent / "output" / Path(__file__).stem
+OUT_STEM = "exp27_cds_yolo_auprc"
+
+
+def load_all() -> pl.DataFrame:
+    parts: list[pl.DataFrame] = []
+    missing: list[str] = []
+    for step in STEPS:
+        uri = f"{S3_BASE}/exp27-cds-yolo-step-{step}/mendelian_traits.parquet"
+        try:
+            df = pl.read_parquet(uri)
+        except Exception as exc:
+            missing.append(f"  step-{step}: {exc}")
+            continue
+        parts.append(df.with_columns(pl.lit(step).alias("step")))
+    if missing:
+        print(
+            f"WARNING: {len(missing)} of {len(STEPS)} parquets unreadable:\n"
+            + "\n".join(missing),
+            file=sys.stderr,
+        )
+    assert parts, "no parquets loaded — has the sweep started?"
+    return pl.concat(parts)
+
+
+def main() -> None:
+    all_df = load_all()
+    df = all_df.filter(
+        (pl.col("score_type") == SCORE_TYPE) & (pl.col("subset").is_in(SUBSETS))
+    )
+    assert not df.is_empty(), (
+        f"empty after filtering on {SCORE_TYPE} + {SUBSETS}; "
+        f"got score_types={sorted(all_df['score_type'].unique().to_list())}, "
+        f"subsets={sorted(all_df['subset'].unique().to_list())}"
+    )
+
+    fig, axes = plt.subplots(1, 3, figsize=(13.5, 4), sharex=True)
+    fig.suptitle("Exp27 CDS YOLO — convergence on mendelian CDS subsets", y=1.02)
+
+    for ax, subset in zip(axes, SUBSETS):
+        sub = df.filter(pl.col("subset") == subset).sort("step")
+        head = sub.row(0, named=True)
+        n_groups = int(head["n_groups"])
+        n_rows = int(head["n_rows"])
+        ax.plot(
+            sub["step"].to_numpy(),
+            sub["value"].to_numpy(),
+            marker="o",
+            color=ARM_COLOR,
+            label=ARM_LABEL,
+            linewidth=1.5,
+            markersize=5,
+        )
+        ax.set_title(f"{SUBSET_LABELS[subset]}\n(n={n_groups} vs. {n_rows - n_groups})")
+        ax.set_xlabel("Training Step")
+        ax.set_ylabel("AUPRC")
+        ax.grid(False)
+        for spine in ("top", "right"):
+            ax.spines[spine].set_visible(False)
+
+    axes[-1].legend(
+        loc="center left", bbox_to_anchor=(1.02, 0.5), title="Model", frameon=False
+    )
+    plt.tight_layout()
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    for ext in ("svg", "png"):
+        out = OUT_DIR / f"{OUT_STEM}.{ext}"
+        plt.savefig(out, dpi=150, bbox_inches="tight")
+        print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plots/exp59_evolutionary_timescales.py
+++ b/plots/exp59_evolutionary_timescales.py
@@ -1,7 +1,6 @@
 """Plot minus_llr_avg AUPRC vs training step for the three exp59 evolutionary
-timescales (mammals / vertebrates / animals), on three mendelian subsets:
-3' UTR (the downstream-of-CDS target region the model trained on) plus
-synonymous + splicing as CDS off-target sanity panels.
+timescales (mammals / vertebrates / animals), on 3' UTR variants — the
+downstream-of-CDS target region the model trained on.
 
 Reads metrics parquets directly from S3, no local download needed. Writes
 both SVG (the artifact to upload to GitHub) and PNG (local-iteration
@@ -34,11 +33,9 @@ ARM_COLORS: dict[str, str] = {
     "animals": "#e8d840",
 }
 STEPS: tuple[int, ...] = (1000, 2000, 3000, 4000, 5000, 9000, 13000, 16999)
-SUBSETS: tuple[str, ...] = ("3_prime_UTR_variant", "synonymous_variant", "splicing")
+SUBSETS: tuple[str, ...] = ("3_prime_UTR_variant",)
 SUBSET_LABELS: dict[str, str] = {
     "3_prime_UTR_variant": "3' UTR",
-    "synonymous_variant": "Synonymous",
-    "splicing": "Splicing",
 }
 S3_BASE = "s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics"
 SCORE_TYPE = "minus_llr_avg"
@@ -86,7 +83,11 @@ def main() -> None:
         f"subsets={sorted(all_df['subset'].unique().to_list())}"
     )
 
-    fig, axes = plt.subplots(1, 3, figsize=(13.5, 4), sharex=True)
+    # Single panel + legend on the right needs extra width so tight_layout
+    # doesn't shrink the axes to make room.
+    fig, axes = plt.subplots(1, len(SUBSETS), figsize=(7, 4), sharex=True)
+    if len(SUBSETS) == 1:
+        axes = [axes]
     fig.suptitle("Exp59 Evolutionary Timescales — downstream of CDS, Qwen 0.6B", y=1.02)
 
     for ax, subset in zip(axes, SUBSETS):

--- a/plots/exp59_evolutionary_timescales.py
+++ b/plots/exp59_evolutionary_timescales.py
@@ -1,0 +1,129 @@
+"""Plot minus_llr_avg AUPRC vs training step for the three exp59 evolutionary
+timescales (mammals / vertebrates / animals), on three mendelian subsets:
+3' UTR (the downstream-of-CDS target region the model trained on) plus
+synonymous + splicing as CDS off-target sanity panels.
+
+Reads metrics parquets directly from S3, no local download needed. Writes
+both SVG (the artifact to upload to GitHub) and PNG (local-iteration
+format — agents can `Read` PNGs to visually sanity-check, and PNGs
+render inline in agent conversations) into
+`plots/output/exp59_evolutionary_timescales/`.
+
+Usage:
+    uv run python plots/exp59_evolutionary_timescales.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import polars as pl
+
+ARMS: tuple[str, ...] = ("mammals", "vertebrates", "animals")
+ARM_LABELS: dict[str, str] = {
+    "mammals": "Mammals (~100 Mya, 81 species)",
+    "vertebrates": "Vertebrates (~600 Mya, 317 species)",
+    "animals": "Animals (~800 Mya, 499 species)",
+}
+# Same teal / green / yellow palette as exp58 — same arms, same timescales.
+ARM_COLORS: dict[str, str] = {
+    "mammals": "#216b6b",
+    "vertebrates": "#5fb35f",
+    "animals": "#e8d840",
+}
+STEPS: tuple[int, ...] = (1000, 2000, 3000, 4000, 5000, 9000, 13000, 16999)
+SUBSETS: tuple[str, ...] = ("3_prime_UTR_variant", "synonymous_variant", "splicing")
+SUBSET_LABELS: dict[str, str] = {
+    "3_prime_UTR_variant": "3' UTR",
+    "synonymous_variant": "Synonymous",
+    "splicing": "Splicing",
+}
+S3_BASE = "s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics"
+SCORE_TYPE = "minus_llr_avg"
+OUT_DIR = Path(__file__).parent / "output" / Path(__file__).stem
+OUT_STEM = "exp59_evolutionary_timescales_auprc"
+
+
+def load_all() -> pl.DataFrame:
+    """Load every (arm × step) metrics parquet from S3, tag with arm + step,
+    concat into one tidy frame."""
+    parts: list[pl.DataFrame] = []
+    missing: list[str] = []
+    for arm in ARMS:
+        for step in STEPS:
+            uri = f"{S3_BASE}/exp59-{arm}-step-{step}/mendelian_traits.parquet"
+            try:
+                df = pl.read_parquet(uri)
+            except Exception as exc:
+                missing.append(f"  {arm}-step-{step}: {exc}")
+                continue
+            parts.append(
+                df.with_columns(
+                    pl.lit(arm).alias("arm"),
+                    pl.lit(step).alias("step"),
+                )
+            )
+    if missing:
+        print(
+            f"WARNING: {len(missing)} of {len(ARMS) * len(STEPS)} parquets unreadable:\n"
+            + "\n".join(missing),
+            file=sys.stderr,
+        )
+    assert parts, "no parquets loaded — has the sweep started?"
+    return pl.concat(parts)
+
+
+def main() -> None:
+    all_df = load_all()
+    df = all_df.filter(
+        (pl.col("score_type") == SCORE_TYPE) & (pl.col("subset").is_in(SUBSETS))
+    )
+    assert not df.is_empty(), (
+        f"empty after filtering on {SCORE_TYPE} + {SUBSETS}; "
+        f"got score_types={sorted(all_df['score_type'].unique().to_list())}, "
+        f"subsets={sorted(all_df['subset'].unique().to_list())}"
+    )
+
+    fig, axes = plt.subplots(1, 3, figsize=(13.5, 4), sharex=True)
+    fig.suptitle("Exp59 Evolutionary Timescales — downstream of CDS, Qwen 0.6B", y=1.02)
+
+    for ax, subset in zip(axes, SUBSETS):
+        sub = df.filter(pl.col("subset") == subset)
+        head = sub.row(0, named=True)
+        n_groups = int(head["n_groups"])
+        n_rows = int(head["n_rows"])
+        for arm in ARMS:
+            arm_df = sub.filter(pl.col("arm") == arm).sort("step")
+            if arm_df.is_empty():
+                continue
+            ax.plot(
+                arm_df["step"].to_numpy(),
+                arm_df["value"].to_numpy(),
+                marker="o",
+                color=ARM_COLORS[arm],
+                label=ARM_LABELS[arm],
+                linewidth=1.5,
+                markersize=5,
+            )
+        ax.set_title(f"{SUBSET_LABELS[subset]}\n(n={n_groups} vs. {n_rows - n_groups})")
+        ax.set_xlabel("Training Step")
+        ax.set_ylabel("AUPRC")
+        ax.grid(False)
+        for spine in ("top", "right"):
+            ax.spines[spine].set_visible(False)
+
+    axes[-1].legend(
+        loc="center left", bbox_to_anchor=(1.02, 0.5), title="Model", frameon=False
+    )
+    plt.tight_layout()
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    for ext in ("svg", "png"):
+        out = OUT_DIR / f"{OUT_STEM}.{ext}"
+        plt.savefig(out, dpi=150, bbox_inches="tight")
+        print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plots/exp59_evolutionary_timescales.py
+++ b/plots/exp59_evolutionary_timescales.py
@@ -83,11 +83,11 @@ def main() -> None:
         f"subsets={sorted(all_df['subset'].unique().to_list())}"
     )
 
-    # Single panel + legend on the right needs extra width so tight_layout
-    # doesn't shrink the axes to make room.
-    fig, axes = plt.subplots(1, len(SUBSETS), figsize=(7, 4), sharex=True)
-    if len(SUBSETS) == 1:
-        axes = [axes]
+    # Extra width for the right-anchored legend so tight_layout doesn't squash the axes.
+    fig, axes = plt.subplots(
+        1, len(SUBSETS), figsize=(7, 4), sharex=True, squeeze=False
+    )
+    axes = axes[0]
     fig.suptitle("Exp59 Evolutionary Timescales — downstream of CDS, Qwen 0.6B", y=1.02)
 
     for ax, subset in zip(axes, SUBSETS):


### PR DESCRIPTION
## Summary

- Adds 4 new plot recipes in `plots/` mirroring the existing `exp55_*` / `exp58_*` template (read pre-computed AUPRC metrics from `s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics/`, filter on `score_type == "minus_llr_avg"`, emit one panel per consequence subset with one line per arm, save SVG+PNG to `plots/output/<recipe>/`).
- All four target a previously-published experiment whose issue body still embeds a **pre-#194** evals_v1 plot. The new recipes re-render those convergence stories against the post-#194 stratified k=9 matched eval (`mendelian_traits`, `hf_revision 4aed58e…`).
- No library code changed; each recipe is a self-contained script. Issue comments embedding the rendered SVGs will follow once this PR is merged so the recipe permalinks point at `main`.

### Recipes added

| File | Issue | Arms | Steps | Panels |
|---|---|---|---|---|
| `plots/exp59_evolutionary_timescales.py` | #59 | mammals / vertebrates / animals | 1k, 2k, 3k, 4k, 5k, 9k, 13k, 16999 | 3' UTR |
| `plots/exp21_promoters_yolo.py` | #21 | exp21-promoters-yolo (1 arm) | 2k, 6k, 10k, 12k, 14k, 16k, 18k, 20k, 22k | Promoter, 5' UTR |
| `plots/exp27_cds_yolo.py` | #27 | exp27-cds-yolo (1 arm) | 2k, 6k, 10k, 14k, 18k, 22k, 26k, 34k | Missense, Synonymous, Splicing |
| `plots/exp13_promoter_cds_mixture.py` | #13 | 4-way: 100% promoter (exp21) / 50-50 mix / 10-90 mix / 100% CDS (exp27) | per-arm native step lists | Promoter, 5' UTR, Missense, Synonymous, Splicing |

### Preview

**exp59** — `3' UTR` is the downstream-of-CDS target the model trained on. Mammals reaches the ceiling fastest; longer-timescale arms catch up by step 16999 — same qualitative story as the old #59 plot.

![exp59](https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/c785daa5a1a938365ace6861791fa3e978ac53cf/exp59_evolutionary_timescales_auprc.svg)

**exp21** — `Promoter` (tss_proximal) + `5' UTR` are the promoter targets the model trained on. Both show the plateau pattern the old #21 plot called out (rises fast in the first ~5k steps, then flattens).

![exp21](https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/c785daa5a1a938365ace6861791fa3e978ac53cf/exp21_promoters_yolo_auprc.svg)

**exp27** — `Missense` / `Synonymous` / `Splicing` (same panel set as exp58). Splicing is the strongest signal, rising past 0.6 by step 34000; missense plateaus around 0.48–0.50 — consistent with the "matches Evo 2, behind GPN-Star" framing from the body plot.

![exp27](https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/c785daa5a1a938365ace6861791fa3e978ac53cf/exp27_cds_yolo_auprc.svg)

**exp13** — 4-way mixture sweep. Promoter panels (Promoter, 5' UTR) are dominated by the 100% promoter arm; CDS panels (Missense, Synonymous, Splicing) by 100% CDS; the 50/50 arm tracks both regions; the 10/90 arm tracks CDS more closely than promoters. Same conclusion as the old #13 plot.

![exp13](https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/7642e8056065f82780bb590d3ee5063851125c40/exp13_promoter_cds_mixture_auprc.svg)

## Test plan

- [x] Each recipe runs cleanly: `uv run python plots/expN_<short>.py` produces SVG + PNG under `plots/output/<recipe>/` with no "WARNING: N of M parquets unreadable" output (all `(arm, step)` metrics exist on S3).
- [x] Visual sanity-check of each PNG — curve shapes match the qualitative narrative of the old plot on the corresponding issue.
- [x] `simplify` skill code-quality pass: exp13 ARMS → NamedTuple (kills the `type: ignore`); single-arm exp21/exp27 drop the one-entry legend and fold the model details into the suptitle; exp59 swaps the `if len(SUBSETS) == 1` guard for `squeeze=False`; `tss_proximal` panels labeled "Promoter" to match `exp55` / dashboard heatmap.
- [ ] Once merged: post `🤖`-prefixed comments embedding each SVG (gist raw URLs above) on issues #13, #21, #27, #59, plus #55 and #58 for the already-existing recipes that have never had their rendered output posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
