### PR TITLE
Add DART-Eval caQTL/dsQTL datasets to evals pipeline with train/test splits

### DIFF
--- a/snakemake/evals/README.md
+++ b/snakemake/evals/README.md
@@ -52,15 +52,23 @@ These two skip the matching pipeline entirely: `dart_eval_dataset_unsplit` (in
 `workflow/rules/dart_eval.smk`) parses + annotates the raw TSV straight into
 `results/dataset_unsplit/{caqtl,dsqtl}.parquet`, which the generic
 `split_dataset_by_chrom` rule then splits. They have **no** `results/qc/`
-artifact (no matching to diagnose). The reference genome for `check_ref_alt` is
-read directly from S3 (`canonical_genome_path`) via pyfaidx.
+artifact (no matching to diagnose).
 
-The raw TSVs live only on Synapse and need authentication. Create a free
-Synapse account + a [Personal Access Token](https://www.synapse.org/#!PersonalAccessTokens:)
-(scopes: View, Download) and export it before building these datasets:
+Building them needs **Synapse auth**: the raw TSVs live only on Synapse, so
+create a free Synapse account + a [Personal Access Token](https://www.synapse.org/#!PersonalAccessTokens:)
+(scopes: View, Download) and export it — the download is plain HTTPS via
+`curl`, no `synapseclient` needed. (AWS credentials with S3 read access are
+also required, as for the rest of the pipeline — see [Storage](#storage).)
+
+The `dart_eval_stage_genome` rule downloads the GRCh38 reference (+ `.fai`/`.gzi`
+indexes) to local disk once via boto3, so `check_ref_alt` reads from disk
+rather than doing a per-variant S3 round-trip.
 
 ```bash
-export SYNAPSE_AUTH_TOKEN=...   # download uses plain HTTPS (curl); no synapseclient needed
+export SYNAPSE_AUTH_TOKEN=...   # Synapse PAT
+uv run snakemake \
+  results/dataset/caqtl/{train,test}.parquet \
+  results/dataset/dsqtl/{train,test}.parquet
 ```
 
 ## Matching scheme

--- a/snakemake/evals/README.md
+++ b/snakemake/evals/README.md
@@ -40,18 +40,18 @@ Unlike the two matched datasets above they are **not matched and not
 subsampled**: every significant QTL (positive) and control variant (negative)
 within accessible peaks is kept at its natural ratio (≈1:11 for caQTL, ≈1:48
 for dsQTL). The `consequence*` and `distance_*` columns are added as
-**reference annotations only** — they are not used to filter or match. The
-signed study `effect_size` is oriented to the `alt` allele (positive ⇒ alt
-increases accessibility, matching an alt-vs-ref / LLR model score; sign-flipped
-where ref/alt were swapped to the reference); caQTL additionally carries the
-raw `pval` and `se` for the record. For dsQTL the `effect_size` is present for
-the significant variants only (controls have no measured effect).
+**reference annotations only** — they are not used to filter or match. The signed study `effect` is oriented to the
+`alt` allele (positive ⇒ alt increases accessibility, matching an alt-vs-ref /
+LLR model score; sign-flipped where ref/alt were swapped to the reference), and
+`effect_size` is its unsigned magnitude (`|effect|`); caQTL additionally carries
+the raw `pval` and `se` for the record. For dsQTL `effect`/`effect_size` are
+present for the significant variants only (controls have no measured effect).
 
 Evaluation follows DART-Eval Task 5 / ARSENAL, with the two metrics computed
 over **different variant sets**: a binary **AUROC/AUPRC over all variants**
 (significant QTLs vs controls, via `label`), and a **Pearson correlation over
 the positive variants only** (a model's signed alt-vs-ref score vs the signed
-`effect_size`). The dataset cards document this.
+`effect`). The dataset cards document this.
 
 - **caqtl** — African caQTLs (DeGorter et al. 2023), Synapse `syn60756043`
   (`Afr.CaQTLS.tsv`). Native **GRCh38**.

--- a/snakemake/evals/README.md
+++ b/snakemake/evals/README.md
@@ -40,7 +40,18 @@ Unlike the two matched datasets above they are **not matched and not
 subsampled**: every significant QTL (positive) and control variant (negative)
 within accessible peaks is kept at its natural ratio (≈1:11 for caQTL, ≈1:48
 for dsQTL). The `consequence*` and `distance_*` columns are added as
-**reference annotations only** — they are not used to filter or match.
+**reference annotations only** — they are not used to filter or match. The
+signed study `effect_size` is oriented to the `alt` allele (positive ⇒ alt
+increases accessibility, matching an alt-vs-ref / LLR model score; sign-flipped
+where ref/alt were swapped to the reference); caQTL additionally carries the
+raw `pval` and `se` for the record. For dsQTL the `effect_size` is present for
+the significant variants only (controls have no measured effect).
+
+Evaluation follows DART-Eval Task 5 / ARSENAL, with the two metrics computed
+over **different variant sets**: a binary **AUROC/AUPRC over all variants**
+(significant QTLs vs controls, via `label`), and a **Pearson correlation over
+the positive variants only** (a model's signed alt-vs-ref score vs the signed
+`effect_size`). The dataset cards document this.
 
 - **caqtl** — African caQTLs (DeGorter et al. 2023), Synapse `syn60756043`
   (`Afr.CaQTLS.tsv`). Native **GRCh38**.

--- a/snakemake/evals/README.md
+++ b/snakemake/evals/README.md
@@ -17,6 +17,8 @@ commit `e59d612e9`, so HGMD pathogenic SNVs are included as a positive source.
 |---|---|---|---|
 | `mendelian_traits` | Mendelian disease pathogenic SNVs | HGMD ∪ OMIM ∪ Smedley et al. 2016 (de-duped, AF<0.001) | gnomAD common (AN≥25k, AF>0.001) |
 | `complex_traits` | UKBB fine-mapped complex-trait variants | SuSiE+FINEMAP `max(PIP across the traits where this variant was fine-mapped) > 0.9` | `max(PIP) < 0.01` AND no SuSiE/FINEMAP combine-step null PIP among those traits (`label_variants_by_pip(use_null_pip_guard=True)`) |
+| `caqtl` | DART-Eval African caQTLs (ATAC), GRCh38 | Significant caQTLs in peaks | Control variants in peaks (no matching) |
+| `dsqtl` | DART-Eval Yoruban dsQTLs (DNase), hg19→GRCh38 | Significant dsQTLs in peaks | Control variants in peaks (no matching) |
 
 Only `mendelian_traits` has a corresponding `_harness_255` eval-harness
 variant. A 255 bp window centered on each variant is materialized into
@@ -28,6 +30,38 @@ for the online lm_eval VEP scorer to average per variant (#179, #175 conclusion 
 `complex_traits` has no harness variant: it's scored offline only via
 `snakemake/analysis/evals_v2/`, which already does FWD+RC averaging in the
 batched VEP path.
+
+### DART-Eval caQTL / dsQTL
+
+`caqtl` and `dsqtl` are the [DART-Eval](https://github.com/kundajelab/DART-Eval)
+Task-5 chromatin-accessibility QTL benchmarks, brought in to give them
+train/test splits (DART-Eval ships none for this task — see issue #139).
+Unlike the two matched datasets above they are **not matched and not
+subsampled**: every significant QTL (positive) and control variant (negative)
+within accessible peaks is kept at its natural ratio (≈1:11 for caQTL, ≈1:48
+for dsQTL). The `consequence*` and `distance_*` columns are added as
+**reference annotations only** — they are not used to filter or match.
+
+- **caqtl** — African caQTLs (DeGorter et al. 2023), Synapse `syn60756043`
+  (`Afr.CaQTLS.tsv`). Native **GRCh38**.
+- **dsqtl** — Yoruban dsQTLs (Degner et al. 2012), Synapse `syn60756039`
+  (`yoruban.dsqtls.benchmarking.tsv`). **hg19**, lifted to GRCh38 via
+  `lift_hg19_to_hg38`.
+
+These two skip the matching pipeline entirely: `dart_eval_dataset_unsplit` (in
+`workflow/rules/dart_eval.smk`) parses + annotates the raw TSV straight into
+`results/dataset_unsplit/{caqtl,dsqtl}.parquet`, which the generic
+`split_dataset_by_chrom` rule then splits. They have **no** `results/qc/`
+artifact (no matching to diagnose). The reference genome for `check_ref_alt` is
+read directly from S3 (`canonical_genome_path`) via pyfaidx.
+
+The raw TSVs live only on Synapse and need authentication. Create a free
+Synapse account + a [Personal Access Token](https://www.synapse.org/#!PersonalAccessTokens:)
+(scopes: View, Download) and export it before building these datasets:
+
+```bash
+export SYNAPSE_AUTH_TOKEN=...   # download uses plain HTTPS (curl); no synapseclient needed
+```
 
 ## Matching scheme
 
@@ -204,6 +238,7 @@ Top-level keys:
 | `datasets` | Which datasets `rule all` builds + uploads. |
 | `mendelian_traits.*` | HGMD URL, Smedley URL, ClinVar release pin, submission summary date, AF threshold. |
 | `complex_traits.*` | Fine-mapping repo, LD-score S3 path, PIP thresholds. |
+| `dart_eval.*` | Synapse FileEntity IDs for the caQTL / dsQTL TSVs. |
 
 `config/complex_traits.csv` lists the 119 UKBB traits used for `complex_traits`.
 
@@ -238,9 +273,12 @@ Examples:
 - `bolinas-dna/evals_mendelian_traits`
 - `bolinas-dna/evals_complex_traits`
 - `bolinas-dna/evals_mendelian_traits_harness_255`
+- `bolinas-dna/evals_caqtl`
+- `bolinas-dna/evals_dsqtl`
 
 Locally, files live in `results/dataset/{dataset}/{train,test}.parquet`, and
-matching diagnostics in `results/qc/{dataset}.parquet`.
+matching diagnostics in `results/qc/{dataset}.parquet` (matched datasets only —
+`caqtl`/`dsqtl` have none).
 
 ### Eval-harness columns
 

--- a/snakemake/evals/config/config.yaml
+++ b/snakemake/evals/config/config.yaml
@@ -22,6 +22,8 @@ datasets:
   - mendelian_traits
   - complex_traits
   - mendelian_traits_harness_255
+  - caqtl
+  - dsqtl
 
 # ----- Shared trait-pipeline parameters -----
 annotation_url: http://ftp.ensembl.org/pub/release-107/gtf/homo_sapiens/Homo_sapiens.GRCh38.107.chr.gtf.gz
@@ -103,3 +105,11 @@ complex_traits:
   ldscore_s3: s3://pan-ukb-us-east-1/ld_release/UKBB.EUR.ldscore.ht
   pip_pos_threshold: 0.9
   pip_neg_threshold: 0.01
+
+# ----- DART-Eval caQTL / dsQTL (Task 5 variant-effect-prediction) -----
+# Synapse FileEntity IDs (downloaded over HTTP with a Synapse PAT; export
+# SYNAPSE_AUTH_TOKEN). caqtl = Afr.CaQTLS.tsv (DeGorter et al. 2023, GRCh38);
+# dsqtl = yoruban.dsqtls.benchmarking.tsv (Degner et al. 2012, hg19 -> lifted).
+dart_eval:
+  caqtl_synapse_id: syn60756043
+  dsqtl_synapse_id: syn60756039

--- a/snakemake/evals/workflow/Snakefile
+++ b/snakemake/evals/workflow/Snakefile
@@ -11,6 +11,7 @@ include: "rules/smedley.smk"
 include: "rules/ldscore.smk"
 include: "rules/mendelian_traits.smk"
 include: "rules/complex_traits.smk"
+include: "rules/dart_eval.smk"
 
 
 # `rule all` builds the local split parquets + matching diagnostics but does
@@ -23,9 +24,12 @@ rule all:
             dataset=config["datasets"],
             split=SPLITS,
         ),
+        # QC (matching diagnostics) only exists for the matched datasets;
+        # harness derivatives and the unmatched DART-Eval datasets (caqtl,
+        # dsqtl) have no `dataset_matching_qc` rule.
         expand(
             "results/qc/{dataset}.parquet",
-            dataset=[d for d in config["datasets"] if not d.endswith("_harness_255")],
+            dataset=[d for d in config["datasets"] if d in QC_CONTINUOUS_FEATURES],
         ),
 
 

--- a/snakemake/evals/workflow/rules/common.smk
+++ b/snakemake/evals/workflow/rules/common.smk
@@ -141,8 +141,9 @@ rule materialize_eval_harness_dataset:
 
 
 def _hf_qc_input(wildcards):
-    """QC parquet input — only matched datasets have one (not the harness derivatives)."""
-    if "_harness_" in wildcards.dataset:
+    """QC parquet input — only the matched datasets have one. Harness
+    derivatives and the unmatched DART-Eval datasets (caqtl, dsqtl) don't."""
+    if wildcards.dataset not in QC_CONTINUOUS_FEATURES:
         return []
     return f"results/qc/{wildcards.dataset}.parquet"
 

--- a/snakemake/evals/workflow/rules/dart_eval.smk
+++ b/snakemake/evals/workflow/rules/dart_eval.smk
@@ -41,6 +41,31 @@ rule dart_eval_download:
         "-o {output}"
 
 
+rule dart_eval_stage_genome:
+    """Stage the canonical bgzipped GRCh38 reference (+ .fai/.gzi indexes)
+    onto local disk so check_ref_alt reads from disk instead of doing a
+    per-variant S3 round-trip (~100x faster on ~110k variants). Downloaded
+    once via boto3 (the s3 storage plugin's dependency — no s3fs needed) and
+    kept local via local() so snakemake doesn't round-trip it back to storage.
+    pyfaidx needs the .fai (and, for BGZF, .gzi) as same-named siblings."""
+    output:
+        fa=local("results/genome_staged/GRCh38.fa.gz"),
+        fai=local("results/genome_staged/GRCh38.fa.gz.fai"),
+        gzi=local("results/genome_staged/GRCh38.fa.gz.gzi"),
+    params:
+        src=config["canonical_genome_path"],
+    run:
+        import boto3
+        from urllib.parse import urlparse
+
+        u = urlparse(params.src)
+        bucket, key = u.netloc, u.path.lstrip("/")
+        s3 = boto3.client("s3")
+        s3.download_file(bucket, key, output.fa)
+        s3.download_file(bucket, key + ".fai", output.fai)
+        s3.download_file(bucket, key + ".gzi", output.gzi)
+
+
 rule dart_eval_dataset_unsplit:
     """Parse + annotate a DART-Eval QTL TSV into the standard variant schema
     with consequence + distance annotations. No matching, no subsampling —
@@ -52,15 +77,17 @@ rule dart_eval_dataset_unsplit:
         exon_nc="results/intervals/exon_nc.parquet",
         tss_pc="results/intervals/tss_pc.parquet",
         tss_nc="results/intervals/tss_nc.parquet",
+        # Locally-staged GRCh38 (see dart_eval_stage_genome) — fai/gzi are
+        # pyfaidx sibling indexes, declared so snakemake stages them too.
+        # local() marks them as on-disk (not storage) to match the producer.
+        genome=local("results/genome_staged/GRCh38.fa.gz"),
+        genome_fai=local("results/genome_staged/GRCh38.fa.gz.fai"),
+        genome_gzi=local("results/genome_staged/GRCh38.fa.gz.gzi"),
     output:
         "results/dataset_unsplit/{ds}.parquet",
     wildcard_constraints:
         ds="caqtl|dsqtl",
     params:
-        # Canonical bgzipped + indexed GRCh38 read directly from S3 via pyfaidx
-        # (same reference the materialize rule uses). check_ref_alt does a
-        # single-base lookup per variant.
-        genome_path=config["canonical_genome_path"],
         lift=lambda wc: DART_EVAL[wc.ds]["lift"],
     run:
         # Select the parser inside the run block — a function object in `params`
@@ -71,7 +98,7 @@ rule dart_eval_dataset_unsplit:
         V = parse(raw)
         annotate_variants(
             V,
-            genome=Genome(params.genome_path),
+            genome=Genome(input.genome),
             consequence_paths=list(input.consequences),
             chroms=CHROMS,
             exon_pc=pl.read_parquet(input.exon_pc),

--- a/snakemake/evals/workflow/rules/dart_eval.smk
+++ b/snakemake/evals/workflow/rules/dart_eval.smk
@@ -94,7 +94,10 @@ rule dart_eval_dataset_unsplit:
         # has an unstable repr (memory address) that would churn snakemake's
         # params-hash and trigger spurious reruns.
         parse = DART_EVAL[wildcards.ds]["parse"]
-        raw = pl.read_csv(input.tsv, separator="\t", infer_schema_length=10000)
+        # infer_schema_length=None: scan the whole TSV for dtype inference
+        # (the files are bounded; avoids mis-inferring a flag column from a
+        # non-representative first chunk).
+        raw = pl.read_csv(input.tsv, separator="\t", infer_schema_length=None)
         V = parse(raw)
         annotate_variants(
             V,

--- a/snakemake/evals/workflow/rules/dart_eval.smk
+++ b/snakemake/evals/workflow/rules/dart_eval.smk
@@ -1,0 +1,85 @@
+from marin_dna.pipelines.evals.dart_eval import (
+    annotate_variants,
+    parse_caqtl,
+    parse_dsqtl,
+)
+
+
+# DART-Eval Task-5 chromatin-accessibility QTL datasets. caQTL is native
+# GRCh38; dsQTL is hg19 and lifted. Positives = significant QTLs in peaks,
+# negatives = control variants in peaks; kept at natural ratio (no matching /
+# no subsampling). See snakemake/evals/README.md and the dart_eval library
+# module for provenance.
+DART_EVAL = {
+    "caqtl": {
+        "synapse_id": config["dart_eval"]["caqtl_synapse_id"],
+        "parse": parse_caqtl,
+        "lift": False,
+    },
+    "dsqtl": {
+        "synapse_id": config["dart_eval"]["dsqtl_synapse_id"],
+        "parse": parse_dsqtl,
+        "lift": True,
+    },
+}
+
+
+rule dart_eval_download:
+    """Download a DART-Eval input TSV from Synapse over plain HTTP using a
+    Personal Access Token (no synapseclient dependency). Requires a free
+    Synapse account; export the PAT as SYNAPSE_AUTH_TOKEN before running."""
+    output:
+        "results/dart_eval/{ds}.tsv",
+    wildcard_constraints:
+        ds="caqtl|dsqtl",
+    params:
+        syn_id=lambda wc: DART_EVAL[wc.ds]["synapse_id"],
+    shell:
+        'test -n "$SYNAPSE_AUTH_TOKEN" || {{ echo "ERROR: set SYNAPSE_AUTH_TOKEN (a Synapse Personal Access Token) to download DART-Eval data" >&2; exit 1; }}; '
+        'curl -fL -H "Authorization: Bearer $SYNAPSE_AUTH_TOKEN" '
+        '"https://repo-prod.prod.sagebase.org/repo/v1/entity/{params.syn_id}/file" '
+        "-o {output}"
+
+
+rule dart_eval_dataset_unsplit:
+    """Parse + annotate a DART-Eval QTL TSV into the standard variant schema
+    with consequence + distance annotations. No matching, no subsampling —
+    `split_dataset_by_chrom` then produces the train/test parquets."""
+    input:
+        tsv="results/dart_eval/{ds}.tsv",
+        consequences=expand("results/consequences/{chrom}.parquet", chrom=CHROMS),
+        exon_pc="results/intervals/exon_pc.parquet",
+        exon_nc="results/intervals/exon_nc.parquet",
+        tss_pc="results/intervals/tss_pc.parquet",
+        tss_nc="results/intervals/tss_nc.parquet",
+    output:
+        "results/dataset_unsplit/{ds}.parquet",
+    wildcard_constraints:
+        ds="caqtl|dsqtl",
+    params:
+        # Canonical bgzipped + indexed GRCh38 read directly from S3 via pyfaidx
+        # (same reference the materialize rule uses). check_ref_alt does a
+        # single-base lookup per variant.
+        genome_path=config["canonical_genome_path"],
+        lift=lambda wc: DART_EVAL[wc.ds]["lift"],
+    run:
+        # Select the parser inside the run block — a function object in `params`
+        # has an unstable repr (memory address) that would churn snakemake's
+        # params-hash and trigger spurious reruns.
+        parse = DART_EVAL[wildcards.ds]["parse"]
+        raw = pl.read_csv(input.tsv, separator="\t", infer_schema_length=10000)
+        V = parse(raw)
+        annotate_variants(
+            V,
+            genome=Genome(params.genome_path),
+            consequence_paths=list(input.consequences),
+            chroms=CHROMS,
+            exon_pc=pl.read_parquet(input.exon_pc),
+            exon_nc=pl.read_parquet(input.exon_nc),
+            tss_pc=pl.read_parquet(input.tss_pc),
+            tss_nc=pl.read_parquet(input.tss_nc),
+            exon_proximal_dist=config["exon_proximal_dist"],
+            tss_proximal_dist=config["tss_proximal_dist"],
+            lift=params.lift,
+            name=wildcards.ds,
+        ).write_parquet(output[0])

--- a/src/marin_dna/pipelines/evals/dart_eval.py
+++ b/src/marin_dna/pipelines/evals/dart_eval.py
@@ -126,23 +126,21 @@ def _assemble(
     pos_col: str,
     a1_col: str,
     a2_col: str,
-    label_col: str,
-    positive_value: int,
+    label_expr: pl.Expr,
     effect_col: str,
     name: str,
 ) -> pl.DataFrame:
     """Project the raw frame onto the standard schema. ``allele1``/``allele2``
     become ``ref``/``alt`` provisionally — `check_ref_alt` (in
-    ``annotate_variants``) reorients them against the reference. The label is
-    ``True`` where the (int-cast) ``label_col`` equals ``positive_value``."""
+    ``annotate_variants``) reorients them against the reference. ``label_expr``
+    is the boolean positive/negative indicator built by the caller (the two
+    datasets encode the label differently)."""
     cols = [
         _strip_chr(pl.col(chrom_col)).alias("chrom"),
         pl.col(pos_col).cast(pl.Int64).alias("pos"),
         pl.col(a1_col).cast(pl.Utf8).str.to_uppercase().alias("ref"),
         pl.col(a2_col).cast(pl.Utf8).str.to_uppercase().alias("alt"),
-        (pl.col(label_col).cast(pl.Int64, strict=False) == positive_value).alias(
-            "label"
-        ),
+        label_expr.alias("label"),
     ]
     if effect_col in df.columns:
         cols.append(pl.col(effect_col).cast(pl.Float64).alias("effect_size"))
@@ -158,21 +156,25 @@ def _assemble(
 def parse_caqtl(df: pl.DataFrame) -> pl.DataFrame:
     """Parse a raw ``Afr.CaQTLS.tsv`` frame into the standard schema.
 
-    Restricts to DART-Eval's benchmark set (``IsUsed`` and ``in_peaks``), maps
-    ``label`` 1→positive / 0→negative, and keeps SNVs only. Native GRCh38.
+    Restricts to DART-Eval's benchmark set (``IsUsed`` and ``in_peaks`` — this
+    reproduces the published 6,821 positive / 77,999 control counts), uses the
+    boolean ``label`` (True = significant caQTL, False = control), and keeps
+    SNVs only. Native GRCh38.
     """
     _require_columns(df, CAQTL_REQUIRED, "caQTL")
     df = df.filter(_truthy(df, "IsUsed") & _truthy(df, "in_peaks"))
-    _assert_label_values(df, "label", {0, 1}, "caQTL")
+    # `label` is a boolean flag (True = significant caQTL, False = control).
+    assert df.schema["label"] == pl.Boolean, (
+        f"caQTL: expected boolean `label`, got {df.schema['label']}"
+    )
     out = _assemble(
         df,
         chrom_col="chr_hg38",
         pos_col="pos_hg38",
         a1_col="allele1",
         a2_col="allele2",
-        label_col="label",
-        positive_value=1,
-        effect_col="Beta",
+        label_expr=pl.col("label"),
+        effect_col="beta",
         name="caqtl",
     )
     assert out["label"].null_count() == 0, "caQTL: null labels after parse"
@@ -183,9 +185,9 @@ def parse_dsqtl(df: pl.DataFrame) -> pl.DataFrame:
     """Parse a raw ``yoruban.dsqtls.benchmarking.tsv`` frame into the standard
     schema.
 
-    Restricts to ``var.isused``, maps ``var.label`` 1→positive / −1→negative,
-    and keeps SNVs only. hg19 coordinates (lifted to GRCh38 in
-    ``annotate_variants``).
+    Restricts to ``var.isused`` (reproduces the published 560 positive / 26,813
+    control counts), maps ``var.label`` 1→positive / −1→negative, and keeps
+    SNVs only. hg19 coordinates (lifted to GRCh38 in ``annotate_variants``).
     """
     _require_columns(df, DSQTL_REQUIRED, "dsQTL")
     df = df.filter(_truthy(df, "var.isused"))
@@ -196,8 +198,7 @@ def parse_dsqtl(df: pl.DataFrame) -> pl.DataFrame:
         pos_col="var.pos",
         a1_col="var.allele1",
         a2_col="var.allele2",
-        label_col="var.label",
-        positive_value=1,
+        label_expr=pl.col("var.label") == 1,
         effect_col="obs.estimate",
         name="dsqtl",
     )

--- a/src/marin_dna/pipelines/evals/dart_eval.py
+++ b/src/marin_dna/pipelines/evals/dart_eval.py
@@ -37,11 +37,6 @@ from marin_dna.pipelines.evals.variants import (
     lift_hg19_to_hg38,
 )
 
-# Standard lead columns produced by both datasets (coordinates + label, plus the
-# signed study effect and its magnitude). Downstream annotation appends
-# consequence / distance columns.
-STANDARD_COLS = COORDINATES + ["label", "effect", "effect_size"]
-
 # Expected raw-TSV columns (DART-Eval variant_tasks.py).
 CAQTL_REQUIRED = [
     "chr_hg38",
@@ -260,6 +255,7 @@ def annotate_variants(
             (caQTL).
         name: label for log/assert messages.
     """
+    assert V.height > 0, f"{name}: empty input frame"
     n_in = V.height
     if lift:
         V = V.pipe(lift_hg19_to_hg38).filter(pl.col("pos") != -1)
@@ -271,7 +267,9 @@ def annotate_variants(
     # swap moves the effect allele to ref, flip the sign to keep `effect` signed
     # relative to the FINAL alt (i.e. effect of alt vs ref — what an alt-vs-ref /
     # LLR model score correlates against). Liftover RCs both alleles but
-    # preserves ref/alt roles, so only the swap flips the sign.
+    # preserves ref/alt roles, so only the swap flips the sign. A high flip rate
+    # is expected when the study codes allele1 as the non-reference allele
+    # (e.g. dsQTL, ~81%).
     V = V.with_columns(pl.col("alt").alias("_pre_alt"))
     V = check_ref_alt(V, genome)
     n_ref = V.height

--- a/src/marin_dna/pipelines/evals/dart_eval.py
+++ b/src/marin_dna/pipelines/evals/dart_eval.py
@@ -129,12 +129,19 @@ def _assemble(
     label_expr: pl.Expr,
     effect_col: str,
     name: str,
+    extra_cols: dict[str, str] | None = None,
 ) -> pl.DataFrame:
     """Project the raw frame onto the standard schema. ``allele1``/``allele2``
     become ``ref``/``alt`` provisionally — `check_ref_alt` (in
     ``annotate_variants``) reorients them against the reference. ``label_expr``
     is the boolean positive/negative indicator built by the caller (the two
-    datasets encode the label differently)."""
+    datasets encode the label differently).
+
+    ``effect_size`` is the study effect, parsed as the effect of ``allele2``
+    (= ``alt`` here); ``annotate_variants`` flips its sign for variants whose
+    ref/alt get swapped so it stays signed relative to the final ``alt``.
+    ``extra_cols`` maps output name -> source column for dataset-specific
+    passthrough floats (e.g. caQTL ``pval``/``se``), cast to Float64."""
     cols = [
         _strip_chr(pl.col(chrom_col)).alias("chrom"),
         pl.col(pos_col).cast(pl.Int64).alias("pos"),
@@ -142,14 +149,15 @@ def _assemble(
         pl.col(a2_col).cast(pl.Utf8).str.to_uppercase().alias("alt"),
         label_expr.alias("label"),
     ]
-    if effect_col in df.columns:
-        cols.append(pl.col(effect_col).cast(pl.Float64).alias("effect_size"))
-    else:
-        print(
-            f"WARNING [dart_eval {name}]: effect-size column {effect_col!r} "
-            "absent; effect_size set to null"
-        )
-        cols.append(pl.lit(None, dtype=pl.Float64).alias("effect_size"))
+    for out_name, src in {"effect_size": effect_col, **(extra_cols or {})}.items():
+        if src in df.columns:
+            cols.append(pl.col(src).cast(pl.Float64).alias(out_name))
+        else:
+            print(
+                f"WARNING [dart_eval {name}]: column {src!r} absent; "
+                f"{out_name} set to null"
+            )
+            cols.append(pl.lit(None, dtype=pl.Float64).alias(out_name))
     return df.select(cols)
 
 
@@ -176,6 +184,9 @@ def parse_caqtl(df: pl.DataFrame) -> pl.DataFrame:
         label_expr=pl.col("label"),
         effect_col="beta",
         name="caqtl",
+        # caQTL-only reference columns (not used by the eval, kept for the
+        # record): association p-value and the standard error of beta.
+        extra_cols={"pval": "pval", "se": "se"},
     )
     assert out["label"].null_count() == 0, "caQTL: null labels after parse"
     return out.pipe(filter_snp)
@@ -254,11 +265,27 @@ def annotate_variants(
     n_lift = V.height
     V = V.pipe(filter_chroms)
     n_chrom = V.height
+    # Record alt before check_ref_alt may swap ref<->alt. effect_size is parsed
+    # as the effect of the study allele we assigned to alt (allele2), so when a
+    # swap moves the effect allele to ref, flip the sign to keep effect_size
+    # signed relative to the FINAL alt (i.e. effect of alt vs ref — what an
+    # alt-vs-ref / LLR model score correlates against). Liftover RCs both
+    # alleles but preserves ref/alt roles, so only the swap flips the sign.
+    V = V.with_columns(pl.col("alt").alias("_pre_alt"))
     V = check_ref_alt(V, genome)
     n_ref = V.height
+    swapped = pl.col("alt") != pl.col("_pre_alt")
+    n_flipped = V.filter(swapped).height
+    V = V.with_columns(
+        pl.when(swapped)
+        .then(-pl.col("effect_size"))
+        .otherwise(pl.col("effect_size"))
+        .alias("effect_size")
+    ).drop("_pre_alt")
     print(
         f"[dart_eval annotate {name}] attrition: in={n_in} "
-        f"after_lift={n_lift} after_chrom_filter={n_chrom} after_ref_alt={n_ref}"
+        f"after_lift={n_lift} after_chrom_filter={n_chrom} after_ref_alt={n_ref} "
+        f"effect_size_sign_flipped={n_flipped}"
     )
     # All drops above are build-correctness QC, not class balancing. A uniform
     # coordinate-base (0- vs 1-based) or genome-build error would make ref_alt

--- a/src/marin_dna/pipelines/evals/dart_eval.py
+++ b/src/marin_dna/pipelines/evals/dart_eval.py
@@ -38,9 +38,9 @@ from marin_dna.pipelines.evals.variants import (
 )
 
 # Standard lead columns produced by both datasets (coordinates + label, plus the
-# study effect size for reference). Downstream annotation appends consequence /
-# distance columns.
-STANDARD_COLS = COORDINATES + ["label", "effect_size"]
+# signed study effect and its magnitude). Downstream annotation appends
+# consequence / distance columns.
+STANDARD_COLS = COORDINATES + ["label", "effect", "effect_size"]
 
 # Expected raw-TSV columns (DART-Eval variant_tasks.py).
 CAQTL_REQUIRED = [
@@ -137,11 +137,12 @@ def _assemble(
     is the boolean positive/negative indicator built by the caller (the two
     datasets encode the label differently).
 
-    ``effect_size`` is the study effect, parsed as the effect of ``allele2``
+    ``effect`` is the signed study effect, parsed as the effect of ``allele2``
     (= ``alt`` here); ``annotate_variants`` flips its sign for variants whose
-    ref/alt get swapped so it stays signed relative to the final ``alt``.
-    ``extra_cols`` maps output name -> source column for dataset-specific
-    passthrough floats (e.g. caQTL ``pval``/``se``), cast to Float64."""
+    ref/alt get swapped so it stays signed relative to the final ``alt``, then
+    derives ``effect_size = abs(effect)`` (the unsigned magnitude). ``extra_cols``
+    maps output name -> source column for dataset-specific passthrough floats
+    (e.g. caQTL ``pval``/``se``), cast to Float64."""
     cols = [
         _strip_chr(pl.col(chrom_col)).alias("chrom"),
         pl.col(pos_col).cast(pl.Int64).alias("pos"),
@@ -149,7 +150,7 @@ def _assemble(
         pl.col(a2_col).cast(pl.Utf8).str.to_uppercase().alias("alt"),
         label_expr.alias("label"),
     ]
-    for out_name, src in {"effect_size": effect_col, **(extra_cols or {})}.items():
+    for out_name, src in {"effect": effect_col, **(extra_cols or {})}.items():
         if src in df.columns:
             cols.append(pl.col(src).cast(pl.Float64).alias(out_name))
         else:
@@ -246,7 +247,7 @@ def annotate_variants(
     reference. These are reported (printed) and guarded by a retention assert.
 
     Args:
-        V: parsed frame (``chrom, pos, ref, alt, label, effect_size``); ``pos``
+        V: parsed frame (``chrom, pos, ref, alt, label, effect``); ``pos``
             is 1-based.
         genome: reference for ``check_ref_alt`` (GRCh38).
         consequence_paths: per-chrom consequence parquet paths, parallel to
@@ -265,12 +266,12 @@ def annotate_variants(
     n_lift = V.height
     V = V.pipe(filter_chroms)
     n_chrom = V.height
-    # Record alt before check_ref_alt may swap ref<->alt. effect_size is parsed
-    # as the effect of the study allele we assigned to alt (allele2), so when a
-    # swap moves the effect allele to ref, flip the sign to keep effect_size
-    # signed relative to the FINAL alt (i.e. effect of alt vs ref — what an
-    # alt-vs-ref / LLR model score correlates against). Liftover RCs both
-    # alleles but preserves ref/alt roles, so only the swap flips the sign.
+    # Record alt before check_ref_alt may swap ref<->alt. `effect` is parsed as
+    # the effect of the study allele we assigned to alt (allele2), so when a
+    # swap moves the effect allele to ref, flip the sign to keep `effect` signed
+    # relative to the FINAL alt (i.e. effect of alt vs ref — what an alt-vs-ref /
+    # LLR model score correlates against). Liftover RCs both alleles but
+    # preserves ref/alt roles, so only the swap flips the sign.
     V = V.with_columns(pl.col("alt").alias("_pre_alt"))
     V = check_ref_alt(V, genome)
     n_ref = V.height
@@ -278,14 +279,16 @@ def annotate_variants(
     n_flipped = V.filter(swapped).height
     V = V.with_columns(
         pl.when(swapped)
-        .then(-pl.col("effect_size"))
-        .otherwise(pl.col("effect_size"))
-        .alias("effect_size")
+        .then(-pl.col("effect"))
+        .otherwise(pl.col("effect"))
+        .alias("effect")
     ).drop("_pre_alt")
+    # Magnitude alongside the signed effect (orientation-independent).
+    V = V.with_columns(pl.col("effect").abs().alias("effect_size"))
     print(
         f"[dart_eval annotate {name}] attrition: in={n_in} "
         f"after_lift={n_lift} after_chrom_filter={n_chrom} after_ref_alt={n_ref} "
-        f"effect_size_sign_flipped={n_flipped}"
+        f"effect_sign_flipped={n_flipped}"
     )
     # All drops above are build-correctness QC, not class balancing. A uniform
     # coordinate-base (0- vs 1-based) or genome-build error would make ref_alt

--- a/src/marin_dna/pipelines/evals/dart_eval.py
+++ b/src/marin_dna/pipelines/evals/dart_eval.py
@@ -1,0 +1,286 @@
+"""DART-Eval caQTL / dsQTL variant-effect-prediction datasets.
+
+Parsing + annotation for the two DART-Eval Task-5 chromatin-accessibility QTL
+benchmarks, brought into the ``snakemake/evals`` pipeline with train/test
+splits and **no matching / no subsampling** (rules in
+``snakemake/evals/workflow/rules/dart_eval.smk``).
+
+Sources (DART-Eval, Patel *et al.* NeurIPS 2024 D&B;
+https://github.com/kundajelab/DART-Eval):
+
+- **caQTL** — African caQTLs (DeGorter *et al.* 2023), Synapse ``syn60756043``,
+  file ``Afr.CaQTLS.tsv``. Native **GRCh38** (``chr_hg38`` / ``pos_hg38``).
+- **dsQTL** — Yoruban dsQTLs (Degner *et al.* 2012), Synapse ``syn60756039``,
+  file ``yoruban.dsqtls.benchmarking.tsv``. **hg19** → lifted to GRCh38.
+
+Positives are statistically significant QTLs falling within accessible peaks;
+negatives are control variants in peaks. Every positive and negative is kept
+at its natural ratio — there is no class balancing.
+
+The TSV column names / encodings below come from DART-Eval's
+``variant_tasks.py``; ``parse_caqtl`` / ``parse_dsqtl`` assert loudly if the
+real file deviates so a schema drift can't silently corrupt the dataset.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from marin_dna.data.genome import Genome
+from marin_dna.pipelines.evals.trait_intervals import add_exon, add_tss
+from marin_dna.pipelines.evals.variants import (
+    COORDINATES,
+    attach_per_chrom_consequences,
+    check_ref_alt,
+    filter_chroms,
+    filter_snp,
+    lift_hg19_to_hg38,
+)
+
+# Standard lead columns produced by both datasets (coordinates + label, plus the
+# study effect size for reference). Downstream annotation appends consequence /
+# distance columns.
+STANDARD_COLS = COORDINATES + ["label", "effect_size"]
+
+# Expected raw-TSV columns (DART-Eval variant_tasks.py).
+CAQTL_REQUIRED = [
+    "chr_hg38",
+    "pos_hg38",
+    "allele1",
+    "allele2",
+    "IsUsed",
+    "in_peaks",
+    "label",
+]
+DSQTL_REQUIRED = [
+    "var.chrom",
+    "var.pos",
+    "var.allele1",
+    "var.allele2",
+    "var.isused",
+    "var.label",
+]
+
+# polars numeric dtypes (membership test is version-robust).
+_NUMERIC_DTYPES = frozenset(
+    {
+        pl.Int8,
+        pl.Int16,
+        pl.Int32,
+        pl.Int64,
+        pl.UInt8,
+        pl.UInt16,
+        pl.UInt32,
+        pl.UInt64,
+        pl.Float32,
+        pl.Float64,
+    }
+)
+
+
+def _strip_chr(col: pl.Expr) -> pl.Expr:
+    """Drop a leading ``chr`` so chromosome names match our ``CHROMS``
+    convention (``"1"``..``"22"``, ``"X"``, ``"Y"``)."""
+    return col.cast(pl.Utf8).str.replace(r"^chr", "")
+
+
+def _require_columns(df: pl.DataFrame, cols: list[str], name: str) -> None:
+    missing = [c for c in cols if c not in df.columns]
+    assert not missing, (
+        f"{name} TSV missing expected columns {missing}; got {df.columns}"
+    )
+
+
+def _truthy(df: pl.DataFrame, col: str) -> pl.Expr:
+    """Boolean expression for a flag column that may be stored as bool, 0/1
+    integer, or a string like ``"True"``/``"1"``."""
+    dt = df.schema[col]
+    if dt == pl.Boolean:
+        return pl.col(col)
+    if dt in _NUMERIC_DTYPES:
+        return pl.col(col) != 0
+    return pl.col(col).cast(pl.Utf8).str.to_lowercase().is_in(["1", "true", "t", "yes"])
+
+
+def _assert_label_values(
+    df: pl.DataFrame, col: str, allowed: set[int], name: str
+) -> None:
+    raw = df.get_column(col)
+    as_int = raw.cast(pl.Int64, strict=False)
+    # Casting must not introduce nulls — that would mean a non-integer label.
+    assert as_int.null_count() == raw.null_count(), (
+        f"{name} {col!r} has non-integer label values"
+    )
+    vals = set(as_int.drop_nulls().unique().to_list())
+    extra = vals - allowed
+    assert not extra, (
+        f"{name} {col!r} has unexpected values {sorted(extra)} "
+        f"(allowed {sorted(allowed)}) after the used/in-peaks filter"
+    )
+
+
+def _assemble(
+    df: pl.DataFrame,
+    *,
+    chrom_col: str,
+    pos_col: str,
+    a1_col: str,
+    a2_col: str,
+    label_col: str,
+    positive_value: int,
+    effect_col: str,
+    name: str,
+) -> pl.DataFrame:
+    """Project the raw frame onto the standard schema. ``allele1``/``allele2``
+    become ``ref``/``alt`` provisionally — `check_ref_alt` (in
+    ``annotate_variants``) reorients them against the reference. The label is
+    ``True`` where the (int-cast) ``label_col`` equals ``positive_value``."""
+    cols = [
+        _strip_chr(pl.col(chrom_col)).alias("chrom"),
+        pl.col(pos_col).cast(pl.Int64).alias("pos"),
+        pl.col(a1_col).cast(pl.Utf8).str.to_uppercase().alias("ref"),
+        pl.col(a2_col).cast(pl.Utf8).str.to_uppercase().alias("alt"),
+        (pl.col(label_col).cast(pl.Int64, strict=False) == positive_value).alias(
+            "label"
+        ),
+    ]
+    if effect_col in df.columns:
+        cols.append(pl.col(effect_col).cast(pl.Float64).alias("effect_size"))
+    else:
+        print(
+            f"WARNING [dart_eval {name}]: effect-size column {effect_col!r} "
+            "absent; effect_size set to null"
+        )
+        cols.append(pl.lit(None, dtype=pl.Float64).alias("effect_size"))
+    return df.select(cols)
+
+
+def parse_caqtl(df: pl.DataFrame) -> pl.DataFrame:
+    """Parse a raw ``Afr.CaQTLS.tsv`` frame into the standard schema.
+
+    Restricts to DART-Eval's benchmark set (``IsUsed`` and ``in_peaks``), maps
+    ``label`` 1→positive / 0→negative, and keeps SNVs only. Native GRCh38.
+    """
+    _require_columns(df, CAQTL_REQUIRED, "caQTL")
+    df = df.filter(_truthy(df, "IsUsed") & _truthy(df, "in_peaks"))
+    _assert_label_values(df, "label", {0, 1}, "caQTL")
+    out = _assemble(
+        df,
+        chrom_col="chr_hg38",
+        pos_col="pos_hg38",
+        a1_col="allele1",
+        a2_col="allele2",
+        label_col="label",
+        positive_value=1,
+        effect_col="Beta",
+        name="caqtl",
+    )
+    assert out["label"].null_count() == 0, "caQTL: null labels after parse"
+    return out.pipe(filter_snp)
+
+
+def parse_dsqtl(df: pl.DataFrame) -> pl.DataFrame:
+    """Parse a raw ``yoruban.dsqtls.benchmarking.tsv`` frame into the standard
+    schema.
+
+    Restricts to ``var.isused``, maps ``var.label`` 1→positive / −1→negative,
+    and keeps SNVs only. hg19 coordinates (lifted to GRCh38 in
+    ``annotate_variants``).
+    """
+    _require_columns(df, DSQTL_REQUIRED, "dsQTL")
+    df = df.filter(_truthy(df, "var.isused"))
+    _assert_label_values(df, "var.label", {1, -1}, "dsQTL")
+    out = _assemble(
+        df,
+        chrom_col="var.chrom",
+        pos_col="var.pos",
+        a1_col="var.allele1",
+        a2_col="var.allele2",
+        label_col="var.label",
+        positive_value=1,
+        effect_col="obs.estimate",
+        name="dsqtl",
+    )
+    assert out["label"].null_count() == 0, "dsQTL: null labels after parse"
+    return out.pipe(filter_snp)
+
+
+def annotate_variants(
+    V: pl.DataFrame,
+    *,
+    genome: Genome,
+    consequence_paths: list[str],
+    chroms: list[str],
+    exon_pc: pl.DataFrame,
+    exon_nc: pl.DataFrame,
+    tss_pc: pl.DataFrame,
+    tss_nc: pl.DataFrame,
+    exon_proximal_dist: int,
+    tss_proximal_dist: int,
+    lift: bool,
+    name: str = "",
+) -> pl.DataFrame:
+    """Liftover (optional) + ref/alt orientation + consequence/distance
+    annotations, with **no** matching-style filtering or subsampling.
+
+    Mirrors the annotation portion of ``complex_traits_annotate`` +
+    ``complex_traits_dataset_all`` but deliberately skips ``build_dataset``,
+    which drops ``exclude_consequences``, restricts negatives to consequences
+    seen in positives, and asserts every consequence maps to a group — all
+    matching-prep behaviours that would violate "no subsampling".
+
+    Drops are limited to build-correctness QC: unmapped liftover positions,
+    non-canonical contigs, and variants whose alleles don't match the
+    reference. These are reported (printed) and guarded by a retention assert.
+
+    Args:
+        V: parsed frame (``chrom, pos, ref, alt, label, effect_size``); ``pos``
+            is 1-based.
+        genome: reference for ``check_ref_alt`` (GRCh38).
+        consequence_paths: per-chrom consequence parquet paths, parallel to
+            ``chroms``.
+        chroms: per-path chromosome labels, parallel to ``consequence_paths``.
+        exon_pc/exon_nc/tss_pc/tss_nc: nearest-feature interval frames.
+        exon_proximal_dist/tss_proximal_dist: proximity thresholds for the
+            ``consequence_final`` recategorization.
+        lift: if True, lift hg19→GRCh38 first (dsQTL); else assume GRCh38
+            (caQTL).
+        name: label for log/assert messages.
+    """
+    n_in = V.height
+    if lift:
+        V = V.pipe(lift_hg19_to_hg38).filter(pl.col("pos") != -1)
+    n_lift = V.height
+    V = V.pipe(filter_chroms)
+    n_chrom = V.height
+    V = check_ref_alt(V, genome)
+    n_ref = V.height
+    print(
+        f"[dart_eval annotate {name}] attrition: in={n_in} "
+        f"after_lift={n_lift} after_chrom_filter={n_chrom} after_ref_alt={n_ref}"
+    )
+    # All drops above are build-correctness QC, not class balancing. A uniform
+    # coordinate-base (0- vs 1-based) or genome-build error would make ref_alt
+    # reject ~everything — guard with a loose retention floor.
+    assert n_ref >= 0.5 * n_in, (
+        f"check_ref_alt kept only {n_ref}/{n_in} variants for {name!r} — "
+        "suspect a coordinate-base (0- vs 1-based) or genome-build mismatch"
+    )
+    V = attach_per_chrom_consequences(V, consequence_paths, chroms)
+    # songlab/hg38-variant-consequences covers all possible SNVs, so every
+    # (already SNV-filtered) variant must receive a consequence.
+    assert V["consequence"].null_count() == 0, f"{name}: variants with null consequence"
+    assert V["consequence_cre"].null_count() == 0, (
+        f"{name}: variants with null consequence_cre"
+    )
+    V = (
+        V.pipe(add_exon, exon_pc, exon_nc, exon_proximal_dist)
+        .pipe(add_tss, tss_pc, tss_nc, tss_proximal_dist)
+        .sort(COORDINATES)
+    )
+    assert V["label"].dtype == pl.Boolean, f"{name}: label is not Boolean"
+    assert (V["pos"] > 0).all(), f"{name}: non-positive positions after annotation"
+    assert V["consequence_final"].null_count() == 0, (
+        f"{name}: null consequence_final after annotation"
+    )
+    return V

--- a/src/marin_dna/pipelines/evals/hf_readme.py
+++ b/src/marin_dna/pipelines/evals/hf_readme.py
@@ -477,6 +477,12 @@ def render_dart_eval(
     total = c["train_total"] + c["test_total"]
     pos = c["train_pos"] + c["test_pos"]
     neg = c["train_neg"] + c["test_neg"]
+    pval_se_rows = (
+        "| `pval` | float | caQTL association p-value (reference only) |\n"
+        "| `se` | float | Standard error of the effect size (reference only) |\n"
+        if dataset == "caqtl"
+        else ""
+    )
     return f"""{_frontmatter(m["extra_tags"])}
 
 # evals_{dataset}
@@ -521,8 +527,8 @@ Chromosome-parity split (same convention as the other `evals_*` datasets).
 |---|---|---|
 | `chrom`, `pos`, `ref`, `alt` | str / int / str / str | Variant coordinates (1-based, GRCh38). `ref`/`alt` oriented against the reference. |
 | `label` | bool | `True` for a significant {m["qtl"]}, `False` for a control variant |
-| `effect_size` | float | Study effect size ({"Beta" if dataset == "caqtl" else "obs.estimate"}); reference metadata |
-| `consequence`, `consequence_cre`, `consequence_final` | str | Ensembl VEP consequence (raw, with-CRE-class, and after TSS/exon-proximity recategorization); reference annotations |
+| `effect_size` | float | Signed study effect size (`{"beta" if dataset == "caqtl" else "obs.estimate"}`), **oriented to the `alt` allele** — positive ⇒ `alt` increases accessibility; sign-flipped for variants whose ref/alt were swapped to match the reference{", and present for positives only" if dataset == "dsqtl" else ""}. |
+{pval_se_rows}| `consequence`, `consequence_cre`, `consequence_final` | str | Ensembl VEP consequence (raw, with-CRE-class, and after TSS/exon-proximity recategorization); reference annotations |
 | `distance_tss_pc`, `distance_tss_nc`, `distance_tss` | int | Distance to nearest protein-coding / non-protein-coding TSS, and the minimum |
 | `tss_closest_pc_gene_id`, `tss_closest_nc_gene_id`, `tss_closest_gene_id` | str | Ensembl gene IDs at those distances |
 | `distance_exon_pc`, `distance_exon_nc`, `distance_exon` | int | Same shape, for nearest exon |
@@ -530,6 +536,26 @@ Chromosome-parity split (same convention as the other `evals_*` datasets).
 
 The consequence/distance columns are **reference annotations only** — they are
 not used to match or filter the variant set.
+
+## Evaluation
+
+Following [DART-Eval](https://github.com/kundajelab/DART-Eval) Task 5 (§4.5) and
+[ARSENAL](https://www.biorxiv.org/content/10.64898/2026.02.05.703637v1.full),
+score each variant with a model's allelic effect (e.g. an alt-vs-ref
+log-likelihood ratio) and report two complementary metrics, **each over a
+different variant set**:
+
+- **Classification — AUROC / AUPRC over _all_ variants:** significant
+  {m["qtl"]}s (`label = True`) vs control variants (`label = False`).
+- **Pearson correlation over the _positive_ variants only** (`label = True`):
+  between `effect_size` (signed, oriented to `alt`) and the model's signed
+  alt-vs-ref score. DART-Eval Table 6: *"for the positive variants, we computed
+  the correlation between measured and predicted allelic effects."* Controls
+  are not used in the correlation{
+        " (and for dsQTL they have no measured effect_size)"
+        if dataset == "dsqtl"
+        else ""
+    }.
 
 ## Provenance
 

--- a/src/marin_dna/pipelines/evals/hf_readme.py
+++ b/src/marin_dna/pipelines/evals/hf_readme.py
@@ -440,6 +440,115 @@ Same terms as the raw companion dataset.
 """
 
 
+_DART_EVAL_META = {
+    "caqtl": {
+        "assay": "ATAC-seq chromatin accessibility",
+        "qtl": "caQTL",
+        "study": "African caQTLs, DeGorter *et al.* 2023 (bioRxiv)",
+        "synapse": "syn60756043",
+        "build": "GRCh38 (native)",
+        "extra_tags": ["variant-effect-prediction", "chromatin-accessibility", "caqtl"],
+    },
+    "dsqtl": {
+        "assay": "DNase-seq chromatin accessibility",
+        "qtl": "dsQTL",
+        "study": "Yoruban dsQTLs, Degner *et al.* *Nature* 2012",
+        "synapse": "syn60756039",
+        "build": "GRCh38 (lifted from hg19)",
+        "extra_tags": ["variant-effect-prediction", "chromatin-accessibility", "dsqtl"],
+    },
+}
+
+
+def render_dart_eval(
+    dataset: str,
+    sha: str,
+    train_path: str | Path,
+    test_path: str | Path,
+) -> str:
+    """Dataset card for the DART-Eval caQTL/dsQTL datasets.
+
+    Unlike the matched datasets these are **not** matched or subsampled — all
+    positives and negatives are kept at their natural ratio — so there is no
+    retention or AUPRC-leak diagnostic (no `qc_path`).
+    """
+    m = _DART_EVAL_META[dataset]
+    c = _split_counts(train_path, test_path)
+    total = c["train_total"] + c["test_total"]
+    pos = c["train_pos"] + c["test_pos"]
+    neg = c["train_neg"] + c["test_neg"]
+    return f"""{_frontmatter(m["extra_tags"])}
+
+# evals_{dataset}
+
+Variant-effect-prediction benchmark of **{m["qtl"]}s** ({m["assay"]}):
+statistically significant chromatin-accessibility QTLs vs control variants,
+both within accessible peaks. Sourced from
+[DART-Eval](https://github.com/kundajelab/DART-Eval) Task 5 and brought into
+the `marin-dna` evals pipeline with chromosome-based **train/test splits** for
+model development.
+
+**No matching and no subsampling** — every positive and negative is kept at
+its natural ratio (≈1:{round(neg / pos) if pos else "?"} positive:negative).
+
+## Description
+
+| | |
+|---|---|
+| Positives | Significant {m["qtl"]}s within accessible peaks (`label = True`) |
+| Negatives | Control variants in peaks, no significant association (`label = False`) |
+| Assay | {m["assay"]} |
+| Source study | {m["study"]} |
+| Source data | DART-Eval, Synapse [`{m["synapse"]}`](https://www.synapse.org/Synapse:{m["synapse"]}) |
+| Genome build | {m["build"]} |
+| Variant type | SNVs only |
+| Coordinates | 1-based (`pos` is 1-based; `ref`/`alt` are single bases) |
+| Matching | none (natural class ratio) |
+
+## Splits
+
+Chromosome-parity split (same convention as the other `evals_*` datasets).
+
+| Split | Variants | Positives | Negatives | Chromosomes |
+|---|---:|---:|---:|---|
+| `train` | {c["train_total"]:,} | {c["train_pos"]:,} | {c["train_neg"]:,} | odd: 1, 3, …, X |
+| `test` | {c["test_total"]:,} | {c["test_pos"]:,} | {c["test_neg"]:,} | even: 2, 4, …, Y |
+| **total** | **{total:,}** | **{pos:,}** | **{neg:,}** | |
+
+## Columns
+
+| Column | Type | Description |
+|---|---|---|
+| `chrom`, `pos`, `ref`, `alt` | str / int / str / str | Variant coordinates (1-based, GRCh38). `ref`/`alt` oriented against the reference. |
+| `label` | bool | `True` for a significant {m["qtl"]}, `False` for a control variant |
+| `effect_size` | float | Study effect size ({"Beta" if dataset == "caqtl" else "obs.estimate"}); reference metadata |
+| `consequence`, `consequence_cre`, `consequence_final` | str | Ensembl VEP consequence (raw, with-CRE-class, and after TSS/exon-proximity recategorization); reference annotations |
+| `distance_tss_pc`, `distance_tss_nc`, `distance_tss` | int | Distance to nearest protein-coding / non-protein-coding TSS, and the minimum |
+| `tss_closest_pc_gene_id`, `tss_closest_nc_gene_id`, `tss_closest_gene_id` | str | Ensembl gene IDs at those distances |
+| `distance_exon_pc`, `distance_exon_nc`, `distance_exon` | int | Same shape, for nearest exon |
+| `exon_closest_pc_gene_id`, `exon_closest_nc_gene_id`, `exon_closest_gene_id` | str | Same shape |
+
+The consequence/distance columns are **reference annotations only** — they are
+not used to match or filter the variant set.
+
+## Provenance
+
+Built by the [`marin-dna`]({REPO_ROOT_URL}) eval pipeline at commit
+[`{sha[:7]}`]({REPO_ROOT_URL}/tree/{sha}/snakemake/evals).
+
+- Curation pipeline: {_pipeline_link(sha)}
+- Rules: {_file_link(sha, "snakemake/evals/workflow/rules/dart_eval.smk")}
+- Parsing + annotation: {_file_link(sha, "src/marin_dna/pipelines/evals/dart_eval.py")}
+
+## Citation
+
+If you use this benchmark, please cite the upstream sources:
+
+- DART-Eval — Patel *et al.* 2024, [arXiv 2412.05430](https://arxiv.org/abs/2412.05430) (NeurIPS D&B 2024)
+- {m["qtl"]} study — {m["study"]}
+"""
+
+
 def render(
     dataset: str,
     sha: str,
@@ -456,4 +565,6 @@ def render(
     if dataset.startswith("mendelian_traits_harness_"):
         window = int(dataset.rsplit("_", 1)[1])
         return render_harness(sha, train_path, test_path, window_size=window)
+    if dataset in _DART_EVAL_META:
+        return render_dart_eval(dataset, sha, train_path, test_path)
     raise ValueError(f"no README template for dataset {dataset!r}")

--- a/src/marin_dna/pipelines/evals/hf_readme.py
+++ b/src/marin_dna/pipelines/evals/hf_readme.py
@@ -531,11 +531,12 @@ Chromosome-parity split (same convention as the other `evals_*` datasets).
 |---|---|---|
 | `chrom`, `pos`, `ref`, `alt` | str / int / str / str | Variant coordinates (1-based, GRCh38). `ref`/`alt` oriented against the reference. |
 | `label` | bool | `True` for a significant {m["qtl"]}, `False` for a control variant |
-| `effect_size` | float | Signed study effect size (`{
+| `effect` | float | **Signed** study effect (`{
         "beta" if dataset == "caqtl" else "obs.estimate"
     }`), **oriented to the `alt` allele** — positive ⇒ `alt` increases accessibility; sign-flipped for variants whose ref/alt were swapped to match the reference{
         ", and present for positives only" if dataset == "dsqtl" else ""
-    }. |
+    }. This is the value the Pearson correlation uses. |
+| `effect_size` | float | Unsigned effect magnitude (absolute value of `effect`). |
 {
         pval_se_rows
     }| `consequence`, `consequence_cre`, `consequence_final` | str | Ensembl VEP consequence (raw, with-CRE-class, and after TSS/exon-proximity recategorization); reference annotations |
@@ -558,7 +559,7 @@ different variant set**:
 - **Classification — AUROC / AUPRC over _all_ variants:** significant
   {m["qtl"]}s (`label = True`) vs control variants (`label = False`).
 - **Pearson correlation over the _positive_ variants only** (`label = True`):
-  between `effect_size` (signed, oriented to `alt`) and the model's signed
+  between `effect` (signed, oriented to `alt`) and the model's signed
   alt-vs-ref score. DART-Eval Table 6: *"for the positive variants, we computed
   the correlation between measured and predicted allelic effects."* Controls
   are not used in the correlation{

--- a/src/marin_dna/pipelines/evals/hf_readme.py
+++ b/src/marin_dna/pipelines/evals/hf_readme.py
@@ -505,7 +505,9 @@ its natural ratio (≈1:{round(neg / pos) if pos else "?"} positive:negative).
 | Negatives | Control variants in peaks, no significant association (`label = False`) |
 | Assay | {m["assay"]} |
 | Source study | {m["study"]} |
-| Source data | DART-Eval, Synapse [`{m["synapse"]}`](https://www.synapse.org/Synapse:{m["synapse"]}) |
+| Source data | DART-Eval, Synapse [`{m["synapse"]}`](https://www.synapse.org/Synapse:{
+        m["synapse"]
+    }) |
 | Genome build | {m["build"]} |
 | Variant type | SNVs only |
 | Coordinates | 1-based (`pos` is 1-based; `ref`/`alt` are single bases) |
@@ -517,8 +519,10 @@ Chromosome-parity split (same convention as the other `evals_*` datasets).
 
 | Split | Variants | Positives | Negatives | Chromosomes |
 |---|---:|---:|---:|---|
-| `train` | {c["train_total"]:,} | {c["train_pos"]:,} | {c["train_neg"]:,} | odd: 1, 3, …, X |
-| `test` | {c["test_total"]:,} | {c["test_pos"]:,} | {c["test_neg"]:,} | even: 2, 4, …, Y |
+| `train` | {c["train_total"]:,} | {c["train_pos"]:,} | {
+        c["train_neg"]:,} | odd: 1, 3, …, X |
+| `test` | {c["test_total"]:,} | {c["test_pos"]:,} | {
+        c["test_neg"]:,} | even: 2, 4, …, Y |
 | **total** | **{total:,}** | **{pos:,}** | **{neg:,}** | |
 
 ## Columns
@@ -527,8 +531,14 @@ Chromosome-parity split (same convention as the other `evals_*` datasets).
 |---|---|---|
 | `chrom`, `pos`, `ref`, `alt` | str / int / str / str | Variant coordinates (1-based, GRCh38). `ref`/`alt` oriented against the reference. |
 | `label` | bool | `True` for a significant {m["qtl"]}, `False` for a control variant |
-| `effect_size` | float | Signed study effect size (`{"beta" if dataset == "caqtl" else "obs.estimate"}`), **oriented to the `alt` allele** — positive ⇒ `alt` increases accessibility; sign-flipped for variants whose ref/alt were swapped to match the reference{", and present for positives only" if dataset == "dsqtl" else ""}. |
-{pval_se_rows}| `consequence`, `consequence_cre`, `consequence_final` | str | Ensembl VEP consequence (raw, with-CRE-class, and after TSS/exon-proximity recategorization); reference annotations |
+| `effect_size` | float | Signed study effect size (`{
+        "beta" if dataset == "caqtl" else "obs.estimate"
+    }`), **oriented to the `alt` allele** — positive ⇒ `alt` increases accessibility; sign-flipped for variants whose ref/alt were swapped to match the reference{
+        ", and present for positives only" if dataset == "dsqtl" else ""
+    }. |
+{
+        pval_se_rows
+    }| `consequence`, `consequence_cre`, `consequence_final` | str | Ensembl VEP consequence (raw, with-CRE-class, and after TSS/exon-proximity recategorization); reference annotations |
 | `distance_tss_pc`, `distance_tss_nc`, `distance_tss` | int | Distance to nearest protein-coding / non-protein-coding TSS, and the minimum |
 | `tss_closest_pc_gene_id`, `tss_closest_nc_gene_id`, `tss_closest_gene_id` | str | Ensembl gene IDs at those distances |
 | `distance_exon_pc`, `distance_exon_nc`, `distance_exon` | int | Same shape, for nearest exon |

--- a/src/marin_dna/pipelines/evals/hf_readme.py
+++ b/src/marin_dna/pipelines/evals/hf_readme.py
@@ -479,7 +479,7 @@ def render_dart_eval(
     neg = c["train_neg"] + c["test_neg"]
     pval_se_rows = (
         "| `pval` | float | caQTL association p-value (reference only) |\n"
-        "| `se` | float | Standard error of the effect size (reference only) |\n"
+        "| `se` | float | Standard error of the effect estimate (`beta`); reference only |\n"
         if dataset == "caqtl"
         else ""
     )
@@ -576,6 +576,14 @@ Built by the [`marin-dna`]({REPO_ROOT_URL}) eval pipeline at commit
 - Curation pipeline: {_pipeline_link(sha)}
 - Rules: {_file_link(sha, "snakemake/evals/workflow/rules/dart_eval.smk")}
 - Parsing + annotation: {_file_link(sha, "src/marin_dna/pipelines/evals/dart_eval.py")}
+
+## License
+
+Released under the terms of its upstream sources. The variant set is
+redistributed from [DART-Eval](https://github.com/kundajelab/DART-Eval) (Task 5)
+and derives from the original QTL study ({m["study"]}); DART-Eval ships no
+explicit license, so consult it and the source study for redistribution and
+commercial-use terms.
 
 ## Citation
 

--- a/tests/pipelines/evals/test_dart_eval.py
+++ b/tests/pipelines/evals/test_dart_eval.py
@@ -30,6 +30,8 @@ class TestParseCaqtl:
                 # caQTL `label` is a boolean flag in the real TSV.
                 "label": [True, False, True, True, False],
                 "beta": [0.5, -0.2, 0.1, 0.1, 0.0],
+                "pval": [0.01, 0.5, 0.2, 0.3, 0.9],
+                "se": [0.1, 0.2, 0.3, 0.4, 0.5],
             }
         )
 
@@ -41,6 +43,16 @@ class TestParseCaqtl:
         assert out["label"].to_list() == [True, False]  # boolean label preserved
         assert out["effect_size"].to_list() == [0.5, -0.2]
         assert out.columns[:6] == ["chrom", "pos", "ref", "alt", "label", "effect_size"]
+
+    def test_pval_se_carried(self) -> None:
+        out = parse_caqtl(self._raw())
+        assert out["pval"].to_list() == [0.01, 0.5]
+        assert out["se"].to_list() == [0.1, 0.2]
+
+    def test_pval_se_null_when_absent(self) -> None:
+        out = parse_caqtl(self._raw().drop("pval", "se"))
+        assert out["pval"].null_count() == out.height
+        assert out["se"].null_count() == out.height
 
     def test_label_is_boolean(self) -> None:
         assert parse_caqtl(self._raw())["label"].dtype == pl.Boolean
@@ -248,6 +260,8 @@ class TestAnnotateVariants:
             assert c in out.columns
         assert out["label"].dtype == pl.Boolean
         assert out["consequence"].null_count() == 0
+        # No swap (genome returns the ref base for each) -> effect_size unchanged.
+        assert out.sort("pos")["effect_size"].to_list() == [0.5, -0.2, 0.1]
 
     def test_null_consequence_raises(self, tmp_path, intervals) -> None:
         V = _variants()
@@ -298,6 +312,9 @@ class TestAnnotateVariants:
         )
         assert out["ref"][0] == "C"
         assert out["alt"][0] == "G"
+        # alt changed C->G (swapped) -> effect_size flips sign (+1.0 -> -1.0) to
+        # stay signed relative to the final alt allele.
+        assert out["effect_size"][0] == -1.0
 
     def test_low_retention_raises(self, tmp_path, intervals) -> None:
         # Genome base never matches either allele -> check_ref_alt drops all.

--- a/tests/pipelines/evals/test_dart_eval.py
+++ b/tests/pipelines/evals/test_dart_eval.py
@@ -41,8 +41,11 @@ class TestParseCaqtl:
         assert out.height == 2
         assert out["chrom"].to_list() == ["1", "2"]  # "chr" stripped
         assert out["label"].to_list() == [True, False]  # boolean label preserved
-        assert out["effect_size"].to_list() == [0.5, -0.2]
-        assert out.columns[:6] == ["chrom", "pos", "ref", "alt", "label", "effect_size"]
+        assert out["effect"].to_list() == [
+            0.5,
+            -0.2,
+        ]  # signed; effect_size=abs added later
+        assert out.columns[:6] == ["chrom", "pos", "ref", "alt", "label", "effect"]
 
     def test_pval_se_carried(self) -> None:
         out = parse_caqtl(self._raw())
@@ -83,9 +86,9 @@ class TestParseCaqtl:
         with pytest.raises(AssertionError, match="missing expected columns"):
             parse_caqtl(self._raw().drop("label"))
 
-    def test_missing_effect_size_is_null(self) -> None:
+    def test_missing_effect_is_null(self) -> None:
         out = parse_caqtl(self._raw().drop("beta"))
-        assert out["effect_size"].null_count() == out.height
+        assert out["effect"].null_count() == out.height
 
     def test_lowercase_alleles_uppercased(self) -> None:
         df = self._raw().with_columns(
@@ -119,7 +122,7 @@ class TestParseDsqtl:
         assert out.height == 2
         assert out["chrom"].to_list() == ["1", "2"]
         assert out["label"].to_list() == [True, False]  # 1->True, -1->False
-        assert out["effect_size"].to_list() == [0.3, -0.1]
+        assert out["effect"].to_list() == [0.3, -0.1]
 
     def test_negative_one_is_false(self) -> None:
         out = parse_dsqtl(self._raw())
@@ -201,7 +204,7 @@ def _variants() -> pl.DataFrame:
             "ref": ["A", "C", "G"],
             "alt": ["T", "G", "A"],
             "label": [True, False, True],
-            "effect_size": [0.5, -0.2, 0.1],
+            "effect": [0.5, -0.2, 0.1],
         }
     )
 
@@ -255,13 +258,15 @@ class TestAnnotateVariants:
             "distance_tss_pc",
             "distance_tss",
             "label",
+            "effect",
             "effect_size",
         ):
             assert c in out.columns
         assert out["label"].dtype == pl.Boolean
         assert out["consequence"].null_count() == 0
-        # No swap (genome returns the ref base for each) -> effect_size unchanged.
-        assert out.sort("pos")["effect_size"].to_list() == [0.5, -0.2, 0.1]
+        # No swap (genome returns the ref base) -> effect unchanged; effect_size=|effect|.
+        assert out.sort("pos")["effect"].to_list() == [0.5, -0.2, 0.1]
+        assert out.sort("pos")["effect_size"].to_list() == [0.5, 0.2, 0.1]
 
     def test_null_consequence_raises(self, tmp_path, intervals) -> None:
         V = _variants()
@@ -280,7 +285,7 @@ class TestAnnotateVariants:
                 "ref": ["G"],
                 "alt": ["C"],
                 "label": [True],
-                "effect_size": [1.0],
+                "effect": [1.0],
             }
         )
         genome = FakeGenome({("1", 1700): "C"})
@@ -312,9 +317,10 @@ class TestAnnotateVariants:
         )
         assert out["ref"][0] == "C"
         assert out["alt"][0] == "G"
-        # alt changed C->G (swapped) -> effect_size flips sign (+1.0 -> -1.0) to
-        # stay signed relative to the final alt allele.
-        assert out["effect_size"][0] == -1.0
+        # alt changed C->G (swapped) -> effect flips sign (+1.0 -> -1.0) to stay
+        # signed relative to the final alt; effect_size = |effect| = 1.0.
+        assert out["effect"][0] == -1.0
+        assert out["effect_size"][0] == 1.0
 
     def test_low_retention_raises(self, tmp_path, intervals) -> None:
         # Genome base never matches either allele -> check_ref_alt drops all.

--- a/tests/pipelines/evals/test_dart_eval.py
+++ b/tests/pipelines/evals/test_dart_eval.py
@@ -27,8 +27,9 @@ class TestParseCaqtl:
                 "allele2": ["T", "G", "T", "T", "T"],
                 "IsUsed": [1, 1, 0, 1, 1],
                 "in_peaks": [1, 1, 1, 0, 1],
-                "label": [1, 0, 1, 1, 0],
-                "Beta": [0.5, -0.2, 0.1, 0.1, 0.0],
+                # caQTL `label` is a boolean flag in the real TSV.
+                "label": [True, False, True, True, False],
+                "beta": [0.5, -0.2, 0.1, 0.1, 0.0],
             }
         )
 
@@ -37,7 +38,7 @@ class TestParseCaqtl:
         # r3 dropped (IsUsed=0), r4 dropped (in_peaks=0), r5 dropped (indel).
         assert out.height == 2
         assert out["chrom"].to_list() == ["1", "2"]  # "chr" stripped
-        assert out["label"].to_list() == [True, False]  # 1->True, 0->False
+        assert out["label"].to_list() == [True, False]  # boolean label preserved
         assert out["effect_size"].to_list() == [0.5, -0.2]
         assert out.columns[:6] == ["chrom", "pos", "ref", "alt", "label", "effect_size"]
 
@@ -59,28 +60,19 @@ class TestParseCaqtl:
         )
         assert parse_caqtl(df).height == 2
 
-    def test_unexpected_label_raises(self) -> None:
-        df = self._raw().with_columns(
-            pl.when(pl.col("pos_hg38") == 100)
-            .then(2)
-            .otherwise(pl.col("label"))
-            .alias("label")
-        )
-        with pytest.raises(AssertionError, match="unexpected values"):
+    def test_non_boolean_label_raises(self) -> None:
+        # caQTL `label` must be boolean in the real TSV; an int-coded label is
+        # schema drift and should fail loudly.
+        df = self._raw().with_columns(pl.col("label").cast(pl.Int64))
+        with pytest.raises(AssertionError, match="expected boolean"):
             parse_caqtl(df)
 
     def test_missing_column_raises(self) -> None:
         with pytest.raises(AssertionError, match="missing expected columns"):
             parse_caqtl(self._raw().drop("label"))
 
-    def test_string_label_dtype(self) -> None:
-        # label stored as strings "1"/"0" must still map to bool.
-        df = self._raw().with_columns(pl.col("label").cast(pl.Utf8))
-        out = parse_caqtl(df)
-        assert out["label"].to_list() == [True, False]
-
     def test_missing_effect_size_is_null(self) -> None:
-        out = parse_caqtl(self._raw().drop("Beta"))
+        out = parse_caqtl(self._raw().drop("beta"))
         assert out["effect_size"].null_count() == out.height
 
     def test_lowercase_alleles_uppercased(self) -> None:

--- a/tests/pipelines/evals/test_dart_eval.py
+++ b/tests/pipelines/evals/test_dart_eval.py
@@ -1,0 +1,328 @@
+"""Tests for DART-Eval caQTL/dsQTL parsing + annotation."""
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from marin_dna.data.utils import load_annotation
+from marin_dna.pipelines.evals.dart_eval import (
+    annotate_variants,
+    parse_caqtl,
+    parse_dsqtl,
+)
+from marin_dna.pipelines.evals.trait_intervals import get_exon, get_tss
+
+
+# --------------------------------------------------------------------------- #
+# parse_caqtl
+# --------------------------------------------------------------------------- #
+class TestParseCaqtl:
+    def _raw(self) -> pl.DataFrame:
+        return pl.DataFrame(
+            {
+                "chr_hg38": ["chr1", "chr2", "chr3", "chr4", "chr5"],
+                "pos_hg38": [100, 200, 300, 400, 500],
+                "allele1": ["A", "C", "A", "A", "AT"],
+                "allele2": ["T", "G", "T", "T", "T"],
+                "IsUsed": [1, 1, 0, 1, 1],
+                "in_peaks": [1, 1, 1, 0, 1],
+                "label": [1, 0, 1, 1, 0],
+                "Beta": [0.5, -0.2, 0.1, 0.1, 0.0],
+            }
+        )
+
+    def test_filters_and_maps(self) -> None:
+        out = parse_caqtl(self._raw())
+        # r3 dropped (IsUsed=0), r4 dropped (in_peaks=0), r5 dropped (indel).
+        assert out.height == 2
+        assert out["chrom"].to_list() == ["1", "2"]  # "chr" stripped
+        assert out["label"].to_list() == [True, False]  # 1->True, 0->False
+        assert out["effect_size"].to_list() == [0.5, -0.2]
+        assert out.columns[:6] == ["chrom", "pos", "ref", "alt", "label", "effect_size"]
+
+    def test_label_is_boolean(self) -> None:
+        assert parse_caqtl(self._raw())["label"].dtype == pl.Boolean
+
+    def test_boolean_flag_dtype(self) -> None:
+        df = self._raw().with_columns(
+            pl.col("IsUsed").cast(pl.Boolean), pl.col("in_peaks").cast(pl.Boolean)
+        )
+        assert parse_caqtl(df).height == 2
+
+    def test_string_flag_dtype(self) -> None:
+        df = self._raw().with_columns(
+            pl.when(pl.col("IsUsed") == 1)
+            .then(pl.lit("True"))
+            .otherwise(pl.lit("False"))
+            .alias("IsUsed")
+        )
+        assert parse_caqtl(df).height == 2
+
+    def test_unexpected_label_raises(self) -> None:
+        df = self._raw().with_columns(
+            pl.when(pl.col("pos_hg38") == 100)
+            .then(2)
+            .otherwise(pl.col("label"))
+            .alias("label")
+        )
+        with pytest.raises(AssertionError, match="unexpected values"):
+            parse_caqtl(df)
+
+    def test_missing_column_raises(self) -> None:
+        with pytest.raises(AssertionError, match="missing expected columns"):
+            parse_caqtl(self._raw().drop("label"))
+
+    def test_string_label_dtype(self) -> None:
+        # label stored as strings "1"/"0" must still map to bool.
+        df = self._raw().with_columns(pl.col("label").cast(pl.Utf8))
+        out = parse_caqtl(df)
+        assert out["label"].to_list() == [True, False]
+
+    def test_missing_effect_size_is_null(self) -> None:
+        out = parse_caqtl(self._raw().drop("Beta"))
+        assert out["effect_size"].null_count() == out.height
+
+    def test_lowercase_alleles_uppercased(self) -> None:
+        df = self._raw().with_columns(
+            pl.col("allele1").str.to_lowercase(), pl.col("allele2").str.to_lowercase()
+        )
+        out = parse_caqtl(df)
+        assert out["ref"].to_list() == ["A", "C"]
+        assert out["alt"].to_list() == ["T", "G"]
+
+
+# --------------------------------------------------------------------------- #
+# parse_dsqtl
+# --------------------------------------------------------------------------- #
+class TestParseDsqtl:
+    def _raw(self) -> pl.DataFrame:
+        return pl.DataFrame(
+            {
+                "var.chrom": ["chr1", "chr2", "chr3", "chr4"],
+                "var.pos": [100, 200, 300, 400],
+                "var.allele1": ["A", "C", "A", "G"],
+                "var.allele2": ["T", "G", "T", "GC"],
+                "var.isused": [1, 1, 0, 1],
+                "var.label": [1, -1, 1, -1],
+                "obs.estimate": [0.3, -0.1, 0.2, 0.4],
+            }
+        )
+
+    def test_filters_and_maps(self) -> None:
+        out = parse_dsqtl(self._raw())
+        # r3 dropped (isused=0), r4 dropped (indel G->GC).
+        assert out.height == 2
+        assert out["chrom"].to_list() == ["1", "2"]
+        assert out["label"].to_list() == [True, False]  # 1->True, -1->False
+        assert out["effect_size"].to_list() == [0.3, -0.1]
+
+    def test_negative_one_is_false(self) -> None:
+        out = parse_dsqtl(self._raw())
+        assert out.filter(pl.col("chrom") == "2")["label"][0] is False
+
+    def test_unexpected_label_zero_raises(self) -> None:
+        df = self._raw().with_columns(
+            pl.when(pl.col("var.pos") == 100)
+            .then(0)
+            .otherwise(pl.col("var.label"))
+            .alias("var.label")
+        )
+        with pytest.raises(AssertionError, match="unexpected values"):
+            parse_dsqtl(df)
+
+    def test_missing_column_raises(self) -> None:
+        with pytest.raises(AssertionError, match="missing expected columns"):
+            parse_dsqtl(self._raw().drop("var.label"))
+
+
+# --------------------------------------------------------------------------- #
+# annotate_variants
+# --------------------------------------------------------------------------- #
+class FakeGenome:
+    """(chrom, 1-based-pos) -> base; mimics Genome.__call__(chrom, start, end)."""
+
+    def __init__(self, table: dict[tuple[str, int], str]) -> None:
+        self._table = table
+
+    def __call__(self, chrom: str, start: int, end: int, strand: str = "+") -> str:
+        assert end == start + 1, "fake genome only supports single-base lookups"
+        return self._table[(chrom, end)]
+
+
+SYNTHETIC_GTF = """\
+1\thavana\ttranscript\t1001\t2000\t.\t+\t.\tgene_id "ENSG_PLUS"; transcript_id "T1"; transcript_biotype "protein_coding";
+1\thavana\texon\t1001\t1100\t.\t+\t.\tgene_id "ENSG_PLUS"; transcript_id "T1"; transcript_biotype "protein_coding";
+1\thavana\texon\t1500\t1600\t.\t+\t.\tgene_id "ENSG_PLUS"; transcript_id "T1"; transcript_biotype "protein_coding";
+1\thavana\ttranscript\t5000\t6000\t.\t+\t.\tgene_id "ENSG_LNCRNA"; transcript_id "T3"; transcript_biotype "lncRNA";
+1\thavana\texon\t5000\t6000\t.\t+\t.\tgene_id "ENSG_LNCRNA"; transcript_id "T3"; transcript_biotype "lncRNA";
+"""
+
+
+@pytest.fixture
+def intervals(tmp_path: Path) -> dict[str, pl.DataFrame]:
+    gtf = tmp_path / "synthetic.gtf"
+    gtf.write_text(SYNTHETIC_GTF)
+    ann = load_annotation(str(gtf))
+    nc = pl.col("transcript_biotype") != "protein_coding"
+    return {
+        "tss_pc": get_tss(ann),
+        "tss_nc": get_tss(ann, biotype_filter=nc),
+        "exon_pc": get_exon(ann),
+        "exon_nc": get_exon(ann, biotype_filter=nc),
+    }
+
+
+def _write_consequences(tmp_path: Path, rows: list[dict]) -> str:
+    path = tmp_path / "1.parquet"
+    pl.DataFrame(
+        rows,
+        schema={
+            "chrom": pl.String,
+            "pos": pl.Int64,
+            "ref": pl.String,
+            "alt": pl.String,
+            "consequence": pl.String,
+            "consequence_cre": pl.String,
+        },
+    ).write_parquet(path)
+    return str(path)
+
+
+def _variants() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "chrom": ["1", "1", "1"],
+            "pos": [1150, 1700, 50000],
+            "ref": ["A", "C", "G"],
+            "alt": ["T", "G", "A"],
+            "label": [True, False, True],
+            "effect_size": [0.5, -0.2, 0.1],
+        }
+    )
+
+
+def _annotate(tmp_path, intervals, V, cons_rows, *, lift=False):
+    genome = FakeGenome(
+        {("1", p): r for p, r in zip(V["pos"].to_list(), V["ref"].to_list())}
+    )
+    cons = _write_consequences(tmp_path, cons_rows)
+    return annotate_variants(
+        V,
+        genome=genome,
+        consequence_paths=[cons],
+        chroms=["1"],
+        exon_pc=intervals["exon_pc"],
+        exon_nc=intervals["exon_nc"],
+        tss_pc=intervals["tss_pc"],
+        tss_nc=intervals["tss_nc"],
+        exon_proximal_dist=30,
+        tss_proximal_dist=1000,
+        lift=lift,
+    )
+
+
+class TestAnnotateVariants:
+    def _full_cons(self, V: pl.DataFrame) -> list[dict]:
+        return [
+            {
+                "chrom": "1",
+                "pos": p,
+                "ref": r,
+                "alt": a,
+                "consequence": "intron_variant",
+                "consequence_cre": "intron_variant",
+            }
+            for p, r, a in zip(
+                V["pos"].to_list(), V["ref"].to_list(), V["alt"].to_list()
+            )
+        ]
+
+    def test_no_drop_and_columns(self, tmp_path, intervals) -> None:
+        V = _variants()
+        out = _annotate(tmp_path, intervals, V, self._full_cons(V))
+        assert out.height == 3  # nothing dropped (all refs match, all in cons set)
+        for c in (
+            "consequence",
+            "consequence_cre",
+            "consequence_final",
+            "distance_exon_pc",
+            "distance_exon",
+            "distance_tss_pc",
+            "distance_tss",
+            "label",
+            "effect_size",
+        ):
+            assert c in out.columns
+        assert out["label"].dtype == pl.Boolean
+        assert out["consequence"].null_count() == 0
+
+    def test_null_consequence_raises(self, tmp_path, intervals) -> None:
+        V = _variants()
+        # Omit the last variant from the consequence set -> null consequence.
+        partial = self._full_cons(V)[:2]
+        with pytest.raises(AssertionError, match="null consequence"):
+            _annotate(tmp_path, intervals, V, partial)
+
+    def test_ref_alt_swap(self, tmp_path, intervals) -> None:
+        # Genome says base at ("1", 1700) is "C" but variant lists ref="G";
+        # check_ref_alt should swap so ref="C", alt="G".
+        V = pl.DataFrame(
+            {
+                "chrom": ["1"],
+                "pos": [1700],
+                "ref": ["G"],
+                "alt": ["C"],
+                "label": [True],
+                "effect_size": [1.0],
+            }
+        )
+        genome = FakeGenome({("1", 1700): "C"})
+        cons = _write_consequences(
+            tmp_path,
+            [
+                {
+                    "chrom": "1",
+                    "pos": 1700,
+                    "ref": "C",
+                    "alt": "G",
+                    "consequence": "intron_variant",
+                    "consequence_cre": "intron_variant",
+                }
+            ],
+        )
+        out = annotate_variants(
+            V,
+            genome=genome,
+            consequence_paths=[cons],
+            chroms=["1"],
+            exon_pc=intervals["exon_pc"],
+            exon_nc=intervals["exon_nc"],
+            tss_pc=intervals["tss_pc"],
+            tss_nc=intervals["tss_nc"],
+            exon_proximal_dist=30,
+            tss_proximal_dist=1000,
+            lift=False,
+        )
+        assert out["ref"][0] == "C"
+        assert out["alt"][0] == "G"
+
+    def test_low_retention_raises(self, tmp_path, intervals) -> None:
+        # Genome base never matches either allele -> check_ref_alt drops all.
+        V = _variants()
+        genome = FakeGenome({("1", p): "N" for p in V["pos"].to_list()})
+        cons = _write_consequences(tmp_path, self._full_cons(V))
+        with pytest.raises(AssertionError, match="coordinate-base"):
+            annotate_variants(
+                V,
+                genome=genome,
+                consequence_paths=[cons],
+                chroms=["1"],
+                exon_pc=intervals["exon_pc"],
+                exon_nc=intervals["exon_nc"],
+                tss_pc=intervals["tss_pc"],
+                tss_nc=intervals["tss_nc"],
+                exon_proximal_dist=30,
+                tss_proximal_dist=1000,
+                lift=False,
+            )

--- a/tests/pipelines/evals/test_hf_readme.py
+++ b/tests/pipelines/evals/test_hf_readme.py
@@ -161,6 +161,26 @@ class TestRender:
         with pytest.raises(ValueError, match="no README template"):
             hf_readme.render("not_a_real_dataset", SHA, train, test)
 
+    @pytest.mark.parametrize("dataset", ["caqtl", "dsqtl"])
+    def test_dart_eval_renders(self, tmp_path: Path, dataset: str) -> None:
+        # DART-Eval datasets are unmatched -> no qc_path.
+        train, test = _matched_train_test(tmp_path)
+        md = hf_readme.render(dataset, SHA, train, test)
+        assert md.startswith("---\n")
+        for tag in ("biology", "genomics", "dna"):
+            assert tag in md
+        for header in (
+            f"# evals_{dataset}",
+            "## Splits",
+            "## Columns",
+            "## Provenance",
+            "## Citation",
+        ):
+            assert header in md, f"missing header: {header}"
+        assert "No matching and no subsampling" in md
+        assert "DART-Eval" in md
+        assert SHA[:7] in md
+
     def test_retention_table_handles_zero_input(self, tmp_path: Path) -> None:
         path = tmp_path / "qc.parquet"
         pl.DataFrame(


### PR DESCRIPTION
Follows up on #139. DART-Eval was deferred there because its variant-effect-prediction task ships no held-out validation split. This brings DART-Eval Task-5's two chromatin-accessibility QTL benchmarks — **caQTL** (African caQTLs, DeGorter et al. 2023) and **dsQTL** (Yoruban dsQTLs, Degner et al. 2012) — into `snakemake/evals` with chromosome-parity train/test splits.

Per the request: **no matching, no subsampling** (all positives + negatives at their natural ratio), **consequence + distance annotations** for reference, the standard columns, and **hg38** (caQTL native; dsQTL lifted from hg19). HF upload is wired (`bolinas-dna/evals_{caqtl,dsqtl}`).

## What's here
- `src/marin_dna/pipelines/evals/dart_eval.py` — `parse_caqtl`/`parse_dsqtl` + `annotate_variants`. Reuses `lift_hg19_to_hg38`, `check_ref_alt`, `attach_per_chrom_consequences`, `add_exon`/`add_tss`; **deliberately skips `build_dataset`** (which would subsample). Produces signed `effect` (oriented to alt; sign-flipped on a ref/alt swap) + `effect_size = abs(effect)`, plus caQTL-only `pval`/`se`.
- `snakemake/evals/workflow/rules/dart_eval.smk` — Synapse download (curl + `$SYNAPSE_AUTH_TOKEN`, **no new dependency**) → `dart_eval_stage_genome` (one-time local boto3 download of the GRCh38 reference so `check_ref_alt` reads from disk) → annotate → `dataset_unsplit`; existing `split_dataset_by_chrom` produces the splits.
- Wiring: `config.yaml`, `Snakefile` (qc-gate fix), `common.smk` (`_hf_qc_input`), `hf_readme.py` (`render_dart_eval`). Tests + README.

## Continuous label & metric usage
The QTL **effect** is signed. Per DART-Eval's code it's the effect of `allele2` vs `allele1` (it correlates `allele2_scores − allele1_scores` against it). Since we reorient ref/alt to the genome, the signed column **`effect`** is re-expressed as the effect of `alt` vs `ref` (sign-flipped for the ~18% caQTL / ~81% dsQTL variants `check_ref_alt` swapped) — matching an alt-vs-ref / LLR model score. A companion **`effect_size = |effect|`** carries the unsigned magnitude.

Both papers ([DART-Eval](https://arxiv.org/abs/2412.05430) Task 5 §4.5, [ARSENAL](https://www.biorxiv.org/content/10.64898/2026.02.05.703637v1.full)) use **two metrics over different variant sets**, now documented in the dataset cards + README:
- **Classification (AUROC/AUPRC)** over **all** variants (significant vs control), via `label`.
- **Pearson correlation** over the **positive variants only** (`label=True`): signed `effect` vs the model's signed alt-vs-ref score. (DART-Eval Table 6: *"for the positive variants, we computed the correlation…"*.) caQTL carries `effect`/`effect_size` for all variants; dsQTL only for positives (controls have no measured effect) — exactly what the positives-only correlation needs.

## Data access
Synapse-only (`syn60756043`, `syn60756039`), **open access**. Download is plain HTTPS via a Synapse PAT — no `synapseclient`. The reference genome is staged from S3 via the s3 storage plugin's boto3 — no `s3fs`.

## Verification — ✅ built end-to-end against the real Synapse data
- **caQTL: 84,820** (41,382 + 43,438) = **6,821 pos / 77,999 neg** — **exact match** to DART-Eval's published counts.
- **dsQTL: 27,346** (15,018 + 12,328) = **559 pos / 26,787 neg** — 99.9% of published (560 / 26,813); the 27-variant delta is hg19→hg38 liftover loss.
- `check_ref_alt` retention: caQTL 100%, dsQTL 100% post-liftover — confirms the 1-based coordinate base.
- **`effect` sign verified vs raw**: caQTL no-swap `effect == beta` (69,817/69,817), swapped `== −beta` (15,003/15,003); `effect_size == |effect|` for every non-null row (caQTL 84,820, dsQTL 605). caQTL `pval`/`se` 0 nulls; dsQTL positives all have `effect`.
- Boolean `label`; train ⊆ odd / test ⊆ even chroms, disjoint; consequence/distance 0 nulls; SNV-only ACGT.
- Outputs at `s3://oa-bolinas/snakemake/evals/results/dataset/{caqtl,dsqtl}/{train,test}.parquet`.
- `277 passed, 3 skipped` (evals suite); ruff clean.

**Uploaded** to [`bolinas-dna/evals_caqtl`](https://huggingface.co/datasets/bolinas-dna/evals_caqtl) and [`bolinas-dna/evals_dsqtl`](https://huggingface.co/datasets/bolinas-dna/evals_dsqtl) (public; train/test parquets + dataset card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

