### PR TITLE
dashboard: add caQTL / dsQTL leaderboard pages

### DIFF
--- a/dashboard/models.yaml
+++ b/dashboard/models.yaml
@@ -23,7 +23,7 @@
 #   family       enum    marin_dna | conservation | alphagenome | gpn_star.
 #                        Drives parquet path + per-method filter in the library.
 #   description  string  short tag for cards + (some) inline labels.
-#   datasets     [str]   subset of {mendelian_traits, complex_traits}.
+#   datasets     [str]   subset of {mendelian_traits, complex_traits, caqtl, dsqtl}.
 #   training     dict    (marin_dna only) data, params, window_size, objective.
 #   experiment   int     (optional) experiment number — for grouping.
 #   issue        url     (optional) GitHub issue tracking the experiment.
@@ -41,31 +41,31 @@
   display: phastCons (100v)
   family: conservation
   description: phastCons across 100 vertebrates
-  datasets: [mendelian_traits, complex_traits]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
 
 - id: phastCons_43p
   display: phastCons (43p)
   family: conservation
   description: phastCons across 43 primates
-  datasets: [mendelian_traits, complex_traits]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
 
 - id: phastCons_470m
   display: phastCons (470m)
   family: conservation
   description: phastCons across 470 mammals
-  datasets: [mendelian_traits, complex_traits]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
 
 - id: phyloP_100v
   display: phyloP (100v)
   family: conservation
   description: phyloP across 100 vertebrates
-  datasets: [mendelian_traits, complex_traits]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
 
 - id: phyloP_447m
   display: phyloP (447m)
   family: conservation
   description: phyloP across 447 mammals
-  datasets: [mendelian_traits, complex_traits]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
 
 # ---------------------------------------------------------------------------
 # marin_dna gLMs — evals_v2 pipeline. Registry order matches the legacy
@@ -146,7 +146,7 @@
   wandb: https://wandb.ai/gonzalobenegas/marin/runs/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0
   checkpoint:
     gcs: gs://marin-us-central1/checkpoints/dna-bolinas-enhancer-curation-v0.1-proj_v30-6692f0/hf/step-9999
-  datasets: [mendelian_traits, complex_traits]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
 
 # Convergence-style entries (final checkpoint only here per "last checkpoint
 # per run" convention). Scored on mendelian only in the evals_v2 config.
@@ -381,7 +381,7 @@
   display: AlphaGenome
   family: alphagenome
   description: variant scorer, API
-  datasets: [mendelian_traits, complex_traits]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
 
 - id: GPN-Star-V
   display: GPN-Star (V)

--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -30,6 +30,8 @@ export default {
       pages: [
         {name: "Mendelian traits", path: "/leaderboards/mendelian"},
         {name: "Complex traits", path: "/leaderboards/complex"},
+        {name: "caQTL", path: "/leaderboards/caqtl"},
+        {name: "dsQTL", path: "/leaderboards/dsqtl"},
       ],
     },
     {

--- a/dashboard/src/components/qtl.js
+++ b/dashboard/src/components/qtl.js
@@ -1,0 +1,266 @@
+// QTL leaderboard: single selected-metric table + forest plot.
+//
+// caQTL / dsQTL use the `qtl_global` eval path (PR #217) — no consequence
+// subsets, no matched negatives. The metrics are global AUPRC (the DART-Eval
+// Task-5 ranking metric, significant-QTL vs control) plus Pearson/Spearman of
+// the variant score vs the measured `effect_size` over positives only. A
+// single shared color scale can't serve AUPRC and the correlations (different
+// ranges), so the page puts a metric selector (AUPRC | Pearson | Spearman) on
+// top and this component renders ONE column of the chosen metric + a forest
+// plot, with the color scale AND forest x-axis derived from the displayed
+// values — so the range adapts per metric and never clamps a real value
+// (e.g. dsQTL AlphaGenome AUPRC ≈ 0.40 vs caQTL's ≈ 0.28).
+//
+// Deliberately separate from heatmap.js: that component is built around the
+// matched-pair consequence-subset model (SUBSET_DISPLAY, N_POSITIVES_MIN
+// gating, GLOBAL/MACRO aggregates, caller-owned sort state). Bending it to a
+// single metric-indexed column with a per-view domain would add a conditional
+// at each of those points — more entangled, not less. CSS classes
+// (`lb-heatmap`, `lb-cell`, `lb-method`, `lb-forest`, …) are shared so the
+// page's <style> block styles both; the forest-plot draw is copied here and
+// parameterized by (domain, ticks, label).
+
+import * as d3 from "npm:d3";
+import {html, svg} from "npm:htl";
+
+import {attachModelPopover, modelHref} from "./model-cards.js";
+
+// The three metric rows (the `subset` overload from
+// leaderboard.fetch_method_metrics' QTL branch), in display order.
+export const QTL_METRICS = ["AUPRC", "pearson", "spearman"];
+export const QTL_METRIC_LABEL = {
+  AUPRC: "AUPRC",
+  pearson: "Pearson r",
+  spearman: "Spearman ρ",
+};
+
+// Static estimates of the rendered <thead> / tbody-row heights; the forest
+// plot uses them for its initial draw, then a rAF callback re-measures the
+// real heights and redraws so each dot lands in its row's vertical center.
+// Match the CSS row heights in the QTL pages' <style> block.
+const HEATMAP_HEADER_PX = 48;
+const HEATMAP_ROW_PX = 30;
+
+// Random-performance baseline per metric. AUPRC's is the positive rate
+// (prevalence = n_pos / n_rows) — data-driven, so it's the dataset's own value
+// (≈0.077 caQTL, ≈0.021 dsQTL) with no hard-coded constant. The correlations'
+// is 0 (no association). Color and the forest axis are anchored here so a
+// random method reads as "no signal", mirroring the matched-pair heatmap's
+// 0.10 floor.
+function metricBaseline(metric, rows) {
+  if (metric !== "AUPRC") return 0;
+  // Every AUPRC row carries the dataset's n (= n_rows) and n_positives, so any
+  // row gives the prevalence; they're identical across methods.
+  const r = rows[0];
+  return r && r.n > 0 ? r.n_positives / r.n : 0;
+}
+
+// Two domains, both anchored at `baseline` (random performance) and recomputed
+// per render (so switching metric or filtering families rescales).
+//   - colorDomain spans [baseline, max value]: color encodes the value (not the
+//     whisker, so a cell's shade doesn't move with its SE), and a method at or
+//     below random clamps to the palest shade.
+//   - axisDomain widens to fit the ± SE whiskers AND the baseline, so the
+//     forest plot never clamps a whisker and always shows the random marker.
+// The printed value + forest axis are the source of truth; color is an aid.
+function colorDomain(rows, baseline) {
+  if (rows.length === 0) return [baseline, baseline + 1];
+  const hi = Math.max(...rows.map((r) => r.value));
+  return [baseline, Math.max(hi, baseline + 1e-6)];
+}
+
+function axisDomain(rows, baseline) {
+  if (rows.length === 0) return [baseline, baseline + 1];
+  const hi = Math.max(...rows.map((r) => r.value + r.se));
+  const lo = Math.min(baseline, ...rows.map((r) => r.value - r.se));
+  const pad = (hi - lo) * 0.06 || 0.01;
+  return [lo, hi + pad];
+}
+
+function niceTicks([lo, hi]) {
+  const t = d3.ticks(lo, hi, 5);
+  return t.length ? t : [lo, hi];
+}
+
+function qtlColor(v, [lo, hi]) {
+  if (v == null) return "#ffffff";
+  const t = hi > lo ? Math.max(0, Math.min(1, (v - lo) / (hi - lo))) : 0;
+  return d3.interpolateYlGn(0.1 + 0.85 * t);
+}
+
+function qtlTextColor(v, domain) {
+  if (v == null) return "#666";
+  return d3.lab(qtlColor(v, domain)).l > 60 ? "#000" : "#fff";
+}
+
+const fmtVal = (v) => v.toFixed(3);
+const fmtN = (n) => n.toLocaleString("en-US");
+// Forest x-axis tick labels: round to ≤6 decimals and trim trailing zeros, so
+// d3.ticks float artifacts (e.g. 0.15000000000000002) render clean.
+const fmtTick = d3.format("~f");
+
+// Header count differs by metric: AUPRC is over all variants, the
+// correlations over positives only.
+function headerCount(metric, n) {
+  return metric === "AUPRC" ? `n=${fmtN(n)}` : `n=${fmtN(n)} pos`;
+}
+
+/**
+ * Single-metric QTL table + forest plot.
+ *
+ * @param {object} opts
+ * @param {Array}  opts.rows long-form QTL rows for ONE dataset; `subset`
+ *   holds the metric name (AUPRC / pearson / spearman). Output of
+ *   leaderboard.normalized_rows, filtered to one dataset (+ family/protocol/search).
+ * @param {string} opts.metric "AUPRC" | "pearson" | "spearman".
+ * @param {Map}    opts.modelById id → model metadata (links + hover popover).
+ * @returns {HTMLElement}
+ */
+export function qtlTable({rows, metric, modelById}) {
+  const label = QTL_METRIC_LABEL[metric] ?? metric;
+
+  // One value per method at the selected metric, sorted descending.
+  const byMethod = new Map();
+  for (const r of rows) {
+    if (r.subset !== metric) continue;
+    byMethod.set(r.method_id, {
+      method_id: r.method_id,
+      method_display: r.method_display,
+      family: r.family,
+      value: r.value,
+      se: r.se,
+      n: r.n,
+      n_positives: r.n_positives,
+    });
+  }
+  const sorted = [...byMethod.values()].sort(
+    (a, b) => b.value - a.value || a.method_display.localeCompare(b.method_display),
+  );
+  if (sorted.length === 0) {
+    return html`<div class="lb-forest-empty">No methods match the current filters for ${label}.</div>`;
+  }
+
+  const baseline = metricBaseline(metric, sorted);
+  const colorDom = colorDomain(sorted, baseline);
+  const axisDom = axisDomain(sorted, baseline);
+  const ticks = niceTicks(axisDom);
+  const n = sorted[0].n; // same across methods (one dataset, one metric)
+
+  const table = html`<table class="lb-heatmap lb-qtl">
+    <colgroup>
+      <col style="width: 210px"></col>
+      <col style="width: 150px"></col>
+    </colgroup>
+    <thead>
+      <tr>
+        <th class="lb-method-header">Model</th>
+        <th class="lb-col lb-col-sorted">
+          <span class="lb-col-label">${label}</span><br><small>${headerCount(metric, n)}</small>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      ${sorted.map((m) => {
+        const meta = modelById.get(m.method_id);
+        const anchor = html`<a href=${modelHref(m.method_id)}><code>${m.method_display}</code></a>`;
+        if (meta) attachModelPopover(anchor, meta);
+        const bg = qtlColor(m.value, colorDom);
+        const fg = qtlTextColor(m.value, colorDom);
+        return html`<tr>
+          <td class="lb-method">
+            <span class=${`lb-family lb-family-${m.family}`} title=${m.family}></span>
+            ${anchor}
+          </td>
+          <td class="lb-cell lb-col-sorted" style=${`background-color: ${bg}; color: ${fg};`}>
+            ${fmtVal(m.value)}
+          </td>
+        </tr>`;
+      })}
+    </tbody>
+  </table>`;
+
+  // Forest plot adjacent on the right. Initial draw uses the static height
+  // estimates; a rAF callback then re-measures and redraws so dots align to
+  // the browser's actually-rendered rows.
+  const forestSlot = html`<div class="lb-forest-slot"></div>`;
+  forestSlot.appendChild(qtlForestPlot(sorted, {axisDom, colorDom, ticks, label, baseline}));
+  const root = html`<div class="lb-heatmap-wrap"><div class="lb-heatmap-row">${table}${forestSlot}</div></div>`;
+  requestAnimationFrame(() =>
+    realignForest(table, forestSlot, sorted, {axisDom, colorDom, ticks, label, baseline}),
+  );
+  return root;
+}
+
+function realignForest(table, forestSlot, sorted, opts) {
+  const thead = table.querySelector("thead");
+  const firstRow = table.querySelector("tbody tr");
+  const lastRow = table.querySelector("tbody tr:last-child");
+  if (!thead || !firstRow) return;
+  const headerPx = thead.getBoundingClientRect().height;
+  const firstRect = firstRow.getBoundingClientRect();
+  const lastRect = lastRow.getBoundingClientRect();
+  const nRows = sorted.length;
+  const rowPx =
+    nRows > 1
+      ? (lastRect.top + lastRect.height / 2 - (firstRect.top + firstRect.height / 2)) /
+        (nRows - 1)
+      : firstRect.height;
+  forestSlot.replaceChildren(qtlForestPlot(sorted, opts, headerPx, rowPx));
+}
+
+// Forest plot: one row per method (current sort order), a colored dot at the
+// value with a ± SE whisker, and a dashed `baseline` line marking random
+// performance. axisDom (x-axis, fits whiskers + baseline), colorDom (dot
+// color, point values), ticks, label, baseline are passed in (per-metric,
+// data-driven) — unlike heatmap.js's forestPlot, hard-wired to the
+// matched-pair [0.1, 1.0] AUPRC scale.
+function qtlForestPlot(
+  sorted,
+  {axisDom: [xMin, xMax], colorDom, ticks, label, baseline},
+  headerPx,
+  rowPx,
+) {
+  if (sorted.length === 0) {
+    return html`<div class="lb-forest-empty">No values for ${label}.</div>`;
+  }
+  const width = 254;
+  const margin = {top: headerPx ?? HEATMAP_HEADER_PX, right: 46, bottom: 32, left: 16};
+  const rowH = rowPx ?? HEATMAP_ROW_PX;
+  const height = margin.top + sorted.length * rowH + margin.bottom;
+  const innerW = width - margin.left - margin.right;
+  const span = xMax - xMin || 1;
+  const xPx = (v) =>
+    margin.left + ((Math.max(xMin, Math.min(xMax, v)) - xMin) / span) * innerW;
+
+  return svg`<svg class="lb-forest" viewBox=${`0 0 ${width} ${height}`} width=${width} style="flex: 0 0 auto;">
+    ${ticks.map(
+      (t) => svg`<g>
+        <line x1=${xPx(t)} x2=${xPx(t)} y1=${margin.top} y2=${height - margin.bottom}
+              stroke="#eee"></line>
+        <text x=${xPx(t)} y=${margin.top - 8} text-anchor="middle" font-size="10" fill="#666">${fmtTick(t)}</text>
+      </g>`,
+    )}
+    <line x1=${xPx(baseline)} x2=${xPx(baseline)} y1=${margin.top} y2=${height - margin.bottom}
+          stroke="#c66" stroke-width="1" stroke-dasharray="3 2"></line>
+    <text x=${xPx(baseline)} y=${margin.top - 19}
+          text-anchor=${xPx(baseline) < margin.left + 22 ? "start" : "middle"}
+          font-size="8.5" fill="#c66">random</text>
+    ${sorted.map((cell, i) => {
+      const y = margin.top + i * rowH + rowH / 2;
+      const cx = xPx(cell.value);
+      const lo = xPx(cell.value - cell.se);
+      const hi = xPx(cell.value + cell.se);
+      const fill = qtlColor(cell.value, colorDom);
+      return svg`<g>
+        <line x1=${lo} x2=${hi} y1=${y} y2=${y} stroke="#666" stroke-width="1"></line>
+        <circle cx=${cx} cy=${y} r="4.5" fill=${fill} stroke="#333" stroke-width="0.5"></circle>
+        <text x=${hi + 5} y=${y} dy="0.32em" font-size="10.5" fill="#444"
+              font-variant-numeric="tabular-nums">${cell.value.toFixed(3)}</text>
+      </g>`;
+    })}
+    <text x=${margin.left + innerW / 2} y=${height - 14} text-anchor="middle"
+          font-size="10.5" font-weight="600" fill="#444">${label}</text>
+    <text x=${margin.left + innerW / 2} y=${height - 2} text-anchor="middle"
+          font-size="9.5" fill="#888">dot = value · whisker = ± SE</text>
+  </svg>`;
+}

--- a/dashboard/src/data/datasets.json.py
+++ b/dashboard/src/data/datasets.json.py
@@ -18,6 +18,20 @@ _METRIC = (
     "AUPRC is 0.10."
 )
 
+# QTL (caqtl/dsqtl) use the `qtl_global` eval path — no matching, no subsets —
+# so the metric story is different from the matched-pair `_METRIC` above
+# (which assumes 1:9 clustering and a 0.10 baseline). Pick one metric at a time
+# via the selector on the page.
+_QTL_METRIC = (
+    "Pick a metric with the selector above. **AUPRC** ± bootstrap SE — over "
+    "*all* variants (significant QTLs vs unmatched control variants); the "
+    "random baseline is the positive rate (not 0.10), which differs per "
+    "dataset. **Pearson r** / **Spearman ρ** ± bootstrap SE — correlation of "
+    "the variant-effect score with the measured `effect_size`, over the "
+    "*positives only*. The color scale and forest-plot axis rescale to the "
+    "selected metric."
+)
+
 DATASETS = {
     "mendelian_traits": {
         "name": "Mendelian Traits",
@@ -53,6 +67,40 @@ DATASETS = {
         "notes": [
             "Per-subset columns exclude subsets with fewer than 30 positives (`n < 300` under 1:9 matching). Most consequence subsets in this dataset fall below that threshold — distal and missense are the only ones reported.",
             "Sorted by Global by default. Score column is `abs_llr_avg` (magnitude) rather than `minus_llr_avg` — for complex-trait fine-mapped variants we don't have a pathogenicity direction, only that the variant is causal.",
+        ],
+    },
+    "caqtl": {
+        "name": "caQTL (chromatin accessibility)",
+        "hf_repo": "bolinas-dna/evals_caqtl",
+        "hf_commit": "9d004a21",
+        "score_type": "abs_llr_avg",
+        "issue": "https://github.com/Open-Athena/marin-dna/issues/214",
+        "split": "train",
+        "positives": "DART-Eval Task-5 significant chromatin-accessibility QTLs (3,173 of 41,382 variants; DeGorter et al. 2023)",
+        "negatives": "DART-Eval Task-5 control variants (non-significant)",
+        "matching": "none — variants scored as-is (no 1:9 matching, no subsetting)",
+        "metric": _QTL_METRIC,
+        "notes": [
+            "DART-Eval Task-5 caQTL benchmark (`eval_protocol: qtl_global`). No consequence subsets and no matched negatives, so the leaderboard is a single selected-metric column (+ forest plot) rather than the per-consequence heatmap.",
+            "Random-baseline AUPRC is the positive rate ≈ 0.077 (3,173 / 41,382). AUPRC is over all variants; Pearson/Spearman over the 3,173 positives only.",
+            "MarinDNA defaults to NucDep (Jensen-Shannon divergence, `jsd_avg`) here — a symmetric distributional distance suited to unsigned QTL effects; the LLR magnitude protocol (`abs_llr_avg`) is one click away via the protocol toggle.",
+        ],
+    },
+    "dsqtl": {
+        "name": "dsQTL (DNase I sensitivity)",
+        "hf_repo": "bolinas-dna/evals_dsqtl",
+        "hf_commit": "b7e02a07",
+        "score_type": "abs_llr_avg",
+        "issue": "https://github.com/Open-Athena/marin-dna/issues/214",
+        "split": "train",
+        "positives": "DART-Eval Task-5 significant DNase-I-sensitivity QTLs (309 of 15,018 variants; Degner et al. 2012, hg19→GRCh38)",
+        "negatives": "DART-Eval Task-5 control variants (non-significant)",
+        "matching": "none — variants scored as-is (no 1:9 matching, no subsetting)",
+        "metric": _QTL_METRIC,
+        "notes": [
+            "DART-Eval Task-5 dsQTL benchmark (`eval_protocol: qtl_global`). Single selected-metric column (+ forest plot); no subsets, no matched negatives.",
+            "Random-baseline AUPRC is the positive rate ≈ 0.021 (309 / 15,018). AUPRC is over all variants; Pearson/Spearman over the 309 positives only — the small positive count makes the correlation SEs wide (~0.06).",
+            "MarinDNA defaults to NucDep (Jensen-Shannon divergence, `jsd_avg`) here — a symmetric distributional distance suited to unsigned QTL effects; the LLR magnitude protocol (`abs_llr_avg`) is one click away via the protocol toggle.",
         ],
     },
 }

--- a/dashboard/src/data/leaderboard.parquet.py
+++ b/dashboard/src/data/leaderboard.parquet.py
@@ -5,10 +5,12 @@ Pulls per-(method, dataset, subset) metric rows from S3 via
 ``dataset`` column, concatenates across datasets, and writes the resulting
 DataFrame as a parquet blob on stdout for the dashboard to read via DuckDB.
 
-Emits one parquet covering the matched-pair eval datasets
-(mendelian_traits, complex_traits). eQTL was retired in PR #194 — see
-issue #172 for the rationale; the page may be reinstated if and when
-the eqtl dataset is rebuilt under the AUPRC pipeline.
+Emits one parquet covering every leaderboard dataset: the matched-pair evals
+(mendelian_traits, complex_traits) and the DART-Eval QTL evals (caqtl, dsqtl,
+PR #217). Each page filters by ``dataset``, so they coexist in one file. For
+QTL rows the ``subset`` column holds the metric name (AUPRC / pearson /
+spearman) instead of a consequence subset — see
+``leaderboard.fetch_method_metrics``. eQTL was retired in PR #194 (issue #172).
 """
 
 from __future__ import annotations
@@ -19,12 +21,17 @@ import polars as pl
 
 from marin_dna.pipelines.evals.leaderboard import normalized_rows
 
-V1_DATASETS: tuple[str, ...] = ("mendelian_traits", "complex_traits")
+LEADERBOARD_DATASETS: tuple[str, ...] = (
+    "mendelian_traits",
+    "complex_traits",
+    "caqtl",
+    "dsqtl",
+)
 
 
 def main() -> None:
     parts = []
-    for dataset in V1_DATASETS:
+    for dataset in LEADERBOARD_DATASETS:
         df = normalized_rows(dataset).with_columns(dataset=pl.lit(dataset))
         parts.append(df)
     out = pl.concat(parts, how="vertical_relaxed")

--- a/dashboard/src/leaderboards/caqtl.md
+++ b/dashboard/src/leaderboards/caqtl.md
@@ -1,0 +1,276 @@
+---
+title: caQTL Leaderboard
+toc: false
+wide: true
+---
+
+# caQTL Leaderboard
+
+```js
+const leaderboard = await FileAttachment("../data/leaderboard.parquet").parquet();
+const methods = await FileAttachment("../data/models.json").json();
+const datasets = await FileAttachment("../data/datasets.json").json();
+import {rowsFromLeaderboard} from "../components/heatmap.js";
+import {qtlTable, QTL_METRICS, QTL_METRIC_LABEL} from "../components/qtl.js";
+import {
+  FAMILY_LABEL,
+  PROTOCOL_OPTIONS,
+  PROTOCOL_DEFAULTS,
+  FamilyProtocolToggle,
+  PillSelect,
+} from "../components/controls.js";
+```
+
+```js
+const allRows = rowsFromLeaderboard(leaderboard);
+const caqtl = allRows.filter(r => r.dataset === "caqtl");
+const modelById = new Map(methods.map(m => [m.id, m]));
+const meta = datasets.caqtl;
+```
+
+## Dataset
+
+```js
+const hfUrl = `https://huggingface.co/datasets/${meta.hf_repo}/tree/${meta.hf_commit}`;
+```
+
+```js
+display(html`<div class="card">
+  <table class="dataset-meta">
+    <tr><td><b>HF dataset</b></td><td><a href=${hfUrl}><code>${meta.hf_repo} @ ${meta.hf_commit}</code></a></td></tr>
+    <tr><td><b>Split</b></td><td><code>${meta.split}</code> (used for both training and development; test held out for final-eval)</td></tr>
+  </table>
+  <div class="dataset-bullets">
+    <div><b>Positives:</b> ${meta.positives}</div>
+    <div><b>Negatives:</b> ${meta.negatives}</div>
+    <div><b>Matching:</b> ${meta.matching}</div>
+    <div><b>Metric:</b> ${meta.metric}</div>
+  </div>
+  <div class="dataset-notes">
+    ${meta.notes.map((n) => html`<div>${n}</div>`)}
+  </div>
+</div>`);
+```
+
+## Leaderboard
+
+```js
+// Only families with caQTL data appear (marin_dna exp136, the 5 conservation
+// tracks, AlphaGenome). Derive the pills from the families actually present
+// in the rows so GPN-Star / Evo 2 (no QTL data) don't render dead pills.
+// Order follows FAMILY_LABEL.
+const present = new Set(caqtl.map(r => r.family));
+const families = Object.keys(FAMILY_LABEL).filter(f => present.has(f));
+// On the QTL benchmark MarinDNA defaults to JSD (the internal protocol key;
+// displayed as "NucDep" per #222), not the global LLR — QTL effects are
+// unsigned, so a symmetric distributional distance fits better here. LLR
+// stays one click away via the toggle.
+const QTL_DEFAULTS = {...PROTOCOL_DEFAULTS, marin_dna: "JSD"};
+const sel = view(FamilyProtocolToggle(families, PROTOCOL_OPTIONS, QTL_DEFAULTS));
+```
+
+```js
+// QTL has no consequence subsets — pick which global metric to rank by.
+// AUPRC is the DART-Eval Task-5 ranking metric; Pearson/Spearman correlate
+// the score with the measured effect_size over positives only.
+const metric = view(PillSelect(QTL_METRICS, "AUPRC", (m) => QTL_METRIC_LABEL[m]));
+```
+
+```js
+const search = view(
+  Inputs.text({
+    label: "Model name",
+    placeholder: "filter by method (e.g. exp136, phyloP)",
+  }),
+);
+```
+
+```js
+const filtered = caqtl.filter(r => {
+  if (!sel.families.includes(r.family)) return false;
+  // One protocol per family. Falls back to DEFAULTS for families that
+  // don't appear in `sel.protocols` (single-option families). qtlTable
+  // then selects the active metric row (AUPRC / pearson / spearman).
+  const wantedProtocol = sel.protocols[r.family] ?? QTL_DEFAULTS[r.family];
+  if (r.protocol !== wantedProtocol) return false;
+  if (search && !r.method_display.toLowerCase().includes(search.toLowerCase())) return false;
+  return true;
+});
+```
+
+<style>
+/* Observable Framework's default theme caps prose elements at 640px and
+   constrains main to ~1072px even on a wide page. Override both so the
+   table and the side-by-side forest plot fit on one row. */
+:root { --observablehq-max-width: 2200px; }
+main > p, main > h1, main > h2, main > h3, main > .card {
+  max-width: none;
+}
+main > h1, main > h2, main > h3, main > p { max-width: 1200px; }
+.card { max-width: 1200px; }
+.lb-heatmap-row { width: max-content; max-width: 100%; }
+.lb-heatmap, .lb-forest { flex: 0 0 auto; }
+
+.lb-heatmap {
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.85em;
+  margin: 1em 0;
+  /* Two columns only (Model + selected metric), so a narrow fixed width —
+     not the matched-pair heatmap's 1290px. Fixed layout + explicit col
+     widths so long model names truncate with an ellipsis. */
+  table-layout: fixed;
+  width: 360px;
+}
+.lb-heatmap thead th:not(.lb-method-header) { width: 150px; }
+.lb-heatmap th.lb-method-header { width: 210px; }
+.lb-heatmap th, .lb-heatmap td {
+  padding: 6px 4px;
+  border: 1px solid #ddd;
+}
+/* Explicit row heights so the forest plot to the right (which uses fixed
+   pixel rowH) lines up dot-for-row with the table. Keep in sync with
+   HEATMAP_HEADER_PX / HEATMAP_ROW_PX in dashboard/src/components/qtl.js. */
+.lb-heatmap thead tr { height: 40px; }
+.lb-heatmap tbody tr { height: 28px; }
+.lb-heatmap-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+}
+/* Drop the table's outer top margin inside the side-by-side row so the
+   table's top edge lines up with the forest plot's. */
+.lb-heatmap-row .lb-heatmap { margin: 0; }
+.lb-heatmap thead th {
+  background: #f7f7f7;
+  text-align: center;
+  user-select: none;
+}
+.lb-heatmap td.lb-cell { font-variant-numeric: tabular-nums; padding: 6px 4px; }
+.lb-col-label { white-space: nowrap; }
+.lb-heatmap thead th.lb-col-sorted { background: #d6e8d6; font-weight: 600; }
+.lb-heatmap td.lb-col-sorted { border-left: 2px solid #5c8a5c; border-right: 2px solid #5c8a5c; }
+.lb-heatmap thead th.lb-col-sorted { border-left: 2px solid #5c8a5c; border-right: 2px solid #5c8a5c; border-bottom: 2px solid #5c8a5c; }
+.lb-method-header { text-align: left !important; }
+.lb-method {
+  /* Long model names truncate with an ellipsis. Hover popover surfaces
+     the full name + family + links, so info is one hover away. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.lb-method a {
+  text-decoration: none;
+  display: inline-block;
+  max-width: calc(100% - 22px); /* room for the family swatch + margin */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}
+.lb-method a:hover { text-decoration: underline; }
+.lb-desc { color: #666; font-size: 0.92em; }
+.lb-family {
+  display: inline-block;
+  width: 10px; height: 10px;
+  border-radius: 2px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.lb-cell {
+  text-align: center;
+  font-feature-settings: "tnum";
+}
+.lb-na { text-align: center; color: #aaa; }
+.lb-forest { display: block; }
+.lb-forest-empty { color: #888; margin: 1em 0; font-size: 0.9em; }
+.dataset-meta td { padding: 2px 8px; }
+.dataset-meta td:first-child { white-space: nowrap; }
+.dataset-bullets { margin: 0.5em 0 0.25em; }
+.dataset-bullets div { margin: 2px 0; }
+.dataset-notes { margin-top: 0.5em; color: #666; font-size: 0.9em; }
+.dataset-notes div { margin: 2px 0; }
+.legend-row {
+  display: flex; align-items: center; gap: 12px;
+  margin: 0.5em 0 1em;
+  font-size: 0.85em; color: #444;
+}
+
+/* Metric selector (PillSelect) — single-choice segmented pill. */
+.lb-protocol-segmented {
+  display: inline-flex;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.lb-protocol-btn {
+  appearance: none;
+  background: #fff;
+  border: none;
+  border-left: 1px solid #ccc;
+  padding: 3px 11px;
+  font: inherit;
+  font-size: 0.95em;
+  color: #555;
+  cursor: pointer;
+  transition: background 80ms, color 80ms;
+}
+.lb-protocol-btn:first-child { border-left: none; }
+.lb-protocol-btn:hover:not(.active) { background: #f4f4f4; color: #000; }
+.lb-protocol-btn.active { background: #333; color: #fff; }
+
+/* Model popover on table method-name hover */
+.lb-method-popover {
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: 10px 12px;
+  min-width: 280px;
+  max-width: 360px;
+}
+.lb-pop-header { display: flex; flex-direction: column; gap: 3px; margin-bottom: 4px; }
+.lb-pop-family {
+  display: inline-block;
+  font-size: 0.7em;
+  font-weight: 500;
+  padding: 1px 7px;
+  border-radius: 9999px;
+  color: #fff;
+  width: fit-content;
+}
+.lb-pop-display { font-size: 0.98em; font-weight: 600; }
+.lb-pop-desc { color: #555; margin: 4px 0 6px; font-size: 0.92em; }
+.lb-pop-specs { margin: 6px 0; }
+.lb-pop-row {
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  gap: 10px;
+  align-items: baseline;
+  margin: 2px 0;
+}
+.lb-pop-key {
+  color: #888; text-transform: uppercase; font-size: 0.72em;
+  letter-spacing: 0.04em;
+}
+.lb-pop-val { font-size: 0.92em; }
+.lb-pop-links { margin: 6px 0 2px; font-size: 0.9em; }
+.lb-pop-more {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: 0.82em;
+  color: #3a7bd5;
+}
+.muted { color: #aaa; }
+</style>
+
+<div class="legend-row">
+  <span>Color &amp; forest axis scale to the selected metric, anchored at random performance (dashed line) — AUPRC = positive rate, correlation = 0. Whisker = ± SE.</span>
+</div>
+
+```js
+display(qtlTable({rows: filtered, metric, modelById}));
+```

--- a/dashboard/src/leaderboards/dsqtl.md
+++ b/dashboard/src/leaderboards/dsqtl.md
@@ -1,0 +1,276 @@
+---
+title: dsQTL Leaderboard
+toc: false
+wide: true
+---
+
+# dsQTL Leaderboard
+
+```js
+const leaderboard = await FileAttachment("../data/leaderboard.parquet").parquet();
+const methods = await FileAttachment("../data/models.json").json();
+const datasets = await FileAttachment("../data/datasets.json").json();
+import {rowsFromLeaderboard} from "../components/heatmap.js";
+import {qtlTable, QTL_METRICS, QTL_METRIC_LABEL} from "../components/qtl.js";
+import {
+  FAMILY_LABEL,
+  PROTOCOL_OPTIONS,
+  PROTOCOL_DEFAULTS,
+  FamilyProtocolToggle,
+  PillSelect,
+} from "../components/controls.js";
+```
+
+```js
+const allRows = rowsFromLeaderboard(leaderboard);
+const dsqtl = allRows.filter(r => r.dataset === "dsqtl");
+const modelById = new Map(methods.map(m => [m.id, m]));
+const meta = datasets.dsqtl;
+```
+
+## Dataset
+
+```js
+const hfUrl = `https://huggingface.co/datasets/${meta.hf_repo}/tree/${meta.hf_commit}`;
+```
+
+```js
+display(html`<div class="card">
+  <table class="dataset-meta">
+    <tr><td><b>HF dataset</b></td><td><a href=${hfUrl}><code>${meta.hf_repo} @ ${meta.hf_commit}</code></a></td></tr>
+    <tr><td><b>Split</b></td><td><code>${meta.split}</code> (used for both training and development; test held out for final-eval)</td></tr>
+  </table>
+  <div class="dataset-bullets">
+    <div><b>Positives:</b> ${meta.positives}</div>
+    <div><b>Negatives:</b> ${meta.negatives}</div>
+    <div><b>Matching:</b> ${meta.matching}</div>
+    <div><b>Metric:</b> ${meta.metric}</div>
+  </div>
+  <div class="dataset-notes">
+    ${meta.notes.map((n) => html`<div>${n}</div>`)}
+  </div>
+</div>`);
+```
+
+## Leaderboard
+
+```js
+// Only families with dsQTL data appear (marin_dna exp136, the 5 conservation
+// tracks, AlphaGenome). Derive the pills from the families actually present
+// in the rows so GPN-Star / Evo 2 (no QTL data) don't render dead pills.
+// Order follows FAMILY_LABEL.
+const present = new Set(dsqtl.map(r => r.family));
+const families = Object.keys(FAMILY_LABEL).filter(f => present.has(f));
+// On the QTL benchmark MarinDNA defaults to JSD (the internal protocol key;
+// displayed as "NucDep" per #222), not the global LLR — QTL effects are
+// unsigned, so a symmetric distributional distance fits better here. LLR
+// stays one click away via the toggle.
+const QTL_DEFAULTS = {...PROTOCOL_DEFAULTS, marin_dna: "JSD"};
+const sel = view(FamilyProtocolToggle(families, PROTOCOL_OPTIONS, QTL_DEFAULTS));
+```
+
+```js
+// QTL has no consequence subsets — pick which global metric to rank by.
+// AUPRC is the DART-Eval Task-5 ranking metric; Pearson/Spearman correlate
+// the score with the measured effect_size over positives only.
+const metric = view(PillSelect(QTL_METRICS, "AUPRC", (m) => QTL_METRIC_LABEL[m]));
+```
+
+```js
+const search = view(
+  Inputs.text({
+    label: "Model name",
+    placeholder: "filter by method (e.g. exp136, phyloP)",
+  }),
+);
+```
+
+```js
+const filtered = dsqtl.filter(r => {
+  if (!sel.families.includes(r.family)) return false;
+  // One protocol per family. Falls back to DEFAULTS for families that
+  // don't appear in `sel.protocols` (single-option families). qtlTable
+  // then selects the active metric row (AUPRC / pearson / spearman).
+  const wantedProtocol = sel.protocols[r.family] ?? QTL_DEFAULTS[r.family];
+  if (r.protocol !== wantedProtocol) return false;
+  if (search && !r.method_display.toLowerCase().includes(search.toLowerCase())) return false;
+  return true;
+});
+```
+
+<style>
+/* Observable Framework's default theme caps prose elements at 640px and
+   constrains main to ~1072px even on a wide page. Override both so the
+   table and the side-by-side forest plot fit on one row. */
+:root { --observablehq-max-width: 2200px; }
+main > p, main > h1, main > h2, main > h3, main > .card {
+  max-width: none;
+}
+main > h1, main > h2, main > h3, main > p { max-width: 1200px; }
+.card { max-width: 1200px; }
+.lb-heatmap-row { width: max-content; max-width: 100%; }
+.lb-heatmap, .lb-forest { flex: 0 0 auto; }
+
+.lb-heatmap {
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.85em;
+  margin: 1em 0;
+  /* Two columns only (Model + selected metric), so a narrow fixed width —
+     not the matched-pair heatmap's 1290px. Fixed layout + explicit col
+     widths so long model names truncate with an ellipsis. */
+  table-layout: fixed;
+  width: 360px;
+}
+.lb-heatmap thead th:not(.lb-method-header) { width: 150px; }
+.lb-heatmap th.lb-method-header { width: 210px; }
+.lb-heatmap th, .lb-heatmap td {
+  padding: 6px 4px;
+  border: 1px solid #ddd;
+}
+/* Explicit row heights so the forest plot to the right (which uses fixed
+   pixel rowH) lines up dot-for-row with the table. Keep in sync with
+   HEATMAP_HEADER_PX / HEATMAP_ROW_PX in dashboard/src/components/qtl.js. */
+.lb-heatmap thead tr { height: 40px; }
+.lb-heatmap tbody tr { height: 28px; }
+.lb-heatmap-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+}
+/* Drop the table's outer top margin inside the side-by-side row so the
+   table's top edge lines up with the forest plot's. */
+.lb-heatmap-row .lb-heatmap { margin: 0; }
+.lb-heatmap thead th {
+  background: #f7f7f7;
+  text-align: center;
+  user-select: none;
+}
+.lb-heatmap td.lb-cell { font-variant-numeric: tabular-nums; padding: 6px 4px; }
+.lb-col-label { white-space: nowrap; }
+.lb-heatmap thead th.lb-col-sorted { background: #d6e8d6; font-weight: 600; }
+.lb-heatmap td.lb-col-sorted { border-left: 2px solid #5c8a5c; border-right: 2px solid #5c8a5c; }
+.lb-heatmap thead th.lb-col-sorted { border-left: 2px solid #5c8a5c; border-right: 2px solid #5c8a5c; border-bottom: 2px solid #5c8a5c; }
+.lb-method-header { text-align: left !important; }
+.lb-method {
+  /* Long model names truncate with an ellipsis. Hover popover surfaces
+     the full name + family + links, so info is one hover away. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.lb-method a {
+  text-decoration: none;
+  display: inline-block;
+  max-width: calc(100% - 22px); /* room for the family swatch + margin */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}
+.lb-method a:hover { text-decoration: underline; }
+.lb-desc { color: #666; font-size: 0.92em; }
+.lb-family {
+  display: inline-block;
+  width: 10px; height: 10px;
+  border-radius: 2px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.lb-cell {
+  text-align: center;
+  font-feature-settings: "tnum";
+}
+.lb-na { text-align: center; color: #aaa; }
+.lb-forest { display: block; }
+.lb-forest-empty { color: #888; margin: 1em 0; font-size: 0.9em; }
+.dataset-meta td { padding: 2px 8px; }
+.dataset-meta td:first-child { white-space: nowrap; }
+.dataset-bullets { margin: 0.5em 0 0.25em; }
+.dataset-bullets div { margin: 2px 0; }
+.dataset-notes { margin-top: 0.5em; color: #666; font-size: 0.9em; }
+.dataset-notes div { margin: 2px 0; }
+.legend-row {
+  display: flex; align-items: center; gap: 12px;
+  margin: 0.5em 0 1em;
+  font-size: 0.85em; color: #444;
+}
+
+/* Metric selector (PillSelect) — single-choice segmented pill. */
+.lb-protocol-segmented {
+  display: inline-flex;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.lb-protocol-btn {
+  appearance: none;
+  background: #fff;
+  border: none;
+  border-left: 1px solid #ccc;
+  padding: 3px 11px;
+  font: inherit;
+  font-size: 0.95em;
+  color: #555;
+  cursor: pointer;
+  transition: background 80ms, color 80ms;
+}
+.lb-protocol-btn:first-child { border-left: none; }
+.lb-protocol-btn:hover:not(.active) { background: #f4f4f4; color: #000; }
+.lb-protocol-btn.active { background: #333; color: #fff; }
+
+/* Model popover on table method-name hover */
+.lb-method-popover {
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: 10px 12px;
+  min-width: 280px;
+  max-width: 360px;
+}
+.lb-pop-header { display: flex; flex-direction: column; gap: 3px; margin-bottom: 4px; }
+.lb-pop-family {
+  display: inline-block;
+  font-size: 0.7em;
+  font-weight: 500;
+  padding: 1px 7px;
+  border-radius: 9999px;
+  color: #fff;
+  width: fit-content;
+}
+.lb-pop-display { font-size: 0.98em; font-weight: 600; }
+.lb-pop-desc { color: #555; margin: 4px 0 6px; font-size: 0.92em; }
+.lb-pop-specs { margin: 6px 0; }
+.lb-pop-row {
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  gap: 10px;
+  align-items: baseline;
+  margin: 2px 0;
+}
+.lb-pop-key {
+  color: #888; text-transform: uppercase; font-size: 0.72em;
+  letter-spacing: 0.04em;
+}
+.lb-pop-val { font-size: 0.92em; }
+.lb-pop-links { margin: 6px 0 2px; font-size: 0.9em; }
+.lb-pop-more {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: 0.82em;
+  color: #3a7bd5;
+}
+.muted { color: #aaa; }
+</style>
+
+<div class="legend-row">
+  <span>Color &amp; forest axis scale to the selected metric, anchored at random performance (dashed line) — AUPRC = positive rate, correlation = 0. Whisker = ± SE.</span>
+</div>
+
+```js
+display(qtlTable({rows: filtered, metric, modelById}));
+```

--- a/src/marin_dna/pipelines/evals/leaderboard.py
+++ b/src/marin_dna/pipelines/evals/leaderboard.py
@@ -33,6 +33,17 @@ from marin_dna.pipelines.evals.models import ALL_DATASETS, Model, models_for_dat
 S3 = "s3://oa-bolinas"
 SPLIT = "train"
 
+# Datasets emitted by the `qtl_global` eval path (snakemake `eval_protocol:
+# qtl_global`, PR #217). DART-Eval Task-5 caQTL / dsQTL: no matching and no
+# subsetting, so the metrics parquet is keyed by `metric` (AUPRC / pearson /
+# spearman) × score_type rather than by consequence `subset`. AUPRC is global
+# over all variants; pearson/spearman are score-vs-`effect_size` over positives
+# only. `fetch_method_metrics` branches on this set because the matched-pair
+# row shaping (subset / n_groups / macro-avg) doesn't apply. Declared here in
+# the dashboard-side aggregator rather than read from the pipeline config —
+# the two dataset names are stable and this keeps the loader self-contained.
+QTL_DATASETS: frozenset[str] = frozenset({"caqtl", "dsqtl"})
+
 # `family: gpn_star` AUPRC metrics live on a gist commit (issue #145, last
 # comment) — one parquet per dataset with V/M/P stacked and a `model`
 # column to filter on. Polars `read_parquet` handles https URLs natively
@@ -79,21 +90,35 @@ PROTOCOLS: dict[str, dict[str, dict[str, str]]] = {
         # leaderboards' protocol toggle (see `PROTOCOL_OPTIONS` in
         # `dashboard/src/components/controls.js`). The `_rc` columns are
         # still in the parquet for diagnostics but aren't surfaced.
+        # QTL datasets (caqtl/dsqtl) carry `score_protocol: abs_llr` — an
+        # unsigned magnitude, since QTL effects have no pathogenicity
+        # direction — so LLR picks `abs_llr_avg` (like complex_traits), not
+        # `minus_llr_avg`. The metrics parquet stacks AUPRC + pearson +
+        # spearman per score_type; `fetch_method_metrics` selects the score
+        # column here and keeps all three metric rows.
         "LLR": {
             "mendelian_traits": "minus_llr_avg",
             "complex_traits": "abs_llr_avg",
+            "caqtl": "abs_llr_avg",
+            "dsqtl": "abs_llr_avg",
         },
         "JSD": {
             "mendelian_traits": "jsd_avg",
             "complex_traits": "jsd_avg",
+            "caqtl": "jsd_avg",
+            "dsqtl": "jsd_avg",
         },
         "LLR-FWD": {
             "mendelian_traits": "minus_llr_fwd",
             "complex_traits": "abs_llr_fwd",
+            "caqtl": "abs_llr_fwd",
+            "dsqtl": "abs_llr_fwd",
         },
         "JSD-FWD": {
             "mendelian_traits": "jsd_fwd",
             "complex_traits": "jsd_fwd",
+            "caqtl": "jsd_fwd",
+            "dsqtl": "jsd_fwd",
         },
     },
     "conservation": {
@@ -189,9 +214,17 @@ def fetch_method_metrics(
     method: Model, dataset: str, protocol: str | None = None
 ) -> pl.DataFrame:
     """Return rows ``[subset, value, se, n, n_positives]`` for one
-    ``(method, dataset, protocol)`` — including the ``_global_`` and
-    ``_macro_avg_`` aggregate rows. See ``normalized_rows`` for the
-    column semantics.
+    ``(method, dataset, protocol)``.
+
+    Matched-pair datasets (mendelian_traits, complex_traits) emit one row per
+    consequence ``subset`` plus the ``_global_`` / ``_macro_avg_`` aggregates;
+    ``subset`` carries the consequence name and ``n`` is total variants (or K
+    on the macro row). QTL datasets (``caqtl`` / ``dsqtl`` — the
+    ``qtl_global`` eval path, see ``QTL_DATASETS``) have no subsets: the source
+    parquet is keyed by ``metric`` ∈ {AUPRC, pearson, spearman}, so ``subset``
+    is overloaded to carry the metric name, ``n`` = ``n_rows`` (all variants
+    for AUPRC, positives only for the correlations) and ``n_positives`` =
+    ``n_pos``. See ``normalized_rows`` for the column semantics.
 
     When ``protocol`` is ``None``, defaults to ``DEFAULT_PROTOCOL[family]``.
     """
@@ -225,6 +258,25 @@ def fetch_method_metrics(
             f"{protocol!r} (score_type={score_type!r}) in {path}. The pipeline "
             f"may need to be re-run with this protocol included."
         )
+    if dataset in QTL_DATASETS:
+        # QTL schema: one row per metric (AUPRC / pearson / spearman), no
+        # subset / no n_groups / no macro-avg. Overload `subset` to carry the
+        # metric name so the long-form row schema stays uniform; the dashboard
+        # QTL page renders one method-row per metric and a metric-selector pill
+        # picks the active one. `n_rows` is all variants for AUPRC, positives
+        # only for the correlations — carry both straight through. Early-return
+        # so the matched-pair `n_groups` shaping below (absent from QTL
+        # parquets) is never reached.
+        assert {"metric", "n_rows", "n_pos"} <= set(df.columns), (
+            f"QTL parquet for {method.id!r}/{dataset!r} missing expected "
+            f"columns; got {df.columns}"
+        )
+        df = df.with_columns(
+            pl.col("metric").alias("subset"),
+            pl.col("n_rows").alias("n"),
+            pl.col("n_pos").alias("n_positives"),
+        )
+        return df.select(["subset", "value", "se", "n", "n_positives"])
     df = df.with_columns(
         pl.when(pl.col("subset") == MACRO_AVG_SUBSET)
         .then(pl.col("n_groups"))
@@ -250,15 +302,19 @@ def normalized_rows(dataset: str) -> pl.DataFrame:
       - ``method_display``  — ``Model.display``
       - ``family``          — ``Model.family``
       - ``protocol``        — protocol name (e.g. ``LLR``, ``JSD``, ``cLLR``)
-      - ``subset``          — consequence subset OR ``_global_`` / ``_macro_avg_``
-      - ``value``           — AUPRC
-      - ``se``              — cluster-bootstrap SE
+      - ``subset``          — consequence subset OR ``_global_`` /
+        ``_macro_avg_`` (matched-pair); the metric name ``AUPRC`` /
+        ``pearson`` / ``spearman`` for QTL datasets.
+      - ``value``           — AUPRC (matched-pair, and QTL ``AUPRC`` rows) or
+        the score-vs-effect_size correlation (QTL ``pearson`` / ``spearman``).
+      - ``se``              — cluster-bootstrap SE (row bootstrap for QTL).
       - ``n``               — total variants in the subset (positives +
         matched negatives), except on the ``_macro_avg_`` row where it
-        carries K = number of qualifying subsets.
+        carries K = number of qualifying subsets. For QTL, ``n_rows`` (all
+        variants for AUPRC, positives only for the correlations).
       - ``n_positives``     — positives in the subset (= ``n_groups`` from
-        the source AUPRC parquet); K on the macro row. Drives the
-        dashboard's ≥30-positives display threshold; never rendered.
+        the source AUPRC parquet); K on the macro row; ``n_pos`` for QTL.
+        Drives the dashboard's ≥30-positives display threshold; never rendered.
     """
     # Soft-fail surface, intentionally narrow: only the two legitimate
     # "no data for this protocol yet" exception types.

--- a/src/marin_dna/pipelines/evals/models.py
+++ b/src/marin_dna/pipelines/evals/models.py
@@ -23,7 +23,12 @@ ALL_FAMILIES: tuple[Family, ...] = (
     "gpn_star",
     "evo2",
 )
-ALL_DATASETS: tuple[str, ...] = ("mendelian_traits", "complex_traits")
+ALL_DATASETS: tuple[str, ...] = (
+    "mendelian_traits",
+    "complex_traits",
+    "caqtl",
+    "dsqtl",
+)
 
 
 @dataclass(frozen=True)

--- a/tests/pipelines/evals/test_leaderboard.py
+++ b/tests/pipelines/evals/test_leaderboard.py
@@ -379,6 +379,239 @@ def test_normalized_rows_includes_aggregates_and_per_subset(
     assert df["method_id"].unique().to_list() == ["phyloP_241m"]
 
 
+# ---- QTL (caqtl / dsqtl) ----------------------------------------------------
+#
+# QTL parquets have a different schema from the matched-pair eval: keyed by
+# `metric` (AUPRC / pearson / spearman) × score_type, with NO `subset` and NO
+# `n_groups`. `fetch_method_metrics` must branch on `QTL_DATASETS`, overload
+# `subset` to carry the metric name, and NOT reach the matched-pair shaping
+# (which would `ColumnNotFoundError` on the absent `subset`/`n_groups`).
+
+
+def _qtl_marin_df() -> pl.DataFrame:
+    """marin_dna QTL metrics parquet (caqtl): 3 metrics × 4 referenced
+    score_types. n_rows = all variants for AUPRC, positives only for the
+    correlations (mirrors the real schema)."""
+
+    def rows(score_type: str) -> list[dict]:
+        return [
+            {
+                "metric": "AUPRC",
+                "score_type": score_type,
+                "value": 0.089,
+                "se": 0.0026,
+                "n_rows": 41382,
+                "n_pos": 3173,
+                "model": "exp136",
+                "dataset": "caqtl",
+                "split": "train",
+            },
+            {
+                "metric": "pearson",
+                "score_type": score_type,
+                "value": 0.013,
+                "se": 0.0154,
+                "n_rows": 3173,
+                "n_pos": 3173,
+                "model": "exp136",
+                "dataset": "caqtl",
+                "split": "train",
+            },
+            {
+                "metric": "spearman",
+                "score_type": score_type,
+                "value": 0.009,
+                "se": 0.0177,
+                "n_rows": 3173,
+                "n_pos": 3173,
+                "model": "exp136",
+                "dataset": "caqtl",
+                "split": "train",
+            },
+        ]
+
+    return pl.DataFrame(
+        rows("abs_llr_avg") + rows("jsd_avg") + rows("abs_llr_fwd") + rows("jsd_fwd")
+    )
+
+
+def test_score_type_for_qtl_datasets():
+    # QTL `score_protocol` is abs_llr (unsigned magnitude — no direction), so
+    # LLR picks abs_llr_avg, not minus_llr_avg. conservation / alphagenome
+    # auto-extend via their `{d: ... for d in ALL_DATASETS}` comprehensions.
+    assert score_type_for("marin_dna", "LLR", "caqtl") == "abs_llr_avg"
+    assert score_type_for("marin_dna", "JSD", "dsqtl") == "jsd_avg"
+    assert score_type_for("marin_dna", "LLR-FWD", "caqtl") == "abs_llr_fwd"
+    assert score_type_for("marin_dna", "JSD-FWD", "dsqtl") == "jsd_fwd"
+    assert score_type_for("conservation", "score", "caqtl") == "score"
+    assert score_type_for("conservation", "score", "dsqtl") == "score"
+    assert score_type_for("alphagenome", "L2", "caqtl") == "alphagenome_max_l2"
+    assert score_type_for("alphagenome", "L2", "dsqtl") == "alphagenome_max_l2"
+
+
+def test_fetch_method_metrics_qtl_marin(monkeypatch: pytest.MonkeyPatch):
+    method = _mk_method(id="exp136", family="marin_dna", datasets=("caqtl",))
+    _patch_methods(monkeypatch, (method,))
+    _patch_read_parquet(
+        monkeypatch,
+        {
+            "s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics/"
+            "exp136/caqtl.parquet": _qtl_marin_df(),
+        },
+    )
+    df = fetch_method_metrics(method, "caqtl", protocol="LLR")  # → abs_llr_avg
+    assert set(df["subset"].to_list()) == {"AUPRC", "pearson", "spearman"}
+    # AUPRC uses all variants; the correlations use positives only.
+    auprc = df.filter(pl.col("subset") == "AUPRC")
+    assert auprc["n"][0] == 41382
+    assert auprc["n_positives"][0] == 3173
+    pear = df.filter(pl.col("subset") == "pearson")
+    assert pear["n"][0] == 3173
+    assert abs(pear["value"][0] - 0.013) < 1e-9
+    # Guard: the source schema genuinely lacks the matched-pair columns, so a
+    # regression that drops the QTL branch would crash here (not silently pass).
+    assert "n_groups" not in _qtl_marin_df().columns
+    assert "subset" not in _qtl_marin_df().columns
+
+
+def test_normalized_rows_qtl_marin_emits_metric_rows_per_protocol(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    method = _mk_method(id="exp136", family="marin_dna", datasets=("caqtl",))
+    _patch_methods(monkeypatch, (method,))
+    _patch_read_parquet(
+        monkeypatch,
+        {
+            "s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics/"
+            "exp136/caqtl.parquet": _qtl_marin_df(),
+        },
+    )
+    df = normalized_rows("caqtl")
+    assert set(df["subset"].unique().to_list()) == {"AUPRC", "pearson", "spearman"}
+    # 4 marin_dna protocols (LLR / JSD / LLR-FWD / JSD-FWD) × 3 metrics. The
+    # dashboard later filters to LLR/JSD via PROTOCOL_OPTIONS.
+    assert df.height == 12
+    for proto in df["protocol"].unique().to_list():
+        assert df.filter(pl.col("protocol") == proto).height == 3
+
+
+def test_fetch_method_metrics_qtl_conservation_filters_by_score_name(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # The QTL conservation parquet carries every track (incl. phyloP_241m,
+    # which is NOT on the leaderboard); the `score_name == method.id` filter
+    # keeps only the registered track's 3 metric rows.
+    method = _mk_method(id="phyloP_447m", family="conservation", datasets=("caqtl",))
+    _patch_methods(monkeypatch, (method,))
+
+    def cons_rows(score_name: str, auprc: float) -> list[dict]:
+        return [
+            {
+                "metric": "AUPRC",
+                "score_type": "score",
+                "value": auprc,
+                "se": 0.0019,
+                "n_rows": 41382,
+                "n_pos": 3173,
+                "score_name": score_name,
+                "n_nan": 0,
+                "n_total": 41382,
+                "split": "train",
+                "dataset": "caqtl",
+            },
+            {
+                "metric": "pearson",
+                "score_type": "score",
+                "value": 0.02,
+                "se": 0.016,
+                "n_rows": 3173,
+                "n_pos": 3173,
+                "score_name": score_name,
+                "n_nan": 0,
+                "n_total": 41382,
+                "split": "train",
+                "dataset": "caqtl",
+            },
+            {
+                "metric": "spearman",
+                "score_type": "score",
+                "value": 0.03,
+                "se": 0.017,
+                "n_rows": 3173,
+                "n_pos": 3173,
+                "score_name": score_name,
+                "n_nan": 0,
+                "n_total": 41382,
+                "split": "train",
+                "dataset": "caqtl",
+            },
+        ]
+
+    cons = pl.DataFrame(
+        cons_rows("phyloP_447m", 0.079) + cons_rows("phyloP_241m", 0.076)
+    )
+    _patch_read_parquet(
+        monkeypatch,
+        {
+            "s3://oa-bolinas/snakemake/conservation_eval/results/"
+            "caqtl/metrics_train.parquet": cons,
+        },
+    )
+    df = fetch_method_metrics(method, "caqtl")
+    assert df.height == 3  # only phyloP_447m; phyloP_241m dropped
+    assert set(df["subset"].to_list()) == {"AUPRC", "pearson", "spearman"}
+    assert df.filter(pl.col("subset") == "AUPRC")["value"][0] == 0.079
+
+
+def test_fetch_method_metrics_qtl_alphagenome(monkeypatch: pytest.MonkeyPatch):
+    method = _mk_method(id="AlphaGenome", family="alphagenome", datasets=("caqtl",))
+    _patch_methods(monkeypatch, (method,))
+    ag = pl.DataFrame(
+        [
+            {
+                "metric": "AUPRC",
+                "score_type": "alphagenome_max_l2",
+                "value": 0.282,
+                "se": 0.0082,
+                "n_rows": 41382,
+                "n_pos": 3173,
+                "dataset": "caqtl",
+                "split": "train",
+            },
+            {
+                "metric": "pearson",
+                "score_type": "alphagenome_max_l2",
+                "value": 0.270,
+                "se": 0.0199,
+                "n_rows": 3173,
+                "n_pos": 3173,
+                "dataset": "caqtl",
+                "split": "train",
+            },
+            {
+                "metric": "spearman",
+                "score_type": "alphagenome_max_l2",
+                "value": 0.220,
+                "se": 0.0168,
+                "n_rows": 3173,
+                "n_pos": 3173,
+                "dataset": "caqtl",
+                "split": "train",
+            },
+        ]
+    )
+    _patch_read_parquet(
+        monkeypatch,
+        {
+            "s3://oa-bolinas/snakemake/alphagenome_eval/results/metrics/"
+            "caqtl.parquet": ag,
+        },
+    )
+    df = fetch_method_metrics(method, "caqtl")
+    assert set(df["subset"].to_list()) == {"AUPRC", "pearson", "spearman"}
+    assert df.filter(pl.col("subset") == "AUPRC")["value"][0] == 0.282
+
+
 # ---- BOLINAS_S3_ANON env toggle --------------------------------------------
 
 

--- a/tests/pipelines/evals/test_models.py
+++ b/tests/pipelines/evals/test_models.py
@@ -58,6 +58,31 @@ def test_models_for_dataset_unknown_raises():
         models_for_dataset("not_a_dataset")
 
 
+def test_qtl_datasets_registered_to_expected_methods():
+    """caQTL/dsQTL data exists on S3 only for exp136, the 5 leaderboard
+    conservation tracks, and AlphaGenome (PR #217 — ship what's computed).
+    Guards `dashboard/models.yaml` against drift: a model gaining/losing a
+    QTL `datasets:` entry without the matching S3 parquet would show an
+    empty row (or silently drop) on the QTL leaderboard."""
+    expected = {
+        "exp136-proj_v30-step-9999",
+        "phastCons_100v",
+        "phastCons_43p",
+        "phastCons_470m",
+        "phyloP_100v",
+        "phyloP_447m",
+        "AlphaGenome",
+    }
+    for dataset in ("caqtl", "dsqtl"):
+        ids = {m.id for m in models_for_dataset(dataset)}
+        assert ids == expected, (
+            f"{dataset}: unexpected {ids - expected}, missing {expected - ids}"
+        )
+        # GPN-Star / Evo 2 have no QTL data — must not appear.
+        families = {m.family for m in models_for_dataset(dataset)}
+        assert families == {"marin_dna", "conservation", "alphagenome"}
+
+
 def test_every_family_has_at_least_one_method():
     methods = load_models()
     families_present = {m.family for m in methods}


### PR DESCRIPTION
## Summary

Surfaces the DART-Eval Task-5 **caQTL** and **dsQTL** evals on the leaderboard. The global eval path landed in #217 and the metrics are already on S3, so this is the dashboard wiring. Two new pages (`/leaderboards/caqtl`, `/leaderboards/dsqtl`) rank the **7 methods that have QTL data**: `exp136-proj_v30`, the 5 conservation tracks, and AlphaGenome. GPN-Star / Evo 2 have no QTL data and are excluded.

![caQTL leaderboard](https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/d106e165ec51e049081b88863a381f281b6f95c6/pr-caqtl.png)

<details><summary>dsQTL page (same layout, scale adapts — AlphaGenome AUPRC 0.395)</summary>

![dsQTL leaderboard](https://gist.githubusercontent.com/gonzalobenegas/3649e68fb63ca1f3443e4486078eb4d8/raw/d106e165ec51e049081b88863a381f281b6f95c6/pr-dsqtl.png)

</details>

## Why it isn't just config

QTL has no consequence subsets — the metrics are **global AUPRC** (the DART-Eval ranking metric) plus **Pearson/Spearman** of the score vs `effect_size` over positives only. The parquet is keyed by `metric × score_type` with no `subset`/`n_groups`, so the matched-pair aggregation (and the consequence-subset heatmap, whose color scale is pinned to the 1:9 baseline of 0.10) can't represent it.

- **`leaderboard.py`**: a `QTL_DATASETS` set + an early-return branch in `fetch_method_metrics` maps the QTL schema into the long-form rows (`subset` carries the metric name). The matched-pair path is untouched. marin_dna gets explicit QTL protocol keys; conservation/alphagenome auto-extend.
- **`qtl.js`** (new): a dedicated single-metric **table + forest plot** with a **metric selector** (AUPRC / Pearson / Spearman). The color scale and forest axis are **data-driven per metric/dataset**, so e.g. dsQTL's AlphaGenome at 0.395 isn't clamped and the correlation views rescale. Deliberately separate from the matched-pair `heatmap.js` (different column model) per the repo's "duplication over premature abstraction" guidance.
- **MarinDNA defaults to JSD** on these pages — QTL effects are unsigned, and JSD is the stronger/more appropriate protocol here (exp136 lands at 0.102 caQTL / 0.041 dsQTL vs abs-LLR's 0.089 / 0.030). LLR stays one click away via the protocol toggle.

## What appears (default AUPRC)

| method | caQTL | dsQTL |
|---|---|---|
| AlphaGenome | 0.282 | 0.395 |
| exp136-proj_v30 (JSD) | 0.102 | 0.041 |
| conservation (best track) | 0.083 | 0.031 |

Random-baseline AUPRC ≈ 0.077 (caQTL) / 0.021 (dsQTL) — the positive rate, since the variants are unmatched.

## Verification

- `uv run pytest tests/pipelines/evals/` → **295 passed** (5 new QTL aggregation tests across the three families + a `models_for_dataset` guard). Changed files are ruff- and mypy-clean.
- Ran the dashboard data loader against S3: exactly 7 methods, 3 families (`marin_dna`/`conservation`/`alphagenome`), 3 metrics, AlphaGenome leading both datasets.
- Built the site and screenshotted both pages headless — table, colors, forest-dot alignment, the metric selector re-sorting/rescaling, and the JSD default all render with **zero console errors** (screenshots above).

## Note — pre-existing, out of scope

`pre-commit` flags a **pre-existing** mypy error in `src/marin_dna/pipelines/evals/hf_readme.py:486` (reproduces on this branch with the changes stashed; that file is not touched here). Flagged for a separate fix.

Builds on #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
