### PR TITLE
zoonomia_projection_dataset: species-subset axis (zoonomia-v1-v4_cds-order)

### DIFF
--- a/snakemake/zoonomia_projection_dataset/README.md
+++ b/snakemake/zoonomia_projection_dataset/README.md
@@ -208,6 +208,25 @@ different partitions of the same v1 anchors** — see "v4 region labels" below.
 - Bump `pipeline_version` when ANY of: species TSV, `project_min_p`, alignment backend (rules in `project.smk`), resize / length-filter params changes. This invalidates all per-(pipeline, intervals) HF datasets and the projection itself must be re-run.
 - Bump `intervals_versions` (add a new entry) when you want a new subset definition. Cheap — only `subset_dataset_derived` + shard prep + upload re-run.
 
+**Species axis (third axis — issue #233).** A *species cohort* filters an existing dataset to a subset of the projection's species — a row-filter on the `species` column, orthogonal to `intervals_version` (a row-filter on `query_name`); the two compose. The default 108-family cohort is **implicit** (no label), so every `zoonomia-v1-*` repo above is unchanged. Non-default cohorts get a trailing repo suffix (scheme B): `zoonomia-{pipeline_version}-{intervals_version}-{cohort}`.
+
+A cohort must be a **subset** of the projection's species, so the v1 projection is reused as-is (no re-halLiftover) — `marin_dna.pipelines.projection.subset.filter_to_species` asserts the subset relationship. Cohorts are declared in `species_subsets` (label → species TSV); the `{intervals, species}` combos to build are listed in `species_subset_datasets`. `rule subset_species` writes `results/projection/min{p}/subsets_species/{intervals}-{cohort}.parquet`, which feeds the same `prepare_training_shards → compress_shard → hf_upload_dataset` chain; each cohort dataset ships its own card (`write_species_subset_hf_readme`).
+
+The pipeline ships one cohort dataset:
+
+| HF repo | pipeline | intervals | species cohort | source Parquet |
+|---|---|---|---|---|
+| `bolinas-dna/zoonomia-v1-v4_cds-order` | v1 | v4_cds | `order` (19, one-per-order) | `results/projection/min0.20/subsets_species/v4_cds-order.parquet` |
+
+The `order` cohort (`config/species_zoonomia_447_order_dedup.tsv`, 19 leaves) is a strict subset of the 108-family set, so `zoonomia-v1-v4_cds-order` is the v4 cds region partition restricted to those 19 deeply-diverged species — a species diversity-vs-quantity ablation against the 108-species `zoonomia-v1-v4_cds`, reusing the projection for free.
+
+Build it on the projection/upload cluster, where the v1 projection outputs + metadata are intact (a fresh local checkout otherwise re-plans the projection — `local()` FASTA intermediates are absent and S3 mtimes read as updated, exactly as for the v3/v4 subsets):
+
+```bash
+uv run snakemake --profile workflow/profiles/default \
+    results/upload.done/zoonomia-v1-v4_cds-order
+```
+
 **Run:**
 
 ```bash
@@ -425,7 +444,7 @@ The projection step reads a static, committed species TSV chosen by `species_tsv
 
 The order set is a strict **subset** of the family set — the top-ranked leaf in an order is also the top-ranked in its own family — so `order (19) ⊂ family (108) ⊂ all-447`. Per-leaf assembly metadata (`accession, assembly_level, contig_n50, quality_source`) comes from Zoonomia Supplementary Table 2 when available (true HAL-assembly stats; 85 % of family winners, 79 % of order winners) and NCBI Datasets v2 taxon proxy for the rest.
 
-`species_tsv:` selects which list the projection uses (currently the family set / `v1`). Building a dataset on the order set is tracked separately: because `order ⊂ family`, it can reuse the existing `v1` projection as a cheap species-axis subset rather than re-running halLiftover (issue #230).
+`species_tsv:` selects which list the **projection** uses (currently the family set / `v1`). Building a dataset on the **order** set neither changes `species_tsv` nor re-runs the projection: because `order ⊂ family`, it is a species-axis subset of the existing `v1` projection (see "Species axis" under HuggingFace datasets above — `zoonomia-v1-v4_cds-order`, issue #233), not a new `species_tsv` / projection run.
 
 To regenerate (only when the alignment changes):
 
@@ -470,7 +489,7 @@ workflow/rules/
   filter.smk                                   # filtered BED per cutoff
   project.smk                                  # cross-mammal halLiftover + filter + resize + sequence + subset
   subsets.smk                                  # derive query_names lists for v2 subset; subset_dataset_derived override
-  dataset.smk                                  # RC augment + shuffle + shard + hf upload-large-folder
+  dataset.smk                                  # RC augment + shuffle + shard + hf upload; species-subset axis (subset_species, #233)
   validation.smk                               # seven per-recipe validation parquets + HF upload (rule all_validation)
 scripts/
   calibrate_447m_threshold.py                  # one-off; uses src/marin_dna/conservation/

--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -73,6 +73,24 @@ intervals_versions:
 
 hf_owner: "bolinas-dna"
 
+# ===== Species-subset datasets (third axis; issue #233) =====
+# A species cohort is a row-filter on the `species` column, orthogonal to
+# intervals_versions (a row-filter on `query_name`); the two compose. The
+# default 108-family cohort is implicit (no label) — its zoonomia-v1-* repos
+# stay byte-unchanged. Non-default cohorts get a trailing repo suffix
+# (scheme B): zoonomia-{pipeline_version}-{intervals_version}-{cohort}.
+#
+# A cohort must be a SUBSET of the projection's species so the v1 projection
+# is reused as-is (no re-halLiftover); filter_to_species asserts this. The
+# one-per-order set (19 leaves) is a strict subset of the 108-family set.
+species_subsets:
+  order: "config/species_zoonomia_447_order_dedup.tsv"
+# (intervals_version, species cohort) datasets to build — each reuses the
+# existing intervals subset Parquet, filtered to the cohort. One for now:
+# zoonomia-v1-v4_cds-order (the v4 cds region partition on the 19-order set).
+species_subset_datasets:
+  - { intervals: "v4_cds", species: "order" }
+
 # v2 subset: ± bp band around each mRNA TSS (Ensembl protein_coding biotype).
 # 256 bp matches the BOS+255 model context window.
 tss_flank: 256

--- a/snakemake/zoonomia_projection_dataset/sky/upload.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/upload.yaml
@@ -119,15 +119,6 @@ run: |
         SNAKEMAKE_EXTRA+=(--config "commit_sha=$COMMIT_SHA")
     fi
 
-    # prepare_training_shards requests mem_mb=120000; the shared profile caps
-    # the global budget at 30000 (tuned for the c6id.4xlarge anchor box). On
-    # this r6i.8xlarge (256 GB) raise the cap for species_subset builds so the
-    # shard job schedules. (region mode keeps the existing behavior.)
-    MEM_OVERRIDE=()
-    if [ "$UPLOAD_MODE" = "species_subset" ]; then
-        MEM_OVERRIDE+=(--resources mem_mb=240000)
-    fi
-
     # NOTE: ${SNAKEMAKE_EXTRA[@]} (which may be `--config commit_sha=...`) must
     # NOT be the last option before the positional targets — Snakemake's
     # `--config` greedily consumes following tokens as name=value pairs and
@@ -137,7 +128,6 @@ run: |
     # Dry-run gate first — verify only HF-related rules are scheduled.
     uv run snakemake --profile workflow/profiles/default \
         "${SNAKEMAKE_EXTRA[@]}" \
-        "${MEM_OVERRIDE[@]}" \
         --allowed-rules "${ALLOWED_RULES[@]}" \
         --rerun-triggers mtime \
         --printshellcmds \
@@ -146,7 +136,6 @@ run: |
     # Real run.
     uv run snakemake --profile workflow/profiles/default \
         "${SNAKEMAKE_EXTRA[@]}" \
-        "${MEM_OVERRIDE[@]}" \
         --allowed-rules "${ALLOWED_RULES[@]}" \
         --rerun-triggers mtime \
         --printshellcmds \

--- a/snakemake/zoonomia_projection_dataset/sky/upload.yaml
+++ b/snakemake/zoonomia_projection_dataset/sky/upload.yaml
@@ -27,9 +27,16 @@ file_mounts:
 # still resolve, just not pinned.
 # UPLOAD_VERSION selects which intervals partition to push: v3 (default) or
 # v4 (issue #227). Override at launch: `sky launch ... --env UPLOAD_VERSION=v4`.
+# UPLOAD_MODE selects WHICH datasets to push:
+#   region        (default) — the six v3_*/v4_* region partitions for
+#                  UPLOAD_VERSION (the default 108-family species cohort).
+#   species_subset — the species_subset_datasets combos (issue #233), e.g.
+#                  zoonomia-v1-v4_cds-order. UPLOAD_VERSION is ignored.
+#                  Launch: `sky launch ... --env UPLOAD_MODE=species_subset`.
 envs:
     COMMIT_SHA: ""
     UPLOAD_VERSION: v3
+    UPLOAD_MODE: region
 
 setup: |
     set -euxo pipefail
@@ -59,18 +66,26 @@ run: |
 
     cd snakemake/zoonomia_projection_dataset
 
-    # Target only the six upload.done files for $UPLOAD_VERSION (v3 or v4).
-    # v1/v2 are already pushed and their upload.done markers in S3 satisfy
-    # `rule all_hf` separately; we don't need (or want) to walk that branch.
-    UPLOAD_TARGETS=$(UPLOAD_VERSION="$UPLOAD_VERSION" uv run python -c "
+    # Compute upload.done targets. region mode: the six v3_*/v4_* partitions
+    # for $UPLOAD_VERSION. species_subset mode: the species_subset_datasets
+    # combos (zoonomia-{pv}-{iv}-{cohort}). v1/v2 are already pushed and their
+    # upload.done markers in S3 satisfy `rule all_hf` separately; we don't need
+    # (or want) to walk those branches.
+    UPLOAD_TARGETS=$(UPLOAD_VERSION="$UPLOAD_VERSION" UPLOAD_MODE="$UPLOAD_MODE" uv run python -c "
     import yaml, os
     cfg = yaml.safe_load(open('config/config.yaml'))
-    ver = os.environ['UPLOAD_VERSION']
-    for iv in cfg['intervals_versions']:
-        if iv.startswith(ver + '_'):
-            print(f'results/upload.done/zoonomia-{cfg[\"pipeline_version\"]}-{iv}')
+    pv = cfg['pipeline_version']
+    mode = os.environ['UPLOAD_MODE']
+    if mode == 'species_subset':
+        for d in cfg.get('species_subset_datasets', []):
+            print(f'results/upload.done/zoonomia-{pv}-{d[\"intervals\"]}-{d[\"species\"]}')
+    else:
+        ver = os.environ['UPLOAD_VERSION']
+        for iv in cfg['intervals_versions']:
+            if iv.startswith(ver + '_'):
+                print(f'results/upload.done/zoonomia-{pv}-{iv}')
     ")
-    test -n "$UPLOAD_TARGETS"  # fail loudly if UPLOAD_VERSION matched nothing
+    test -n "$UPLOAD_TARGETS"  # fail loudly if the mode/version matched nothing
 
     # `--allowed-rules` whitelists the v3 chain so Snakemake refuses to
     # walk back into the cross-mammal projection (hal_to_fasta /
@@ -79,17 +94,21 @@ run: |
     # otherwise be re-scheduled despite their downstream outputs
     # (`sequences/{species}.parquet`, `all_species_with_sequence.parquet`)
     # already existing in S3 default-storage.
-    # Both readme rules are whitelisted; only the one matching the target's
-    # wildcard (v3_* or v4_*) actually fires. The region-label / projection
-    # rules are deliberately absent so Snakemake errors rather than walking
-    # back into them — their outputs (query_names, composition, subset
-    # parquets' source) already exist in S3.
+    # All three readme rules are whitelisted; only the one matching the
+    # target's wildcard (v3_* / v4_* / *-{cohort}) actually fires. subset_species
+    # (issue #233) filters the existing intervals subset (e.g. subsets/v4_cds.parquet,
+    # already in S3) to a species cohort — it does NOT touch the projection. The
+    # region-label / projection rules are deliberately absent so Snakemake errors
+    # rather than walking back into them — their outputs (query_names,
+    # composition, subset parquets' source) already exist in S3.
     ALLOWED_RULES=(
         subset_dataset_derived
+        subset_species
         prepare_training_shards
         compress_shard
         dataset_hf_readme_v3
         dataset_hf_readme_v4
+        dataset_hf_readme_species_subset
         hf_upload_dataset
     )
 
@@ -98,6 +117,15 @@ run: |
     SNAKEMAKE_EXTRA=()
     if [ -n "${COMMIT_SHA:-}" ]; then
         SNAKEMAKE_EXTRA+=(--config "commit_sha=$COMMIT_SHA")
+    fi
+
+    # prepare_training_shards requests mem_mb=120000; the shared profile caps
+    # the global budget at 30000 (tuned for the c6id.4xlarge anchor box). On
+    # this r6i.8xlarge (256 GB) raise the cap for species_subset builds so the
+    # shard job schedules. (region mode keeps the existing behavior.)
+    MEM_OVERRIDE=()
+    if [ "$UPLOAD_MODE" = "species_subset" ]; then
+        MEM_OVERRIDE+=(--resources mem_mb=240000)
     fi
 
     # NOTE: ${SNAKEMAKE_EXTRA[@]} (which may be `--config commit_sha=...`) must
@@ -109,6 +137,7 @@ run: |
     # Dry-run gate first — verify only HF-related rules are scheduled.
     uv run snakemake --profile workflow/profiles/default \
         "${SNAKEMAKE_EXTRA[@]}" \
+        "${MEM_OVERRIDE[@]}" \
         --allowed-rules "${ALLOWED_RULES[@]}" \
         --rerun-triggers mtime \
         --printshellcmds \
@@ -117,6 +146,7 @@ run: |
     # Real run.
     uv run snakemake --profile workflow/profiles/default \
         "${SNAKEMAKE_EXTRA[@]}" \
+        "${MEM_OVERRIDE[@]}" \
         --allowed-rules "${ALLOWED_RULES[@]}" \
         --rerun-triggers mtime \
         --printshellcmds \

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
@@ -28,6 +28,72 @@ assert set(INTERVALS_VERSIONS) <= set(INTERVALS_SOURCES), (
     f"{set(INTERVALS_VERSIONS) - set(INTERVALS_SOURCES)}"
 )
 
+# ===== Species-subset datasets (third axis; issue #233) =====
+# A species cohort filters an existing intervals subset to a subset of the
+# projection's species, reusing the v1 projection (no re-halLiftover). The
+# dataset "slug" gains a trailing -{cohort} (scheme B) → repo
+# zoonomia-{pipeline_version}-{intervals_version}-{cohort}. Each slug is
+# registered in INTERVALS_SOURCES like any other dataset so the
+# prepare_training_shards → compress_shard → hf_upload_dataset chain is shared.
+SPECIES_SUBSETS = dict(config.get("species_subsets", {}))
+SPECIES_SUBSET_DATASETS = list(config.get("species_subset_datasets", []))
+SPECIES_SUBSET_SLUGS: list[str] = []
+for _d in SPECIES_SUBSET_DATASETS:
+    _iv, _cohort = _d["intervals"], _d["species"]
+    assert _iv in INTERVALS_SOURCES, (
+        f"species_subset_datasets intervals {_iv!r} is not a known dataset; "
+        f"known: {sorted(INTERVALS_SOURCES)}"
+    )
+    assert _cohort in SPECIES_SUBSETS, (
+        f"species_subset_datasets cohort {_cohort!r} not in species_subsets "
+        f"{sorted(SPECIES_SUBSETS)}"
+    )
+    _slug = f"{_iv}-{_cohort}"
+    INTERVALS_SOURCES[_slug] = (
+        f"results/projection/min{PROJECT_MIN_P}/subsets_species/{_slug}.parquet"
+    )
+    SPECIES_SUBSET_SLUGS.append(_slug)
+
+# Every dataset all_hf pushes: default-species intervals versions + cohort slugs.
+ALL_DATASETS = list(INTERVALS_VERSIONS) + SPECIES_SUBSET_SLUGS
+
+
+# Pin pipeline_version so the zoonomia-{pipeline_version}-{dataset} repo slug
+# parses unambiguously when {dataset} carries a -{cohort} suffix
+# (zoonomia-v1-v4_cds-order → pipeline_version=v1, dataset=v4_cds-order, not
+# pipeline_version=v1-v4_cds). Global: applies to every {pipeline_version}.
+wildcard_constraints:
+    pipeline_version=r"v\d+",
+
+
+rule subset_species:
+    """Filter an intervals subset to a species cohort (the third axis, #233).
+
+    The cohort (e.g. the 19 one-per-order leaves) is a subset of the
+    projection's species — asserted in filter_to_species — so this reuses the
+    v1 projection rather than re-running halLiftover. The output slug
+    {intervals}-{cohort} is the dataset slug used by the shard/upload chain.
+    """
+    input:
+        parquet=lambda wc: INTERVALS_SOURCES[wc.intervals],
+    output:
+        "results/projection/min{min_p}/subsets_species/{intervals}-{cohort}.parquet",
+    wildcard_constraints:
+        intervals=r"v\d+(?:_\w+)?",
+        cohort=r"[a-z0-9]+",
+    params:
+        # Committed local config file — read directly (like common.smk's
+        # species_tsv), NOT a Snakemake input, so the S3 storage provider
+        # doesn't try to resolve it under the bucket prefix.
+        species_tsv=lambda wc: SPECIES_SUBSETS[wc.cohort],
+    threads: 1
+    resources:
+        # Eager read of the intervals-subset Parquet (filter_to_species); same
+        # memory profile as subset_dataset_derived. Runs on the upload cluster.
+        mem_mb=32000,
+    run:
+        filter_to_species(input.parquet, params.species_tsv, output[0])
+
 
 rule prepare_training_shards:
     """Read source Parquet → RC augment → shuffle → shard to JSONL."""
@@ -165,6 +231,52 @@ rule dataset_hf_readme_v4:
         )
 
 
+rule dataset_hf_readme_species_subset:
+    """HF dataset card for a species-subset dataset (e.g. v4_cds-order; #233).
+
+    Separate from the v3/v4 card rules: the card describes the species axis —
+    the cohort, its size, a commit-pinned permalink to the cohort's species
+    TSV — and reads its row count from the cohort-filtered Parquet. Disjoint
+    from the v3/v4 rules by the required -{cohort} suffix in the constraint.
+    """
+    input:
+        # Cohort-filtered Parquet (registered in INTERVALS_SOURCES under the
+        # slug); its row count is the post-projection total for the cohort.
+        source=lambda wc: INTERVALS_SOURCES[wc.intervals_version],
+    output:
+        "results/dataset/zoonomia-{pipeline_version}-{intervals_version}/README.md",
+    wildcard_constraints:
+        pipeline_version=r"v\d+",
+        intervals_version=r"v\d+(?:_\w+)?-[a-z0-9]+",
+    params:
+        commit_sha=GIT_COMMIT_SHA,
+        hf_owner=HF_OWNER,
+        add_rc=ADD_RC,
+        # Committed local config file — read directly (not a Snakemake input,
+        # which the S3 provider would resolve under the bucket prefix).
+        species_tsv=lambda wc: SPECIES_SUBSETS[wc.intervals_version.rsplit("-", 1)[1]],
+    run:
+        from marin_dna.pipelines.zoonomia_projection_dataset.region_labels import (
+            write_species_subset_hf_readme,
+        )
+
+        base_iv, cohort = wildcards.intervals_version.rsplit("-", 1)
+        n_rows = pl.scan_parquet(input.source).select(pl.len()).collect().item()
+        n_samples = n_rows * (2 if params.add_rc else 1)
+        n_species = pl.read_csv(params.species_tsv, separator="\t").height
+        write_species_subset_hf_readme(
+            base_iv,
+            cohort,
+            output[0],
+            commit_sha=params.commit_sha,
+            hf_owner=params.hf_owner,
+            pipeline_version=wildcards.pipeline_version,
+            n_species=n_species,
+            n_samples=n_samples,
+            species_tsv=str(params.species_tsv),
+        )
+
+
 rule hf_upload_dataset:
     """Upload a dataset's compressed shard folder to HF Hub (single train split).
 
@@ -195,7 +307,10 @@ rule hf_upload_dataset:
         has_readme=lambda wc: int(wc.intervals_version.startswith(("v3_", "v4_"))),
     wildcard_constraints:
         pipeline_version=r"v\d+",
-        intervals_version=r"v\d+(?:_\w+)?",
+        # Optional trailing -{cohort} (scheme B) for species-subset datasets,
+        # e.g. v4_cds-order. has_readme below keys off the v3_/v4_ prefix, so
+        # the cohort still ships a card (its README rule is below).
+        intervals_version=r"v\d+(?:_\w+)?(?:-[a-z0-9]+)?",
     threads: workflow.cores
     shell:
         """
@@ -209,10 +324,15 @@ rule hf_upload_dataset:
 
 
 rule all_hf:
-    """Trigger HF push for every (PIPELINE_VERSION × INTERVALS_VERSIONS) combo."""
+    """Trigger HF push for every dataset: PIPELINE_VERSION × (INTERVALS_VERSIONS
+    + species-subset slugs). The cohort slugs (e.g. v4_cds-order) are built by
+    subset_species → the shared shard/upload chain; default-species datasets are
+    unaffected. Target a single dataset directly to avoid rebuilding the rest,
+    e.g. `results/upload.done/zoonomia-v1-v4_cds-order`.
+    """
     input:
         expand(
             "results/upload.done/zoonomia-{p}-{iv}",
             p=[PIPELINE_VERSION],
-            iv=INTERVALS_VERSIONS,
+            iv=ALL_DATASETS,
         ),

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/dataset.smk
@@ -1,5 +1,7 @@
 """Training-shard assembly + HF upload."""
 
+import re
+
 PIPELINE_VERSION = config["pipeline_version"]
 INTERVALS_VERSIONS = list(config["intervals_versions"])
 HF_OWNER = config["hf_owner"]
@@ -48,6 +50,19 @@ for _d in SPECIES_SUBSET_DATASETS:
         f"species_subset_datasets cohort {_cohort!r} not in species_subsets "
         f"{sorted(SPECIES_SUBSETS)}"
     )
+    # Scheme-B slug = f"{iv}-{cohort}" is split on the LAST hyphen downstream
+    # (the subset_species wildcards and the card rule's rsplit), so it only
+    # round-trips if the cohort key is [a-z0-9]+ (no '-'/'_') and the interval
+    # carries no '-'. Validate at load so a bad config fails loudly here, not as
+    # a cryptic "no rule to produce ...{slug}.parquet" deep in the DAG.
+    assert re.fullmatch(r"[a-z0-9]+", _cohort), (
+        f"species cohort key {_cohort!r} must match [a-z0-9]+ (the "
+        f"subset_species `cohort` wildcard); rename it in species_subsets"
+    )
+    assert "-" not in _iv, (
+        f"intervals_version {_iv!r} contains '-', colliding with the "
+        f"-{{cohort}} slug delimiter (scheme B)"
+    )
     _slug = f"{_iv}-{_cohort}"
     INTERVALS_SOURCES[_slug] = (
         f"results/projection/min{PROJECT_MIN_P}/subsets_species/{_slug}.parquet"
@@ -61,9 +76,23 @@ ALL_DATASETS = list(INTERVALS_VERSIONS) + SPECIES_SUBSET_SLUGS
 # Pin pipeline_version so the zoonomia-{pipeline_version}-{dataset} repo slug
 # parses unambiguously when {dataset} carries a -{cohort} suffix
 # (zoonomia-v1-v4_cds-order → pipeline_version=v1, dataset=v4_cds-order, not
-# pipeline_version=v1-v4_cds). Global: applies to every {pipeline_version}.
+# pipeline_version=v1-v4_cds). Load-bearing for prepare_training_shards and
+# compress_shard, which lack a per-rule intervals_version constraint to anchor
+# the split (the readme/upload rules below also pin it). Global: applies to
+# every {pipeline_version} wildcard (all of which live in this file).
 wildcard_constraints:
     pipeline_version=r"v\d+",
+
+
+def _ships_card(dataset: str) -> bool:
+    """Whether a dataset slug ships an HF dataset card.
+
+    True for v3_*/v4_* region partitions and for species-subset cohort slugs
+    (which carry a trailing ``-{cohort}``, e.g. ``v4_cds-order``). v1/v2
+    default-species sets are card-less by design. Keep in sync with the card
+    rules' wildcard_constraints (dataset_hf_readme_v3 / _v4 / _species_subset).
+    """
+    return dataset.startswith(("v3_", "v4_")) or "-" in dataset
 
 
 rule subset_species:
@@ -263,7 +292,7 @@ rule dataset_hf_readme_species_subset:
         base_iv, cohort = wildcards.intervals_version.rsplit("-", 1)
         n_rows = pl.scan_parquet(input.source).select(pl.len()).collect().item()
         n_samples = n_rows * (2 if params.add_rc else 1)
-        n_species = pl.read_csv(params.species_tsv, separator="\t").height
+        n_species = len(load_species(params.species_tsv))
         write_species_subset_hf_readme(
             base_iv,
             cohort,
@@ -295,7 +324,7 @@ rule hf_upload_dataset:
         ),
         readme=lambda wc: (
             f"results/dataset/zoonomia-{wc.pipeline_version}-{wc.intervals_version}/README.md"
-            if wc.intervals_version.startswith(("v3_", "v4_"))
+            if _ships_card(wc.intervals_version)
             else []
         ),
     output:
@@ -304,12 +333,13 @@ rule hf_upload_dataset:
     params:
         repo=lambda wc: f"{HF_OWNER}/zoonomia-{wc.pipeline_version}-{wc.intervals_version}",
         data_dir=lambda wc: f"results/dataset/zoonomia-{wc.pipeline_version}-{wc.intervals_version}",
-        has_readme=lambda wc: int(wc.intervals_version.startswith(("v3_", "v4_"))),
+        has_readme=lambda wc: int(_ships_card(wc.intervals_version)),
     wildcard_constraints:
         pipeline_version=r"v\d+",
         # Optional trailing -{cohort} (scheme B) for species-subset datasets,
-        # e.g. v4_cds-order. has_readme below keys off the v3_/v4_ prefix, so
-        # the cohort still ships a card (its README rule is below).
+        # e.g. v4_cds-order. _ships_card() recognizes both v3_/v4_ region
+        # partitions and -{cohort} slugs (on any base), so every carded dataset
+        # uploads its card; v1/v2 default-species sets stay card-less.
         intervals_version=r"v\d+(?:_\w+)?(?:-[a-z0-9]+)?",
     threads: workflow.cores
     shell:

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/project.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/project.smk
@@ -40,7 +40,7 @@ from marin_dna.pipelines.projection.sequence import (
     parquet_to_bed6,
     parse_bedtools_getfasta_output,
 )
-from marin_dna.pipelines.projection.subset import filter_to_subset
+from marin_dna.pipelines.projection.subset import filter_to_species, filter_to_subset
 
 
 # Two cCREs from SCREEN Registry V4 inside the canonical ZRS limb enhancer

--- a/snakemake/zoonomia_projection_dataset/workflow/rules/project.smk
+++ b/snakemake/zoonomia_projection_dataset/workflow/rules/project.smk
@@ -40,7 +40,11 @@ from marin_dna.pipelines.projection.sequence import (
     parquet_to_bed6,
     parse_bedtools_getfasta_output,
 )
-from marin_dna.pipelines.projection.subset import filter_to_species, filter_to_subset
+from marin_dna.pipelines.projection.subset import (
+    filter_to_species,
+    filter_to_subset,
+    load_species,
+)
 
 
 # Two cCREs from SCREEN Registry V4 inside the canonical ZRS limb enhancer

--- a/src/marin_dna/pipelines/projection/subset.py
+++ b/src/marin_dna/pipelines/projection/subset.py
@@ -67,3 +67,86 @@ def filter_to_subset(
     df = pl.read_parquet(str(all_species_parquet))
     df = df.filter(pl.col("query_name").is_in(keys))
     df.write_parquet(str(out))
+
+
+def load_species(path: str | Path) -> set[str]:
+    """Read the ``species`` column of a species TSV as a set.
+
+    The species TSVs (``config/species_zoonomia_447_<rank>_dedup.tsv``) are
+    tab-separated with a ``species`` header column holding raw HAL leaf names
+    — the same vocabulary as the ``species`` column of the projection
+    Parquets, so the set is the natural form for the downstream ``is_in``
+    filter.
+    """
+    df = pl.read_csv(str(path), separator="\t")
+    assert "species" in df.columns, (
+        f"species TSV {path} missing 'species' column; got {df.columns}"
+    )
+    out = set(df["species"].to_list())
+    assert out, f"no species rows in {path}"
+    return out
+
+
+def filter_to_species(
+    source_parquet: str | Path,
+    species: set[str] | list[str] | str | Path,
+    out_parquet: str | Path,
+) -> None:
+    """Filter a projection Parquet to rows whose ``species`` is in the cohort.
+
+    The species cohort is a row-filter on the ``species`` column, orthogonal
+    to the ``query_name`` filter applied by :func:`filter_to_subset`: the two
+    compose (e.g. the v4_cds intervals subset restricted to the one-per-order
+    species cohort). ``species`` is a set/list of HAL leaf names, or a path to
+    a species TSV (parsed via :func:`load_species`, reading the ``species``
+    column).
+
+    Asserts the requested cohort is a **subset** of the species present in
+    ``source_parquet`` — a missing leaf means the cohort references a species
+    not in this projection (or one with zero rows in this intervals subset),
+    which would silently shrink the dataset, so we fail loudly (CLAUDE.md
+    "fail fast on silent-corruption risks").
+
+    Eager read+filter+write rather than the lazy ``scan``/``sink_parquet``
+    path — same polars-1.x large-Parquet segfault that
+    :func:`filter_to_subset` documents; the source intervals subset fits
+    comfortably in RAM on the upload cluster.
+
+    Args:
+        source_parquet: the intervals-subset Parquet to filter (e.g. the
+            v4_cds subset, carrying all projection species' rows).
+        species: a set/list of HAL leaf names, or a path to a species TSV.
+        out_parquet: destination Parquet (parent dirs created as needed).
+    """
+    if isinstance(species, (str, Path)):
+        keys = load_species(species)
+    else:
+        keys = set(species)
+    assert keys, "empty species cohort"
+
+    df = pl.read_parquet(str(source_parquet))
+    assert "species" in df.columns, (
+        f"source Parquet missing 'species' column; got {df.columns}"
+    )
+    present = set(df["species"].unique().to_list())
+    missing = keys - present
+    assert not missing, (
+        f"species cohort is not a subset of the projection: "
+        f"{sorted(missing)} absent from {source_parquet} "
+        f"({len(present)} species present)"
+    )
+
+    out = df.filter(pl.col("species").is_in(keys))
+    # Given the subset check above, every requested leaf has >=1 row, so this
+    # is a guaranteed invariant — assert it anyway (loud failure beats a
+    # silently short cohort feeding into training).
+    kept = set(out["species"].unique().to_list())
+    assert kept == keys, (
+        f"expected all {len(keys)} cohort species kept; missing "
+        f"{sorted(keys - kept)}"
+    )
+    assert out.height > 0, "species-filtered subset is empty"
+
+    out_path = Path(out_parquet)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out.write_parquet(str(out_path))

--- a/src/marin_dna/pipelines/projection/subset.py
+++ b/src/marin_dna/pipelines/projection/subset.py
@@ -142,8 +142,7 @@ def filter_to_species(
     # silently short cohort feeding into training).
     kept = set(out["species"].unique().to_list())
     assert kept == keys, (
-        f"expected all {len(keys)} cohort species kept; missing "
-        f"{sorted(keys - kept)}"
+        f"expected all {len(keys)} cohort species kept; missing {sorted(keys - kept)}"
     )
     assert out.height > 0, "species-filtered subset is empty"
 

--- a/src/marin_dna/pipelines/zoonomia_projection_dataset/region_labels.py
+++ b/src/marin_dna/pipelines/zoonomia_projection_dataset/region_labels.py
@@ -1013,3 +1013,146 @@ Same as [`{hf_owner}/zoonomia-{pipeline_version}-v1`](https://huggingface.co/dat
 - Sister validation datasets: `{hf_owner}/zoonomia-{pipeline_version}-val_*`
 """
     Path(output_path).write_text(body)
+
+
+# Human-readable description per species cohort (the third dataset axis,
+# issue #233). The default 108-family cohort is implicit and has no entry.
+# {n_species} is substituted at render time.
+_SPECIES_COHORT_BLURBS: dict[str, str] = {
+    "order": (
+        "one representative species per NCBI **order** — {n_species} "
+        "deeply-diverged placental mammals (every pair separated by ~tens of "
+        "millions of years), versus the implicit-default 108 family-deduplicated "
+        "species. A strict **subset** of the family set, so it reuses the v1 "
+        "cross-mammal projection unchanged (no re-`halLiftover`)."
+    ),
+}
+
+
+def write_species_subset_hf_readme(
+    intervals_version: str,
+    cohort: str,
+    output_path: str | Path,
+    *,
+    commit_sha: str,
+    hf_owner: str,
+    pipeline_version: str,
+    n_species: int,
+    n_samples: int,
+    species_tsv: str,
+    github_repo: str = _GITHUB_REPO,
+) -> None:
+    """Write the HF dataset card for a species-subset dataset (issue #233).
+
+    A species-subset dataset is an existing intervals subset
+    (``intervals_version``, e.g. ``v4_cds``) restricted to a species
+    ``cohort`` (e.g. ``order``) — a row-filter on the ``species`` column,
+    orthogonal to the region/intervals axis. The card describes the cohort,
+    its size, and links the base region dataset plus the cohort's species TSV.
+
+    Kept separate from :func:`write_subset_hf_readme_v4` (rather than threading
+    a cohort through its monolithic body) so the frozen default-cohort cards
+    stay reproducible — the same rationale that split v3/v4.
+
+    Args:
+        intervals_version: the base region dataset, e.g. ``"v4_cds"``.
+        cohort: the species cohort key, e.g. ``"order"`` (must be in
+            :data:`_SPECIES_COHORT_BLURBS`).
+        n_species: number of species in the cohort (e.g. 19 for ``order``).
+        n_samples: post-RC row count of this dataset (the exact total across
+            all shards).
+        species_tsv: pipeline-relative path to the cohort's species TSV
+            (e.g. ``config/species_zoonomia_447_order_dedup.tsv``), linked as a
+            commit-pinned permalink.
+    """
+    if cohort not in _SPECIES_COHORT_BLURBS:
+        raise ValueError(
+            f"unknown species cohort {cohort!r}; expected one of "
+            f"{sorted(_SPECIES_COHORT_BLURBS)}"
+        )
+
+    slug = f"{intervals_version}-{cohort}"
+    repo_name = f"{hf_owner}/zoonomia-{pipeline_version}-{slug}"
+    base_repo = f"{hf_owner}/zoonomia-{pipeline_version}-{intervals_version}"
+    pipeline_permalink = (
+        f"https://github.com/{github_repo}/tree/{commit_sha}/{_GITHUB_PIPELINE_PATH}"
+    )
+    pipeline_main_link = (
+        f"https://github.com/{github_repo}/tree/main/{_GITHUB_PIPELINE_PATH}"
+    )
+    species_tsv_permalink = (
+        f"https://github.com/{github_repo}/blob/{commit_sha}/"
+        f"{_GITHUB_PIPELINE_PATH}/{species_tsv}"
+    )
+    cohort_blurb = _SPECIES_COHORT_BLURBS[cohort].format(n_species=n_species)
+
+    body = f"""---
+tags:
+- biology
+- genomics
+- DNA
+---
+
+# `{repo_name}`
+
+The [`{base_repo}`](https://huggingface.co/datasets/{base_repo}) cross-mammal
+training set, restricted to a **species cohort**: {cohort_blurb}
+
+Same human anchors and same per-window sequences as
+[`{base_repo}`](https://huggingface.co/datasets/{base_repo}) — only the set of
+target species differs. This is a **species-axis** subset (a row-filter on the
+`species` column), orthogonal to the region/intervals axis that defines
+`{intervals_version}`. Produced by the
+[`{_GITHUB_PIPELINE_PATH}`]({pipeline_permalink}) pipeline
+(commit [`{commit_sha[:12]}`]({pipeline_permalink})).
+
+## Species cohort (`{cohort}`, {n_species} species)
+
+The cohort is defined by [`{species_tsv}`]({species_tsv_permalink}) — one row
+per species (raw HAL leaf name in the `species` column). Because it is a strict
+subset of the 108-family v1 species set, the cross-mammal projection is reused
+as-is; no re-`halLiftover` is run.
+
+## Size
+
+**{n_samples:,} training samples** across all JSONL.zst shards — the
+`{intervals_version}` anchors projected onto the {n_species}-species cohort,
+after reverse-complement augmentation. Fewer than the implicit-default
+108-species [`{base_repo}`](https://huggingface.co/datasets/{base_repo}) by
+roughly the species ratio.
+
+## Schema
+
+Single `train` split of JSONL.zst shards at `data/train/shard_NNNN.jsonl.zst`,
+identical to [`{base_repo}`](https://huggingface.co/datasets/{base_repo}):
+
+| Column         | Type | Description |
+|---|---|---|
+| `query_name`   | str  | human-window id (`win_<chrom>_<NNN>` from `windows.smk`) |
+| `species`      | str  | one of the {n_species} cohort species |
+| `t_chrom`      | str  | UCSC `chr1`-style |
+| `t_start`      | int  | 0-based half-open |
+| `t_end`        | int  | 0-based half-open; `t_end - t_start == 255` |
+| `t_strand`     | str  | `+` or `-` |
+| `t_src_size`   | int  | target chromosome size |
+| `sequence`     | str  | exactly 255 bp; **strand-aware** (already RC'd if `t_strand == "-"`) |
+| `augmentation` | str  | `+` (original) or `-` (RC of `sequence`) |
+
+## Construction
+
+1. Build the v1 cross-mammal training set and its `{intervals_version}` region
+   partition (see the [pipeline README]({pipeline_permalink}/README.md)).
+2. **Filter** `{intervals_version}` to the `{cohort}` species cohort via
+   `marin_dna.pipelines.projection.subset.filter_to_species` (asserts the
+   cohort is a subset of the projection's species).
+3. RC-augment, shuffle (`seed=42`), shard to JSONL, zstd-compress, upload via
+   `hf upload-large-folder`.
+
+## Source code
+
+- Pipeline: [{_GITHUB_PIPELINE_PATH}]({pipeline_main_link}) (latest)
+- Pinned to this dataset's build: [commit `{commit_sha[:12]}`]({pipeline_permalink})
+- Species cohort list: [`{species_tsv}`]({species_tsv_permalink})
+- Base region dataset: [`{base_repo}`](https://huggingface.co/datasets/{base_repo})
+"""
+    Path(output_path).write_text(body)

--- a/tests/pipelines/projection/test_subset.py
+++ b/tests/pipelines/projection/test_subset.py
@@ -137,7 +137,9 @@ def test_filter_to_subset_empty_keys(tmp_path: Path) -> None:
 def _write_species_tsv(tmp_path: Path, species: list[str]) -> Path:
     """Write a minimal species TSV (header + species column) like the configs."""
     p = tmp_path / "species.tsv"
-    lines = ["species\tfamily\torder\taccession\tassembly_level\tcontig_n50\tquality_source"]
+    lines = [
+        "species\tfamily\torder\taccession\tassembly_level\tcontig_n50\tquality_source"
+    ]
     for s in species:
         lines.append(f"{s}\tFamX\tOrderX\tGCA_0\tScaffold\t1000\tzoonomia_supp_st2")
     p.write_text("\n".join(lines) + "\n")

--- a/tests/pipelines/projection/test_subset.py
+++ b/tests/pipelines/projection/test_subset.py
@@ -6,7 +6,14 @@ from pathlib import Path
 
 import polars as pl
 
-from marin_dna.pipelines.projection.subset import filter_to_subset, load_query_names
+import pytest
+
+from marin_dna.pipelines.projection.subset import (
+    filter_to_species,
+    filter_to_subset,
+    load_query_names,
+    load_species,
+)
 
 
 def test_load_query_names_skips_blanks_and_comments(tmp_path: Path) -> None:
@@ -125,3 +132,65 @@ def test_filter_to_subset_empty_keys(tmp_path: Path) -> None:
     assert "query_name" in got.columns
     assert "species" in got.columns
     assert "sequence" in got.columns
+
+
+def _write_species_tsv(tmp_path: Path, species: list[str]) -> Path:
+    """Write a minimal species TSV (header + species column) like the configs."""
+    p = tmp_path / "species.tsv"
+    lines = ["species\tfamily\torder\taccession\tassembly_level\tcontig_n50\tquality_source"]
+    for s in species:
+        lines.append(f"{s}\tFamX\tOrderX\tGCA_0\tScaffold\t1000\tzoonomia_supp_st2")
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+def test_load_species_reads_species_column(tmp_path: Path) -> None:
+    tsv = _write_species_tsv(tmp_path, ["A", "C"])
+    assert load_species(tsv) == {"A", "C"}
+
+
+def test_filter_to_species_keeps_only_cohort_species(tmp_path: Path) -> None:
+    src = _make_all_species_parquet(tmp_path)  # species A (×3), B (×2), C (×1)
+    out = tmp_path / "cohort.parquet"
+    filter_to_species(src, {"A", "C"}, out)
+
+    got = pl.read_parquet(out)
+    assert set(got["species"].unique()) == {"A", "C"}
+    # A has 3 rows (win_1/2/3), C has 1 (win_1); B (×2) dropped.
+    assert got.height == 4
+    # Orthogonal to the query_name axis: every query_name A/C touch survives.
+    assert set(got["query_name"].unique()) == {"win_1", "win_2", "win_3"}
+
+
+def test_filter_to_species_via_tsv(tmp_path: Path) -> None:
+    src = _make_all_species_parquet(tmp_path)
+    tsv = _write_species_tsv(tmp_path, ["B"])
+    out = tmp_path / "cohort.parquet"
+    filter_to_species(src, tsv, out)
+
+    got = pl.read_parquet(out)
+    assert set(got["species"].unique()) == {"B"}
+    assert got.height == 2  # B is present for win_1 and win_2
+
+
+def test_filter_to_species_rejects_species_not_in_source(tmp_path: Path) -> None:
+    """A cohort leaf absent from the source must fail loudly (not silently shrink)."""
+    src = _make_all_species_parquet(tmp_path)
+    out = tmp_path / "cohort.parquet"
+    with pytest.raises(AssertionError, match="not a subset"):
+        filter_to_species(src, {"A", "Z_absent"}, out)
+
+
+def test_filter_to_species_compose_with_query_name_subset(tmp_path: Path) -> None:
+    """Species filter ∘ query_name filter commute (the v4_cds × order pattern)."""
+    src = _make_all_species_parquet(tmp_path)
+    iv = tmp_path / "iv.parquet"  # intervals subset: win_1, win_2 (all species)
+    filter_to_subset(src, {"win_1", "win_2"}, iv)
+    out = tmp_path / "iv_cohort.parquet"
+    filter_to_species(iv, {"A", "C"}, out)
+
+    got = pl.read_parquet(out)
+    # win_1 → A,C ; win_2 → A (C absent for win_2). 3 rows.
+    assert got.height == 3
+    assert set(got["species"].unique()) == {"A", "C"}
+    assert set(got["query_name"].unique()) == {"win_1", "win_2"}

--- a/tests/pipelines/zoonomia_projection_dataset/test_region_labels.py
+++ b/tests/pipelines/zoonomia_projection_dataset/test_region_labels.py
@@ -1221,3 +1221,62 @@ def test_write_subset_hf_readme_v4_rejects_unknown_subset(
             composition_tsv=composition_tsv,
             n_samples=1,
         )
+
+
+# ---------------------------------------------------------------------------
+# write_species_subset_hf_readme tests (the third dataset axis, issue #233)
+# ---------------------------------------------------------------------------
+
+from marin_dna.pipelines.zoonomia_projection_dataset.region_labels import (  # noqa: E402
+    write_species_subset_hf_readme,
+)
+
+
+def test_write_species_subset_hf_readme_renders_card(tmp_path: Path) -> None:
+    out = tmp_path / "README.md"
+    write_species_subset_hf_readme(
+        "v4_cds",
+        "order",
+        out,
+        commit_sha="0123456789abcdef0123456789abcdef01234567",
+        hf_owner="bolinas-dna",
+        pipeline_version="v1",
+        n_species=19,
+        n_samples=10_123_456,
+        species_tsv="config/species_zoonomia_447_order_dedup.tsv",
+    )
+    body = out.read_text()
+
+    # Repo name (scheme B: cohort trailing) and base region dataset.
+    assert "# `bolinas-dna/zoonomia-v1-v4_cds-order`" in body
+    assert "bolinas-dna/zoonomia-v1-v4_cds" in body
+    # Cohort facts: 19 species, the "order" framing, and reuse-not-reproject.
+    assert "19" in body
+    assert "order" in body
+    assert "no re-`halLiftover`" in body
+    # Size and a commit-pinned permalink to the species TSV.
+    assert f"{10_123_456:,}" in body
+    assert (
+        "https://github.com/Open-Athena/marin-dna/blob/"
+        "0123456789abcdef0123456789abcdef01234567/"
+        "snakemake/zoonomia_projection_dataset/"
+        "config/species_zoonomia_447_order_dedup.tsv" in body
+    )
+    # Exactly the three canonical tags (biology / genomics / DNA).
+    front_matter, _, _ = body.partition("---\n\n")
+    assert front_matter.count("- ") == 3
+
+
+def test_write_species_subset_hf_readme_rejects_unknown_cohort(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unknown species cohort"):
+        write_species_subset_hf_readme(
+            "v4_cds",
+            "bogus_cohort",
+            tmp_path / "bogus.md",
+            commit_sha="a" * 40,
+            hf_owner="bolinas-dna",
+            pipeline_version="v1",
+            n_species=3,
+            n_samples=1,
+            species_tsv="config/whatever.tsv",
+        )


### PR DESCRIPTION
## What

Adds the **species cohort** axis ([#233](https://github.com/Open-Athena/marin-dna/issues/233)) — a third, orthogonal dataset axis alongside `pipeline_version` and `intervals_version`. A cohort is a row-filter on the `species` column; it composes with the `query_name` intervals filter. This PR ships the reusable machinery plus the wiring for the first cohort dataset, **`bolinas-dna/zoonomia-v1-v4_cds-order`** (the v4 `cds` region partition restricted to the 19 one-per-order species), which **reuses the existing v1 projection** — no re-`halLiftover`.

Closes #233. The species-subset axis **and** the first cohort dataset `bolinas-dna/zoonomia-v1-v4_cds-order` are now complete — built and uploaded (10,089,622 post-RC samples; see the [build record](https://github.com/Open-Athena/marin-dna/issues/233#issuecomment-4613865202) on #233).

## Naming (scheme B — cohort trailing, family implicit)

The 108-family cohort stays the implicit default, so the 14 published `zoonomia-v1-*` repos are byte-unchanged. Non-default cohorts get a trailing suffix:

```
zoonomia-{pipeline_version}-{intervals_version}-{cohort}   →   zoonomia-v1-v4_cds-order
```

## Changes

- **Library** — `filter_to_species` / `load_species` in `projection/subset.py` (eager read+filter+write, mirroring `filter_to_subset`'s documented large-Parquet pattern; asserts the cohort is a subset of the source's species — fail loud on a silently-short set). 5 new tests.
- **Config** — `species_subsets` (label → species TSV) + `species_subset_datasets` (`{intervals, species}` combos); ships `v4_cds × order`.
- **`dataset.smk`** — register cohort slugs in `INTERVALS_SOURCES`; `rule subset_species` → `subsets_species/{intervals}-{cohort}.parquet`; a global `pipeline_version=r"v\d+"` constraint so `zoonomia-v1-v4_cds-order` parses unambiguously (`pipeline_version=v1`, not `v1-v4_cds`); broadened `hf_upload_dataset`'s `intervals_version` regex; a cohort HF-card rule; `all_hf` → `ALL_DATASETS`.
- **`region_labels.py`** — `write_species_subset_hf_readme` (a **separate** function, keeping the frozen v3/v4 cards reproducible — the same rationale that split v3/v4) + 2 tests. Tags stay `biology, genomics, DNA`; card carries a commit-pinned permalink to the order species TSV.
- **README** — a "Species axis" section (naming, mechanics, build command) + refreshed the stale order-set note.

## Verification

- `uv run pytest tests/pipelines/projection/ tests/pipelines/zoonomia_projection_dataset/` → **159 passed** (incl. 7 new: 5 species-filter + 2 card).
- Workflow parses; `subset_species` and `dataset_hf_readme_species_subset` are registered.
- **Dry-run delta** of `zoonomia-v1-v4_cds-order` vs the existing, already-built `zoonomia-v1-v4_cds` is **exactly** `+subset_species` and the card swap (`dataset_hf_readme_v4` → `dataset_hf_readme_species_subset`) — the projection cascade is identical, so the cohort introduces **no new upstream work**. (Both plans show the projection cascade *locally* only because of the documented fresh-checkout artifact — `local()` FASTA intermediates absent + S3 mtimes read as updated; on the upload cluster, where the v1 projection metadata + `local()` files are intact, both collapse to the dataset-assembly tail.)
- Pre-commit ruff + mypy pass (`SKIP=snakefmt` only, per the known snakefmt-0.11.2 `.smk` breakage).

## Not in this PR

- **The HF upload action itself** (a runtime step, not a code change). `zoonomia-v1-v4_cds-order` has already been built and uploaded by running this code (`sky/upload.yaml --env UPLOAD_MODE=species_subset`, reusing the v1 projection — no re-`halLiftover`; 10,089,622 post-RC samples). Re-running is only needed if the dataset changes.
- Other intervals × order, or other cohorts (e.g. all-447) — each is one `species_subset_datasets` line; non-subset cohorts would need a `pipeline_version` bump + re-projection (out of scope).

<details>
<summary>Dry-run job stats — family <code>zoonomia-v1-v4_cds</code> (existing) vs cohort <code>zoonomia-v1-v4_cds-order</code> (new)</summary>

```
EXISTING family: zoonomia-v1-v4_cds          NEW cohort: zoonomia-v1-v4_cds-order
job                        count              job                                 count
-----------------------  -------              --------------------------------  -------
hal_to_fasta                 108              hal_to_fasta                          108
project_one_species          108              project_one_species                   108
fasta_to_2bit                108              fasta_to_2bit                         108
extract_sequences            108              extract_sequences                     108
merge_sequences                1              merge_sequences                         1
subset_dataset_derived         1              subset_dataset_derived                  1
                                              subset_species                          1   ← new
dataset_hf_readme_v4           1              dataset_hf_readme_species_subset        1   ← swapped
prepare_training_shards        1              prepare_training_shards                 1
compress_shard                64              compress_shard                         64
hf_upload_dataset              1              hf_upload_dataset                       1
total                        501              total                                 502
```

The projection cascade (top six rows) is identical and is the fresh-checkout artifact; it is **not** re-run on the upload cluster.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

