### PR TITLE
Add caQTL/dsQTL (DART-Eval) global eval path across evals_v2 / conservation / alphagenome

### DIFF
--- a/snakemake/alphagenome_eval/README.md
+++ b/snakemake/alphagenome_eval/README.md
@@ -65,6 +65,13 @@ results/
   the metric loss has been small in practice.
 - **No edge filtering.** The 1MB sequence context wraps near chromosome ends;
   AlphaGenome handles this internally.
+- **Retries transient `INTERNAL` errors.** AlphaGenome's backend intermittently
+  returns `StatusCode.INTERNAL` ("bad machine" outages — a known, maintainer-
+  acknowledged server-side issue). The SDK's built-in `@retry_rpc` only retries
+  `RESOURCE_EXHAUSTED` / `UNAVAILABLE`, so `score_variants_alphagenome` re-wraps
+  `score_variant` to also retry `INTERNAL` / `DEADLINE_EXCEEDED` (10 attempts,
+  exponential backoff). Without this a single bad-machine hit aborts the whole
+  dataset; large runs (the ~41k-variant caQTL set) effectively require it.
 
 ## Setup
 

--- a/snakemake/alphagenome_eval/README.md
+++ b/snakemake/alphagenome_eval/README.md
@@ -31,6 +31,21 @@ For each `dataset` in `config["datasets"]`:
    rows plus `_global_` (pooled) and `_macro_avg_` (mean of qualifying
    subsets) aggregates.
 
+### QTL datasets (`caqtl` / `dsqtl`, `eval_protocol: qtl_global`)
+
+The DART-Eval Task-5 chromatin-accessibility QTL benchmarks (PR #214) are
+**unmatched** (no `subset` / `match_group`), so a dataset entry with
+`eval_protocol: qtl_global` skips the per-subset path: scoring and max-across-
+tracks aggregation are unchanged, but `compute_metrics` calls
+`compute_qtl_metrics` — **global AUPRC** over all variants plus **Pearson /
+Spearman** of `alphagenome_max_l2` vs the dataset's `effect_size` over
+**positive variants only**. The metrics parquet then has a `metric` column
+(`AUPRC` / `pearson` / `spearman`) and no subset rows.
+
+> **API budget:** caQTL (84,820 variants) + dsQTL (27,346) is ~10× the
+> ~12K of mendelian_traits — one forward-strand call each. Budget the
+> wallclock accordingly and keep `num_workers` at 4 (rate-limit ceiling).
+
 ## Outputs
 
 S3 bucket `s3://oa-bolinas/snakemake/alphagenome_eval/`:
@@ -116,7 +131,7 @@ uv run snakemake
 | --- | --- |
 | `input_hf_prefix` | HF prefix for `f"{prefix}_{dataset}"`. |
 | `split` | `train` (test held out). |
-| `datasets` | List of `{name, hf_revision}` entries. The SHA pins the HF commit consumed; bumping it forces a re-run via snakemake's `params:` hash (re-spends API budget). SHAs mirror `snakemake/analysis/evals_v2/config/config.yaml`. |
+| `datasets` | List of `{name, hf_revision, [eval_protocol]}` entries. The SHA pins the HF commit consumed; bumping it forces a re-run via snakemake's `params:` hash (re-spends API budget). SHAs mirror `snakemake/analysis/evals_v2/config/config.yaml`. Optional `eval_protocol` ∈ `{matched_pair (default), qtl_global}` — `qtl_global` selects the global AUPRC + positives-only `effect_size` correlation path for caqtl/dsqtl. |
 | `num_workers` | Threads in the API ThreadPoolExecutor. Keep ≤ 4. |
 | `score_column` | Column name written by `aggregate_max` and consumed by `compute_metrics`. |
 | `n_bootstrap` | AUPRC cluster-bootstrap iterations per subset. |

--- a/snakemake/alphagenome_eval/README.md
+++ b/snakemake/alphagenome_eval/README.md
@@ -42,9 +42,9 @@ Spearman** of `alphagenome_max_l2` vs the dataset's `effect_size` over
 **positive variants only**. The metrics parquet then has a `metric` column
 (`AUPRC` / `pearson` / `spearman`) and no subset rows.
 
-> **API budget:** caQTL (84,820 variants) + dsQTL (27,346) is ~10× the
-> ~12K of mendelian_traits — one forward-strand call each. Budget the
-> wallclock accordingly and keep `num_workers` at 4 (rate-limit ceiling).
+> **API budget:** the train split alone is caQTL 41,382 + dsQTL 15,018
+> variants (~56K, ~5× mendelian_traits' ~11K) — one forward-strand call each.
+> Keep `num_workers` at 4 (rate-limit ceiling); a single 4-worker run is ~4 h.
 
 ## Outputs
 

--- a/snakemake/alphagenome_eval/config/config.yaml
+++ b/snakemake/alphagenome_eval/config/config.yaml
@@ -9,6 +9,15 @@ datasets:
     hf_revision: 4aed58e50c5dea0b878a665007af2ef9e5108e9f
   - name: complex_traits
     hf_revision: 22f86a89c65cb8f3007ac3cc2739f40efefa4340
+  # DART-Eval QTL benchmarks (PR #214). `qtl_global` → no subset/match_group;
+  # global AUPRC + Pearson/Spearman of alphagenome_max_l2 vs `effect_size`
+  # over positives only.
+  - name: caqtl
+    hf_revision: 9d004a21812c067b9ba1ebfe72f51b9095a5d0f8
+    eval_protocol: qtl_global
+  - name: dsqtl
+    hf_revision: b7e02a07beb831c7047286aacd3ddfd299d6f88f
+    eval_protocol: qtl_global
 
 # AlphaGenome rate-limits — keep workers low (4 has been a safe ceiling).
 num_workers: 4

--- a/snakemake/alphagenome_eval/workflow/rules/common.smk
+++ b/snakemake/alphagenome_eval/workflow/rules/common.smk
@@ -6,8 +6,17 @@ import pandas as pd
 from datasets import load_dataset
 
 from marin_dna.pipelines.evals.alphagenome import score_variants_alphagenome
-from marin_dna.pipelines.evals.conservation import REQUIRED_VARIANT_COLUMNS
-from marin_dna.pipelines.evals.metrics import compute_auprc_metrics
+from marin_dna.pipelines.evals.conservation import (
+    QTL_VARIANT_COLUMNS,
+    REQUIRED_VARIANT_COLUMNS,
+)
+from marin_dna.pipelines.evals.metrics import compute_auprc_metrics, compute_qtl_metrics
+
+# Per-dataset eval protocol — see snakemake/analysis/evals_v2 common.smk.
+# `matched_pair` (default) → per-subset AUPRC + cluster bootstrap.
+# `qtl_global` → global AUPRC + positives-only effect_size correlation on the
+# unmatched DART-Eval QTL datasets (caqtl/dsqtl).
+EVAL_PROTOCOLS = ("matched_pair", "qtl_global")
 
 
 def get_dataset_config(name):
@@ -17,4 +26,26 @@ def get_dataset_config(name):
     raise ValueError(f"dataset {name!r} not found in config")
 
 
+def get_dataset_protocol(name):
+    """Eval protocol for a dataset (default `matched_pair`)."""
+    return get_dataset_config(name).get("eval_protocol", "matched_pair")
+
+
+def get_dataset_variant_columns(name):
+    """Required variant columns for a dataset, keyed by eval protocol."""
+    return (
+        QTL_VARIANT_COLUMNS
+        if get_dataset_protocol(name) == "qtl_global"
+        else REQUIRED_VARIANT_COLUMNS
+    )
+
+
 DATASETS = [d["name"] for d in config["datasets"]]
+
+# Fail fast on an unknown eval_protocol (typo) at parse time.
+for _d in config["datasets"]:
+    _ep = _d.get("eval_protocol", "matched_pair")
+    assert _ep in EVAL_PROTOCOLS, (
+        f"dataset {_d['name']!r} `eval_protocol` must be one of "
+        f"{sorted(EVAL_PROTOCOLS)}, got {_ep!r}"
+    )

--- a/snakemake/alphagenome_eval/workflow/rules/metrics.smk
+++ b/snakemake/alphagenome_eval/workflow/rules/metrics.smk
@@ -5,6 +5,12 @@ for the 1:k matched structure. Output schema mirrors
 `marin_dna.pipelines.evals.metrics.compute_auprc_metrics`:
 `[score_type, subset, value, se, n_groups, n_rows]` plus `_global_` and
 `_macro_avg_` aggregate rows per score_type.
+
+For `eval_protocol: qtl_global` datasets (caqtl/dsqtl) the unmatched path
+runs instead via `compute_qtl_metrics`: one row per (metric × score_type),
+metric ∈ {AUPRC, pearson, spearman} — global AUPRC + Pearson/Spearman of
+`alphagenome_max_l2` vs `effect_size` over positives only (a `metric`
+column, no subset rows).
 """
 
 
@@ -21,20 +27,33 @@ rule compute_metrics:
     run:
         score_col = config["score_column"]
         df = pd.read_parquet(input[0])
-        for col in REQUIRED_VARIANT_COLUMNS:
+        eval_protocol = get_dataset_protocol(wildcards.dataset)
+        for col in get_dataset_variant_columns(wildcards.dataset):
             assert col in df.columns, f"scores parquet missing column {col!r}"
         assert (
             score_col in df.columns
         ), f"scores parquet missing score column {score_col!r}"
 
-        metrics = compute_auprc_metrics(
-            dataset=df[list(REQUIRED_VARIANT_COLUMNS)],
-            scores=df[[score_col]],
-            score_columns=[score_col],
-            n_bootstrap=params.n_bootstrap,
-            rng=params.bootstrap_seed,
-        )
+        if eval_protocol == "qtl_global":
+            metrics = compute_qtl_metrics(
+                dataset=df[["label", "effect_size"]],
+                scores=df[[score_col]],
+                score_columns=[score_col],
+                n_bootstrap=params.n_bootstrap,
+                rng=params.bootstrap_seed,
+            )
+        else:
+            metrics = compute_auprc_metrics(
+                dataset=df[list(REQUIRED_VARIANT_COLUMNS)],
+                scores=df[[score_col]],
+                score_columns=[score_col],
+                n_bootstrap=params.n_bootstrap,
+                rng=params.bootstrap_seed,
+            )
         metrics["dataset"] = wildcards.dataset
         metrics["split"] = config["split"]
         metrics.to_parquet(output[0], index=False)
-        print(f"[alphagenome_eval] {wildcards.dataset}: {len(metrics)} subset rows")
+        print(
+            f"[alphagenome_eval] {wildcards.dataset} ({eval_protocol}): "
+            f"{len(metrics)} metric rows"
+        )

--- a/snakemake/alphagenome_eval/workflow/rules/score.smk
+++ b/snakemake/alphagenome_eval/workflow/rules/score.smk
@@ -23,11 +23,16 @@ rule compute_per_track_l2:
         ds = load_dataset(
             params.hf_path, split=config["split"], revision=params.hf_revision
         ).to_pandas()
-        for col in REQUIRED_VARIANT_COLUMNS:
+        # qtl_global datasets (caqtl/dsqtl) carry effect_size, no
+        # subset/match_group.
+        variant_cols = get_dataset_variant_columns(wildcards.dataset)
+        for col in variant_cols:
             assert col in ds.columns, f"dataset missing column {col!r}"
 
+        # subset_n_pairs is a matched-pair smoke knob (slices on match_group);
+        # QTL datasets have none, so it's ignored for them (null in production).
         n_pairs = config.get("subset_n_pairs")
-        if n_pairs is not None:
+        if n_pairs is not None and get_dataset_protocol(wildcards.dataset) == "matched_pair":
             keep = ds["match_group"].drop_duplicates().head(int(n_pairs))
             ds = ds[ds["match_group"].isin(keep)].reset_index(drop=True)
             print(
@@ -42,7 +47,7 @@ rule compute_per_track_l2:
 
         out = pd.concat(
             [
-                ds[list(REQUIRED_VARIANT_COLUMNS)].reset_index(drop=True),
+                ds[list(variant_cols)].reset_index(drop=True),
                 per_track.reset_index(drop=True),
             ],
             axis=1,
@@ -64,10 +69,13 @@ rule aggregate_max:
     run:
         score_col = config["score_column"]
         df = pd.read_parquet(input[0])
-        track_cols = [c for c in df.columns if c not in REQUIRED_VARIANT_COLUMNS]
+        # Exclude the variant columns (which for QTL datasets include
+        # effect_size) so only the real per-track L2 columns are max-reduced.
+        variant_cols = get_dataset_variant_columns(wildcards.dataset)
+        track_cols = [c for c in df.columns if c not in variant_cols]
         assert track_cols, "no per-track columns found in input parquet"
 
-        out = df[list(REQUIRED_VARIANT_COLUMNS)].copy()
+        out = df[list(variant_cols)].copy()
         out[score_col] = df[track_cols].max(axis=1)
         assert (
             out[score_col].notna().all()

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -44,6 +44,28 @@ The metrics parquet has columns
 with aggregate rows `_global_` and `_macro_avg_` per `score_type` —
 see `marin_dna.pipelines.evals.metrics.compute_auprc_metrics` for details.
 
+### QTL datasets (`caqtl` / `dsqtl`, `eval_protocol: qtl_global`)
+
+The DART-Eval Task-5 chromatin-accessibility QTL benchmarks (PR #214) are
+**unmatched** — no `subset`, no `match_group`, no subsampling — so they take a
+separate global path selected by `eval_protocol: qtl_global` on the dataset
+entry. Scoring is identical (they still set `score_protocol: abs_llr`, so the
+score columns are `abs_llr_{fwd,rc,avg}` + `jsd_{fwd,rc,avg}` — abs-LLR and
+JSD), but the metric step calls
+`marin_dna.pipelines.evals.metrics.compute_qtl_metrics` instead, emitting **one
+row per (metric × score_type)** with a `metric` column ∈ `{AUPRC, pearson,
+spearman}`:
+
+- **AUPRC** over *all* variants (significant QTL vs control via `label`), with
+  a plain row-bootstrap SE.
+- **Pearson / Spearman** of the score vs the dataset's `effect_size` (unsigned
+  `|effect|`), over the **positive variants only** — controls are excluded
+  (for `dsqtl` they carry no measured effect at all).
+
+These metrics parquets have columns
+`[metric, score_type, value, se, n_rows, n_pos, model, dataset, split]` — note
+the `metric` column and the absence of subset rows.
+
 ## Conventions
 
 - **Train split only.** Test is held out for the final-eval pass; train is
@@ -131,7 +153,7 @@ Two unavoidable AWS-side failure modes worth knowing about:
 | `input_hf_prefix` | HF prefix for `f"{prefix}_{dataset.name}"`. |
 | `genome_path` | Canonical GRCh38 FASTA. fsspec URI (e.g. `s3://...`) or local path. The S3 path requires `--group genome-s3` at install time. |
 | `split` | `train` (or `test` once held-out eval is unlocked). |
-| `datasets` | List of `{name, hf_revision, score_protocol}`. `hf_revision` is the pinned HF dataset commit SHA — bumping it triggers re-execution. `score_protocol` ∈ `{minus_llr, abs_llr}`. |
+| `datasets` | List of `{name, hf_revision, score_protocol, [eval_protocol]}`. `hf_revision` is the pinned HF dataset commit SHA — bumping it triggers re-execution. `score_protocol` ∈ `{minus_llr, abs_llr}`. Optional `eval_protocol` ∈ `{matched_pair (default), qtl_global}` — `qtl_global` selects the global AUPRC + positives-only `effect_size` correlation path for the unmatched caqtl/dsqtl datasets. |
 | `models` | List of `{name, window_size, ...}`. Each entry has exactly one of `gcs_path` (full GCS URI incl. `/hf/step-{N}`) or `hf_repo` (HuggingFace Hub repo ID), plus two optional fields: `datasets: [...]` to restrict which `datasets` this checkpoint evaluates on (defaults to all), and `batch_size: N` to override the global `inference.batch_size` for this checkpoint (useful when context size differs from the global default's tuning). |
 | `inference.*` | Batch size, workers, `data_transform_on_the_fly`, `torch_compile`; `rc` (also score the reverse-complement strand — doubles inference time); `n_bootstrap` (AUPRC bootstrap iterations per subset × score_type); `bootstrap_seed` (reproducibility seed; bumping triggers metrics re-execution). |
 
@@ -143,6 +165,9 @@ Pipeline rules are thin glue around:
   → per-strand score atoms (`llr_fwd`, `llr_rc`, `jsd_fwd`, `jsd_rc`).
 - `marin_dna.pipelines.evals.metrics.compute_auprc_metrics` — score columns
   → AUPRC ± cluster-bootstrap SE per subset (cluster = `match_group`).
+- `marin_dna.pipelines.evals.metrics.compute_qtl_metrics` — score columns
+  → global AUPRC + positives-only Pearson/Spearman vs `effect_size`
+  (the `eval_protocol: qtl_global` path for caqtl/dsqtl).
 
 Both are tested at `tests/pipelines/evals/test_metrics.py`,
 `tests/pipelines/evals/test_inference.py`, and `tests/model/test_scoring.py`.

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -23,6 +23,21 @@ datasets:
     hf_revision: 22f86a89c65cb8f3007ac3cc2739f40efefa4340  # PR #194 k=9 rebuild
     score_protocol: abs_llr     # fine-mapped positives — magnitude regardless of direction
 
+  # DART-Eval Task-5 chromatin-accessibility QTL benchmarks (PR #214). No
+  # matching / no subsampling, so `eval_protocol: qtl_global` selects the
+  # global path: AUPRC over all variants + Pearson/Spearman of the score vs
+  # `effect_size` over positives only (no subset/match_group, no macro-avg).
+  # `score_protocol: abs_llr` still drives the LLR→score transform, yielding
+  # the `abs_llr_{fwd,rc,avg}` + `jsd_{fwd,rc,avg}` score columns (abs-LLR + JSD).
+  - name: caqtl
+    hf_revision: 9d004a21812c067b9ba1ebfe72f51b9095a5d0f8
+    score_protocol: abs_llr
+    eval_protocol: qtl_global
+  - name: dsqtl
+    hf_revision: b7e02a07beb831c7047286aacd3ddfd299d6f88f
+    score_protocol: abs_llr
+    eval_protocol: qtl_global
+
 # Model checkpoints. Each entry must have exactly one of:
 #   - `gcs_path`: full GCS URI to the checkpoint directory (includes /hf/step-{N});
 #                  pulled with `gcloud storage cp -r`.
@@ -71,6 +86,9 @@ models:
   - name: exp136-proj_v30-step-9999
     gcs_path: gs://marin-us-central1/checkpoints/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0/hf/step-9999
     window_size: 255   # 255 bp DNA + BOS = 256 total tokens
+    # Explicit so only this checkpoint expands to the new QTL datasets; every
+    # other model stays scoped to mendelian_traits (see entries below).
+    datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
 
   # exp136 — enhancer-curation proj_v30, intermediate checkpoints (issue #136).
   # Native Levanter checkpoints were saved at every num_train_steps // 3 step

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -6,9 +6,22 @@ import numpy as np
 import pandas as pd
 from datasets import load_dataset
 
-from marin_dna.pipelines.evals.conservation import REQUIRED_VARIANT_COLUMNS
+from marin_dna.pipelines.evals.conservation import (
+    QTL_VARIANT_COLUMNS,
+    REQUIRED_VARIANT_COLUMNS,
+)
 from marin_dna.pipelines.evals.inference import compute_variant_scores
-from marin_dna.pipelines.evals.metrics import SCORE_PROTOCOLS, compute_auprc_metrics
+from marin_dna.pipelines.evals.metrics import (
+    SCORE_PROTOCOLS,
+    compute_auprc_metrics,
+    compute_qtl_metrics,
+)
+
+# Per-dataset eval protocol. `matched_pair` (default) → per-subset AUPRC +
+# cluster bootstrap over `match_group` (mendelian/complex). `qtl_global` →
+# global AUPRC + positives-only effect_size correlation on the unmatched
+# DART-Eval QTL datasets (caqtl/dsqtl), which carry no subset/match_group.
+EVAL_PROTOCOLS = ("matched_pair", "qtl_global")
 
 
 def get_dataset_config(name):
@@ -16,6 +29,20 @@ def get_dataset_config(name):
         if d["name"] == name:
             return d
     raise ValueError(f"dataset {name!r} not found in config")
+
+
+def get_dataset_protocol(name):
+    """Eval protocol for a dataset (default `matched_pair`)."""
+    return get_dataset_config(name).get("eval_protocol", "matched_pair")
+
+
+def get_dataset_variant_columns(name):
+    """Required variant columns for a dataset, keyed by eval protocol."""
+    return (
+        QTL_VARIANT_COLUMNS
+        if get_dataset_protocol(name) == "qtl_global"
+        else REQUIRED_VARIANT_COLUMNS
+    )
 
 
 def get_model_config(name):
@@ -40,6 +67,11 @@ for _d in config["datasets"]:
     assert _d["score_protocol"] in SCORE_PROTOCOLS, (
         f"dataset {_d['name']!r} `score_protocol` must be one of "
         f"{sorted(SCORE_PROTOCOLS)}, got {_d['score_protocol']!r}"
+    )
+    _ep = _d.get("eval_protocol", "matched_pair")
+    assert _ep in EVAL_PROTOCOLS, (
+        f"dataset {_d['name']!r} `eval_protocol` must be one of "
+        f"{sorted(EVAL_PROTOCOLS)}, got {_ep!r}"
     )
 
 

--- a/snakemake/analysis/evals_v2/workflow/rules/inference.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/inference.smk
@@ -38,7 +38,11 @@ rule compute_scores:
         ds = load_dataset(
             params.hf_path, split=config["split"], revision=params.hf_revision
         ).to_pandas()
-        for col in REQUIRED_VARIANT_COLUMNS:
+        # qtl_global datasets (caqtl/dsqtl) carry no subset/match_group; they
+        # require effect_size instead. `compute_variant_scores` only reads
+        # chrom/pos/ref/alt, and the concat below preserves every ds column,
+        # so effect_size reaches the scores parquet for the metric step.
+        for col in get_dataset_variant_columns(wildcards.dataset):
             assert col in ds.columns, f"dataset missing column {col!r}"
 
         scores = compute_variant_scores(

--- a/snakemake/analysis/evals_v2/workflow/rules/metrics.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/metrics.smk
@@ -17,9 +17,15 @@ Score-type fan-out:
 transform (so `abs_llr_avg = |(llr_fwd + llr_rc)/2|`, matching the
 prior in-runner averaging behavior).
 
-Output parquet has one row per (subset × score_type) plus aggregate
-rows `_global_` and `_macro_avg_` per score_type — see
+Output parquet (matched_pair datasets) has one row per (subset × score_type)
+plus aggregate rows `_global_` and `_macro_avg_` per score_type — see
 `marin_dna.pipelines.evals.metrics.compute_auprc_metrics`.
+
+For `eval_protocol: qtl_global` datasets (caqtl/dsqtl) the unmatched path
+runs instead: `compute_qtl_metrics` emits one row per (metric × score_type)
+where metric ∈ {AUPRC, pearson, spearman} — global AUPRC over all variants
+plus Pearson/Spearman of the score vs `effect_size` over positives only. No
+subset/match_group, so the parquet has a `metric` column and no subset rows.
 """
 
 
@@ -39,7 +45,8 @@ rule compute_metrics:
         protocol = params.score_protocol
         transform = SCORE_PROTOCOLS[protocol]
         df = pd.read_parquet(input[0])
-        for col in REQUIRED_VARIANT_COLUMNS:
+        eval_protocol = get_dataset_protocol(wildcards.dataset)
+        for col in get_dataset_variant_columns(wildcards.dataset):
             assert col in df.columns, f"scores parquet missing column {col!r}"
 
         if "llr_rc" in df.columns:
@@ -57,18 +64,29 @@ rule compute_metrics:
                 score_cols.append(jsd_col)
         assert score_cols, "no score columns to evaluate — scores parquet schema?"
 
-        metrics = compute_auprc_metrics(
-            dataset=df[list(REQUIRED_VARIANT_COLUMNS)],
-            scores=df[score_cols],
-            score_columns=score_cols,
-            n_bootstrap=params.n_bootstrap,
-            rng=params.bootstrap_seed,
-        )
+        if eval_protocol == "qtl_global":
+            # Global AUPRC + positives-only effect_size correlation. No
+            # subset/match_group; metrics frame carries a `metric` column.
+            metrics = compute_qtl_metrics(
+                dataset=df[["label", "effect_size"]],
+                scores=df[score_cols],
+                score_columns=score_cols,
+                n_bootstrap=params.n_bootstrap,
+                rng=params.bootstrap_seed,
+            )
+        else:
+            metrics = compute_auprc_metrics(
+                dataset=df[list(REQUIRED_VARIANT_COLUMNS)],
+                scores=df[score_cols],
+                score_columns=score_cols,
+                n_bootstrap=params.n_bootstrap,
+                rng=params.bootstrap_seed,
+            )
         metrics["model"] = wildcards.model
         metrics["dataset"] = wildcards.dataset
         metrics["split"] = config["split"]
         metrics.to_parquet(output[0], index=False)
         print(
-            f"[evals_v2] {wildcards.model} {wildcards.dataset}: "
-            f"{len(metrics)} subset rows (score_cols={score_cols})"
+            f"[evals_v2] {wildcards.model} {wildcards.dataset} "
+            f"({eval_protocol}): {len(metrics)} metric rows (score_cols={score_cols})"
         )

--- a/snakemake/conservation_eval/README.md
+++ b/snakemake/conservation_eval/README.md
@@ -49,6 +49,19 @@ distal, splicing, promoter, …) — `_global_` and `_macro_avg_` aggregate rows
 flow through the parquet (used by the dashboard) but are excluded from the
 markdown.
 
+### QTL datasets (`caqtl` / `dsqtl`, `eval_protocol: qtl_global`)
+
+The DART-Eval Task-5 chromatin-accessibility QTL benchmarks (PR #214) are
+**unmatched** (no `subset` / `match_group`), so a dataset entry with
+`eval_protocol: qtl_global` takes a global path instead: scoring is identical
+(single-base bigWig lookup), but aggregation calls
+`aggregate_conservation_qtl_metrics`, which reports — per track — **global
+AUPRC** over all variants plus **Pearson / Spearman** of the track score vs the
+dataset's `effect_size` (unsigned `|effect|`) over **positive variants only**
+(controls excluded; `dsqtl` controls have no measured effect). Same `fillna(0)`
+and bootstrap-seed conventions; the bootstrap resamples rows (AUPRC) / positive
+rows (correlations). The markdown is a single `metric × track` table.
+
 ## Tracks
 
 | Name | Source URL | Notes |
@@ -121,7 +134,10 @@ results/
 ```
 
 Each `metrics_{split}.parquet` has columns `[score_type, score_name, subset,
-value, se, n_groups, n_rows, n_nan, n_total, split, dataset]`.
+value, se, n_groups, n_rows, n_nan, n_total, split, dataset]`. For
+`qtl_global` datasets (caqtl/dsqtl) the schema is instead `[metric, score_type,
+value, se, n_rows, n_pos, score_name, n_nan, n_total, split, dataset]` —
+`metric` ∈ `{AUPRC, pearson, spearman}`, no subset rows.
 
 ## Library
 
@@ -129,7 +145,10 @@ Snakemake rules are thin glue around `marin_dna.evals.conservation`:
 
 - `score_variants_at_positions(df, bw_path)` — bigWig lookup, NaN preserved.
 - `aggregate_conservation_metrics(parquet_paths, *, n_bootstrap, bootstrap_seed)`
-  — `(metrics_df, markdown)` with AUPRC + cluster-bootstrap SE.
+  — `(metrics_df, markdown)` with AUPRC + cluster-bootstrap SE (matched-pair).
+- `aggregate_conservation_qtl_metrics(parquet_paths, *, n_bootstrap, bootstrap_seed)`
+  — `(metrics_df, markdown)` with global AUPRC + positives-only `effect_size`
+  correlation (the `qtl_global` path for caqtl/dsqtl).
 
 Tests live at `tests/pipelines/evals/test_conservation.py` and
 `tests/pipelines/evals/test_pairwise_accuracy.py` (CPU-only, no real bigWig download).

--- a/snakemake/conservation_eval/config/config.yaml
+++ b/snakemake/conservation_eval/config/config.yaml
@@ -9,6 +9,15 @@ datasets:
     hf_revision: 4aed58e50c5dea0b878a665007af2ef9e5108e9f  # PR #194 k=9 rebuild
   - name: complex_traits
     hf_revision: 22f86a89c65cb8f3007ac3cc2739f40efefa4340  # PR #194 k=9 rebuild
+  # DART-Eval QTL benchmarks (PR #214). `qtl_global` → no subset/match_group;
+  # global AUPRC + Pearson/Spearman of the track score vs `effect_size` over
+  # positives only.
+  - name: caqtl
+    hf_revision: 9d004a21812c067b9ba1ebfe72f51b9095a5d0f8
+    eval_protocol: qtl_global
+  - name: dsqtl
+    hf_revision: b7e02a07beb831c7047286aacd3ddfd299d6f88f
+    eval_protocol: qtl_global
 
 # Splits to score. Train-only convention — the test split is held out for
 # the final-eval pass; all development / iteration uses train. Mirrors

--- a/snakemake/conservation_eval/workflow/rules/common.smk
+++ b/snakemake/conservation_eval/workflow/rules/common.smk
@@ -6,8 +6,10 @@ from datasets import load_dataset
 
 from marin_dna.pipelines.evals.conservation import (
     CONSERVATION_TRACKS,
+    QTL_VARIANT_COLUMNS,
     REQUIRED_VARIANT_COLUMNS,
     aggregate_conservation_metrics,
+    aggregate_conservation_qtl_metrics,
     score_variants_at_positions,
 )
 
@@ -17,6 +19,12 @@ SPLITS = config["splits"]
 DATASETS = [d["name"] for d in config["datasets"]]
 INPUT_HF_PREFIX = config["input_hf_prefix"]
 
+# Per-dataset eval protocol — see snakemake/analysis/evals_v2 common.smk.
+# `matched_pair` (default) → per-subset AUPRC + cluster bootstrap.
+# `qtl_global` → global AUPRC + positives-only effect_size correlation on the
+# unmatched DART-Eval QTL datasets (caqtl/dsqtl).
+EVAL_PROTOCOLS = ("matched_pair", "qtl_global")
+
 
 def get_dataset_config(name: str) -> dict:
     # Per-dataset entry lookup (name, hf_revision). Mirrors the helper in
@@ -25,6 +33,29 @@ def get_dataset_config(name: str) -> dict:
         if d["name"] == name:
             return d
     raise KeyError(f"unknown dataset {name!r}")
+
+
+def get_dataset_protocol(name: str) -> str:
+    """Eval protocol for a dataset (default `matched_pair`)."""
+    return get_dataset_config(name).get("eval_protocol", "matched_pair")
+
+
+def get_dataset_variant_columns(name: str) -> tuple[str, ...]:
+    """Required variant columns for a dataset, keyed by eval protocol."""
+    return (
+        QTL_VARIANT_COLUMNS
+        if get_dataset_protocol(name) == "qtl_global"
+        else REQUIRED_VARIANT_COLUMNS
+    )
+
+
+# Fail fast on an unknown eval_protocol (typo) at parse time.
+for _d in config["datasets"]:
+    _ep = _d.get("eval_protocol", "matched_pair")
+    assert _ep in EVAL_PROTOCOLS, (
+        f"dataset {_d['name']!r} `eval_protocol` must be one of "
+        f"{sorted(EVAL_PROTOCOLS)}, got {_ep!r}"
+    )
 
 
 # Sanity-check up-front: every score listed in config must be a known track.

--- a/snakemake/conservation_eval/workflow/rules/score.smk
+++ b/snakemake/conservation_eval/workflow/rules/score.smk
@@ -19,13 +19,16 @@ rule score_variants:
         ds = load_dataset(
             hf_path, split=wildcards.split, revision=params.hf_revision
         ).to_pandas()
-        for col in REQUIRED_VARIANT_COLUMNS:
+        # qtl_global datasets (caqtl/dsqtl) require effect_size (no
+        # subset/match_group); carry it through to the aggregate step.
+        variant_cols = get_dataset_variant_columns(wildcards.dataset)
+        for col in variant_cols:
             assert col in ds.columns, f"dataset missing column {col!r}"
 
         scores = score_variants_at_positions(ds, input.bw)
         assert len(scores) == len(ds)
 
-        out = ds[list(REQUIRED_VARIANT_COLUMNS)].copy()
+        out = ds[list(variant_cols)].copy()
         out["score"] = scores
         n_nan = int(out["score"].isna().sum())
         print(
@@ -55,11 +58,18 @@ rule aggregate_metrics:
     run:
         # input.parquets are S3-fetched local temp paths, in expand() order (= SCORES).
         parquet_paths = dict(zip(SCORES, input.parquets))
-        metrics, md = aggregate_conservation_metrics(
-            parquet_paths,
-            n_bootstrap=params.n_bootstrap,
-            bootstrap_seed=params.bootstrap_seed,
-        )
+        if get_dataset_protocol(wildcards.dataset) == "qtl_global":
+            metrics, md = aggregate_conservation_qtl_metrics(
+                parquet_paths,
+                n_bootstrap=params.n_bootstrap,
+                bootstrap_seed=params.bootstrap_seed,
+            )
+        else:
+            metrics, md = aggregate_conservation_metrics(
+                parquet_paths,
+                n_bootstrap=params.n_bootstrap,
+                bootstrap_seed=params.bootstrap_seed,
+            )
         metrics["split"] = wildcards.split
         metrics["dataset"] = wildcards.dataset
         metrics.to_parquet(output.metrics, index=False)

--- a/src/marin_dna/pipelines/evals/alphagenome.py
+++ b/src/marin_dna/pipelines/evals/alphagenome.py
@@ -38,6 +38,19 @@ ALPHAGENOME_TRACKS: tuple[str, ...] = (
 # ``dna_client.SUPPORTED_SEQUENCE_LENGTHS[f"SEQUENCE_LENGTH_{SEQUENCE_LENGTH}"]``.
 SEQUENCE_LENGTH: str = "1MB"
 
+# Transient gRPC status codes retried per variant. The SDK's `@retry_rpc` on
+# `score_variant` retries only {RESOURCE_EXHAUSTED, UNAVAILABLE}; AlphaGenome's
+# known server-side "bad machine" outages surface as INTERNAL (not retried by
+# default), which would abort a whole dataset. Stored as names and resolved to
+# `grpc.StatusCode` at call time so this module imports without grpc installed.
+SCORE_VARIANT_RETRY_STATUS: tuple[str, ...] = (
+    "INTERNAL",
+    "UNAVAILABLE",
+    "RESOURCE_EXHAUSTED",
+    "DEADLINE_EXCEEDED",
+)
+SCORE_VARIANT_MAX_ATTEMPTS: int = 10
+
 
 def make_scorers() -> tuple[list["_vs.CenterMaskScorer"], dict[str, str]]:
     """Build the 7 CenterMaskScorer(width=None, L2_DIFF_LOG1P) scorers.
@@ -135,26 +148,19 @@ def score_variants_alphagenome(
 
     # The SDK decorates `score_variant` with `@retry_rpc`, but its default
     # `retry_status_codes` is only {RESOURCE_EXHAUSTED, UNAVAILABLE} — it does
-    # NOT retry `INTERNAL`. AlphaGenome's known, maintainer-acknowledged
-    # "bad machine" backend outages surface precisely as
-    # `StatusCode.INTERNAL` ("Internal error encountered"; see the
-    # alphagenomecommunity.com "StatusCode.INTERNAL" thread), so a single
-    # bad-machine hit raises straight through and aborts the whole dataset
-    # (no per-variant recovery). Re-wrap with the SDK's own `retry_rpc`,
-    # widening the retry set to include INTERNAL (+ DEADLINE_EXCEEDED) and
-    # bumping attempts — each retry re-establishes the RPC and is routed to a
-    # (hopefully healthy) different backend machine. Reuses the SDK's tested
-    # exponential-backoff implementation rather than hand-rolling one.
+    # NOT retry INTERNAL, which is exactly how AlphaGenome's known,
+    # maintainer-acknowledged "bad machine" backend outages surface
+    # (alphagenomecommunity.com "StatusCode.INTERNAL" thread). Unretried, a
+    # single bad-machine hit aborts the whole dataset. Re-wrap with the SDK's
+    # own `retry_rpc` over the widened `SCORE_VARIANT_RETRY_STATUS` set so a
+    # retry re-establishes the RPC on a (hopefully healthy) different machine.
+    # (score_variant is already @retry_rpc-decorated; this outer wrapper is a
+    # superset of those codes, so the nesting is redundant-but-benign.)
     score_variant_with_retry = dna_client.retry_rpc(
         model.score_variant,
-        max_attempts=10,
+        max_attempts=SCORE_VARIANT_MAX_ATTEMPTS,
         retry_status_codes=frozenset(
-            {
-                grpc.StatusCode.INTERNAL,
-                grpc.StatusCode.UNAVAILABLE,
-                grpc.StatusCode.RESOURCE_EXHAUSTED,
-                grpc.StatusCode.DEADLINE_EXCEEDED,
-            }
+            getattr(grpc.StatusCode, name) for name in SCORE_VARIANT_RETRY_STATUS
         ),
     )
     sequence_length = dna_client.SUPPORTED_SEQUENCE_LENGTHS[

--- a/src/marin_dna/pipelines/evals/alphagenome.py
+++ b/src/marin_dna/pipelines/evals/alphagenome.py
@@ -119,6 +119,7 @@ def score_variants_alphagenome(
         One row per input variant (same order), columns = ``"{assay}_{idx}"``
         track names with raw L2_DIFF_LOG1P scores.
     """
+    import grpc
     from alphagenome.data import genome
     from alphagenome.models import dna_client, variant_scorers
 
@@ -131,6 +132,31 @@ def score_variants_alphagenome(
     assert not missing, f"V missing required columns: {missing}"
 
     model = dna_client.create(api_key)
+
+    # The SDK decorates `score_variant` with `@retry_rpc`, but its default
+    # `retry_status_codes` is only {RESOURCE_EXHAUSTED, UNAVAILABLE} — it does
+    # NOT retry `INTERNAL`. AlphaGenome's known, maintainer-acknowledged
+    # "bad machine" backend outages surface precisely as
+    # `StatusCode.INTERNAL` ("Internal error encountered"; see the
+    # alphagenomecommunity.com "StatusCode.INTERNAL" thread), so a single
+    # bad-machine hit raises straight through and aborts the whole dataset
+    # (no per-variant recovery). Re-wrap with the SDK's own `retry_rpc`,
+    # widening the retry set to include INTERNAL (+ DEADLINE_EXCEEDED) and
+    # bumping attempts — each retry re-establishes the RPC and is routed to a
+    # (hopefully healthy) different backend machine. Reuses the SDK's tested
+    # exponential-backoff implementation rather than hand-rolling one.
+    score_variant_with_retry = dna_client.retry_rpc(
+        model.score_variant,
+        max_attempts=10,
+        retry_status_codes=frozenset(
+            {
+                grpc.StatusCode.INTERNAL,
+                grpc.StatusCode.UNAVAILABLE,
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                grpc.StatusCode.DEADLINE_EXCEEDED,
+            }
+        ),
+    )
     sequence_length = dna_client.SUPPORTED_SEQUENCE_LENGTHS[
         f"SEQUENCE_LENGTH_{SEQUENCE_LENGTH}"
     ]
@@ -151,7 +177,7 @@ def score_variants_alphagenome(
         # specifically want forward-strand to match TraitGym's call.
         interval.strand = "+"
 
-        scores = model.score_variant(
+        scores = score_variant_with_retry(
             interval=interval,
             variant=variant,
             organism=organism,

--- a/src/marin_dna/pipelines/evals/conservation.py
+++ b/src/marin_dna/pipelines/evals/conservation.py
@@ -34,6 +34,7 @@ from marin_dna.pipelines.evals.metrics import (
     GLOBAL_SUBSET,
     MACRO_AVG_SUBSET,
     compute_auprc_metrics,
+    compute_qtl_metrics,
 )
 
 
@@ -69,6 +70,21 @@ REQUIRED_VARIANT_COLUMNS: tuple[str, ...] = (
     "label",
     "subset",
     "match_group",
+)
+
+# Columns the unmatched DART-Eval QTL datasets (``caqtl`` / ``dsqtl``, PR
+# #214) carry instead: no ``subset`` / ``match_group`` (no matching, no
+# subsampling), but a continuous ``effect_size`` (unsigned ``|effect|``) used
+# by the positives-only correlation metric. Asserted by the ``eval_protocol:
+# qtl_global`` branch of each pipeline's score/metric rules. Shared home here
+# mirrors ``REQUIRED_VARIANT_COLUMNS`` (imported by all three eval pipelines).
+QTL_VARIANT_COLUMNS: tuple[str, ...] = (
+    "chrom",
+    "pos",
+    "ref",
+    "alt",
+    "label",
+    "effect_size",
 )
 
 
@@ -308,5 +324,118 @@ def _build_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
             for s in score_names
         ]
         lines.append("| " + " | ".join([subset, str(n_total), *vals]) + " |")
+
+    return "\n".join(lines) + "\n"
+
+
+def aggregate_conservation_qtl_metrics(
+    parquet_paths: dict[str, str | Path],
+    *,
+    n_bootstrap: int = 1000,
+    bootstrap_seed: int | None = 0,
+) -> tuple[pd.DataFrame, str]:
+    """Global QTL metrics across per-track scored parquets (caqtl/dsqtl).
+
+    The ``eval_protocol: qtl_global`` counterpart to
+    ``aggregate_conservation_metrics``: the DART-Eval QTL datasets have no
+    ``subset`` / ``match_group``, so there is no per-subset stratification or
+    cluster bootstrap. Each input parquet is ``score_variants_at_positions``
+    output plus the QTL variant columns: must contain ``[label, effect_size,
+    score]``. ``score`` may be NaN (no alignment in the bigWig).
+
+    Per track: NaN count recorded, then ``score`` is filled with 0 (same
+    rationale as the matched-pair path — 0 is meaningful for phyloP/phastCons)
+    before ``compute_qtl_metrics`` computes global AUPRC + positives-only
+    Pearson/Spearman vs ``effect_size``.
+
+    Args:
+        parquet_paths: mapping ``score_name -> parquet path``. Order is
+            preserved in the markdown table.
+        n_bootstrap: bootstrap iterations per (metric, track).
+        bootstrap_seed: seed for the bootstrap; ``None`` for fresh randomness.
+            Default ``0`` keeps outputs bit-stable across re-runs.
+
+    Returns:
+        ``(metrics_df, markdown)`` where ``metrics_df`` has columns
+        ``[metric, score_type, value, se, n_rows, n_pos, score_name, n_nan,
+        n_total]``. ``score_type`` is always ``"score"``; ``score_name`` is
+        the conservation track.
+    """
+    assert parquet_paths, "parquet_paths must be non-empty"
+
+    score_names = list(parquet_paths)
+    required = ("label", "effect_size", "score")
+    all_metrics: list[pd.DataFrame] = []
+
+    for score_name in score_names:
+        df = pd.read_parquet(parquet_paths[score_name])
+        for col in required:
+            assert col in df.columns, (
+                f"{parquet_paths[score_name]}: missing column {col!r}"
+            )
+
+        m = compute_qtl_metrics(
+            dataset=df[["label", "effect_size"]],
+            scores=df[["score"]].fillna(0),
+            score_columns=["score"],
+            n_bootstrap=n_bootstrap,
+            rng=bootstrap_seed,
+        )
+        m["score_name"] = score_name
+        m["n_nan"] = int(df["score"].isna().sum())
+        m["n_total"] = int(len(df))
+        all_metrics.append(m)
+
+    metrics = pd.concat(all_metrics, ignore_index=True)
+    md = _build_qtl_markdown(metrics, score_names)
+    return metrics, md
+
+
+def _build_qtl_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
+    """Render the global QTL metrics as a markdown table (metric × track)."""
+    lines: list[str] = []
+    lines.append("### caQTL/dsQTL — global metrics (value ± bootstrap SE)")
+    lines.append("")
+    lines.append(
+        "AUPRC over all variants (significant QTL vs control). Pearson / "
+        "Spearman of the conservation score vs `effect_size`, over positive "
+        "variants only. Scores are `.fillna(0)` before scoring (0 = no "
+        "alignment at that locus — neither conserved nor accelerated). "
+        "Bootstrap SE resamples rows (AUPRC) / positive rows (correlations)."
+    )
+    lines.append("")
+    n_pos = int(metrics["n_pos"].iloc[0])
+    n_total = int(metrics["n_total"].iloc[0])
+    lines.append(f"n_total = {n_total}; n_positives = {n_pos}.")
+    lines.append("")
+
+    val = metrics.pivot_table(
+        index="metric", columns="score_name", values="value", aggfunc="first"
+    )
+    se = metrics.pivot_table(
+        index="metric", columns="score_name", values="se", aggfunc="first"
+    )
+    header = ["metric", *score_names]
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("| " + " | ".join(["---"] * len(header)) + " |")
+    for metric in ("AUPRC", "pearson", "spearman"):
+        if metric not in val.index:
+            continue
+        cells = []
+        for s in score_names:
+            v = val.loc[metric, s] if s in val.columns else float("nan")
+            e = se.loc[metric, s] if s in se.columns else float("nan")
+            cells.append(f"{v:.3f} ± {e:.3f}" if pd.notna(v) and pd.notna(e) else "—")
+        lines.append("| " + " | ".join([metric, *cells]) + " |")
+
+    # Per-track NaN counts (no alignment; filled with 0 before scoring).
+    nan_map = (
+        metrics.drop_duplicates("score_name").set_index("score_name")["n_nan"].to_dict()
+    )
+    lines.append("")
+    lines.append(
+        "NaN scores per track (filled with 0): "
+        + ", ".join(f"{s}={int(nan_map.get(s, 0))}" for s in score_names)
+    )
 
     return "\n".join(lines) + "\n"

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -1,15 +1,22 @@
 """Metric utilities for variant-effect evaluations.
 
-Three metric families live here:
+Four metric families live here:
 
 - ``auprc_with_bootstrap_se`` / ``compute_auprc_metrics``: AUPRC with a
   cluster bootstrap SE that resamples ``match_group``s (preserving the
-  matched-pair clustering). Used by the ``evals_v2`` pipeline after PR
-  #194 moved the matched-pair datasets to a 1:k structure that the
-  Wald-binomial pairwise metric can't represent.
+  matched-pair clustering). Used by the ``evals_v2``, ``conservation_eval``,
+  and ``alphagenome_eval`` pipelines on the matched-pair datasets
+  (``mendelian_traits`` / ``complex_traits``), whose 1:k structure (PR #194)
+  the Wald-binomial pairwise metric can't represent.
+- ``compute_qtl_metrics``: global AUPRC (plain row bootstrap) plus Pearson /
+  Spearman of the model score vs ``effect_size`` over the positive variants
+  only. For the unmatched DART-Eval QTL datasets (``caqtl`` / ``dsqtl``,
+  PR #214) that carry no ``subset`` / ``match_group``. The same three
+  pipelines select this path per-dataset via ``eval_protocol: qtl_global``.
 - ``pairwise_accuracy`` / ``compute_pairwise_metrics``: matched-pair within-
-  ``match_group`` accuracy (ties = 0.5) with Wald-binomial SE. Used by the
-  ``conservation_eval`` pipeline (1:1 match groups).
+  ``match_group`` accuracy (ties = 0.5) with Wald-binomial SE. Used on 1:1
+  match groups by the ``gpn_star_eval`` pipeline, the ``scripts/evo2_eval/``
+  scripts, and the ``lm_eval`` DNA-VEP harness (``dna_vep_llr_eval``).
 - ``METRIC_FUNCTIONS`` / ``compute_metrics``: classical AUPRC / AUROC /
   Spearman over (label, score) pairs. Still used by older pipelines
   (``snakemake/analysis/evals_v1/``, ``scripts/evo2_eval/``).
@@ -20,7 +27,7 @@ from typing import Callable
 
 import numpy as np
 import pandas as pd
-from scipy.stats import spearmanr
+from scipy.stats import pearsonr, spearmanr
 from sklearn.metrics import average_precision_score, roc_auc_score
 
 
@@ -331,6 +338,167 @@ def compute_auprc_metrics(
                 "n_rows": sum(r["n_rows"] for r in qualifying),
             }
         )
+
+    return pd.DataFrame(rows)
+
+
+def _correlation_with_bootstrap_se(
+    x: np.ndarray,
+    y: np.ndarray,
+    *,
+    method: str,
+    n_bootstrap: int,
+    rng: np.random.Generator,
+) -> tuple[float, float]:
+    """Point correlation + row-bootstrap SE between paired ``x`` and ``y``.
+
+    Args:
+        x: first variable (e.g. model score over positives).
+        y: second variable (e.g. ``effect_size`` over positives).
+        method: ``"pearson"`` or ``"spearman"``.
+        n_bootstrap: bootstrap iterations (resamples rows with replacement).
+        rng: ``numpy.random.Generator`` — threaded in so the caller controls
+            reproducibility.
+
+    Returns:
+        ``(value, se)``. ``se`` is the std (``ddof=1``, NaN-tolerant) of the
+        bootstrap distribution; degenerate resamples with zero variance in
+        either variable contribute NaN and are dropped from the std.
+    """
+    assert method in ("pearson", "spearman"), f"unknown method {method!r}"
+    assert len(x) == len(y), f"length mismatch: x={len(x)} y={len(y)}"
+    corr_fn = pearsonr if method == "pearson" else spearmanr
+    point = float(corr_fn(x, y)[0])
+    n = len(x)
+    boot = np.empty(n_bootstrap, dtype=float)
+    for b in range(n_bootstrap):
+        idx = rng.integers(0, n, size=n)
+        xb, yb = x[idx], y[idx]
+        # Correlation is undefined when a resample is constant in either var.
+        if np.std(xb) == 0 or np.std(yb) == 0:
+            boot[b] = np.nan
+            continue
+        boot[b] = corr_fn(xb, yb)[0]
+    se = float(np.nanstd(boot, ddof=1))
+    return point, se
+
+
+def compute_qtl_metrics(
+    dataset: pd.DataFrame,
+    scores: pd.DataFrame,
+    score_columns: list[str] | None = None,
+    *,
+    n_bootstrap: int = 1000,
+    rng: np.random.Generator | int | None = 0,
+) -> pd.DataFrame:
+    """Global AUPRC + positives-only ``effect_size`` correlations per score column.
+
+    For the unmatched DART-Eval QTL datasets (``caqtl`` / ``dsqtl``), which
+    have no ``subset`` / ``match_group`` — so there is no per-subset
+    stratification and no cluster structure. Two metric families, mirroring
+    DART-Eval Task 5 (and the dataset cards):
+
+    - **AUPRC** over **all** rows (significant QTL vs control via ``label``).
+      Computed through ``auprc_with_bootstrap_se`` with singleton
+      ``match_group``s (``np.arange(n)``), which degenerates the cluster
+      bootstrap to a plain row bootstrap — a consistent point estimate + SE
+      with no separate code path.
+    - **Pearson** and **Spearman** between each model score and
+      ``effect_size`` (the unsigned ``|effect|`` magnitude), over the
+      **positive variants only** (``label == True``). Controls are excluded
+      — for ``dsqtl`` they carry no measured effect at all. Each gets a
+      row-bootstrap SE over the positive rows.
+
+    The ``rng`` default ``0`` (a single ``Generator`` threaded through every
+    bootstrap below) keeps outputs bit-stable across re-runs on identical
+    inputs — same rationale as ``auprc_with_bootstrap_se``.
+
+    Args:
+        dataset: DataFrame with columns ``[label, effect_size]`` (row-aligned
+            with ``scores``). ``effect_size`` may be NaN for controls but
+            **must** be present for every positive.
+        scores: DataFrame whose columns are model scores; row-aligned with
+            ``dataset``. Must not contain NaN.
+        score_columns: score column names to evaluate. Defaults to all
+            columns of ``scores``.
+        n_bootstrap: bootstrap iterations per (metric, score_column).
+        rng: ``numpy.random.Generator``, seed int, or ``None``.
+
+    Returns:
+        DataFrame with columns ``[metric, score_type, value, se, n_rows,
+        n_pos]``. ``metric`` is one of ``"AUPRC"``, ``"pearson"``,
+        ``"spearman"``; three rows per score column. ``n_rows`` is the number
+        of rows the metric used (all rows for AUPRC, positives for the
+        correlations); ``n_pos`` is the positive count throughout.
+    """
+    for col in ("label", "effect_size"):
+        assert col in dataset.columns, f"dataset missing required column {col!r}"
+    assert len(dataset) == len(scores), (
+        f"length mismatch: dataset={len(dataset)} scores={len(scores)}"
+    )
+    if score_columns is None:
+        score_columns = list(scores.columns)
+
+    label = np.asarray(dataset["label"]).astype(int)
+    effect_size = np.asarray(dataset["effect_size"], dtype=float)
+    pos_mask = label == 1
+    n_pos = int(pos_mask.sum())
+    n_rows = int(len(label))
+    assert 0 < n_pos < n_rows, (
+        f"AUPRC needs both classes, got n_pos={n_pos} of n={n_rows}"
+    )
+    assert n_pos >= 2, f"correlation needs >=2 positives, got n_pos={n_pos}"
+    # Positives must carry a measured effect (dsQTL controls legitimately
+    # don't; a NaN here means a positive is missing its effect — fail loud).
+    n_nan_pos = int(np.isnan(effect_size[pos_mask]).sum())
+    assert n_nan_pos == 0, (
+        f"{n_nan_pos} positive variants have NaN effect_size — expected a "
+        f"measured effect for every positive"
+    )
+
+    rng = np.random.default_rng(rng)
+    es_pos = effect_size[pos_mask]
+    rows: list[dict] = []
+    for score_col in score_columns:
+        score = np.asarray(scores[score_col], dtype=float)
+        assert not np.isnan(score).any(), (
+            f"score column {score_col!r} has NaN; fill upstream with a "
+            f"semantically appropriate default before scoring"
+        )
+
+        auprc = auprc_with_bootstrap_se(
+            label=label,
+            score=score,
+            match_group=np.arange(n_rows),
+            n_bootstrap=n_bootstrap,
+            rng=rng,
+        )
+        rows.append(
+            {
+                "metric": "AUPRC",
+                "score_type": score_col,
+                "value": auprc["value"],
+                "se": auprc["se"],
+                "n_rows": n_rows,
+                "n_pos": n_pos,
+            }
+        )
+
+        score_pos = score[pos_mask]
+        for method in ("pearson", "spearman"):
+            value, se = _correlation_with_bootstrap_se(
+                score_pos, es_pos, method=method, n_bootstrap=n_bootstrap, rng=rng
+            )
+            rows.append(
+                {
+                    "metric": method,
+                    "score_type": score_col,
+                    "value": value,
+                    "se": se,
+                    "n_rows": n_pos,
+                    "n_pos": n_pos,
+                }
+            )
 
     return pd.DataFrame(rows)
 

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -407,7 +407,24 @@ def compute_qtl_metrics(
       ``effect_size`` (the unsigned ``|effect|`` magnitude), over the
       **positive variants only** (``label == True``). Controls are excluded
       — for ``dsqtl`` they carry no measured effect at all. Each gets a
-      row-bootstrap SE over the positive rows.
+      paired row-bootstrap SE over the positive rows (the same resampled
+      indices draw both the score and ``effect_size``).
+
+    Standard errors are **nonparametric bootstrap** — the std of the bootstrap
+    distribution (``ddof=1``, NaN-tolerant) over ``n_bootstrap`` resamples —
+    *not* closed-form. Rationale: AUPRC has no clean closed form, and the
+    bootstrap keeps all three SEs uniform and assumption-free. The closed-form
+    alternatives (Pearson Fisher-z = ``.confidence_interval()`` on
+    ``scipy.stats.pearsonr``; Spearman has no built-in CI/SE, only the
+    Bonett–Wright approximation) lean on a bivariate-normal / large-n
+    assumption that ``effect_size`` (a right-skewed ``|effect|`` magnitude) and
+    the scores don't meet — though at these sample sizes they land close to the
+    bootstrap regardless (e.g. caqtl Pearson SE ≈ 0.017 either way). **Caveat:**
+    these are *marginal, single-scorer* SEs. A difference between two scorers
+    must **not** be read off overlapping ``±se`` bars — the scorers share the
+    same variants (correlated estimates), so a rigorous comparison needs a
+    paired-delta bootstrap (resample variants once, recompute both scorers,
+    take the difference), as in ``paired_metric_delta_bootstrap``.
 
     The ``rng`` default ``0`` (a single ``Generator`` threaded through every
     bootstrap below) keeps outputs bit-stable across re-runs on identical

--- a/tests/pipelines/evals/test_alphagenome.py
+++ b/tests/pipelines/evals/test_alphagenome.py
@@ -9,6 +9,8 @@ import pytest
 
 from marin_dna.pipelines.evals.alphagenome import (
     ALPHAGENOME_TRACKS,
+    SCORE_VARIANT_MAX_ATTEMPTS,
+    SCORE_VARIANT_RETRY_STATUS,
     SEQUENCE_LENGTH,
     parse_score_response,
 )
@@ -25,6 +27,16 @@ def test_alphagenome_constants():
         "RNA_SEQ",
     )
     assert SEQUENCE_LENGTH == "1MB"
+
+
+def test_score_variant_retry_includes_internal():
+    """Regression guard: INTERNAL must stay in the per-variant retry set —
+    it's the code AlphaGenome's "bad machine" outages raise, and the SDK's
+    default retry set excludes it (dropping it would re-break large runs)."""
+    assert "INTERNAL" in SCORE_VARIANT_RETRY_STATUS
+    # The SDK already covers these two; we widen, not narrow.
+    assert {"UNAVAILABLE", "RESOURCE_EXHAUSTED"} <= set(SCORE_VARIANT_RETRY_STATUS)
+    assert SCORE_VARIANT_MAX_ATTEMPTS >= 2
 
 
 def test_parse_score_response_single_track_per_assay():

--- a/tests/pipelines/evals/test_conservation.py
+++ b/tests/pipelines/evals/test_conservation.py
@@ -8,6 +8,7 @@ import pytest
 from marin_dna.pipelines.evals.conservation import (
     CONSERVATION_TRACKS,
     aggregate_conservation_metrics,
+    aggregate_conservation_qtl_metrics,
     score_variants_at_positions,
 )
 from marin_dna.pipelines.evals.metrics import GLOBAL_SUBSET, MACRO_AVG_SUBSET
@@ -129,6 +130,81 @@ def _scored_parquet(tmp_path, name, scores, labels, subsets, match_groups):
     )
     df.to_parquet(path, index=False)
     return path
+
+
+def _qtl_scored_parquet(tmp_path, name, scores, labels, effect_sizes):
+    """Write a fake qtl_global scored-variant parquet (no subset/match_group)."""
+    path = tmp_path / f"{name}.parquet"
+    n = len(scores)
+    df = pd.DataFrame(
+        {
+            "chrom": ["chr1"] * n,
+            "pos": list(range(1, n + 1)),
+            "ref": ["A"] * n,
+            "alt": ["T"] * n,
+            "label": labels,
+            "effect_size": effect_sizes,
+            "score": scores,
+        }
+    )
+    df.to_parquet(path, index=False)
+    return path
+
+
+def test_aggregate_conservation_qtl_metrics(tmp_path):
+    """qtl_global aggregation: per-track global AUPRC + positives-only
+    effect_size correlation, with the expected schema, NaN→0 fill, and a
+    metric × track markdown table."""
+    rng = np.random.default_rng(0)
+    n_pos, n_neg = 20, 80
+    labels = [True] * n_pos + [False] * n_neg
+    es_pos = rng.uniform(0.1, 2.0, n_pos)
+    # Positives carry effect_size; controls are NaN (the dsQTL case).
+    effect_sizes = list(es_pos) + [np.nan] * n_neg
+    # Track 1: positives' score == effect_size (perfect corr) + low controls;
+    # one control's score is NaN (filled with 0 by the aggregator, n_nan=1).
+    s1 = list(es_pos) + list(rng.uniform(0.0, 0.05, n_neg))
+    s1[n_pos] = np.nan  # first control
+    # Track 2: random scores.
+    s2 = list(rng.uniform(0, 1, n_pos + n_neg))
+    p1 = _qtl_scored_parquet(tmp_path, "phyloP_241m", s1, labels, effect_sizes)
+    p2 = _qtl_scored_parquet(tmp_path, "phastCons_43p", s2, labels, effect_sizes)
+
+    metrics, md = aggregate_conservation_qtl_metrics(
+        {"phyloP_241m": p1, "phastCons_43p": p2}, n_bootstrap=50
+    )
+
+    # 3 metrics × 2 tracks = 6 rows; QTL schema (metric col, no subset rows).
+    assert len(metrics) == 6
+    assert set(metrics["metric"]) == {"AUPRC", "pearson", "spearman"}
+    assert set(metrics["score_name"]) == {"phyloP_241m", "phastCons_43p"}
+    assert {
+        "metric",
+        "score_type",
+        "value",
+        "se",
+        "n_rows",
+        "n_pos",
+        "score_name",
+        "n_nan",
+        "n_total",
+    } <= set(metrics.columns)
+    assert (metrics["score_type"] == "score").all()
+
+    t1 = metrics[metrics["score_name"] == "phyloP_241m"]
+    assert int(t1["n_total"].iloc[0]) == n_pos + n_neg
+    assert int(t1["n_pos"].iloc[0]) == n_pos
+    assert int(t1["n_nan"].iloc[0]) == 1  # the single NaN score (filled with 0)
+    # Track 1: positives' score == effect_size → perfect corr; positives all
+    # outrank controls → AUPRC = 1.
+    assert t1[t1["metric"] == "pearson"]["value"].iloc[0] == pytest.approx(
+        1.0, abs=1e-9
+    )
+    assert t1[t1["metric"] == "AUPRC"]["value"].iloc[0] == pytest.approx(1.0, abs=1e-12)
+
+    assert "caQTL/dsQTL" in md
+    for tok in ("phyloP_241m", "phastCons_43p", "AUPRC", "pearson", "spearman"):
+        assert tok in md
 
 
 def test_aggregate_conservation_metrics_nan_accounting(tmp_path):

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -19,6 +19,7 @@ from marin_dna.pipelines.evals.metrics import (
     auprc_with_bootstrap_se,
     compute_auprc_metrics,
     compute_metrics,
+    compute_qtl_metrics,
 )
 
 
@@ -412,3 +413,160 @@ def test_compute_auprc_metrics_n_min_excludes_small_subsets():
         (metrics["score_type"] == "score") & (metrics["subset"] == GLOBAL_SUBSET)
     ].iloc[0]
     assert global_row["n_groups"] == 50
+
+
+# ---------------------------------------------------------------------------
+# compute_qtl_metrics (unmatched DART-Eval QTL datasets: caqtl / dsqtl)
+# ---------------------------------------------------------------------------
+
+
+def _qtl_data(
+    n_pos: int = 40,
+    n_neg: int = 360,
+    *,
+    seed: int = 0,
+    perfect: bool = False,
+    control_effect_size_nan: bool = True,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Synthesize an unmatched QTL dataset (no subset/match_group).
+
+    Positives carry a measured ``effect_size``. Controls' ``effect_size`` is
+    NaN by default (the dsQTL case — controls have no measured effect). With
+    ``perfect=True``, positives' score equals their effect_size (→ pearson /
+    spearman = 1 over positives) and controls score low (→ AUPRC = 1)."""
+    rng = np.random.default_rng(seed)
+    n = n_pos + n_neg
+    label = np.concatenate([np.ones(n_pos, dtype=bool), np.zeros(n_neg, dtype=bool)])
+
+    es_pos = rng.uniform(0.1, 2.0, n_pos)
+    effect_size = np.full(n, np.nan)
+    effect_size[:n_pos] = es_pos
+    if not control_effect_size_nan:
+        effect_size[n_pos:] = rng.uniform(0.1, 2.0, n_neg)
+
+    score = np.empty(n)
+    if perfect:
+        score[:n_pos] = es_pos  # positives: score == effect_size
+        score[n_pos:] = rng.uniform(0.0, 0.05, n_neg)  # controls clearly lower
+    else:
+        score[:] = rng.uniform(0.0, 1.0, n)
+
+    dataset = pd.DataFrame({"label": label, "effect_size": effect_size})
+    scores = pd.DataFrame({"score": score})
+    return dataset, scores
+
+
+def test_compute_qtl_metrics_shape():
+    """Three rows per score column (AUPRC, pearson, spearman); fixed columns."""
+    dataset, scores = _qtl_data(seed=3)
+    scores["score2"] = np.random.default_rng(4).uniform(size=len(dataset))
+    metrics = compute_qtl_metrics(dataset, scores, n_bootstrap=20, rng=0)
+    assert len(metrics) == 2 * 3  # 2 score columns × 3 metrics
+    assert set(metrics["metric"]) == {"AUPRC", "pearson", "spearman"}
+    assert set(metrics["score_type"]) == {"score", "score2"}
+    assert set(metrics.columns) == {
+        "metric",
+        "score_type",
+        "value",
+        "se",
+        "n_rows",
+        "n_pos",
+    }
+    assert metrics["value"].notna().all()
+    assert metrics["se"].notna().all()
+
+
+def test_compute_qtl_metrics_auprc_matches_sklearn():
+    """The AUPRC row equals sklearn's average_precision_score over all rows."""
+    dataset, scores = _qtl_data(seed=11)
+    metrics = compute_qtl_metrics(dataset, scores, n_bootstrap=10, rng=0)
+    auprc_row = metrics[metrics["metric"] == "AUPRC"].iloc[0]
+    expected = float(
+        average_precision_score(dataset["label"].astype(int), scores["score"])
+    )
+    assert auprc_row["value"] == pytest.approx(expected)
+    assert auprc_row["n_rows"] == len(dataset)
+    assert auprc_row["n_pos"] == int(dataset["label"].sum())
+
+
+def test_compute_qtl_metrics_perfect_correlation_and_separation():
+    """Positives' score == effect_size → pearson = spearman = 1 (SE≈0); and
+    controls scoring lower → AUPRC = 1."""
+    dataset, scores = _qtl_data(perfect=True, seed=5)
+    metrics = compute_qtl_metrics(dataset, scores, n_bootstrap=50, rng=0)
+    by_metric = metrics.set_index("metric")["value"]
+    assert by_metric["pearson"] == pytest.approx(1.0, abs=1e-9)
+    assert by_metric["spearman"] == pytest.approx(1.0, abs=1e-9)
+    assert by_metric["AUPRC"] == pytest.approx(1.0, abs=1e-12)
+    # Perfectly monotone positives → every bootstrap resample also corr=1.
+    corr_se = metrics[metrics["metric"].isin(["pearson", "spearman"])]["se"]
+    assert (corr_se < 1e-9).all()
+    # The correlation rows used only the positives.
+    n_pos = int(dataset["label"].sum())
+    assert metrics.loc[metrics["metric"] == "pearson", "n_rows"].iloc[0] == n_pos
+
+
+def test_compute_qtl_metrics_correlation_uses_positives_only():
+    """Controls are excluded from the correlation: positives are perfectly
+    correlated while controls are anti-correlated; result stays ~1."""
+    rng = np.random.default_rng(0)
+    n_pos, n_neg = 30, 200
+    es_pos = rng.uniform(0.1, 2.0, n_pos)
+    es_neg = rng.uniform(0.1, 2.0, n_neg)
+    label = np.concatenate([np.ones(n_pos, bool), np.zeros(n_neg, bool)])
+    effect_size = np.concatenate([es_pos, es_neg])
+    # Positives: score == effect_size (corr +1). Controls: score == -effect_size
+    # (corr -1). If controls leaked in, the pooled correlation would collapse.
+    score = np.concatenate([es_pos, -es_neg])
+    dataset = pd.DataFrame({"label": label, "effect_size": effect_size})
+    scores = pd.DataFrame({"score": score})
+    metrics = compute_qtl_metrics(dataset, scores, n_bootstrap=10, rng=0)
+    assert metrics.set_index("metric").loc["pearson", "value"] == pytest.approx(
+        1.0, abs=1e-9
+    )
+
+
+def test_compute_qtl_metrics_control_effect_size_nan_ok():
+    """Controls with NaN effect_size (the dsQTL case) must not raise — only
+    positives are required to carry a measured effect."""
+    dataset, scores = _qtl_data(control_effect_size_nan=True, seed=2)
+    assert dataset.loc[~dataset["label"], "effect_size"].isna().all()
+    metrics = compute_qtl_metrics(dataset, scores, n_bootstrap=10, rng=0)
+    assert metrics["value"].notna().all()
+
+
+def test_compute_qtl_metrics_seed_reproducibility():
+    dataset, scores = _qtl_data(seed=9)
+    a = compute_qtl_metrics(dataset, scores, n_bootstrap=50, rng=0)
+    b = compute_qtl_metrics(dataset, scores, n_bootstrap=50, rng=0)
+    pd.testing.assert_frame_equal(a, b)
+
+
+def test_compute_qtl_metrics_missing_effect_size_raises():
+    dataset, scores = _qtl_data(seed=1)
+    with pytest.raises(AssertionError, match="effect_size"):
+        compute_qtl_metrics(dataset.drop(columns=["effect_size"]), scores)
+
+
+def test_compute_qtl_metrics_nan_effect_size_positive_raises():
+    """A positive missing its effect_size is a data error — fail loud."""
+    dataset, scores = _qtl_data(seed=1)
+    dataset.loc[0, "effect_size"] = np.nan  # row 0 is a positive
+    with pytest.raises(AssertionError, match="effect_size"):
+        compute_qtl_metrics(dataset, scores, n_bootstrap=10, rng=0)
+
+
+def test_compute_qtl_metrics_single_class_raises():
+    dataset = pd.DataFrame(
+        {"label": [True, True, True], "effect_size": [1.0, 2.0, 3.0]}
+    )
+    scores = pd.DataFrame({"score": [0.1, 0.2, 0.3]})
+    with pytest.raises(AssertionError, match="both classes"):
+        compute_qtl_metrics(dataset, scores, n_bootstrap=10, rng=0)
+
+
+def test_compute_qtl_metrics_nan_score_raises():
+    dataset, scores = _qtl_data(seed=1)
+    scores.loc[5, "score"] = np.nan
+    with pytest.raises(AssertionError, match="NaN"):
+        compute_qtl_metrics(dataset, scores, n_bootstrap=10, rng=0)


### PR DESCRIPTION
🤖 Wires the two DART-Eval Task-5 chromatin-accessibility QTL benchmarks — **caQTL** and **dsQTL** ([`bolinas-dna/evals_caqtl`](https://huggingface.co/datasets/bolinas-dna/evals_caqtl), [`bolinas-dna/evals_dsqtl`](https://huggingface.co/datasets/bolinas-dna/evals_dsqtl), added in #214) — into the three zero-shot variant-effect pipelines: `evals_v2`, `conservation_eval`, and `alphagenome_eval`.

Follow-up to #139 / #214.

## Why a new code path

These datasets are built with **no matching / no subsampling**, so they carry no `subset` or `match_group` — but all three pipelines assert the shared `REQUIRED_VARIANT_COLUMNS` (which includes both) and feed `compute_auprc_metrics`, which requires them and force-computes a per-subset macro-average. So caqtl/dsqtl need a dedicated **global-only** path.

## What's here

- **`metrics.py`** — new `compute_qtl_metrics`: per score column, **global AUPRC** over all variants (significant QTL vs control) plus **Pearson & Spearman** of the score vs `effect_size` over **positive variants only**. Global AUPRC reuses `auprc_with_bootstrap_se` with singleton groups (= a plain row bootstrap); the correlations get a positive-row bootstrap SE. Returns `[metric, score_type, value, se, n_rows, n_pos]`.
- **`conservation.py`** — `QTL_VARIANT_COLUMNS` + `aggregate_conservation_qtl_metrics`.
- **Pipeline wiring (all three)** — per-dataset `eval_protocol: qtl_global` (default `matched_pair`) selects the path; `get_dataset_protocol` / `get_dataset_variant_columns` helpers; score/metric rules branch on it and carry `effect_size` through to the metric step. `exp136-proj_v30-step-9999` scoped to all 4 datasets (`score_protocol: abs_llr` → `abs_llr_{fwd,rc,avg}` + `jsd_{fwd,rc,avg}` = abs-LLR + JSD).
- **Docstring fix** — `pairwise_accuracy` / `compute_pairwise_metrics` is used by `gpn_star_eval`, `evo2_eval`, and `dna_vep_llr_eval`, **not** `conservation_eval` (which now uses `compute_auprc_metrics`). The function is kept — it is not dead.
- Tests for `compute_qtl_metrics`; the three pipeline READMEs updated.

## Metric semantics

Per #214 + the dataset cards, with the requested tweak:

- **binary AUPRC** over all variants (`label`: significant QTL vs control).
- **Pearson + Spearman vs `effect_size`** — the unsigned `|effect|` magnitude, **not** the signed `effect` — among positive variants only. The magnitude target matches the non-directional scores in use (abs-LLR, JSD, phyloP/phastCons, AlphaGenome max-L2). For `dsqtl`, controls have no measured effect, so positives-only is exactly what the correlation needs.

The QTL metrics parquet has a `metric` column and no subset rows; the matched-pair (`mendelian_traits` / `complex_traits`) path is unchanged.

## Verification

- `uv run pytest tests/pipelines/evals/` → **287 passed, 3 skipped** (30 in `test_metrics.py`, incl. the new `compute_qtl_metrics` cases).
- ruff clean. pre-commit green except a **pre-existing** mypy error in `hf_readme.py:486` (a file untouched by this PR; landed with #214).
- Dry-runs for all three pipelines plan **only** the caqtl/dsqtl jobs (checkpoints / bigWigs served from the S3 cache) — no mendelian/complex reruns.

## Not in this PR

- The actual eval **runs** (SkyPilot) — landing next; results will be recorded in an issue, not here.
- Dashboard / plots integration for caqtl/dsqtl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
