### PR TITLE
evals_v2 + dashboard: add exp135-1B-m5.1 (Eric's mix-v0.9 5-way +distal)

### DIFF
--- a/dashboard/models.yaml
+++ b/dashboard/models.yaml
@@ -367,6 +367,24 @@
     gcs: gs://marin-us-east5/checkpoints/dna-bolinas-mix-v0.9-p1B-i16-uniform_to_upstream_3.6-07bc9c/hf/step-8333
   datasets: [mendelian_traits]
 
+# Eric's 5-way distal mix (Slack #bolinas, 2026-05-30): continued training
+# from the animal-only uniform mix (~110B tokens), then a 5-way mixture adding
+# the new distal data (mammal ncRNA + mammal ccRE/enhancer). Final checkpoint
+# step-59158.
+- id: mix-v0.9-p1B-i24-exp135-m5.1-step-59158
+  display: exp135-1B-m5.1
+  family: marin_dna
+  description: mix v0.9, 5-way +distal (cont. from animal mix), 1B
+  training:
+    data: bolinas_mix_v0.9_zoonomia_m5.1
+    params: 1.0e9
+    window_size: 255
+    objective: CLM
+  wandb: https://wandb.ai/eric-czech/marin/runs/dna-bolinas-mix-v0.9-p1B-i24-exp135-zoonomia-m5.1-bef41e
+  checkpoint:
+    gcs: gs://marin-us-east5/checkpoints/dna-bolinas-mix-v0.9-p1B-i24-exp135-zoonomia-m5.1-bef41e/hf/step-59158
+  datasets: [mendelian_traits]
+
 # ---------------------------------------------------------------------------
 # External baselines (AlphaGenome, GPN-Star).
 # ---------------------------------------------------------------------------

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -134,6 +134,16 @@ models:
     window_size: 255
     datasets: [mendelian_traits]
 
+  # exp135-1B-m5.1 (Slack #bolinas, 2026-05-30): continued training from the
+  # animal-only uniform mix (~110B tokens), then a 5-way mix adding the new
+  # distal data (mammal ncRNA + mammal ccRE/enhancer). Final HF checkpoint
+  # step-59158; same 1B Qwen3 / 255 bp + BOS as the other mix-v0.9 runs.
+  # Scoped to mendelian_traits to match the other mix-v0.9 entries.
+  - name: mix-v0.9-p1B-i24-exp135-m5.1-step-59158
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-mix-v0.9-p1B-i24-exp135-zoonomia-m5.1-bef41e/hf/step-59158
+    window_size: 255
+    datasets: [mendelian_traits]
+
   # exp21 — animal-promoters-yolo (issue #21, wandb animal-promoters-yolo-r01-213a8e).
   # 512 bp context, no BOS. Scoped to mendelian_traits only: complex signal
   # was weak in #21, and the matched-pair mendelian dataset is the one of


### PR DESCRIPTION
🤖 Adds Eric Czech's **exp135-1B-m5.1** checkpoint to the Mendelian leaderboard.

## What

A new `marin_dna` entry for Eric's continued-training 1B run (Slack #bolinas, 2026-05-30): trained ~110B tokens on the animal-only uniform mixture, then continued on a 5-way mixture adding the new distal data (mammal ncRNA + mammal ccRE/enhancer).

- **run**: `dna-bolinas-mix-v0.9-p1B-i24-exp135-zoonomia-m5.1-bef41e`
- **checkpoint**: `gs://marin-us-east5/checkpoints/dna-bolinas-mix-v0.9-p1B-i24-exp135-zoonomia-m5.1-bef41e/hf/step-59158`
- Qwen3 1B, 255 bp + BOS — same architecture/convention as the other mix-v0.9 / exp166-v0.1-p1B runs.

## Changes

- `snakemake/analysis/evals_v2/config/config.yaml` — model entry (`gcs_path`, `window_size: 255`, scoped to `mendelian_traits`).
- `dashboard/models.yaml` — registry entry (`id: mix-v0.9-p1B-i24-exp135-m5.1-step-59158`, `display: exp135-1B-m5.1`).

Scoped to `mendelian_traits` to match the other two mix-v0.9 entries (i0-uniform, i16-upstream).

## Eval

Ran the evals_v2 pipeline on one A10G; the metrics parquet is on S3 at `.../results/metrics/mix-v0.9-p1B-i24-exp135-m5.1-step-59158/mendelian_traits.parquet`. Verified both dashboard loaders (`models.json.py`, `leaderboard.parquet.py`) ingest it.

Result (mendelian, default LLR protocol, AUPRC) — new best among bolinas models:

| model | global | macro-avg |
| --- | --- | --- |
| **exp135-1B-m5.1** (this PR) | **0.400** | **0.395** |
| mix-v0.9-p1B-upstream_3.6 | 0.379 | 0.330 |
| mix-v0.9-p1B-uniform | 0.369 | 0.325 |
| exp166-v0.1-p1B | 0.273 | 0.316 |

The leaderboard row appears once this merges to `main` (dashboard CI rebuilds).
