### PR TITLE
Migrate online lm_eval VEP metric to FWD/RC-avg + AUPRC; pin HF dataset commit

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -15,17 +15,12 @@ top-level README).
 
 ## Launch
 
-Open an IAP tunnel to the iris controller (port-forward, no shell):
+`--cluster=marin` resolves the named cluster config and **auto-establishes the
+controller tunnel** (SSH-through-IAP) — no manual port-forward needed. Just make
+sure `gcloud` is authed first (`gcloud auth login`):
 
 ```bash
-gcloud compute start-iap-tunnel iris-controller-marin 10000 \
-  --local-host-port=localhost:10000 --zone=us-central1-a
-```
-
-Then submit:
-
-```bash
-uv run iris --controller-url=http://localhost:10000 --cluster=marin job run \
+uv run iris --cluster=marin job run \
   --no-wait \
   --user gonzalo \
   --job-name <descriptive-name> \
@@ -38,6 +33,17 @@ uv run iris --controller-url=http://localhost:10000 --cluster=marin job run \
   -- python experiments/<your-script>.py
 ```
 
+- **Don't** use `gcloud compute start-iap-tunnel … 10000`: the IAP firewall only
+  allows port 22, so a direct TCP forward to the controller's port 10000 fails
+  with `ERROR: … [4033: 'not authorized']`. `--cluster=marin` handles the tunnel
+  for you. If you genuinely need a persistent manual tunnel (e.g. to reuse one
+  across many invocations), open it via **SSH**-through-IAP and pass
+  `--controller-url`:
+  ```bash
+  gcloud compute ssh iris-controller-marin --zone=us-central1-a \
+    --project=hai-gcp-models --tunnel-through-iap -- -L 10000:localhost:10000 -N
+  # then add: --controller-url=http://localhost:10000
+  ```
 - `--no-wait` returns immediately; follow with `iris job logs <id> -f`.
 - `--cpu 1 --memory 2g` is the right coordinator footprint — `executor_main`
   parents spawn TPU sub-tasks via `remote(...)`; the parent stays CPU-only.

--- a/experiments/parity/exp225_online_auprc_parity.py
+++ b/experiments/parity/exp225_online_auprc_parity.py
@@ -1,0 +1,193 @@
+# Copyright The Marin Authors / MarinDNA Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Online-vs-offline AUPRC parity check for the migrated mendelian VEP task (#225).
+
+Trains a **tiny** Qwen3 (not 1B — we only need a non-degenerate model, fast) for
+**10 steps** on the smallest v3 subset, with the ``mendelian_traits_255`` lm-eval
+task firing in-training. This exercises the *real in-training setting* (the path
+that reported chance in #187), now on FWD/RC-avg + AUPRC. The run:
+
+  * logs ``lm_eval/mendelian_traits_255/<subset>/<fwd|rc|avg>/auprc`` cells to
+    WandB at steps 5 and 10 (online AUPRC), and
+  * saves a reloadable HF checkpoint at ``<output_path>/hf/step-{5,10}/``.
+
+We then run ``snakemake/analysis/evals_v2/`` on the step-10 HF checkpoint (one
+small GPU sky node) and confirm **online AUPRC == offline AUPRC per subset,
+within bootstrap SE**. At 10 steps the model is ~untrained, so both sit near the
+AUPRC baseline (≈0.1 ``_global_`` on the 1:9 dataset) — the test is *agreement
+between the two code paths on the same checkpoint* + that the in-training path
+runs end-to-end and emits AUPRC cells (it would have asserted-crashed under the
+old PA aggregator on the 1:9 dataset).
+
+Tiny model, not 1B: model size is irrelevant to a scoring-path/plumbing parity
+check, and a tiny transformer cuts JIT-compile + step time so we iterate fast.
+The scoring-relevant knobs are kept fixed: ``tokenizer-char-bos`` + 255 bp
+window (256 tokens with BOS), same as the real per-region runs.
+
+Launch from a CPU box with an iris tunnel open (see ``experiments/README.md``):
+
+    uv run iris --cluster=marin job run \\
+        --no-wait --user gonzalo --job-name exp225-auprc-parity \\
+        --cpu 1 --memory 2g --extra marin --region us-east5 \\
+        -e WANDB_API_KEY "$(grep -A2 api.wandb.ai ~/.netrc | grep password | awk '{print $2}')" \\
+        -e HF_HUB_DOWNLOAD_TIMEOUT 120 -e UV_LOCK_TIMEOUT 7200 \\
+        -- python experiments/parity/exp225_online_auprc_parity.py
+"""
+
+import os
+
+import jmp
+from fray.cluster import ResourceConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
+from levanter.main.train_lm import TrainLmConfig
+from levanter.models.qwen import Qwen3Config
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from levanter.utils.mesh import MeshConfig
+from marin.execution import ExecutorStep, executor_main, this_output_path
+from marin.execution.remote import remote
+from marin.processing.tokenize import lm_mixture_data_config
+from marin.training.training import TrainLmOnPodConfig
+
+# Reuse the per-region builders verbatim where we can — these imports double as a
+# sanity check on the per-region module's importability.
+from experiments.per_region.exp187_per_region import (
+    TPU_TYPES,
+    TRAIN_DATASETS,
+    TRAIN_FORMAT,
+    _build_optimizer,
+    _eval_harness_config,
+    _model_seq_len,
+    _run_train_with_marin_dna_imports,
+    _tokenize,
+    _train_remote_env_vars,
+)
+
+EXP_ISSUE = 225
+VERSION = "v0.1"
+
+# Smallest v3 subset → fastest first-time fetch + tokenize, and the tokenize
+# cache is shared with exp187 (same name + format) so this is a cache-hit.
+STRATEGY = "v3_tss_region_and_utr5"
+DATASET = TRAIN_DATASETS[STRATEGY]
+
+# Tiny Qwen3 — geometry chosen for speed, not skill. head_dim = 128 / 2 = 64.
+HIDDEN_DIM = 128
+INTERMEDIATE_DIM = 512
+NUM_LAYERS = 2
+NUM_HEADS = 2
+NUM_KV_HEADS = 2
+
+# Small batch — a tiny model + 10 steps needs no more, and it keeps the step
+# fast. v5p-8 data-parallel shards this fine with allow_nondivisible_batch_size.
+BATCH_SIZE = 256
+
+NUM_TRAIN_STEPS = 10
+# Eval + HF-save at steps 5 and 10. NB: keep these strictly LESS than
+# NUM_TRAIN_STEPS (5 != 10) — exp160 saw HF saves silently never land when
+# ``hf_save_steps == num_train_steps`` (the final-step callback didn't fire);
+# 5 makes step 10 a 2× multiple, which the smoke test verified does save.
+EVAL_AND_SAVE_STEPS = 5
+
+WANDB_PROJECT = "marin"
+RUN_NAME = f"dna-exp{EXP_ISSUE}-online-auprc-parity-tiny-{VERSION}"
+
+
+def _build_tiny_model_config() -> Qwen3Config:
+    return Qwen3Config(
+        hidden_dim=HIDDEN_DIM,
+        intermediate_dim=INTERMEDIATE_DIM,
+        num_layers=NUM_LAYERS,
+        num_heads=NUM_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        max_seq_len=_model_seq_len(),
+        rope=Llama3RotaryEmbeddingsConfig(),
+    )
+
+
+def _build_single_component_mixture():
+    """Just the one training subset — the LL-gap val recipes aren't needed for
+    this parity check, so we skip them (fewer tokenize jobs)."""
+    component = _tokenize(
+        f"marin_dna-zoonomia-v1-{STRATEGY}-char-bos", DATASET, TRAIN_FORMAT
+    )
+    return lm_mixture_data_config(
+        components={STRATEGY: component},
+        weights={STRATEGY: 1.0},
+    )
+
+
+def _build_train_step() -> ExecutorStep:
+    tags = (
+        "dna",
+        "marin_dna",
+        f"exp{EXP_ISSUE}",
+        "parity",
+        "online-auprc",
+        VERSION,
+        f"region={STRATEGY}",
+        "scale=tiny",
+        f"bs={BATCH_SIZE}",
+        f"steps={NUM_TRAIN_STEPS}",
+    )
+
+    inner = TrainLmConfig(
+        data=_build_single_component_mixture(),
+        model=_build_tiny_model_config(),
+        train_seq_len=_model_seq_len(),
+        optimizer=_build_optimizer(),
+        eval_harness=_eval_harness_config(),
+        eval_harness_steps=EVAL_AND_SAVE_STEPS,
+        # hf_save_path is auto-set by marin to ``<output_path>/hf`` since
+        # output_path is set on the pod config; we only override the cadence.
+        hf_save_steps=EVAL_AND_SAVE_STEPS,
+        trainer=TrainerConfig(
+            tracker=WandbConfig(
+                project=WANDB_PROJECT,
+                tags=list(tags),
+                group=f"dna-exp{EXP_ISSUE}-{VERSION}",
+                name=RUN_NAME,
+                replicate_path=this_output_path(),
+            ),
+            mp=jmp.get_policy("p=f32,c=bfloat16"),
+            train_batch_size=BATCH_SIZE,
+            num_train_steps=NUM_TRAIN_STEPS,
+            steps_per_eval=EVAL_AND_SAVE_STEPS,
+            checkpointer=CheckpointerConfig(
+                keep=[dict(every=EVAL_AND_SAVE_STEPS)],
+            ),
+            mesh=MeshConfig(axes={"replica": 1, "data": -1, "model": 1}),
+            allow_nondivisible_batch_size=True,
+        ),
+    )
+    pod_config = TrainLmOnPodConfig(
+        train_config=inner,
+        resources=ResourceConfig.with_tpu(TPU_TYPES, ram="300g"),
+        output_path=this_output_path(),
+    )
+    return ExecutorStep(
+        name=os.path.join("checkpoints", RUN_NAME),
+        fn=remote(
+            _run_train_with_marin_dna_imports,
+            resources=ResourceConfig.with_tpu(TPU_TYPES, ram="300g"),
+            pip_dependency_groups=["marin", "tpu"],
+            env_vars=_train_remote_env_vars(),
+        ),
+        config=pod_config,
+    )
+
+
+def main() -> None:
+    executor_main(
+        steps=[_build_train_step()],
+        description=(
+            f"DNA MarinDNA exp{EXP_ISSUE} — tiny 10-step online-vs-offline AUPRC "
+            f"parity check on {STRATEGY} {VERSION}"
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/parity/issue225_online_auprc_parity.py
+++ b/experiments/parity/issue225_online_auprc_parity.py
@@ -28,11 +28,11 @@ window (256 tokens with BOS), same as the real per-region runs.
 Launch from a CPU box with an iris tunnel open (see ``experiments/README.md``):
 
     uv run iris --cluster=marin job run \\
-        --no-wait --user gonzalo --job-name exp225-auprc-parity \\
+        --no-wait --user gonzalo --job-name issue225-auprc-parity \\
         --cpu 1 --memory 2g --extra marin --region us-east5 \\
         -e WANDB_API_KEY "$(grep -A2 api.wandb.ai ~/.netrc | grep password | awk '{print $2}')" \\
         -e HF_HUB_DOWNLOAD_TIMEOUT 120 -e UV_LOCK_TIMEOUT 7200 \\
-        -- python experiments/parity/exp225_online_auprc_parity.py
+        -- python experiments/parity/issue225_online_auprc_parity.py
 """
 
 import os

--- a/experiments/per_region/exp187_per_region.py
+++ b/experiments/per_region/exp187_per_region.py
@@ -15,9 +15,10 @@ In-training validation:
   * 5 region-specific ``zoonomia-v1-val_*`` recipes (LL gap) from PR #171,
     each tokenized functional + nonfunctional. Drops ``val_utr5`` / ``val_promoter``
     in favor of the gene-centric ``val_tss_pc``.
-  * ``mendelian_traits_255`` lm-eval task (PR #186) — PairwiseAccuracy per
-    consequence subset + Global + Macro Avg + FWD/RC strand averaging. The
-    leaderboard headline is ``_macro_avg_/avg/pairwise_accuracy`` (per #161).
+  * ``mendelian_traits_255`` lm-eval task (PR #186) — per consequence subset +
+    Global + Macro Avg + FWD/RC strand averaging. The metric migrated to AUPRC +
+    cluster-bootstrap SE in #225 (was PairwiseAccuracy when this arm first ran);
+    the leaderboard headline is ``_macro_avg_/avg/auprc`` (per #161).
 
 HF checkpoint saving is enabled by setting ``hf_save_steps`` to match the
 eval cadence (every 500 steps). ``hf_save_path`` is auto-set by marin's
@@ -78,7 +79,7 @@ from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 from levanter.utils.mesh import MeshConfig
 from marin.evaluation.evaluation_config import convert_to_levanter_task_config
-from marin.execution.executor import (
+from marin.execution import (
     ExecutorStep,
     ensure_versioned,
     executor_main,
@@ -321,8 +322,8 @@ def _build_optimizer() -> AdamConfig:
 
 
 def _eval_harness_config() -> LmEvalHarnessConfig:
-    """Wire the post-#186 mendelian eval (PairwiseAccuracy + Global + Macro Avg
-    + FWD/RC strand averaging). Same shape as exp179_eval_only.py."""
+    """Wire the mendelian eval (AUPRC + Global + Macro Avg + FWD/RC strand
+    averaging; metric migrated from PA in #225). Same shape as exp179_eval_only.py."""
     return LmEvalHarnessConfig(
         task_spec=convert_to_levanter_task_config([MENDELIAN_TRAITS_255]),
     )

--- a/experiments/smoke_tests/smoke_per_region.py
+++ b/experiments/smoke_tests/smoke_per_region.py
@@ -13,8 +13,8 @@ What it validates:
     + the 5 ``zoonomia-v1-val_*`` recipes.
   * Train loop runs end-to-end on v5p-8.
   * ``MENDELIAN_TRAITS_255`` lm-eval task fires at step 25 + 50, emits
-    ``_macro_avg_/avg/pairwise_accuracy``, ``_global_/avg/pairwise_accuracy``,
-    and per-subset cells under ``lm_eval/mendelian_traits_255/…`` in WandB.
+    ``_macro_avg_/avg/auprc``, ``_global_/avg/auprc``, and per-subset cells
+    under ``lm_eval/mendelian_traits_255/…`` in WandB (AUPRC since #225).
   * The 5 LL-gap traces appear in WandB.
   * HF checkpoint lands at ``<output_path>/hf/step-25/`` and ``step-50/`` with
     ``config.json`` + ``model.safetensors`` + ``tokenizer.json``. Sanity-load
@@ -47,7 +47,7 @@ from levanter.main.train_lm import TrainLmConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 from levanter.utils.mesh import MeshConfig
-from marin.execution.executor import ExecutorStep, executor_main, this_output_path
+from marin.execution import ExecutorStep, executor_main, this_output_path
 from marin.execution.remote import remote
 from marin.training.training import TrainLmOnPodConfig
 

--- a/snakemake/evals/README.md
+++ b/snakemake/evals/README.md
@@ -313,7 +313,8 @@ and emit **two output rows per input variant** — one per strand:
 | `target` | Binary label (renamed from `label`; identical across the two strand rows). |
 
 Two-row layout exists so the online lm_eval VEP scorer (`marin_dna.pipelines.evals.lm_eval.dna_vep_llr_eval`)
-averages per-strand LLRs per variant before computing PairwiseAccuracy — the
+averages each variant's raw LLR across the two strands before computing AUPRC
+(migrated from PairwiseAccuracy in #225) — the
 FWD+RC averaging documented as #175 conclusion 2 (mirrors `snakemake/analysis/evals_v2/`'s
 `inference.rc_avg=true`). Rows are sorted by `(chrom, pos, ref, alt, strand)`
 so per-variant strand pairs are adjacent.

--- a/src/marin_dna/pipelines/evals/lm_eval/dna_vep_llr_eval.py
+++ b/src/marin_dna/pipelines/evals/lm_eval/dna_vep_llr_eval.py
@@ -38,9 +38,11 @@ _logger = logging.getLogger(__name__)
 # qualify for the ``_macro_avg_`` average.
 _MIN_GROUPS_PER_SUBSET = 30
 
-# Mirror `snakemake/analysis/evals_v2/config/config.yaml` so the online AUPRC SE
-# is computed with the same cluster-bootstrap iteration count and seed as the
-# offline parquet — making the two directly comparable on identical scores.
+# Mirror `snakemake/analysis/evals_v2/config/config.yaml` (`inference.n_bootstrap`
+# / `inference.bootstrap_seed`) so the online AUPRC SE matches the offline parquet
+# on identical scores. These also equal `compute_auprc_metrics`' own defaults;
+# there's no shared source of truth linking the three, so keep them in sync if
+# that config's bootstrap knobs are ever changed.
 _N_BOOTSTRAP = 1000
 _BOOTSTRAP_SEED = 0
 
@@ -185,6 +187,12 @@ class _AuprcAggregation:
             rng=_BOOTSTRAP_SEED,
             n_min=_MIN_GROUPS_PER_SUBSET,
         )
+        # Two distinct n_min gates (intentional, not redundant): the `n_min` arg
+        # to compute_auprc_metrics gates which subsets enter `_macro_avg_`; this
+        # loop gate decides which per-subset cells get pushed to the tracker —
+        # WandB has no display-time threshold, so we drop tiny subsets here
+        # (offline keeps every per-subset row in the parquet and filters at the
+        # dashboard). `_global_` / `_macro_avg_` are always pushed.
         for row in metrics.to_dict("records"):
             subset_name = row["subset"]
             n_groups = int(row["n_groups"])
@@ -249,8 +257,12 @@ METRIC_REGISTRY: dict[str, dict] = {
 # Applied to the per-variant **averaged raw LLR** (and to each per-strand raw
 # LLR) inside ``_collapse_variants`` — i.e. after averaging, matching the
 # offline ``evals_v2`` ``{protocol}_avg`` semantics where
-# ``abs_llr_avg = |(llr_fwd + llr_rc)/2|``. ``negate`` is the ``minus_llr``
-# protocol used for the mendelian dataset.
+# ``abs_llr_avg = |(llr_fwd + llr_rc)/2|``. These mirror
+# ``marin_dna.pipelines.evals.metrics.SCORE_PROTOCOLS`` (``negate`` ≡ ``minus_llr``,
+# ``abs`` ≡ ``abs_llr``; ``identity`` is online-only) — if a protocol is
+# added/changed there for the offline leaderboard, mirror it here or the
+# in-training metric silently diverges from the parquet. (``negate`` =
+# ``minus_llr`` is the protocol used for the mendelian dataset.)
 LLR_TRANSFORMS: dict[str, Callable[[float], float]] = {
     "identity": lambda x: x,
     "negate": lambda x: -x,

--- a/src/marin_dna/pipelines/evals/lm_eval/dna_vep_llr_eval.py
+++ b/src/marin_dna/pipelines/evals/lm_eval/dna_vep_llr_eval.py
@@ -7,12 +7,15 @@ For each (variant, strand) row we compute the raw ``LLR = log P(alt|ctx) -
 log P(ref|ctx)``. Rows are grouped per variant; the raw LLR is averaged across
 the FWD/RC strand rows and *then* transformed (``score = llr_transform(mean
 LLR)`` — averaging raw LLR before the transform, matching the offline
-``evals_v2`` ``{protocol}_avg`` semantics). AUPRC + cluster-bootstrap SE is then
-computed per strand and per subset via
-:func:`marin_dna.pipelines.evals.metrics.compute_auprc_metrics` — the same
-helper offline ``snakemake/analysis/evals_v2/`` calls, with the same
-``n_bootstrap`` and seed so the SE matches the offline parquet on identical
-scores. The lm-eval headline scalar is ``_global_/avg/auprc``.
+``evals_v2`` ``{protocol}_avg`` semantics). The **point** AUPRC is then computed
+per strand and per subset via
+:func:`marin_dna.pipelines.evals.metrics.compute_auprc_metrics` (called with
+``n_bootstrap=0``) — the same helper offline ``snakemake/analysis/evals_v2/``
+calls, so the point values match the offline parquet. The cluster-bootstrap SE
+is **not** computed here: this in-training metric tracks the AUPRC trend, and the
+authoritative SE lives in the offline ``evals_v2`` leaderboard (skipping the
+per-eval-step bootstrap keeps the eval cheap). The lm-eval headline scalar is
+``_global_/avg/auprc``.
 """
 
 import logging
@@ -37,14 +40,6 @@ _logger = logging.getLogger(__name__)
 # ``match_group``s a subset needs for its per-subset cell to be reported and to
 # qualify for the ``_macro_avg_`` average.
 _MIN_GROUPS_PER_SUBSET = 30
-
-# Mirror `snakemake/analysis/evals_v2/config/config.yaml` (`inference.n_bootstrap`
-# / `inference.bootstrap_seed`) so the online AUPRC SE matches the offline parquet
-# on identical scores. These also equal `compute_auprc_metrics`' own defaults;
-# there's no shared source of truth linking the three, so keep them in sync if
-# that config's bootstrap knobs are ever changed.
-_N_BOOTSTRAP = 1000
-_BOOTSTRAP_SEED = 0
 
 # Strand → wandb key segment. "+"/"-" would render as math operators in the
 # Workspace search bar; slashes group the panel.
@@ -150,8 +145,9 @@ class _AuprcAggregation:
 
     For each variant: average raw LLR across the strand rows (FWD + RC) then
     transform to ``score_avg``; for 2-strand datasets also emit ``score_fwd`` /
-    ``score_rc``. AUPRC + cluster-bootstrap SE is then computed per subset via
-    :func:`compute_auprc_metrics`. Per-subset rows with ``n_groups`` <
+    ``score_rc``. Point AUPRC is then computed per subset via
+    :func:`compute_auprc_metrics` (``n_bootstrap=0``; no SE — the offline
+    ``evals_v2`` parquet is the authoritative SE source). Per-subset rows with ``n_groups`` <
     :data:`_MIN_GROUPS_PER_SUBSET` are dropped from the tracker push; ``_global_``
     and ``_macro_avg_`` are always emitted. The headline scalar returned to
     lm-eval is the ``_global_`` / ``score_avg`` AUPRC.
@@ -179,12 +175,16 @@ class _AuprcAggregation:
 
         df, score_columns = _collapse_variants(items, self.llr_transform)
 
+        # n_bootstrap=0 → point AUPRC only (no SE): the in-training metric tracks
+        # the AUPRC trend; the cluster-bootstrap SE is computed offline in
+        # evals_v2 (the authoritative leaderboard). Skipping the per-eval-step
+        # bootstrap keeps this eval cheap. The point values still match the
+        # offline parquet (validated in #225).
         metrics = compute_auprc_metrics(
             dataset=df[["label", "subset", "match_group"]],
             scores=df[score_columns],
             score_columns=score_columns,
-            n_bootstrap=_N_BOOTSTRAP,
-            rng=_BOOTSTRAP_SEED,
+            n_bootstrap=0,
             n_min=_MIN_GROUPS_PER_SUBSET,
         )
         # Two distinct n_min gates (intentional, not redundant): the `n_min` arg
@@ -204,7 +204,11 @@ class _AuprcAggregation:
             strand_tag = row["score_type"].removeprefix("score_")
             key = f"{subset_name}/{strand_tag}/{self.metric_name}"
             self.results_store[key] = float(row["value"])
-            self.results_store[f"{key}_se"] = float(row["se"])
+            # Point-only online (se is NaN); push _se only if a finite SE exists,
+            # so this still works if a caller ever re-enables the bootstrap.
+            se = float(row["se"])
+            if pd.notna(se):
+                self.results_store[f"{key}_se"] = se
 
         # lm-eval only propagates the scalar return to wandb; the per-subset
         # cells we computed above only surface if we push them ourselves.

--- a/src/marin_dna/pipelines/evals/lm_eval/dna_vep_llr_eval.py
+++ b/src/marin_dna/pipelines/evals/lm_eval/dna_vep_llr_eval.py
@@ -3,12 +3,16 @@
 
 """LLR-based variant effect prediction (VEP) task for lm-eval-harness.
 
-For each row we compute ``LLR = log P(alt|ctx) - log P(ref|ctx)`` and then
-``score = llr_transform(LLR)``. Rows are grouped per variant into FWD / RC /
-AVG scores; PairwiseAccuracy ± SE is computed per strand and per subset via
-:func:`marin_dna.pipelines.evals.metrics.compute_pairwise_metrics` — the same
-helper offline ``snakemake/analysis/evals_v2/`` calls. The lm-eval headline
-scalar is ``_global_/avg/pairwise_accuracy``.
+For each (variant, strand) row we compute the raw ``LLR = log P(alt|ctx) -
+log P(ref|ctx)``. Rows are grouped per variant; the raw LLR is averaged across
+the FWD/RC strand rows and *then* transformed (``score = llr_transform(mean
+LLR)`` — averaging raw LLR before the transform, matching the offline
+``evals_v2`` ``{protocol}_avg`` semantics). AUPRC + cluster-bootstrap SE is then
+computed per strand and per subset via
+:func:`marin_dna.pipelines.evals.metrics.compute_auprc_metrics` — the same
+helper offline ``snakemake/analysis/evals_v2/`` calls, with the same
+``n_bootstrap`` and seed so the SE matches the offline parquet on identical
+scores. The lm-eval headline scalar is ``_global_/avg/auprc``.
 """
 
 import logging
@@ -23,14 +27,22 @@ from lm_eval.api.task import Task
 from marin_dna.pipelines.evals.metrics import (
     GLOBAL_SUBSET,
     MACRO_AVG_SUBSET,
-    compute_pairwise_metrics,
+    compute_auprc_metrics,
 )
 
 _logger = logging.getLogger(__name__)
 
-# Match `compute_pairwise_metrics`' default `n_min` and the matched-pair
-# leaderboards' convention (#161/#162/#172).
-_MIN_PAIRS_PER_SUBSET = 30
+# Match `compute_auprc_metrics`' default `n_min` and the matched-pair
+# leaderboards' convention (#161/#162/#172): the minimum number of
+# ``match_group``s a subset needs for its per-subset cell to be reported and to
+# qualify for the ``_macro_avg_`` average.
+_MIN_GROUPS_PER_SUBSET = 30
+
+# Mirror `snakemake/analysis/evals_v2/config/config.yaml` so the online AUPRC SE
+# is computed with the same cluster-bootstrap iteration count and seed as the
+# offline parquet — making the two directly comparable on identical scores.
+_N_BOOTSTRAP = 1000
+_BOOTSTRAP_SEED = 0
 
 # Strand → wandb key segment. "+"/"-" would render as math operators in the
 # Workspace search bar; slashes group the panel.
@@ -38,21 +50,121 @@ _STRAND_TAGS = {"+": "fwd", "-": "rc"}
 _AVG_TAG = "avg"
 
 
-class _PairwiseAccuracyAggregation:
-    """Group per-row LLR scores by variant, compute per-subset PA per strand.
+def _collapse_variants(
+    items: list[tuple[float, float, str | None, tuple, int, str]],
+    llr_transform: Callable[[float], float],
+) -> tuple[pd.DataFrame, list[str]]:
+    """Collapse per-(variant, strand) raw-LLR rows into one row per variant.
 
-    For each variant: emit ``score_avg`` (mean of the per-strand scores; equals
-    the single-strand value if only one strand row was present), plus
-    ``score_fwd`` / ``score_rc`` for 2-strand datasets. Per-subset rows with
-    ``n_pairs`` < :data:`_MIN_PAIRS_PER_SUBSET` are dropped; ``_global_`` and
-    ``_macro_avg_`` are always emitted.
+    Each item is ``(llr, target, subset, variant_id, match_group, strand)`` with
+    the **raw** LLR (no transform applied yet). For each variant we average the
+    raw LLR across its strand rows and *then* apply ``llr_transform`` — matching
+    the offline ``evals_v2`` ``{protocol}_avg`` semantics (average raw LLR first,
+    then transform; so ``abs_llr_avg = |(llr_fwd + llr_rc)/2|``). For 2-strand
+    datasets we also emit per-strand ``score_fwd`` / ``score_rc``, each the
+    transform of that strand's raw LLR.
+
+    All the per-variant consistency invariants are asserted here (fail loud near
+    the bug rather than feeding a silently-wrong frame into the metric).
+
+    Returns ``(df, score_columns)`` where ``df`` has columns
+    ``[label, subset, match_group] + score_columns`` and ``score_columns`` is
+    ``["score_fwd", "score_rc", "score_avg"]`` for 2-strand datasets, or just
+    ``["score_avg"]`` for 1-strand datasets (where avg == the single strand).
+    """
+    by_variant: dict[tuple, dict] = defaultdict(dict)
+    meta_by_variant: dict[tuple, dict] = {}
+    for llr, target, subset, variant_id, match_group, strand in items:
+        assert strand in _STRAND_TAGS, (
+            f"variant {variant_id} has unknown strand={strand!r}; "
+            f"expected one of {sorted(_STRAND_TAGS)}"
+        )
+        v = by_variant[variant_id]
+        assert strand not in v, (
+            f"variant {variant_id} has duplicate strand={strand!r} rows"
+        )
+        v[strand] = float(llr)
+        m = meta_by_variant.get(variant_id)
+        if m is None:
+            meta_by_variant[variant_id] = {
+                "target": target,
+                "subset": subset,
+                "match_group": match_group,
+            }
+        else:
+            assert (m["target"], m["subset"], m["match_group"]) == (
+                target,
+                subset,
+                match_group,
+            ), (
+                f"variant {variant_id} has inconsistent meta: "
+                f"{m} vs target={target}, subset={subset}, match_group={match_group}"
+            )
+
+    # Strand set must be uniform across variants — a mixed dataset would
+    # silently make `score_avg` mean different things across rows.
+    expected_strands: set[str] | None = None
+    for variant_id, v in by_variant.items():
+        strands = frozenset(v)
+        if expected_strands is None:
+            expected_strands = set(strands)
+        assert strands == expected_strands, (
+            f"variant {variant_id} has strands={sorted(strands)}; "
+            f"expected {sorted(expected_strands)}"
+        )
+    assert expected_strands, "no items to aggregate"
+    emit_per_strand = len(expected_strands) > 1
+
+    rows: list[dict] = []
+    for variant_id, v in by_variant.items():
+        meta = meta_by_variant[variant_id]
+        strand_llrs = [v[s] for s in expected_strands]
+        # Average RAW LLR across strands, then transform (offline `_avg` order).
+        llr_avg = sum(strand_llrs) / len(strand_llrs)
+        row = {
+            "label": int(meta["target"]),
+            "subset": str(meta["subset"]),
+            "match_group": int(meta["match_group"]),
+            f"score_{_AVG_TAG}": float(llr_transform(llr_avg)),
+        }
+        if emit_per_strand:
+            for s in expected_strands:
+                row[f"score_{_STRAND_TAGS[s]}"] = float(llr_transform(v[s]))
+        rows.append(row)
+
+    df = pd.DataFrame(rows)
+    # fwd, rc, avg ordering — matches how dashboards typically list them.
+    per_strand_cols = (
+        [f"score_{_STRAND_TAGS[s]}" for s in _STRAND_TAGS if s in expected_strands]
+        if emit_per_strand
+        else []
+    )
+    score_columns = per_strand_cols + [f"score_{_AVG_TAG}"]
+    return df, score_columns
+
+
+class _AuprcAggregation:
+    """Group per-row raw LLR by variant, compute per-subset AUPRC per strand.
+
+    For each variant: average raw LLR across the strand rows (FWD + RC) then
+    transform to ``score_avg``; for 2-strand datasets also emit ``score_fwd`` /
+    ``score_rc``. AUPRC + cluster-bootstrap SE is then computed per subset via
+    :func:`compute_auprc_metrics`. Per-subset rows with ``n_groups`` <
+    :data:`_MIN_GROUPS_PER_SUBSET` are dropped from the tracker push; ``_global_``
+    and ``_macro_avg_`` are always emitted. The headline scalar returned to
+    lm-eval is the ``_global_`` / ``score_avg`` AUPRC.
     """
 
     def __init__(
-        self, results_store: dict, metric_name: str, task_name: str | None = None
+        self,
+        results_store: dict,
+        metric_name: str,
+        llr_transform: Callable[[float], float],
+        task_name: str | None = None,
     ):
         self.results_store = results_store
         self.metric_name = metric_name
+        self.llr_transform = llr_transform
         self.task_name = task_name
 
     def __call__(
@@ -63,85 +175,22 @@ class _PairwiseAccuracyAggregation:
         # same Task instance) doesn't leak prior keys into the tracker push.
         self.results_store.clear()
 
-        by_variant: dict[tuple, dict] = defaultdict(dict)
-        meta_by_variant: dict[tuple, dict] = {}
-        expected_strands: set[str] | None = None
-        for score, target, subset, variant_id, match_group, strand in items:
-            assert strand in _STRAND_TAGS, (
-                f"variant {variant_id} has unknown strand={strand!r}; "
-                f"expected one of {sorted(_STRAND_TAGS)}"
-            )
-            v = by_variant[variant_id]
-            assert strand not in v, (
-                f"variant {variant_id} has duplicate strand={strand!r} rows"
-            )
-            v[strand] = float(score)
-            m = meta_by_variant.get(variant_id)
-            if m is None:
-                meta_by_variant[variant_id] = {
-                    "target": target,
-                    "subset": subset,
-                    "match_group": match_group,
-                }
-            else:
-                assert (m["target"], m["subset"], m["match_group"]) == (
-                    target,
-                    subset,
-                    match_group,
-                ), (
-                    f"variant {variant_id} has inconsistent meta: "
-                    f"{m} vs target={target}, subset={subset}, match_group={match_group}"
-                )
+        df, score_columns = _collapse_variants(items, self.llr_transform)
 
-        # Strand set must be uniform across variants — a mixed dataset would
-        # silently make `score_avg` mean different things across rows.
-        for variant_id, v in by_variant.items():
-            strands = frozenset(v)
-            if expected_strands is None:
-                expected_strands = set(strands)
-            assert strands == expected_strands, (
-                f"variant {variant_id} has strands={sorted(strands)}; "
-                f"expected {sorted(expected_strands)}"
-            )
-        assert expected_strands, "no items to aggregate"
-        emit_per_strand = len(expected_strands) > 1
-
-        rows: list[dict] = []
-        for variant_id, v in by_variant.items():
-            meta = meta_by_variant[variant_id]
-            strand_scores = [v[s] for s in expected_strands]
-            row = {
-                "label": int(meta["target"]),
-                "subset": str(meta["subset"]),
-                "match_group": int(meta["match_group"]),
-                f"score_{_AVG_TAG}": sum(strand_scores) / len(strand_scores),
-            }
-            if emit_per_strand:
-                for s in expected_strands:
-                    row[f"score_{_STRAND_TAGS[s]}"] = v[s]
-            rows.append(row)
-
-        df = pd.DataFrame(rows)
-        # fwd, rc, avg ordering — matches how dashboards typically list them.
-        per_strand_cols = (
-            [f"score_{_STRAND_TAGS[s]}" for s in _STRAND_TAGS if s in expected_strands]
-            if emit_per_strand
-            else []
-        )
-        score_columns = per_strand_cols + [f"score_{_AVG_TAG}"]
-
-        metrics = compute_pairwise_metrics(
+        metrics = compute_auprc_metrics(
             dataset=df[["label", "subset", "match_group"]],
             scores=df[score_columns],
             score_columns=score_columns,
-            n_min=_MIN_PAIRS_PER_SUBSET,
+            n_bootstrap=_N_BOOTSTRAP,
+            rng=_BOOTSTRAP_SEED,
+            n_min=_MIN_GROUPS_PER_SUBSET,
         )
         for row in metrics.to_dict("records"):
             subset_name = row["subset"]
-            n_pairs = int(row["n_pairs"])
+            n_groups = int(row["n_groups"])
             if (
                 subset_name not in (GLOBAL_SUBSET, MACRO_AVG_SUBSET)
-                and n_pairs < _MIN_PAIRS_PER_SUBSET
+                and n_groups < _MIN_GROUPS_PER_SUBSET
             ):
                 continue
             strand_tag = row["score_type"].removeprefix("score_")
@@ -158,7 +207,7 @@ class _PairwiseAccuracyAggregation:
             & (metrics["score_type"] == f"score_{_AVG_TAG}")
         ]
         assert not global_avg.empty, (
-            "compute_pairwise_metrics did not emit a _global_ row for score_avg"
+            "compute_auprc_metrics did not emit a _global_ row for score_avg"
         )
         return float(global_avg["value"].iloc[0])
 
@@ -190,17 +239,18 @@ class _PairwiseAccuracyAggregation:
 
 
 METRIC_REGISTRY: dict[str, dict] = {
-    "pairwise_accuracy": {
-        "aggregation_cls": _PairwiseAccuracyAggregation,
+    "auprc": {
+        "aggregation_cls": _AuprcAggregation,
         "higher_is_better": True,
     },
 }
 
 
-# The aggregation averages transformed scores per variant, not raw LLR. For
-# transforms that commute with averaging (``identity``, ``negate``) this is
-# equivalent to averaging LLR and then transforming — matching the offline
-# ``marin_dna.model.runner`` path. ``abs`` does not commute and will diverge.
+# Applied to the per-variant **averaged raw LLR** (and to each per-strand raw
+# LLR) inside ``_collapse_variants`` — i.e. after averaging, matching the
+# offline ``evals_v2`` ``{protocol}_avg`` semantics where
+# ``abs_llr_avg = |(llr_fwd + llr_rc)/2|``. ``negate`` is the ``minus_llr``
+# protocol used for the mendelian dataset.
 LLR_TRANSFORMS: dict[str, Callable[[float], float]] = {
     "identity": lambda x: x,
     "negate": lambda x: -x,
@@ -225,6 +275,9 @@ class DnaVepLlrEvalTask(Task):
     YAML config fields:
         dataset_path: HuggingFace dataset path
         dataset_name: HuggingFace dataset config name (optional)
+        dataset_revision: HuggingFace dataset commit/revision to pin (optional
+            but recommended — keeps the dataset from silently changing under
+            the eval)
         test_split: dataset split to evaluate on
         metrics: list of metric names from ``METRIC_REGISTRY``
         llr_transform: identity | negate | abs (default: identity)
@@ -233,6 +286,7 @@ class DnaVepLlrEvalTask(Task):
     VERSION = 1
     DATASET_PATH = None
     DATASET_NAME = None
+    DATASET_REVISION = None
 
     def __init__(
         self, data_dir=None, cache_dir=None, download_mode=None, config=None
@@ -244,7 +298,8 @@ class DnaVepLlrEvalTask(Task):
         self._task_name = cfg.get("task")
         self.DATASET_PATH = cfg.get("dataset_path") or self.DATASET_PATH
         self.DATASET_NAME = cfg.get("dataset_name") or self.DATASET_NAME
-        self._metrics = cfg.get("metrics") or ["pairwise_accuracy"]
+        self.DATASET_REVISION = cfg.get("dataset_revision") or self.DATASET_REVISION
+        self._metrics = cfg.get("metrics") or ["auprc"]
         self._test_split = cfg.get("test_split") or "test"
         unknown = [m for m in self._metrics if m not in METRIC_REGISTRY]
         if unknown:
@@ -277,6 +332,7 @@ class DnaVepLlrEvalTask(Task):
         self.dataset = datasets.load_dataset(
             path=self.DATASET_PATH,
             name=self.DATASET_NAME,
+            revision=self.DATASET_REVISION,
             data_dir=data_dir,
             cache_dir=cache_dir,
             download_mode=download_mode,
@@ -326,8 +382,11 @@ class DnaVepLlrEvalTask(Task):
     def process_results(self, doc, results):
         log_prob_ref = results[0][0]
         log_prob_alt = results[1][0]
+        # Emit the **raw** LLR; `_collapse_variants` averages raw LLR across
+        # FWD/RC per variant and applies `llr_transform` afterwards (matching
+        # offline `{protocol}_avg`). Transforming here would only be equivalent
+        # for transforms that commute with averaging (`negate`), not `abs`.
         llr = log_prob_alt - log_prob_ref
-        score = self._llr_transform(llr)
         # Defensive casts: HF can return numpy scalars in dataset rows; the
         # variant_id tuple must be hashable for per-variant collapse.
         variant_id = (
@@ -340,7 +399,7 @@ class DnaVepLlrEvalTask(Task):
         strand = str(doc.get("strand", "+"))
         return {
             metric: (
-                score,
+                llr,
                 doc["target"],
                 doc.get("subset"),
                 variant_id,
@@ -355,6 +414,7 @@ class DnaVepLlrEvalTask(Task):
             metric: METRIC_REGISTRY[metric]["aggregation_cls"](
                 results_store=self._subset_results,
                 metric_name=metric,
+                llr_transform=self._llr_transform,
                 task_name=self._task_name,
             )
             for metric in self._metrics

--- a/src/marin_dna/pipelines/evals/lm_eval/mendelian_traits_255.yaml
+++ b/src/marin_dna/pipelines/evals/lm_eval/mendelian_traits_255.yaml
@@ -13,10 +13,12 @@ dataset_revision: 7b92f047f9a36f90e9ac47886afa2a99264ee35c
 # "train" encompasses both training and validation variants in the original dataset.
 test_split: train
 llr_transform: negate
-# AUPRC ± cluster-bootstrap SE — same metric (and same n_bootstrap/seed) as
-# snakemake/analysis/evals_v2/, so the online number is directly comparable to
-# the offline parquet. Per-variant raw LLR is averaged across the two strand-
-# tagged rows (FWD + RC) and then transformed before AUPRC (see
-# dna_vep_llr_eval._collapse_variants / _AuprcAggregation).
+# AUPRC (point estimate) — same metric as snakemake/analysis/evals_v2/, computed
+# on the same variants, so the online point values are directly comparable to the
+# offline parquet. The cluster-bootstrap SE is computed offline there; this
+# in-training metric tracks the AUPRC trend (no per-eval-step bootstrap). Per-
+# variant raw LLR is averaged across the two strand-tagged rows (FWD + RC) and
+# then transformed before AUPRC (see dna_vep_llr_eval._collapse_variants /
+# _AuprcAggregation).
 metrics:
   - auprc

--- a/src/marin_dna/pipelines/evals/lm_eval/mendelian_traits_255.yaml
+++ b/src/marin_dna/pipelines/evals/lm_eval/mendelian_traits_255.yaml
@@ -2,11 +2,17 @@ task: mendelian_traits_255
 class: !function dna_vep_llr_eval.DnaVepLlrEvalTask
 dataset_path: bolinas-dna/evals_mendelian_traits_harness_255
 dataset_name: default
+# Pin the HF dataset commit so the eval is reproducible and the dataset can't
+# silently change under it (it did: 1:1 → 1:9 re-upload on 2026-05-19, #194).
+# Bump this deliberately when the harness dataset is intentionally updated.
+dataset_revision: 7b92f047f9a36f90e9ac47886afa2a99264ee35c
 # "train" encompasses both training and validation variants in the original dataset.
 test_split: train
 llr_transform: negate
-# PairwiseAccuracy ± SE — same metric as snakemake/analysis/evals_v2/. Per-variant
-# scores are averaged across the two strand-tagged rows (FWD + RC) before the
-# metric is computed (see dna_vep_llr_eval._PairwiseAccuracyAggregation).
+# AUPRC ± cluster-bootstrap SE — same metric (and same n_bootstrap/seed) as
+# snakemake/analysis/evals_v2/, so the online number is directly comparable to
+# the offline parquet. Per-variant raw LLR is averaged across the two strand-
+# tagged rows (FWD + RC) and then transformed before AUPRC (see
+# dna_vep_llr_eval._collapse_variants / _AuprcAggregation).
 metrics:
-  - pairwise_accuracy
+  - auprc

--- a/src/marin_dna/pipelines/evals/lm_eval/mendelian_traits_255.yaml
+++ b/src/marin_dna/pipelines/evals/lm_eval/mendelian_traits_255.yaml
@@ -4,7 +4,11 @@ dataset_path: bolinas-dna/evals_mendelian_traits_harness_255
 dataset_name: default
 # Pin the HF dataset commit so the eval is reproducible and the dataset can't
 # silently change under it (it did: 1:1 → 1:9 re-upload on 2026-05-19, #194).
-# Bump this deliberately when the harness dataset is intentionally updated.
+# This harness repo is the sequence-materialized view of the matched-pair source
+# bolinas-dna/evals_mendelian_traits, which offline evals_v2 pins separately
+# (config.yaml `hf_revision: 4aed58e…`, the #194 k=9 rebuild). 7b92f04 is verified
+# k=9 (10 variants / match_group). When the source is rebuilt, re-materialize the
+# harness and bump BOTH pins together or online/offline silently drift apart.
 dataset_revision: 7b92f047f9a36f90e9ac47886afa2a99264ee35c
 # "train" encompasses both training and validation variants in the original dataset.
 test_split: train

--- a/src/marin_dna/pipelines/evals/lm_eval/task_configs.py
+++ b/src/marin_dna/pipelines/evals/lm_eval/task_configs.py
@@ -9,10 +9,13 @@ remain in marin (see ``experiments.evals.task_configs``).
 
 from marin.evaluation.evaluation_config import EvalTaskConfig
 
-# Bumped to version 1 in #179: PairwiseAccuracy + per-variant FWD/RC averaging
-# replaces the old per-row AUPRC. Cached eval results from version 0 are not
-# comparable, and the dataset moves from bolinas-dna/evals-traitgym_mendelian_v2_*
-# to bolinas-dna/evals_mendelian_traits_harness_255 (snakemake/evals/ output).
+# The ``1`` is ``num_fewshot``, not a version field: this VEP task overrides
+# construct_requests and prepends no few-shot context (the #225 online-vs-offline
+# parity — where offline uses no few-shot at all — confirms it's a no-op for
+# scoring). #179 (ab)used it as a cache-busting bump (0 → 1) when it changed the
+# metric + dataset. #225 migrated the online metric to AUPRC + per-variant FWD/RC
+# averaging (was PairwiseAccuracy); the dataset is
+# bolinas-dna/evals_mendelian_traits_harness_255 (snakemake/evals/ output).
 MENDELIAN_TRAITS_255 = EvalTaskConfig(
     "mendelian_traits_255", 1, task_alias="mendelian_traits_255"
 )

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -150,14 +150,16 @@ def auprc_with_bootstrap_se(
         score: numeric score per row. Must not contain NaN — fill
             upstream (same rationale as ``pairwise_accuracy``).
         match_group: integer group id; cluster bootstrap unit.
-        n_bootstrap: number of bootstrap iterations.
+        n_bootstrap: number of bootstrap iterations. ``<= 0`` skips the
+            resample loop and returns ``se=NaN`` (point estimate only) — used on
+            the online in-training hot path, where the SE is computed offline.
         rng: ``numpy.random.Generator``, seed int, or ``None``.
 
     Returns:
         ``{"value", "se", "n_groups", "n_rows"}``. ``value`` is the
         point-estimate AUPRC over all input rows; ``se`` is the std of
         the bootstrap distribution (``ddof=1``, NaN-tolerant for
-        degenerate resamples).
+        degenerate resamples), or ``NaN`` when ``n_bootstrap <= 0``.
     """
     assert len(label) == len(score) == len(match_group), (
         f"length mismatch: label={len(label)} score={len(score)} "
@@ -177,28 +179,35 @@ def auprc_with_bootstrap_se(
 
     point = float(average_precision_score(label_arr, score_arr))
 
-    rng = np.random.default_rng(rng)
     # `groupby(mg_arr).indices` is an O(n) hash-based group → positional-
     # index map. The earlier `[np.where(inv == i)[0] for i in groups]`
     # form was O(n_groups · n_rows) and dominated the non-AP cost when
-    # n_groups was ~10³ within a subset.
+    # n_groups was ~10³ within a subset. Computed even for the point-only
+    # path below — `n_groups` feeds the macro-average n_min gate.
     group_to_rows: list[np.ndarray] = list(
         pd.Series(mg_arr).groupby(mg_arr).indices.values()
     )
     n_groups = len(group_to_rows)
 
-    boot = np.empty(n_bootstrap, dtype=float)
-    for b in range(n_bootstrap):
-        sampled = rng.integers(0, n_groups, size=n_groups)
-        idx = np.concatenate([group_to_rows[i] for i in sampled])
-        y = label_arr[idx]
-        # Rare degenerate resamples may be single-class — AUPRC undefined.
-        s = int(y.sum())
-        if s == 0 or s == len(y):
-            boot[b] = np.nan
-            continue
-        boot[b] = average_precision_score(y, score_arr[idx])
-    se = float(np.nanstd(boot, ddof=1))
+    if n_bootstrap <= 0:
+        # Point estimate only — skip the resample loop. Used on the in-training
+        # lm_eval hot path (online VEP), where a per-eval-step bootstrap is too
+        # slow and the SE is redundant with the offline evals_v2 parquet.
+        se = float("nan")
+    else:
+        rng = np.random.default_rng(rng)
+        boot = np.empty(n_bootstrap, dtype=float)
+        for b in range(n_bootstrap):
+            sampled = rng.integers(0, n_groups, size=n_groups)
+            idx = np.concatenate([group_to_rows[i] for i in sampled])
+            y = label_arr[idx]
+            # Rare degenerate resamples may be single-class — AUPRC undefined.
+            s = int(y.sum())
+            if s == 0 or s == len(y):
+                boot[b] = np.nan
+                continue
+            boot[b] = average_precision_score(y, score_arr[idx])
+        se = float(np.nanstd(boot, ddof=1))
     return {
         "value": point,
         "se": se,

--- a/tests/pipelines/evals/test_dna_vep_llr_eval.py
+++ b/tests/pipelines/evals/test_dna_vep_llr_eval.py
@@ -235,7 +235,6 @@ def test_per_subset_rows_below_n_min_groups_are_dropped():
 
     assert "missense/avg/auprc" in store
     assert "splicing/avg/auprc" not in store
-    assert "splicing/avg/auprc_se" not in store
     assert "_global_/avg/auprc" in store
     assert "_macro_avg_/avg/auprc" in store
 

--- a/tests/pipelines/evals/test_dna_vep_llr_eval.py
+++ b/tests/pipelines/evals/test_dna_vep_llr_eval.py
@@ -4,131 +4,247 @@
 """Tests for the lm_eval task class ``DnaVepLlrEvalTask``.
 
 Pin down the per-strand + AVG aggregation logic — the load-bearing piece for
-#179 parity with the offline batched VEP path. Avoids loading any HF dataset;
-the tests construct synthetic doc dicts and call ``process_results`` /
-``aggregation`` directly.
+parity with the offline ``snakemake/analysis/evals_v2/`` batched VEP path
+(#225: FWD/RC-avg + AUPRC). Avoids loading any HF dataset; the tests construct
+synthetic per-variant rows and call the collapse helper / aggregation directly.
 """
 
 import math
 
+import numpy as np
 import pytest
 
 pytest.importorskip("lm_eval", reason="install with `uv sync --extra marin` to run")
 
 from marin_dna.pipelines.evals.lm_eval.dna_vep_llr_eval import (  # noqa: E402
+    _BOOTSTRAP_SEED,
+    _MIN_GROUPS_PER_SUBSET,
+    _N_BOOTSTRAP,
+    LLR_TRANSFORMS,
     METRIC_REGISTRY,
-    _PairwiseAccuracyAggregation,
+    _AuprcAggregation,
+    _collapse_variants,
 )
+from marin_dna.pipelines.evals.metrics import (  # noqa: E402
+    compute_auprc_metrics,
+)
+
+_NEGATE = LLR_TRANSFORMS["negate"]
+_IDENTITY = LLR_TRANSFORMS["identity"]
 
 
 def _items_from_per_variant(per_variant_rows):
     """Flatten per-variant rows into the
-    (score, target, subset, variant_id, match_group, strand) tuples that
-    ``DnaVepLlrEvalTask.aggregation()`` consumes.
+    (llr, target, subset, variant_id, match_group, strand) tuples that
+    ``DnaVepLlrEvalTask.aggregation()`` consumes. The first element is the
+    **raw** LLR (the transform is applied inside the aggregation).
 
     ``per_variant_rows`` is a list of
-        (variant_id, target, subset, match_group, strand_to_score)
-    where ``strand_to_score`` is a dict ``{"+": s}`` or ``{"+": s, "-": s}``.
+        (variant_id, target, subset, match_group, strand_to_llr)
+    where ``strand_to_llr`` is a dict ``{"+": llr}`` or ``{"+": llr, "-": llr}``.
     """
     items = []
-    for variant_id, target, subset, match_group, strand_to_score in per_variant_rows:
-        for strand, s in strand_to_score.items():
-            items.append((s, target, subset, variant_id, match_group, strand))
+    for variant_id, target, subset, match_group, strand_to_llr in per_variant_rows:
+        for strand, llr in strand_to_llr.items():
+            items.append((llr, target, subset, variant_id, match_group, strand))
     return items
 
 
-def _run_aggregation(items, metric_name="pairwise_accuracy", task_name=None):
+def _run_aggregation(
+    items, *, transform=_IDENTITY, metric_name="auprc", task_name=None
+):
     store: dict[str, float] = {}
-    agg = _PairwiseAccuracyAggregation(
-        results_store=store, metric_name=metric_name, task_name=task_name
+    agg = _AuprcAggregation(
+        results_store=store,
+        metric_name=metric_name,
+        llr_transform=transform,
+        task_name=task_name,
     )
     scalar = agg(items)
     return scalar, store
 
 
-def test_metric_registry_has_pairwise_accuracy():
-    assert "pairwise_accuracy" in METRIC_REGISTRY
-    assert METRIC_REGISTRY["pairwise_accuracy"]["higher_is_better"] is True
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+def test_metric_registry_has_auprc():
+    assert "auprc" in METRIC_REGISTRY
+    assert METRIC_REGISTRY["auprc"]["higher_is_better"] is True
+    # PA was retired here in #225 (invalid on the 1:9 matched-pair dataset).
+    assert "pairwise_accuracy" not in METRIC_REGISTRY
 
 
-def test_one_strand_per_variant_emits_only_avg():
-    """1-strand dataset: only the avg keys are emitted (avg == single-strand score).
+# --------------------------------------------------------------------------- #
+# _collapse_variants — raw-LLR averaging, then transform; column shape
+# --------------------------------------------------------------------------- #
+def test_collapse_one_strand_emits_only_avg_column():
+    items = _items_from_per_variant(
+        [
+            (("1", 100, "G", "A"), 1, "missense", 1, {"+": -2.0}),
+            (("1", 200, "T", "A"), 0, "missense", 1, {"+": 0.5}),
+        ]
+    )
+    df, score_columns = _collapse_variants(items, _IDENTITY)
+    assert score_columns == ["score_avg"]
+    assert set(df.columns) == {"label", "subset", "match_group", "score_avg"}
+    assert len(df) == 2
 
-    No fwd/rc keys because they would be redundant with avg. 4 perfectly-separable
-    matched pairs (in 30+ pairs to satisfy macro_avg n_min=30) => global PA = 1.0.
-    """
-    per_variant: list = []
-    for i in range(30):
-        per_variant.append((("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": 0.9}))
-        per_variant.append((("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.1}))
+
+def test_collapse_two_strands_emits_fwd_rc_avg_columns():
+    items = _items_from_per_variant(
+        [
+            (("1", 100, "G", "A"), 1, "missense", 1, {"+": -2.0, "-": -1.0}),
+            (("1", 200, "T", "A"), 0, "missense", 1, {"+": 0.5, "-": 0.1}),
+        ]
+    )
+    df, score_columns = _collapse_variants(items, _IDENTITY)
+    assert score_columns == ["score_fwd", "score_rc", "score_avg"]
+    assert set(df.columns) == {
+        "label",
+        "subset",
+        "match_group",
+        "score_fwd",
+        "score_rc",
+        "score_avg",
+    }
+
+
+def test_collapse_averages_raw_llr_then_transforms_negate():
+    """``score_avg`` = transform(mean raw LLR), not mean(transform(LLR))."""
+    items = _items_from_per_variant(
+        [(("1", 100, "G", "A"), 1, "missense", 1, {"+": -3.0, "-": -1.0})]
+    )
+    df, _ = _collapse_variants(items, _NEGATE)
+    row = df.iloc[0]
+    # mean raw LLR = -2.0; negate => +2.0
+    assert row["score_avg"] == pytest.approx(2.0)
+    assert row["score_fwd"] == pytest.approx(3.0)  # -(-3)
+    assert row["score_rc"] == pytest.approx(1.0)  # -(-1)
+
+
+def test_collapse_average_before_abs_is_not_average_of_abs():
+    """The ordering pin: ``abs`` does NOT commute with averaging. With
+    llr_fwd=+2, llr_rc=-2 the raw mean is 0, so ``abs(mean)=0`` — whereas
+    ``mean(abs)`` would be 2. We must do raw-mean-then-transform (offline
+    ``abs_llr_avg`` semantics)."""
+    items = _items_from_per_variant(
+        [(("1", 100, "G", "A"), 1, "missense", 1, {"+": 2.0, "-": -2.0})]
+    )
+    df, _ = _collapse_variants(items, LLR_TRANSFORMS["abs"])
+    row = df.iloc[0]
+    assert row["score_avg"] == pytest.approx(0.0)  # abs(mean(+2,-2)) = abs(0)
+    assert row["score_fwd"] == pytest.approx(2.0)
+    assert row["score_rc"] == pytest.approx(2.0)
+
+
+# --------------------------------------------------------------------------- #
+# AUPRC values + exact parity with a direct compute_auprc_metrics call
+# --------------------------------------------------------------------------- #
+def test_perfectly_separable_global_auprc_is_one():
+    """Positives ranked strictly above negatives => global AUPRC = 1.0."""
+    per_variant = []
+    for i in range(_MIN_GROUPS_PER_SUBSET):
+        per_variant.append((("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": 5.0}))
+        per_variant.append((("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.0}))
     items = _items_from_per_variant(per_variant)
     scalar, store = _run_aggregation(items)
-
     assert scalar == pytest.approx(1.0)
-    assert store["_global_/avg/pairwise_accuracy"] == pytest.approx(1.0)
-    assert store["missense/avg/pairwise_accuracy"] == pytest.approx(1.0)
-    assert store["_macro_avg_/avg/pairwise_accuracy"] == pytest.approx(1.0)
-    # No fwd/rc keys for 1-strand datasets.
-    fwd_keys = [k for k in store if "/fwd/" in k]
-    rc_keys = [k for k in store if "/rc/" in k]
-    assert fwd_keys == [], f"unexpected fwd keys for 1-strand dataset: {fwd_keys}"
-    assert rc_keys == [], f"unexpected rc keys for 1-strand dataset: {rc_keys}"
+    assert store["_global_/avg/auprc"] == pytest.approx(1.0)
+    assert store["missense/avg/auprc"] == pytest.approx(1.0)
+    assert store["_macro_avg_/avg/auprc"] == pytest.approx(1.0)
 
 
-def test_two_strands_per_variant_emits_fwd_rc_avg_separately():
-    """2-strand dataset: fwd / rc / avg PA all stored, avg returned as scalar.
+def test_aggregation_matches_direct_compute_auprc_metrics():
+    """The aggregation is faithful glue: every emitted (subset, strand) cell —
+    value AND cluster-bootstrap SE — equals a direct ``compute_auprc_metrics``
+    call on the collapsed frame (same n_bootstrap + seed => bit-identical)."""
+    rng = np.random.default_rng(123)
+    per_variant = []
+    # missense: 40 groups (1:1) — qualifying. Positives get lower raw LLR
+    # (pathogenic), so under `negate` (minus_llr) they score higher.
+    for i in range(40):
+        pos_llr = {"+": float(rng.normal(-2, 1)), "-": float(rng.normal(-2, 1))}
+        neg_llr = {"+": float(rng.normal(0, 1)), "-": float(rng.normal(0, 1))}
+        per_variant.append((("1", 100 + i, "G", "A"), 1, "missense", i + 1, pos_llr))
+        per_variant.append((("1", 200 + i, "T", "A"), 0, "missense", i + 1, neg_llr))
+    # tss: 35 groups (1:1) — qualifying, weaker signal.
+    for i in range(35):
+        pos_llr = {"+": float(rng.normal(-0.5, 1)), "-": float(rng.normal(-0.5, 1))}
+        neg_llr = {"+": float(rng.normal(0, 1)), "-": float(rng.normal(0, 1))}
+        per_variant.append((("2", 100 + i, "G", "A"), 1, "tss", 1000 + i, pos_llr))
+        per_variant.append((("2", 200 + i, "T", "A"), 0, "tss", 1000 + i, neg_llr))
+    items = _items_from_per_variant(per_variant)
 
-    Set up so:
-      - FWD scores would give PA = 0.5 (tied within each pair)
-      - RC scores would give PA = 1.0 (perfectly separable)
-      - AVG breaks the FWD tie in favor of the positive => AVG PA = 1.0
-    """
-    per_variant: list = []
-    for i in range(30):
+    df, score_columns = _collapse_variants(items, _NEGATE)
+    expected = compute_auprc_metrics(
+        dataset=df[["label", "subset", "match_group"]],
+        scores=df[score_columns],
+        score_columns=score_columns,
+        n_bootstrap=_N_BOOTSTRAP,
+        rng=_BOOTSTRAP_SEED,
+        n_min=_MIN_GROUPS_PER_SUBSET,
+    )
+
+    _, store = _run_aggregation(items, transform=_NEGATE)
+
+    for row in expected.to_dict("records"):
+        tag = row["score_type"].removeprefix("score_")
+        key = f"{row['subset']}/{tag}/auprc"
+        assert store[key] == pytest.approx(row["value"]), key
+        assert store[f"{key}_se"] == pytest.approx(row["se"]), f"{key}_se"
+    # Sanity: the strong subset out-scores the weak one and both beat baseline.
+    assert store["missense/avg/auprc"] > store["tss/avg/auprc"]
+    assert store["_global_/avg/auprc"] > 0.5
+
+
+def test_se_present_and_finite_for_each_strand():
+    per_variant = []
+    for i in range(_MIN_GROUPS_PER_SUBSET):
         per_variant.append(
-            (("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": 0.5, "-": 0.9})
+            (("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": -2.0, "-": -1.5})
         )
         per_variant.append(
-            (("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.5, "-": 0.1})
+            (("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.2, "-": 0.4})
         )
     items = _items_from_per_variant(per_variant)
-    scalar, store = _run_aggregation(items)
-
-    # AVG breaks FWD ties => 1.0 globally
-    assert scalar == pytest.approx(1.0)
-    assert store["_global_/avg/pairwise_accuracy"] == pytest.approx(1.0)
-    # FWD: every pair tied => PA = 0.5
-    assert store["_global_/fwd/pairwise_accuracy"] == pytest.approx(0.5)
-    assert store["missense/fwd/pairwise_accuracy"] == pytest.approx(0.5)
-    # RC: perfectly separated => PA = 1.0
-    assert store["_global_/rc/pairwise_accuracy"] == pytest.approx(1.0)
-    assert store["missense/rc/pairwise_accuracy"] == pytest.approx(1.0)
-    # Macro-avg present for all three.
-    assert "_macro_avg_/fwd/pairwise_accuracy" in store
-    assert "_macro_avg_/rc/pairwise_accuracy" in store
-    assert "_macro_avg_/avg/pairwise_accuracy" in store
+    _, store = _run_aggregation(items, transform=_NEGATE)
+    for tag in ("fwd", "rc", "avg"):
+        assert f"_global_/{tag}/auprc" in store
+        assert f"_global_/{tag}/auprc_se" in store
+        assert math.isfinite(store[f"_global_/{tag}/auprc_se"])
 
 
-def test_two_strands_se_present_for_each():
-    """Each (subset, strand_tag) emits a paired ``..._se`` key."""
-    per_variant: list = []
-    for i in range(30):
+def test_per_subset_rows_below_n_min_groups_are_dropped():
+    """Per-subset cells with fewer than ``_MIN_GROUPS_PER_SUBSET`` match_groups
+    are NOT stored (leaderboard convention). ``_global_`` / ``_macro_avg_`` are
+    always stored."""
+    per_variant = []
+    for i in range(_MIN_GROUPS_PER_SUBSET):  # qualifying
         per_variant.append(
-            (("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": 0.9, "-": 0.8})
+            (("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": -2.0})
+        )
+        per_variant.append((("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.5}))
+    for i in range(5):  # below threshold
+        per_variant.append(
+            (("2", 100 + i, "G", "A"), 1, "splicing", 1000 + i, {"+": -2.0})
         )
         per_variant.append(
-            (("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.1, "-": 0.2})
+            (("2", 200 + i, "T", "A"), 0, "splicing", 1000 + i, {"+": 0.5})
         )
     items = _items_from_per_variant(per_variant)
     _, store = _run_aggregation(items)
-    for tag in ("fwd", "rc", "avg"):
-        assert f"_global_/{tag}/pairwise_accuracy" in store
-        assert f"_global_/{tag}/pairwise_accuracy_se" in store
-        assert math.isfinite(store[f"_global_/{tag}/pairwise_accuracy_se"])
+
+    assert "missense/avg/auprc" in store
+    assert "splicing/avg/auprc" not in store
+    assert "splicing/avg/auprc_se" not in store
+    assert "_global_/avg/auprc" in store
+    assert "_macro_avg_/avg/auprc" in store
 
 
+# --------------------------------------------------------------------------- #
+# Defensive invariants (raised inside _collapse_variants)
+# --------------------------------------------------------------------------- #
 def test_inconsistent_target_within_variant_fails_loud():
-    """Two rows with the same variant_id but different targets must fail."""
     items = [
         (0.5, 1, "missense", ("1", 11, "G", "A"), 1, "+"),
         (0.6, 0, "missense", ("1", 11, "G", "A"), 1, "-"),  # contradicting target
@@ -156,7 +272,6 @@ def test_inconsistent_match_group_within_variant_fails_loud():
 
 
 def test_duplicate_strand_within_variant_fails_loud():
-    """Two rows with the same variant_id AND same strand must fail."""
     items = [
         (0.5, 1, "missense", ("1", 11, "G", "A"), 1, "+"),
         (0.6, 1, "missense", ("1", 11, "G", "A"), 1, "+"),  # duplicate strand
@@ -172,82 +287,24 @@ def test_unknown_strand_fails_loud():
 
 
 def test_heterogeneous_strand_sets_fails_loud():
-    """One variant has both strands, another only one — must fail.
-
-    A mixed dataset would silently make ``score_avg`` mean different things
-    across rows.
-    """
+    """One variant has both strands, another only one — must fail (a mixed
+    dataset would silently make ``score_avg`` mean different things)."""
     items = [
-        # variant A has both strands
         (0.5, 1, "missense", ("1", 11, "G", "A"), 1, "+"),
         (0.7, 1, "missense", ("1", 11, "G", "A"), 1, "-"),
-        # variant B has only "+"
         (0.3, 0, "missense", ("1", 12, "T", "A"), 1, "+"),
     ]
     with pytest.raises(AssertionError, match="has strands="):
         _run_aggregation(items)
 
 
-def test_per_subset_rows_with_n_below_30_are_dropped():
-    """Per-subset rows with fewer than 30 matched pairs are NOT stored
-    (leaderboard convention). ``_global_`` and ``_macro_avg_`` are always stored.
-    """
-    per_variant: list = []
-    # 30 pairs in "missense" — qualifying.
-    for i in range(30):
-        per_variant.append((("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": 0.9}))
-        per_variant.append((("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.1}))
-    # 5 pairs in "splicing" — below threshold.
-    for i in range(5):
-        per_variant.append(
-            (("2", 100 + i, "G", "A"), 1, "splicing", 100 + i, {"+": 0.9})
-        )
-        per_variant.append(
-            (("2", 200 + i, "T", "A"), 0, "splicing", 100 + i, {"+": 0.1})
-        )
-    items = _items_from_per_variant(per_variant)
-    _, store = _run_aggregation(items)
-
-    # Qualifying subset is present.
-    assert "missense/avg/pairwise_accuracy" in store
-    # Below-threshold subset is dropped.
-    assert "splicing/avg/pairwise_accuracy" not in store
-    assert "splicing/avg/pairwise_accuracy_se" not in store
-    # Aggregate rows always emitted.
-    assert "_global_/avg/pairwise_accuracy" in store
-    assert "_macro_avg_/avg/pairwise_accuracy" in store
-
-
-def test_se_is_finite_and_consistent_with_wald():
-    """Standard error matches the Wald binomial form ``sqrt(p*(1-p)/n)``.
-
-    Uses 30 1-strand pairs (n_min=30 macro-avg gate) with 20 wins, 10 losses
-    => global AVG PA = 20/30.
-    """
-    per_variant: list = []
-    for i in range(20):
-        per_variant.append((("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": 0.9}))
-        per_variant.append((("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.1}))
-    for i in range(20, 30):
-        per_variant.append((("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": 0.1}))
-        per_variant.append((("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.9}))
-    items = _items_from_per_variant(per_variant)
-    scalar, store = _run_aggregation(items)
-    assert scalar == pytest.approx(20 / 30)
-    n_pairs = 30
-    expected_se = math.sqrt((20 / 30) * (1 - 20 / 30) / n_pairs)
-    assert store["_global_/avg/pairwise_accuracy_se"] == pytest.approx(expected_se)
-
-
+# --------------------------------------------------------------------------- #
+# Tracker push
+# --------------------------------------------------------------------------- #
 def test_aggregation_pushes_per_subset_to_levanter_tracker(monkeypatch):
     """All ``results_store`` entries are forwarded to ``levanter.tracker.log``
     under the ``lm_eval/<task_name>/<key>`` prefix so per-subset/per-strand cells
-    actually surface in wandb (lm-eval itself only logs the scalar return value).
-
-    Logged (not summary-only) so the wandb backend writes both run history —
-    making the cells available as workspace charts — and auto-fills the
-    summary panel from the latest logged value.
-    """
+    surface in wandb (lm-eval itself only logs the scalar return value)."""
     import levanter.tracker
 
     pushed: list[tuple[dict, int | None]] = []
@@ -257,16 +314,16 @@ def test_aggregation_pushes_per_subset_to_levanter_tracker(monkeypatch):
 
     monkeypatch.setattr(levanter.tracker, "log", fake_log)
 
-    per_variant: list = []
-    for i in range(30):
+    per_variant = []
+    for i in range(_MIN_GROUPS_PER_SUBSET):
         per_variant.append(
-            (("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": 0.9, "-": 0.8})
+            (("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": -2.0, "-": -1.5})
         )
         per_variant.append(
-            (("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.1, "-": 0.2})
+            (("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.2, "-": 0.4})
         )
     items = _items_from_per_variant(per_variant)
-    _run_aggregation(items, task_name="mendelian_traits_255")
+    _run_aggregation(items, transform=_NEGATE, task_name="mendelian_traits_255")
 
     assert len(pushed) == 1
     payload, step = pushed[0]
@@ -275,7 +332,7 @@ def test_aggregation_pushes_per_subset_to_levanter_tracker(monkeypatch):
     assert step is None
     assert all(k.startswith("lm_eval/mendelian_traits_255/") for k in payload)
     expected = {
-        f"lm_eval/mendelian_traits_255/{sub}/{tag}/pairwise_accuracy"
+        f"lm_eval/mendelian_traits_255/{sub}/{tag}/auprc"
         for sub in ("_global_", "_macro_avg_", "missense")
         for tag in ("fwd", "rc", "avg")
     }
@@ -283,10 +340,7 @@ def test_aggregation_pushes_per_subset_to_levanter_tracker(monkeypatch):
 
 
 def test_aggregation_skips_tracker_push_without_task_name(monkeypatch):
-    """When constructed without a task_name (e.g. unit tests), keys are
-    prefixed with just ``lm_eval/`` — and tracker errors are swallowed
-    so a missing/noop tracker doesn't tank the eval.
-    """
+    """When the tracker raises (missing/noop), the eval must not crash."""
     import levanter.tracker
 
     def raising_log(payload, *, step=None, commit=None):
@@ -294,13 +348,12 @@ def test_aggregation_skips_tracker_push_without_task_name(monkeypatch):
 
     monkeypatch.setattr(levanter.tracker, "log", raising_log)
 
-    per_variant: list = []
-    for i in range(30):
-        per_variant.append((("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": 0.9}))
-        per_variant.append((("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.1}))
+    # Separable under the default (identity) transform => global AUPRC = 1.0.
+    per_variant = []
+    for i in range(_MIN_GROUPS_PER_SUBSET):
+        per_variant.append((("1", 100 + i, "G", "A"), 1, "missense", i + 1, {"+": 5.0}))
+        per_variant.append((("1", 200 + i, "T", "A"), 0, "missense", i + 1, {"+": 0.0}))
     items = _items_from_per_variant(per_variant)
-    scalar, store = _run_aggregation(
-        items
-    )  # no task_name; tracker raises; must not crash
+    scalar, store = _run_aggregation(items)  # tracker raises; must not crash
     assert scalar == pytest.approx(1.0)
-    assert "_global_/avg/pairwise_accuracy" in store
+    assert "_global_/avg/auprc" in store

--- a/tests/pipelines/evals/test_dna_vep_llr_eval.py
+++ b/tests/pipelines/evals/test_dna_vep_llr_eval.py
@@ -9,17 +9,13 @@ parity with the offline ``snakemake/analysis/evals_v2/`` batched VEP path
 synthetic per-variant rows and call the collapse helper / aggregation directly.
 """
 
-import math
-
 import numpy as np
 import pytest
 
 pytest.importorskip("lm_eval", reason="install with `uv sync --extra marin` to run")
 
 from marin_dna.pipelines.evals.lm_eval.dna_vep_llr_eval import (  # noqa: E402
-    _BOOTSTRAP_SEED,
     _MIN_GROUPS_PER_SUBSET,
-    _N_BOOTSTRAP,
     LLR_TRANSFORMS,
     METRIC_REGISTRY,
     _AuprcAggregation,
@@ -155,9 +151,10 @@ def test_perfectly_separable_global_auprc_is_one():
 
 
 def test_aggregation_matches_direct_compute_auprc_metrics():
-    """The aggregation is faithful glue: every emitted (subset, strand) cell —
-    value AND cluster-bootstrap SE — equals a direct ``compute_auprc_metrics``
-    call on the collapsed frame (same n_bootstrap + seed => bit-identical)."""
+    """The aggregation is faithful glue: every emitted (subset, strand) cell's
+    point AUPRC equals a direct ``compute_auprc_metrics`` call on the collapsed
+    frame. Online is point-only (``n_bootstrap=0``), so no ``_se`` cells are
+    emitted."""
     rng = np.random.default_rng(123)
     per_variant = []
     # missense: 40 groups (1:1) — qualifying. Positives get lower raw LLR
@@ -180,8 +177,7 @@ def test_aggregation_matches_direct_compute_auprc_metrics():
         dataset=df[["label", "subset", "match_group"]],
         scores=df[score_columns],
         score_columns=score_columns,
-        n_bootstrap=_N_BOOTSTRAP,
-        rng=_BOOTSTRAP_SEED,
+        n_bootstrap=0,
         n_min=_MIN_GROUPS_PER_SUBSET,
     )
 
@@ -191,13 +187,16 @@ def test_aggregation_matches_direct_compute_auprc_metrics():
         tag = row["score_type"].removeprefix("score_")
         key = f"{row['subset']}/{tag}/auprc"
         assert store[key] == pytest.approx(row["value"]), key
-        assert store[f"{key}_se"] == pytest.approx(row["se"]), f"{key}_se"
+        assert f"{key}_se" not in store, f"online is point-only; unexpected {key}_se"
     # Sanity: the strong subset out-scores the weak one and both beat baseline.
     assert store["missense/avg/auprc"] > store["tss/avg/auprc"]
     assert store["_global_/avg/auprc"] > 0.5
 
 
-def test_se_present_and_finite_for_each_strand():
+def test_point_only_no_se_cells_emitted():
+    """Online is point-only (n_bootstrap=0): per-(subset, strand) point AUPRC
+    cells are present, but NO ``_se`` cells are emitted (the cluster-bootstrap SE
+    lives in the offline evals_v2 parquet)."""
     per_variant = []
     for i in range(_MIN_GROUPS_PER_SUBSET):
         per_variant.append(
@@ -210,8 +209,8 @@ def test_se_present_and_finite_for_each_strand():
     _, store = _run_aggregation(items, transform=_NEGATE)
     for tag in ("fwd", "rc", "avg"):
         assert f"_global_/{tag}/auprc" in store
-        assert f"_global_/{tag}/auprc_se" in store
-        assert math.isfinite(store[f"_global_/{tag}/auprc_se"])
+    se_keys = [k for k in store if k.endswith("_se")]
+    assert se_keys == [], f"online should emit no SE cells, got {se_keys}"
 
 
 def test_per_subset_rows_below_n_min_groups_are_dropped():

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -206,6 +206,19 @@ def test_auprc_random_scores_near_baseline():
     assert res["se"] > 0
 
 
+def test_auprc_n_bootstrap_zero_is_point_only():
+    """n_bootstrap=0 → skip the resample loop: identical point AUPRC, se=NaN,
+    and n_groups still computed (it feeds the macro-avg n_min gate). This is the
+    online in-training hot path (SE is computed offline instead)."""
+    labels, scores, mg = _matched_pairs(separable=False, seed=42)
+    full = auprc_with_bootstrap_se(labels, scores, mg, n_bootstrap=200, rng=0)
+    point = auprc_with_bootstrap_se(labels, scores, mg, n_bootstrap=0)
+    assert point["value"] == pytest.approx(full["value"])  # data-only point est.
+    assert np.isnan(point["se"])
+    assert point["n_groups"] == full["n_groups"]
+    assert point["n_rows"] == full["n_rows"]
+
+
 def test_auprc_seed_reproducibility():
     """Same seed → identical SE; different seeds → SE differs (sanity)."""
     labels, scores, mg = _matched_pairs(separable=False, seed=1)


### PR DESCRIPTION
## Summary

The online (in-training) mendelian VEP metric used **PairwiseAccuracy**, which #195 retired offline because it's invalid on the 1:9 (k=9) matched-pair dataset — and on today's 1:9 harness the PA aggregator would **assert-crash** (it asserts exactly 1 positive + 1 negative per `match_group`). This migrates the online task to **AUPRC + cluster-bootstrap SE**, keeping per-variant FWD/RC strand averaging, so the in-training number is directly comparable to the offline `evals_v2` leaderboard.

fixes #225

## Changes

- **`dna_vep_llr_eval.py` + `mendelian_traits_255.yaml`** — replace `_PairwiseAccuracyAggregation` with `_collapse_variants` + `_AuprcAggregation`: average **raw LLR** across the FWD/RC strand rows per variant, then apply the `minus_llr` transform, then `compute_auprc_metrics` (`n_bootstrap=1000`, `seed=0`, `n_min=30` — identical to offline, so the SE matches). Headline scalar is now `_global_/avg/auprc`. The scoring path itself (`construct_requests`, `llr = log_prob_alt − log_prob_ref`) is unchanged from v0/v1.
- **Pin the HF dataset commit** (`dataset_revision=7b92f04…`, threaded through `download()`) so the harness dataset can't silently change under the eval — which is exactly what happened (1:1 → 1:9 re-upload, #194).
- **Tests** rewritten: exact parity vs a direct `compute_auprc_metrics` call (value + cluster-bootstrap SE) and an `abs`-ordering pin (`abs(mean(LLR)) ≠ mean(abs(LLR))`, proving we average raw LLR before transforming). 320 evals tests pass.
- **`experiments/parity/issue225_online_auprc_parity.py`** — tiny 10-step parity harness used to validate the migration in the real in-training setting.
- **Side fixes:** one-line `marin.execution` import correction that un-breaks `exp187`/`smoke_per_region` against the currently-locked marin (`ensure_versioned`/`this_output_path` moved in the #189 bump); `experiments/README.md` iris-launch doc fix (`--cluster=marin` auto-tunnels; `start-iap-tunnel … 10000` fails on the IAP firewall).

## Validation

Online (in-training) AUPRC **== offline `evals_v2` AUPRC within bootstrap SE, across every subset, at both step-5 and step-9** of the tiny run — see the parity tables in #225. Both sit at the ≈0.1 baseline (expected for a ~untrained model); the test confirms the two code paths agree (wiring, metric, `n_min`, FWD/RC averaging, dataset-commit pin) and that the in-training path runs on the 1:9 data without the assert-crash the old PA code would hit. Sign/span scoring correctness rides on the unchanged (and unit-tested) LLR path.

**Follow-up (self-review):** the online metric is now **point AUPRC only** — cluster-bootstrap SE dropped online (computed offline in `evals_v2`); point values unchanged, so the validated parity holds (`f119af4`). Also addressed the stale-doc + drift-hazard review findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


