### PR TITLE
dashboard: render JSD protocol as "NucDep" (nucleotide dependency)

### DIFF
--- a/dashboard/src/components/controls.js
+++ b/dashboard/src/components/controls.js
@@ -35,6 +35,17 @@ export const PROTOCOL_DEFAULTS = {
   evo2: "LLR",
 };
 
+// Protocol *display* labels — render layer only. Internal protocol keys
+// (the parquet `protocol` column / `PROTOCOLS` in
+// src/marin_dna/pipelines/evals/leaderboard.py) are unchanged; this maps a
+// key to how it reads in the UI. JSD is surfaced as "NucDep" (nucleotide
+// dependency). Unlisted keys fall back to themselves.
+export const PROTOCOL_LABEL = {
+  JSD: "NucDep",
+  "JSD-FWD": "NucDep-FWD",
+};
+export const protocolLabel = (p) => PROTOCOL_LABEL[p] ?? p;
+
 // Combined family selector + per-family protocol toggle. Each family renders
 // one compound pill; selecting a family reveals its protocol chips inset inside
 // the same colored pill (only for families with ≥2 protocols — single-protocol
@@ -80,7 +91,7 @@ export function FamilyProtocolToggle(allFamilies, options, defaults, initial = a
                 class=${`lb-cpill-proto${protocols[f] === p ? " active" : ""}`}
                 aria-pressed=${protocols[f] === p ? "true" : "false"}
                 onclick=${() => { protocols[f] = p; render(); fire(); }}
-              >${p}</button>`)}</span>`
+              >${protocolLabel(p)}</button>`)}</span>`
             : null}
         </span>`;
       })}
@@ -144,7 +155,7 @@ export function ComparisonPicker(pairs, initialIdx = 0) {
         render();
         fire();
       }}
-    >${a} → ${b}</button>`));
+    >${protocolLabel(a)} → ${protocolLabel(b)}</button>`));
   }
   render();
   return node;

--- a/dashboard/src/components/controls.js
+++ b/dashboard/src/components/controls.js
@@ -46,6 +46,16 @@ export const PROTOCOL_LABEL = {
 };
 export const protocolLabel = (p) => PROTOCOL_LABEL[p] ?? p;
 
+// Optional hover tooltip per protocol. Surfaces the underlying quantity for
+// renamed protocols on the leaderboard pills, which — unlike the Protocols
+// pages — carry no inline definition. Unlisted keys get no `title` (htl omits
+// the attribute when the value is null).
+export const PROTOCOL_TITLE = {
+  JSD: "Jensen-Shannon divergence (JSD)",
+  "JSD-FWD": "Jensen-Shannon divergence, forward strand only (JSD-FWD)",
+};
+export const protocolTitle = (p) => PROTOCOL_TITLE[p] ?? null;
+
 // Combined family selector + per-family protocol toggle. Each family renders
 // one compound pill; selecting a family reveals its protocol chips inset inside
 // the same colored pill (only for families with ≥2 protocols — single-protocol
@@ -90,6 +100,7 @@ export function FamilyProtocolToggle(allFamilies, options, defaults, initial = a
                 type="button"
                 class=${`lb-cpill-proto${protocols[f] === p ? " active" : ""}`}
                 aria-pressed=${protocols[f] === p ? "true" : "false"}
+                title=${protocolTitle(p)}
                 onclick=${() => { protocols[f] = p; render(); fire(); }}
               >${protocolLabel(p)}</button>`)}</span>`
             : null}

--- a/dashboard/src/index.md
+++ b/dashboard/src/index.md
@@ -16,8 +16,8 @@ Public, version-controlled leaderboards for genomic language models trained unde
 
 A model family's AUPRC depends on which score column you compute it from. These pages compare protocols head-to-head — same models, same dataset, different scoring approach.
 
-- [**MarinDNA**](./protocols/marin_dna) — LLR vs JSD
-- [**Evo 2**](./protocols/evo2) — LLR vs JSD
+- [**MarinDNA**](./protocols/marin_dna) — LLR vs NucDep
+- [**Evo 2**](./protocols/evo2) — LLR vs NucDep
 - [**GPN-Star**](./protocols/gpn-star) — calibrated (cLLR) vs uncalibrated LLR
 
 ## Reference

--- a/dashboard/src/protocols/evo2.md
+++ b/dashboard/src/protocols/evo2.md
@@ -11,7 +11,7 @@ const leaderboard = await FileAttachment("../data/leaderboard.parquet").parquet(
 const methods = await FileAttachment("../data/models.json").json();
 const datasets = await FileAttachment("../data/datasets.json").json();
 import {heatmap, colorLegend, leadingAggregateSubset, rowsFromLeaderboard} from "../components/heatmap.js";
-import {PillSelect, ComparisonPicker, labeledRow} from "../components/controls.js";
+import {PillSelect, ComparisonPicker, labeledRow, protocolLabel} from "../components/controls.js";
 ```
 
 ```js
@@ -111,13 +111,13 @@ for (const cell of grouped.values()) {
 }
 ```
 
-Each cell below is **${alternative} AUPRC − ${baseline} AUPRC**, in percentage points. Green = ${alternative} scores higher; red = the reverse; yellow = no meaningful change.
+Each cell below is **${protocolLabel(alternative)} AUPRC − ${protocolLabel(baseline)} AUPRC**, in percentage points. Green = ${protocolLabel(alternative)} scores higher; red = the reverse; yellow = no meaningful change.
 
 **Protocol definitions** (each score is per-variant; transforms make higher = more variant-effect):
 
 - **LLR** — log-likelihood ratio of mutant vs. reference, averaged across forward and reverse-complement scores. Sign-flipped (`−LLR`) so higher = more pathogenic. *Leaderboard default.*
-- **JSD** — per-position Jensen-Shannon divergence between the model's mutant and reference next-token distributions, averaged first across positions *downstream of the variant*, then across forward and reverse-complement scores.
-- **LLR-FWD / JSD-FWD** — same transforms applied to the forward strand only (no reverse-complement averaging). Surfaced here for strand-symmetry exploration; not used in the leaderboards.
+- **NucDep** (nucleotide dependency) — per-position Jensen-Shannon divergence between the model's mutant and reference next-token distributions, averaged first across positions *downstream of the variant*, then across forward and reverse-complement scores.
+- **LLR-FWD / NucDep-FWD** — same transforms applied to the forward strand only (no reverse-complement averaging). Surfaced here for strand-symmetry exploration; not used in the leaderboards.
 
 Cells aggregate across the same matched groups the [${DATASET_LABEL[dataset]} leaderboard](../leaderboards/${dataset === "mendelian_traits" ? "mendelian" : "complex"}) uses — only the score column changes.
 

--- a/dashboard/src/protocols/marin_dna.md
+++ b/dashboard/src/protocols/marin_dna.md
@@ -11,7 +11,7 @@ const leaderboard = await FileAttachment("../data/leaderboard.parquet").parquet(
 const methods = await FileAttachment("../data/models.json").json();
 const datasets = await FileAttachment("../data/datasets.json").json();
 import {heatmap, colorLegend, leadingAggregateSubset, rowsFromLeaderboard} from "../components/heatmap.js";
-import {PillSelect, ComparisonPicker, labeledRow} from "../components/controls.js";
+import {PillSelect, ComparisonPicker, labeledRow, protocolLabel} from "../components/controls.js";
 ```
 
 ```js
@@ -112,13 +112,13 @@ for (const cell of grouped.values()) {
 }
 ```
 
-Each cell below is **${alternative} AUPRC − ${baseline} AUPRC**, in percentage points. Green = ${alternative} scores higher; red = the reverse; yellow = no meaningful change.
+Each cell below is **${protocolLabel(alternative)} AUPRC − ${protocolLabel(baseline)} AUPRC**, in percentage points. Green = ${protocolLabel(alternative)} scores higher; red = the reverse; yellow = no meaningful change.
 
 **Protocol definitions** (each score is per-variant; transforms make higher = more variant-effect):
 
 - **LLR** — log-likelihood ratio of mutant vs. reference, averaged across forward and reverse-complement scores. Sign-flipped for Mendelian (`−LLR`) and absolute-valued for Complex (`|LLR|`). *Leaderboard default.*
-- **JSD** — per-position Jensen-Shannon divergence between the model's mutant and reference next-token distributions, averaged first across positions *downstream of the variant*, then across forward and reverse-complement scores.
-- **LLR-FWD / JSD-FWD** — same transforms applied to the forward strand only (no reverse-complement averaging). Surfaced here for strand-symmetry exploration; not used in the leaderboards.
+- **NucDep** (nucleotide dependency) — per-position Jensen-Shannon divergence between the model's mutant and reference next-token distributions, averaged first across positions *downstream of the variant*, then across forward and reverse-complement scores.
+- **LLR-FWD / NucDep-FWD** — same transforms applied to the forward strand only (no reverse-complement averaging). Surfaced here for strand-symmetry exploration; not used in the leaderboards.
 
 Cells aggregate across the same matched groups the [${DATASET_LABEL[dataset]} leaderboard](../leaderboards/${dataset === "mendelian_traits" ? "mendelian" : "complex"}) uses — only the score column changes.
 


### PR DESCRIPTION
🤖 Renders the `JSD` scoring protocol as **NucDep** ("nucleotide dependency") everywhere it is shown to users. This is a **display-only alias** — the internal protocol key stays `JSD` everywhere it matters for data: the parquet `protocol` column, `PROTOCOLS` in `src/marin_dna/pipelines/evals/leaderboard.py`, and the dashboard's `PROTOCOL_OPTIONS` / `COMPARISONS` keys are all untouched.

## What changed

Adds a `PROTOCOL_LABEL` map + `protocolLabel()` helper in `dashboard/src/components/controls.js` (mirroring the existing `FAMILY_LABEL` pattern — there was previously no protocol→label indirection, so keys were rendered verbatim), and applies it at every user-facing render site:

- **Leaderboard protocol pills** (`FamilyProtocolToggle`) — MarinDNA & Evo 2 now show "LLR / NucDep".
- **Protocol-comparison Compare buttons** (`ComparisonPicker`) — "LLR → NucDep", "NucDep → NucDep-FWD".
- **Legend prose** on the protocol pages — "Each cell below is NucDep AUPRC − LLR AUPRC…".
- **Protocol definitions** — `JSD` → "**NucDep** (nucleotide dependency) — per-position Jensen-Shannon divergence…" (acronym expanded once, the JSD math kept verbatim); `JSD-FWD` → `NucDep-FWD`.
- **Home-page protocol links** (`index.md`) — "LLR vs NucDep".

`JSD-FWD` renders as `NucDep-FWD` for consistency. GPN-Star (cLLR / LLR) is unaffected.

## Verification

- `npm run build` — all 8 pages render, data loaders run, 11 links validated, no errors.
- Rendered HTML + compiled `controls.js` bundle checked: NucDep in the static prose, the label map + helper present in the bundle.
- Remaining `JSD` occurrences are all internal keys (`PROTOCOL_OPTIONS`, `COMPARISONS`, the `PROTOCOL_LABEL` key side) or code comments — **zero user-facing `JSD`**.

### Screenshots

**Mendelian leaderboard** — MarinDNA & Evo 2 compound pills show "LLR / NucDep" (GPN-Star unchanged):

![Mendelian leaderboard — MarinDNA & Evo 2 pills show LLR / NucDep chips](https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/d55e6c565fef5d077954a23de45afc1f5c243b4a/leaderboard-mendelian.png)

**Protocols → MarinDNA** — Compare buttons, legend line, and protocol definitions all read NucDep:

![Protocols page — Compare buttons, legend, and definitions all read NucDep](https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/39b6f802cbb6ea4cc66fd59debfda05ee1c662fd/protocols-marin_dna.png)
