### PR TITLE
conservation_eval + leaderboard: drop redundant phyloP 241m & 470m (keep 447m)

### DIFF
--- a/dashboard/models.yaml
+++ b/dashboard/models.yaml
@@ -33,7 +33,7 @@
 #   msa          string  (gpn_star only) producer's MSA suffix (e.g. v100-200m).
 
 # ---------------------------------------------------------------------------
-# Conservation tracks — 7 phyloP / phastCons baselines, present on all three
+# Conservation tracks — 5 phyloP / phastCons baselines, present on all three
 # leaderboards. Same parquet path per dataset; per-track filter on score_name.
 # ---------------------------------------------------------------------------
 
@@ -61,22 +61,10 @@
   description: phyloP across 100 vertebrates
   datasets: [mendelian_traits, complex_traits]
 
-- id: phyloP_241m
-  display: phyloP (241m)
-  family: conservation
-  description: phyloP across 241 mammals (Zoonomia)
-  datasets: [mendelian_traits, complex_traits]
-
 - id: phyloP_447m
   display: phyloP (447m)
   family: conservation
   description: phyloP across 447 mammals
-  datasets: [mendelian_traits, complex_traits]
-
-- id: phyloP_470m
-  display: phyloP (470m)
-  family: conservation
-  description: phyloP across 470 mammals
   datasets: [mendelian_traits, complex_traits]
 
 # ---------------------------------------------------------------------------

--- a/snakemake/conservation_eval/README.md
+++ b/snakemake/conservation_eval/README.md
@@ -92,8 +92,9 @@ cd snakemake/conservation_eval
 uv run snakemake -n
 
 # Run locally (CPU-only — wall time is dominated by bigWig downloads on a
-# cold S3 cache; the full 7-track set is ~50 GB total). The cluster bootstrap
-# (1000 iters × 7 tracks × ~10 subsets × 2 datasets ≈ 140k iters) is fast.
+# cold S3 cache; the configured track set — 5 by default — totals tens of GB).
+# The cluster bootstrap (1000 iters × 5 tracks × ~10 subsets × 2 datasets
+# ≈ 100k iters) is fast.
 uv run snakemake
 ```
 

--- a/snakemake/conservation_eval/config/config.yaml
+++ b/snakemake/conservation_eval/config/config.yaml
@@ -22,9 +22,7 @@ splits:
 scores:
   - phyloP_100v
   - phastCons_100v
-  - phyloP_241m
   - phyloP_447m
-  - phyloP_470m
   - phastCons_470m
   - phastCons_43p
 


### PR DESCRIPTION
## What

Keep only **phyloP (447m)** among the three near-identical phyloP mammalian-conservation tracks; drop **phyloP (241m)** (Zoonomia 241-way Cactus) and **phyloP (470m)** (UCSC 470-way multiz) to reduce redundancy on the leaderboard and in the `conservation_eval` run.

## Changes

- **`snakemake/conservation_eval/config/config.yaml`** — removed `phyloP_241m` and `phyloP_470m` from the `scores:` run-list (now 5 tracks: `phyloP_100v`, `phastCons_100v`, `phyloP_447m`, `phastCons_470m`, `phastCons_43p`).
- **`dashboard/models.yaml`** — removed the two leaderboard entries; the `conservation` family now has 5 members.
- **`snakemake/conservation_eval/README.md`** — updated the stale run-cost figures (7-track → 5-track).

## Intentionally kept

The shared `CONSERVATION_TRACKS` registry (`src/marin_dna/pipelines/evals/conservation.py`) is left untouched:

- `phyloP_241m` is the **reference track** for the `zoonomia_projection_dataset` 447m-threshold calibration (`calibrate_447m_threshold.py` reads `CONSERVATION_TRACKS["phyloP_241m"]`), so removing it from the registry would break that pipeline.
- `phyloP_470m` is kept there for symmetry (it has no other consumers).

Existing S3 metric parquets are untouched — `leaderboard.py` only surfaces `score_name`s that have a `models.yaml` entry, so 241m/470m no longer appear regardless.

## Verification

- `uv run pytest tests/pipelines/evals/ tests/pipelines/conservation/` → **297 passed, 3 skipped** (the calibration tests that reference 241m via the untouched registry stay green).
- `conservation_eval` dry-run → *Nothing to be done* (no re-download / re-score of the kept tracks; 241m/470m targets simply no longer requested).
- Dashboard data loader emits exactly 5 conservation entries (241m/470m gone, 447m kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
