### PR TITLE
dashboard: merge leaderboard family + protocol selectors into compound pills

### DIFF
--- a/dashboard/src/components/controls.js
+++ b/dashboard/src/components/controls.js
@@ -17,7 +17,7 @@ export const FAMILY_LABEL = {
 
 // Leaderboard-visible protocol options per family. This is the subset of
 // `PROTOCOLS` (in src/marin_dna/pipelines/evals/leaderboard.py) that the
-// leaderboards' `ProtocolPicker` exposes — additional protocols can live in
+// leaderboards' `FamilyProtocolToggle` exposes — additional protocols can live in
 // `PROTOCOLS` (e.g. `LLR-FWD`, `JSD-FWD` for the AVG-vs-FWD exploration on
 // the Protocols pages) without showing up as leaderboard toggles. Defaults
 // match `DEFAULT_PROTOCOL`.
@@ -34,73 +34,61 @@ export const PROTOCOL_DEFAULTS = {
   evo2: "LLR",
 };
 
-// Pill-row toggle for selecting which families to include. Value is the
-// array of currently-selected family slugs. Renders `all · none` quick
-// actions next to the pills.
-export function FamilyToggle(allFamilies, initial = allFamilies) {
-  const state = new Set(initial);
+// Combined family selector + per-family protocol toggle. Each family renders
+// one compound pill; selecting a family reveals its protocol chips inset inside
+// the same colored pill (only for families with ≥2 protocols — single-protocol
+// families stay plain pills and fall back to `defaults`). Protocol choices
+// persist across deselect/reselect. Renders `all · none` quick actions after
+// the pills. Value is `{families: string[], protocols: {family: protocol}}`.
+export function FamilyProtocolToggle(allFamilies, options, defaults, initial = allFamilies) {
+  const selected = new Set(initial);
+  const protocols = {...defaults};
   const node = html`<div class="lb-family-toggle"></div>`;
-  let _value = [...state];
+  const compute = () => ({families: [...selected], protocols: {...protocols}});
+  let _value = compute();
   Object.defineProperty(node, "value", {get: () => _value});
   function fire() {
-    _value = [...state];
+    _value = compute();
     node.dispatchEvent(new Event("input", {bubbles: true}));
   }
   function setAll(next) {
-    state.clear();
-    next.forEach((f) => state.add(f));
+    selected.clear();
+    next.forEach((f) => selected.add(f));
     render();
     fire();
   }
   function render() {
     node.replaceChildren(html`<div class="lb-family-toggle-row">
-      ${allFamilies.map(
-        (f) => html`<button
-          type="button"
-          class=${`lb-pill family-${f}${state.has(f) ? " active" : ""}`}
-          aria-pressed=${state.has(f) ? "true" : "false"}
-          onclick=${() => {
-            state.has(f) ? state.delete(f) : state.add(f);
-            render();
-            fire();
-          }}
-        >${FAMILY_LABEL[f] ?? f}</button>`,
-      )}
+      ${allFamilies.map((f) => {
+        const protos = options[f] ?? [];
+        const active = selected.has(f);
+        return html`<span class=${`lb-cpill family-${f}${active ? " active" : ""}`}>
+          <button
+            type="button"
+            class="lb-cpill-name"
+            aria-pressed=${active ? "true" : "false"}
+            onclick=${() => {
+              selected.has(f) ? selected.delete(f) : selected.add(f);
+              render();
+              fire();
+            }}
+          >${FAMILY_LABEL[f] ?? f}</button>
+          ${active && protos.length >= 2
+            ? html`<span class="lb-cpill-protos">${protos.map((p) => html`<button
+                type="button"
+                class=${`lb-cpill-proto${protocols[f] === p ? " active" : ""}`}
+                aria-pressed=${protocols[f] === p ? "true" : "false"}
+                onclick=${() => { protocols[f] = p; render(); fire(); }}
+              >${p}</button>`)}</span>`
+            : null}
+        </span>`;
+      })}
       <span class="lb-toggle-actions">
         <button type="button" class="lb-link" onclick=${() => setAll(allFamilies)}>all</button>
         <span aria-hidden="true">·</span>
         <button type="button" class="lb-link" onclick=${() => setAll([])}>none</button>
       </span>
     </div>`);
-  }
-  render();
-  return node;
-}
-
-// Per-family protocol selector. Only families with ≥2 protocols render
-// a toggle row (single-protocol families fall back to PROTOCOL_DEFAULTS).
-// Value is `{family: protocol}` for every family in `options`.
-export function ProtocolPicker(options, defaults) {
-  const state = {...defaults};
-  const node = html`<div class="lb-protocol-picker"></div>`;
-  Object.defineProperty(node, "value", {get: () => ({...state})});
-  function fire() {
-    node.dispatchEvent(new Event("input", {bubbles: true}));
-  }
-  function render() {
-    const groups = [];
-    for (const [fam, protos] of Object.entries(options)) {
-      if (protos.length < 2) continue;
-      groups.push(html`<span class="lb-protocol-group">
-        <span class=${`lb-family-tag family-${fam}`}>${FAMILY_LABEL[fam] ?? fam}</span>
-        <span class="lb-protocol-segmented">${protos.map(p => html`<button
-          type="button"
-          class=${`lb-protocol-btn${state[fam] === p ? " active" : ""}`}
-          onclick=${() => { state[fam] = p; render(); fire(); }}
-        >${p}</button>`)}</span>
-      </span>`);
-    }
-    node.replaceChildren(html`<div class="lb-protocol-picker-row">${groups}</div>`);
   }
   render();
   return node;

--- a/dashboard/src/leaderboards/complex.md
+++ b/dashboard/src/leaderboards/complex.md
@@ -15,8 +15,7 @@ import {
   FAMILY_LABEL,
   PROTOCOL_OPTIONS,
   PROTOCOL_DEFAULTS,
-  FamilyToggle,
-  ProtocolPicker,
+  FamilyProtocolToggle,
   PillToggle,
 } from "../components/controls.js";
 ```
@@ -64,13 +63,13 @@ display(html`<div class="card">
 
 ```js
 // Single source of truth: add/remove a key in `FAMILY_LABEL` (controls.js)
-// to surface a new family pill.
+// to surface a new family pill. Selecting a family reveals its inline
+// protocol toggle (multi-protocol families only).
 const families = Object.keys(FAMILY_LABEL);
-const familyChoice = view(FamilyToggle(families));
+const sel = view(FamilyProtocolToggle(families, PROTOCOL_OPTIONS, PROTOCOL_DEFAULTS));
 ```
 
 ```js
-const protocolChoice = view(ProtocolPicker(PROTOCOL_OPTIONS, PROTOCOL_DEFAULTS));
 const search = view(
   Inputs.text({
     label: "Model name",
@@ -85,10 +84,10 @@ const bestOnly = view(PillToggle("Best per family", false));
 
 ```js
 const filtered = complex.filter(r => {
-  if (!familyChoice.includes(r.family)) return false;
+  if (!sel.families.includes(r.family)) return false;
   // One protocol per family. Falls back to DEFAULTS for families that
-  // don't appear in `protocolChoice` (single-option families).
-  const wantedProtocol = protocolChoice[r.family] ?? PROTOCOL_DEFAULTS[r.family];
+  // don't appear in `sel.protocols` (single-option families).
+  const wantedProtocol = sel.protocols[r.family] ?? PROTOCOL_DEFAULTS[r.family];
   if (r.protocol !== wantedProtocol) return false;
   if (search && !r.method_display.toLowerCase().includes(search.toLowerCase())) return false;
   return true;
@@ -228,39 +227,76 @@ main > h1, main > h2, main > h3, main > p { max-width: 1200px; }
   font-size: 0.85em; color: #444;
 }
 
-/* Family pill toggle */
+/* Compound family pill: the family name is the selection toggle; a selected
+   multi-protocol family shows its protocol chips inset inside the same colored
+   pill (active chip = white, family-colored text). Single-protocol or
+   deselected families render as a plain pill. */
 .lb-family-toggle-row {
-  display: flex; align-items: center; flex-wrap: wrap; gap: 8px;
+  display: flex; align-items: center; flex-wrap: wrap; gap: 20px;
   margin: 0.25em 0 0.75em;
 }
-.lb-pill {
-  appearance: none;
+.lb-cpill {
+  display: inline-flex;
+  align-items: stretch;
   border: 1.5px solid transparent;
-  background: transparent;
   border-radius: 9999px;
-  padding: 3px 10px;
-  font: inherit;
+  overflow: hidden;
   font-size: 0.85em;
-  cursor: pointer;
-  transition: background 80ms, border-color 80ms, color 80ms;
+  line-height: 1;
+  transition: background 80ms, border-color 80ms;
+}
+.lb-cpill:not(.active) { border-color: #ddd; }
+.lb-cpill:not(.active):hover { border-color: #999; }
+.lb-cpill-name {
+  display: inline-flex;
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 4px 12px;
+  font: inherit;
+  font-size: inherit;
+  font-weight: 500;
   color: #999;
+  cursor: pointer;
+  transition: color 80ms;
 }
-.lb-pill:not(.active) {
-  border-color: #ddd;
+.lb-cpill:not(.active):hover .lb-cpill-name { color: #555; }
+.lb-cpill.active .lb-cpill-name { color: #fff; }
+.lb-cpill.active.family-marin_dna      { background: #1f77b4; }
+.lb-cpill.active.family-conservation { background: #7f7f7f; }
+.lb-cpill.active.family-alphagenome  { background: #d62728; }
+.lb-cpill.active.family-gpn_star     { background: #9467bd; }
+.lb-cpill.active.family-evo2         { background: #ff7f0e; }
+/* Inset protocol chips — only rendered for selected multi-protocol families. */
+.lb-cpill-protos {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 1px;
+  padding: 2px;
+  background: rgba(255, 255, 255, 0.22);
 }
-.lb-pill:not(.active):hover {
-  border-color: #999;
-  color: #555;
+.lb-cpill-proto {
+  display: inline-flex;
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-radius: 9999px;
+  padding: 1px 8px;
+  font: inherit;
+  font-size: 0.78em;
+  color: rgba(255, 255, 255, 0.92);
+  cursor: pointer;
+  transition: background 80ms, color 80ms;
 }
-.lb-pill.active {
-  color: #fff;
-  border-color: transparent;
-}
-.lb-pill.active.family-marin_dna      { background: #1f77b4; }
-.lb-pill.active.family-conservation { background: #7f7f7f; }
-.lb-pill.active.family-alphagenome  { background: #d62728; }
-.lb-pill.active.family-gpn_star     { background: #9467bd; }
-.lb-pill.active.family-evo2         { background: #ff7f0e; }
+.lb-cpill-proto:hover:not(.active) { background: rgba(255, 255, 255, 0.18); }
+.lb-cpill-proto.active { background: #fff; }
+.lb-cpill.family-marin_dna      .lb-cpill-proto.active { color: #1f77b4; }
+.lb-cpill.family-conservation .lb-cpill-proto.active { color: #7f7f7f; }
+.lb-cpill.family-alphagenome  .lb-cpill-proto.active { color: #d62728; }
+.lb-cpill.family-gpn_star     .lb-cpill-proto.active { color: #9467bd; }
+.lb-cpill.family-evo2         .lb-cpill-proto.active { color: #ff7f0e; }
 .lb-toggle-actions {
   margin-left: 6px;
   color: #888;
@@ -277,53 +313,6 @@ main > h1, main > h2, main > h3, main > p { max-width: 1200px; }
   cursor: pointer;
 }
 .lb-toggle-actions .lb-link:hover { text-decoration: underline; }
-
-/* Per-family protocol picker (segmented toggle row) */
-.lb-protocol-picker-row {
-  display: flex; align-items: center; flex-wrap: wrap; gap: 16px;
-  margin: 0.25em 0 0.75em;
-  font-size: 0.85em;
-}
-.lb-protocol-group {
-  display: inline-flex; align-items: center; gap: 6px;
-}
-.lb-family-tag {
-  display: inline-block;
-  font-family: var(--monospace);
-  font-size: 0.85em;
-  padding: 1px 7px;
-  border-radius: 9999px;
-  color: #fff;
-}
-.lb-family-tag.family-marin_dna      { background: #1f77b4; }
-.lb-family-tag.family-conservation { background: #7f7f7f; }
-.lb-family-tag.family-alphagenome  { background: #d62728; }
-.lb-family-tag.family-gpn_star     { background: #9467bd; }
-.lb-family-tag.family-evo2         { background: #ff7f0e; }
-.lb-protocol-segmented {
-  display: inline-flex;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  overflow: hidden;
-}
-.lb-protocol-btn {
-  appearance: none;
-  background: #fff;
-  border: none;
-  border-left: 1px solid #ccc;
-  padding: 2px 9px;
-  font: inherit;
-  font-size: 0.95em;
-  color: #555;
-  cursor: pointer;
-  transition: background 80ms, color 80ms;
-}
-.lb-protocol-btn:first-child { border-left: none; }
-.lb-protocol-btn:hover:not(.active) { background: #f4f4f4; color: #000; }
-.lb-protocol-btn.active {
-  background: #333;
-  color: #fff;
-}
 
 /* Standalone on/off pill (Best per family). Lives on its own row; tap
    to toggle. */

--- a/dashboard/src/leaderboards/complex.md
+++ b/dashboard/src/leaderboards/complex.md
@@ -63,8 +63,8 @@ display(html`<div class="card">
 
 ```js
 // Single source of truth: add/remove a key in `FAMILY_LABEL` (controls.js)
-// to surface a new family pill. Selecting a family reveals its inline
-// protocol toggle (multi-protocol families only).
+// to surface a new family pill. Selecting a family reveals its protocol
+// chips inset in the pill (multi-protocol families only).
 const families = Object.keys(FAMILY_LABEL);
 const sel = view(FamilyProtocolToggle(families, PROTOCOL_OPTIONS, PROTOCOL_DEFAULTS));
 ```

--- a/dashboard/src/leaderboards/mendelian.md
+++ b/dashboard/src/leaderboards/mendelian.md
@@ -63,8 +63,8 @@ display(html`<div class="card">
 
 ```js
 // Single source of truth: add/remove a key in `FAMILY_LABEL` (controls.js)
-// to surface a new family pill. Selecting a family reveals its inline
-// protocol toggle (multi-protocol families only).
+// to surface a new family pill. Selecting a family reveals its protocol
+// chips inset in the pill (multi-protocol families only).
 const families = Object.keys(FAMILY_LABEL);
 const sel = view(FamilyProtocolToggle(families, PROTOCOL_OPTIONS, PROTOCOL_DEFAULTS));
 ```

--- a/dashboard/src/leaderboards/mendelian.md
+++ b/dashboard/src/leaderboards/mendelian.md
@@ -15,8 +15,7 @@ import {
   FAMILY_LABEL,
   PROTOCOL_OPTIONS,
   PROTOCOL_DEFAULTS,
-  FamilyToggle,
-  ProtocolPicker,
+  FamilyProtocolToggle,
   PillToggle,
 } from "../components/controls.js";
 ```
@@ -64,13 +63,13 @@ display(html`<div class="card">
 
 ```js
 // Single source of truth: add/remove a key in `FAMILY_LABEL` (controls.js)
-// to surface a new family pill.
+// to surface a new family pill. Selecting a family reveals its inline
+// protocol toggle (multi-protocol families only).
 const families = Object.keys(FAMILY_LABEL);
-const familyChoice = view(FamilyToggle(families));
+const sel = view(FamilyProtocolToggle(families, PROTOCOL_OPTIONS, PROTOCOL_DEFAULTS));
 ```
 
 ```js
-const protocolChoice = view(ProtocolPicker(PROTOCOL_OPTIONS, PROTOCOL_DEFAULTS));
 const search = view(
   Inputs.text({
     label: "Model name",
@@ -85,10 +84,10 @@ const bestOnly = view(PillToggle("Best per family", false));
 
 ```js
 const filtered = mendelian.filter(r => {
-  if (!familyChoice.includes(r.family)) return false;
+  if (!sel.families.includes(r.family)) return false;
   // One protocol per family. Falls back to DEFAULTS for families that
-  // don't appear in `protocolChoice` (single-option families).
-  const wantedProtocol = protocolChoice[r.family] ?? PROTOCOL_DEFAULTS[r.family];
+  // don't appear in `sel.protocols` (single-option families).
+  const wantedProtocol = sel.protocols[r.family] ?? PROTOCOL_DEFAULTS[r.family];
   if (r.protocol !== wantedProtocol) return false;
   if (search && !r.method_display.toLowerCase().includes(search.toLowerCase())) return false;
   return true;
@@ -229,39 +228,76 @@ main > h1, main > h2, main > h3, main > p { max-width: 1200px; }
   font-size: 0.85em; color: #444;
 }
 
-/* Family pill toggle */
+/* Compound family pill: the family name is the selection toggle; a selected
+   multi-protocol family shows its protocol chips inset inside the same colored
+   pill (active chip = white, family-colored text). Single-protocol or
+   deselected families render as a plain pill. */
 .lb-family-toggle-row {
-  display: flex; align-items: center; flex-wrap: wrap; gap: 8px;
+  display: flex; align-items: center; flex-wrap: wrap; gap: 20px;
   margin: 0.25em 0 0.75em;
 }
-.lb-pill {
-  appearance: none;
+.lb-cpill {
+  display: inline-flex;
+  align-items: stretch;
   border: 1.5px solid transparent;
-  background: transparent;
   border-radius: 9999px;
-  padding: 3px 10px;
-  font: inherit;
+  overflow: hidden;
   font-size: 0.85em;
-  cursor: pointer;
-  transition: background 80ms, border-color 80ms, color 80ms;
+  line-height: 1;
+  transition: background 80ms, border-color 80ms;
+}
+.lb-cpill:not(.active) { border-color: #ddd; }
+.lb-cpill:not(.active):hover { border-color: #999; }
+.lb-cpill-name {
+  display: inline-flex;
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 4px 12px;
+  font: inherit;
+  font-size: inherit;
+  font-weight: 500;
   color: #999;
+  cursor: pointer;
+  transition: color 80ms;
 }
-.lb-pill:not(.active) {
-  border-color: #ddd;
+.lb-cpill:not(.active):hover .lb-cpill-name { color: #555; }
+.lb-cpill.active .lb-cpill-name { color: #fff; }
+.lb-cpill.active.family-marin_dna      { background: #1f77b4; }
+.lb-cpill.active.family-conservation { background: #7f7f7f; }
+.lb-cpill.active.family-alphagenome  { background: #d62728; }
+.lb-cpill.active.family-gpn_star     { background: #9467bd; }
+.lb-cpill.active.family-evo2         { background: #ff7f0e; }
+/* Inset protocol chips — only rendered for selected multi-protocol families. */
+.lb-cpill-protos {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 1px;
+  padding: 2px;
+  background: rgba(255, 255, 255, 0.22);
 }
-.lb-pill:not(.active):hover {
-  border-color: #999;
-  color: #555;
+.lb-cpill-proto {
+  display: inline-flex;
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-radius: 9999px;
+  padding: 1px 8px;
+  font: inherit;
+  font-size: 0.78em;
+  color: rgba(255, 255, 255, 0.92);
+  cursor: pointer;
+  transition: background 80ms, color 80ms;
 }
-.lb-pill.active {
-  color: #fff;
-  border-color: transparent;
-}
-.lb-pill.active.family-marin_dna      { background: #1f77b4; }
-.lb-pill.active.family-conservation { background: #7f7f7f; }
-.lb-pill.active.family-alphagenome  { background: #d62728; }
-.lb-pill.active.family-gpn_star     { background: #9467bd; }
-.lb-pill.active.family-evo2         { background: #ff7f0e; }
+.lb-cpill-proto:hover:not(.active) { background: rgba(255, 255, 255, 0.18); }
+.lb-cpill-proto.active { background: #fff; }
+.lb-cpill.family-marin_dna      .lb-cpill-proto.active { color: #1f77b4; }
+.lb-cpill.family-conservation .lb-cpill-proto.active { color: #7f7f7f; }
+.lb-cpill.family-alphagenome  .lb-cpill-proto.active { color: #d62728; }
+.lb-cpill.family-gpn_star     .lb-cpill-proto.active { color: #9467bd; }
+.lb-cpill.family-evo2         .lb-cpill-proto.active { color: #ff7f0e; }
 .lb-toggle-actions {
   margin-left: 6px;
   color: #888;
@@ -278,53 +314,6 @@ main > h1, main > h2, main > h3, main > p { max-width: 1200px; }
   cursor: pointer;
 }
 .lb-toggle-actions .lb-link:hover { text-decoration: underline; }
-
-/* Per-family protocol picker (segmented toggle row) */
-.lb-protocol-picker-row {
-  display: flex; align-items: center; flex-wrap: wrap; gap: 16px;
-  margin: 0.25em 0 0.75em;
-  font-size: 0.85em;
-}
-.lb-protocol-group {
-  display: inline-flex; align-items: center; gap: 6px;
-}
-.lb-family-tag {
-  display: inline-block;
-  font-family: var(--monospace);
-  font-size: 0.85em;
-  padding: 1px 7px;
-  border-radius: 9999px;
-  color: #fff;
-}
-.lb-family-tag.family-marin_dna      { background: #1f77b4; }
-.lb-family-tag.family-conservation { background: #7f7f7f; }
-.lb-family-tag.family-alphagenome  { background: #d62728; }
-.lb-family-tag.family-gpn_star     { background: #9467bd; }
-.lb-family-tag.family-evo2         { background: #ff7f0e; }
-.lb-protocol-segmented {
-  display: inline-flex;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  overflow: hidden;
-}
-.lb-protocol-btn {
-  appearance: none;
-  background: #fff;
-  border: none;
-  border-left: 1px solid #ccc;
-  padding: 2px 9px;
-  font: inherit;
-  font-size: 0.95em;
-  color: #555;
-  cursor: pointer;
-  transition: background 80ms, color 80ms;
-}
-.lb-protocol-btn:first-child { border-left: none; }
-.lb-protocol-btn:hover:not(.active) { background: #f4f4f4; color: #000; }
-.lb-protocol-btn.active {
-  background: #333;
-  color: #fff;
-}
 
 /* Standalone on/off pill (Best per family). Lives on its own row; tap
    to toggle. */


### PR DESCRIPTION
🤖 Redesigns the two Leaderboard control rows (family selector + per-family protocol picker) into a single compound-pill control.

## Why

The family selector and the protocol picker were two independent rows, which (a) **repeated each family name** — it appeared in the family pill *and* again as a colored tag in the protocol row (MarinDNA, GPN-Star, Evo 2) — and (b) **showed protocol toggles even for deselected families**, since the picker rendered every multi-protocol family regardless of what was selected.

## What

Merge them into one control. Each family is a single compound pill; a *selected* multi-protocol family shows its protocol options as inset chips inside the same colored pill (active chip = white with the family's color). Single-protocol families (Conservation, AlphaGenome) and deselected families render as a plain pill — so the protocol choice appears **only for selected models** and can never be mistaken for a separate family.

![Leaderboard compound-pill controls: default and deselected states](https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/0ea9b9724350a4c735f13de2c0ef2bb98c041a70/pr-preview.png)

- `dashboard/src/components/controls.js` — replace `FamilyToggle` + `ProtocolPicker` with one `FamilyProtocolToggle` widget (value `{families, protocols}`).
- `dashboard/src/leaderboards/{mendelian,complex}.md` — single `sel` control, updated filter predicate, and compound-pill CSS (drops the old `.lb-pill` / `.lb-protocol-segmented` / `.lb-family-tag` rules).

Behaviour preserved: the default view (all families selected, protocols at LLR / cLLR / LLR) is visually equivalent to before; the protocol choice persists across deselect→reselect; `all` / `none` and the heatmap filtering are unchanged.

## Verification

- `npm run build` is clean (8 pages render, 11 links validated).
- Drove the live preview with headless Chrome across default / deselect / protocol-flip / none / all on **both** leaderboards; the widget's exposed `{families, protocols}` value matched expectations (single-protocol families carry no chips; multi-protocol families default to LLR / cLLR / LLR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
