### PR TITLE
Widen _frontmatter extra_tags to Sequence[str] to fix repo-wide mypy hook

### DIFF
--- a/src/marin_dna/pipelines/evals/hf_readme.py
+++ b/src/marin_dna/pipelines/evals/hf_readme.py
@@ -10,6 +10,7 @@ numbers always match the dataset being pushed.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 import polars as pl
@@ -18,7 +19,7 @@ REPO_ROOT_URL = "https://github.com/Open-Athena/marin-dna"
 
 
 def _frontmatter(
-    extra_tags: list[str] | None = None, *, size_category: str = "10K<n<100K"
+    extra_tags: Sequence[str] | None = None, *, size_category: str = "10K<n<100K"
 ) -> str:
     tags = ["biology", "genomics", "dna"]
     if extra_tags:


### PR DESCRIPTION
## Problem

The `mypy` pre-commit hook runs on the whole `src/marin_dna/` package (`pass_filenames: false`), so a single pre-existing type error blocked clean commits repo-wide:

```
src/marin_dna/pipelines/evals/hf_readme.py:486: error: Argument 1 to "_frontmatter" has incompatible type "Sequence[str]"; expected "list[str] | None"  [arg-type]
```

## Root cause

`_DART_EVAL_META` is a heterogeneous dict — its inner values are mostly `str` but `extra_tags` is `list[str]` — so mypy infers the common value type as `Sequence[str]`. The access `m["extra_tags"]` is therefore typed `Sequence[str]`, which didn't fit `_frontmatter`'s declared `list[str] | None`.

## Fix

Widened `_frontmatter`'s parameter to `Sequence[str] | None`. This matches how the function actually uses the arg: it only does `if extra_tags:` (truthiness) and `for t in extra_tags` (iteration) — both `Sequence` operations, no list-only ops — so no body change was needed, and it avoids an unnecessary `list(...)` copy at the call site.

## Verification

- `uv run mypy src/marin_dna/pipelines/evals/hf_readme.py` → no issues
- `SKIP=snakefmt uv run pre-commit run mypy --all-files` → passed (snakefmt kept skipped per the known-broken 0.11.2 issue on pre-existing `.smk` files)
- `uv run pytest tests/pipelines/evals/` → 296 passed, 3 skipped; no behavior change

Unrelated to the v4 region-datasets work in PR #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
