### PR TITLE
Nucleotide dependency maps (categorical Jacobian) for autoregressive gLMs in evals_v2

### DIFF
--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -852,3 +852,28 @@ inference:
   bootstrap_seed: 0     # 0 → reproducible across re-runs. Bumping
                         # this triggers metric re-execution via
                         # snakemake's `params:` hash.
+
+
+# ---------------------------------------------------------------------------
+# Nucleotide dependency maps (categorical Jacobian) — interpretation, #237.
+#
+# NOT a metric: these targets are kept off `rule all`. Build explicitly:
+#   snakemake nuc_dep                                  # all (locus, model) plots
+#   snakemake results/plots/nuc_dep/LDLR/<model>.svg   # one map
+#
+# Coordinates are 0-based half-open, GRCh38 (Ensembl chrom names, no `chr`).
+# Loci are reused from the nuc-dep paper's human examples so our maps can be
+# eyeballed against the published figures. Each locus must fit the model's
+# `window_size` (asserted at config load); HBA1 (256 bp) is omitted because it
+# does not fit the 255 bp window of the mix-v0.9 models.
+# ---------------------------------------------------------------------------
+nuc_dep:
+  combine: mean        # symmetrization of the stitched FWD/RC map: mean | max (#237)
+  ord: inf             # vector-norm order collapsing each 4x4 nucleotide block
+  batch_size: 32       # sequences per forward pass (execution-only; tune for VRAM)
+  models:
+    - mix-v0.9-p1B-i24-exp135-m5.1-step-59158
+  loci:
+    LDLR:  {chrom: "19", start: 11089299,  end: 11089425,  strand: "+"}
+    TH:    {chrom: "11", start: 2171682,   end: 2171868,   strand: "-"}
+    GRIA4: {chrom: "11", start: 105609444, end: 105609472, strand: "+"}

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -874,6 +874,9 @@ nuc_dep:
   ord: inf             # vector-norm order collapsing each 4x4 nucleotide block
   batch_size: 32       # sequences per forward pass (execution-only; tune for VRAM)
   dpi: 100             # heatmap raster dpi (the SVG embeds one rasterized image; lower = smaller file)
+  # Models here must use a BOS tokenizer (255 bp + BOS, like exp135): a causal
+  # LM's position 0 has no left-context distribution, so categorical_jacobian
+  # asserts n_prefix>=1. Do NOT add the no-BOS exp55/58/59/exp21 arms.
   models:
     - mix-v0.9-p1B-i24-exp135-m5.1-step-59158
   loci:

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -870,9 +870,10 @@ inference:
 # so a locus == window_size (zero flank) is an intended, supported case.
 # ---------------------------------------------------------------------------
 nuc_dep:
-  combine: mean        # symmetrization of the stitched FWD/RC map: mean | max (#237)
+  combines: [mean, max]  # stitched-FWD/RC symmetrizations to compute, one map each (#237)
   ord: inf             # vector-norm order collapsing each 4x4 nucleotide block
   batch_size: 32       # sequences per forward pass (execution-only; tune for VRAM)
+  dpi: 150             # heatmap raster dpi (the SVG embeds one rasterized image; lower = smaller file)
   models:
     - mix-v0.9-p1B-i24-exp135-m5.1-step-59158
   loci:

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -864,8 +864,10 @@ inference:
 # Coordinates are 0-based half-open, GRCh38 (Ensembl chrom names, no `chr`).
 # Loci are reused from the nuc-dep paper's human examples so our maps can be
 # eyeballed against the published figures. Each locus must fit the model's
-# `window_size` (asserted at config load); HBA1 (256 bp) is omitted because it
-# does not fit the 255 bp window of the mix-v0.9 models.
+# `window_size` (asserted at config load). HBA1 is 256 bp in the paper; we crop
+# 1 bp (trim the 3' end) so it fits the 255 bp window of the mix-v0.9 models —
+# GPN-Star likewise ran HBA1 with the locus filling the whole window (256/256),
+# so a locus == window_size (zero flank) is an intended, supported case.
 # ---------------------------------------------------------------------------
 nuc_dep:
   combine: mean        # symmetrization of the stitched FWD/RC map: mean | max (#237)
@@ -877,3 +879,5 @@ nuc_dep:
     LDLR:  {chrom: "19", start: 11089299,  end: 11089425,  strand: "+"}
     TH:    {chrom: "11", start: 2171682,   end: 2171868,   strand: "-"}
     GRIA4: {chrom: "11", start: 105609444, end: 105609472, strand: "+"}
+    # HBA1: paper locus 176699-176955 (256 bp) cropped to 255 (3' end -1) to fit.
+    HBA1:  {chrom: "16", start: 176699,    end: 176954,    strand: "+"}

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -873,7 +873,7 @@ nuc_dep:
   combines: [mean, max]  # stitched-FWD/RC symmetrizations to compute, one map each (#237)
   ord: inf             # vector-norm order collapsing each 4x4 nucleotide block
   batch_size: 32       # sequences per forward pass (execution-only; tune for VRAM)
-  dpi: 150             # heatmap raster dpi (the SVG embeds one rasterized image; lower = smaller file)
+  dpi: 100             # heatmap raster dpi (the SVG embeds one rasterized image; lower = smaller file)
   models:
     - mix-v0.9-p1B-i24-exp135-m5.1-step-59158
   loci:
@@ -882,3 +882,8 @@ nuc_dep:
     GRIA4: {chrom: "11", start: 105609444, end: 105609472, strand: "+"}
     # HBA1: paper locus 176699-176955 (256 bp) cropped to 255 (3' end -1) to fit.
     HBA1:  {chrom: "16", start: 176699,    end: 176954,    strand: "+"}
+    # tRNA-Arg-TCT-4-1 (gtrnadb GRCh38), a structured ncRNA used in the nuc-dep
+    # paper (Fig 7) — the map should recover its cloverleaf base-pairing. UCSC
+    # display chr1:159141611-159141684 (-) is 1-based inclusive → 0-based
+    # half-open start 159141610, end 159141684 (74 bp).
+    tRNA_Arg_TCT: {chrom: "1", start: 159141610, end: 159141684, strand: "-"}

--- a/snakemake/analysis/evals_v2/workflow/Snakefile
+++ b/snakemake/analysis/evals_v2/workflow/Snakefile
@@ -9,6 +9,7 @@ include: "rules/common.smk"
 include: "rules/download.smk"
 include: "rules/inference.smk"
 include: "rules/metrics.smk"
+include: "rules/interpretation.smk"
 
 
 rule all:

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -106,3 +106,37 @@ def get_model_batch_size(model_name):
         isinstance(bs, int) and bs > 0
     ), f"model {model_name!r} `batch_size` must be a positive int, got {bs!r}"
     return bs
+
+
+# --- Nucleotide dependency maps (interpretation, issue #237) ----------------
+# Optional `nuc_dep:` config section. Targets are kept off `rule all`; see
+# rules/interpretation.smk.
+NUC_DEP_CFG = config.get("nuc_dep", {})
+NUC_DEP_LOCI = list(NUC_DEP_CFG.get("loci", {}))
+NUC_DEP_MODELS = NUC_DEP_CFG.get("models", [])
+
+
+def get_nuc_dep_ord():
+    """Vector-norm order for collapsing each 4x4 Jacobian block. ``inf`` (the
+    default, as in GPN-Star) → ``np.inf``; otherwise a float."""
+    raw = NUC_DEP_CFG.get("ord", "inf")
+    if isinstance(raw, str) and raw.lower() in ("inf", "infinity"):
+        return np.inf
+    return float(raw)
+
+
+# Fail fast: every nuc_dep model is a known checkpoint, and every locus fits the
+# context window of every model it would run on (the categorical Jacobian needs
+# the whole locus inside one window).
+for _m in NUC_DEP_MODELS:
+    assert _m in MODELS, f"nuc_dep model {_m!r} not found in `models`"
+for _loc, _c in NUC_DEP_CFG.get("loci", {}).items():
+    assert _c["end"] > _c["start"], (
+        f"nuc_dep locus {_loc!r}: end {_c['end']} must exceed start {_c['start']}"
+    )
+    for _m in NUC_DEP_MODELS:
+        _ws = get_model_config(_m)["window_size"]
+        assert _c["end"] - _c["start"] <= _ws, (
+            f"nuc_dep locus {_loc!r} span {_c['end'] - _c['start']} bp exceeds "
+            f"model {_m!r} window_size {_ws}"
+        )

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -114,6 +114,7 @@ def get_model_batch_size(model_name):
 NUC_DEP_CFG = config.get("nuc_dep", {})
 NUC_DEP_LOCI = list(NUC_DEP_CFG.get("loci", {}))
 NUC_DEP_MODELS = NUC_DEP_CFG.get("models", [])
+NUC_DEP_COMBINES = NUC_DEP_CFG.get("combines", ["mean"])
 
 
 def get_nuc_dep_ord():
@@ -128,6 +129,8 @@ def get_nuc_dep_ord():
 # Fail fast: every nuc_dep model is a known checkpoint, and every locus fits the
 # context window of every model it would run on (the categorical Jacobian needs
 # the whole locus inside one window).
+for _c in NUC_DEP_COMBINES:
+    assert _c in ("mean", "max"), f"nuc_dep combine {_c!r} must be 'mean' or 'max'"
 for _m in NUC_DEP_MODELS:
     assert _m in MODELS, f"nuc_dep model {_m!r} not found in `models`"
 for _loc, _c in NUC_DEP_CFG.get("loci", {}).items():

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -137,6 +137,9 @@ for _loc, _c in NUC_DEP_CFG.get("loci", {}).items():
     assert _c["end"] > _c["start"], (
         f"nuc_dep locus {_loc!r}: end {_c['end']} must exceed start {_c['start']}"
     )
+    assert _c["strand"] in ("+", "-"), (
+        f"nuc_dep locus {_loc!r}: strand must be '+' or '-', got {_c['strand']!r}"
+    )
     for _m in NUC_DEP_MODELS:
         _ws = get_model_config(_m)["window_size"]
         assert _c["end"] - _c["start"] <= _ws, (

--- a/snakemake/analysis/evals_v2/workflow/rules/interpretation.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/interpretation.smk
@@ -16,8 +16,9 @@ rule compute_nuc_dep:
     input:
         checkpoint="results/checkpoints/{model}",
     output:
-        "results/interpretation/nuc_dep/{locus}/{model}.parquet",
+        "results/interpretation/nuc_dep/{combine}/{locus}/{model}.parquet",
     wildcard_constraints:
+        combine="|".join(NUC_DEP_COMBINES),
         model="|".join(NUC_DEP_MODELS),
         locus="|".join(NUC_DEP_LOCI),
     params:
@@ -28,7 +29,6 @@ rule compute_nuc_dep:
         end=lambda wc: config["nuc_dep"]["loci"][wc.locus]["end"],
         strand=lambda wc: config["nuc_dep"]["loci"][wc.locus]["strand"],
         window_size=lambda wc: get_model_config(wc.model)["window_size"],
-        combine=config["nuc_dep"].get("combine", "mean"),
         norm_ord=get_nuc_dep_ord(),
     threads: config["inference"]["num_workers"]
     run:
@@ -43,7 +43,7 @@ rule compute_nuc_dep:
             end=int(params.end),
             strand=params.strand,
             window_size=int(params.window_size),
-            combine=params.combine,
+            combine=wildcards.combine,  # mean | max — from the output path
             norm_ord=params.norm_ord,
             batch_size=config["nuc_dep"].get("batch_size", 32),
         )
@@ -55,9 +55,9 @@ rule compute_nuc_dep:
 
 rule plot_nuc_dep:
     input:
-        "results/interpretation/nuc_dep/{locus}/{model}.parquet",
+        "results/interpretation/nuc_dep/{combine}/{locus}/{model}.parquet",
     output:
-        "results/plots/nuc_dep/{locus}/{model}.svg",
+        "results/plots/nuc_dep/{combine}/{locus}/{model}.svg",
     run:
         from marin_dna.pipelines.evals.interpretation import plot_dependency_map
 
@@ -69,16 +69,18 @@ rule plot_nuc_dep:
             df,
             output[0],
             chrom=str(config["nuc_dep"]["loci"][wildcards.locus]["chrom"]),
-            title=f"{wildcards.locus} — {wildcards.model}",
+            title=f"{wildcards.locus} ({wildcards.combine}) — {wildcards.model}",
+            dpi=config["nuc_dep"].get("dpi", 150),
         )
 
 
 rule nuc_dep:
-    """Aggregate convenience target: every (locus, model) dependency-map plot.
-    Not part of `rule all`."""
+    """Aggregate convenience target: every (combine, locus, model) dependency-map
+    plot. Not part of `rule all`."""
     input:
         [
-            f"results/plots/nuc_dep/{locus}/{model}.svg"
+            f"results/plots/nuc_dep/{combine}/{locus}/{model}.svg"
+            for combine in NUC_DEP_COMBINES
             for model in NUC_DEP_MODELS
             for locus in NUC_DEP_LOCI
         ],

--- a/snakemake/analysis/evals_v2/workflow/rules/interpretation.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/interpretation.smk
@@ -1,0 +1,84 @@
+"""Nucleotide dependency maps (categorical Jacobian) — interpretation, issue #237.
+
+GPU-bound compute rule + a plot rule. These targets are intentionally kept OUT
+of the default ``rule all`` (which is metrics-only), so they never perturb
+score/metric reruns. Build them explicitly:
+
+    snakemake nuc_dep                                   # all (locus, model) plots
+    snakemake results/plots/nuc_dep/LDLR/<model>.svg    # one map
+
+The compute rule reuses the existing ``download_model`` rule for the checkpoint
+and reads the GRCh38 reference straight from S3, exactly like ``compute_scores``.
+"""
+
+
+rule compute_nuc_dep:
+    input:
+        checkpoint="results/checkpoints/{model}",
+    output:
+        "results/interpretation/nuc_dep/{locus}/{model}.parquet",
+    wildcard_constraints:
+        model="|".join(NUC_DEP_MODELS),
+        locus="|".join(NUC_DEP_LOCI),
+    params:
+        # Output-affecting fields only (tracked by snakemake's `params` rerun
+        # trigger). batch_size is execution-only and read inside `run:`.
+        chrom=lambda wc: str(config["nuc_dep"]["loci"][wc.locus]["chrom"]),
+        start=lambda wc: config["nuc_dep"]["loci"][wc.locus]["start"],
+        end=lambda wc: config["nuc_dep"]["loci"][wc.locus]["end"],
+        strand=lambda wc: config["nuc_dep"]["loci"][wc.locus]["strand"],
+        window_size=lambda wc: get_model_config(wc.model)["window_size"],
+        combine=config["nuc_dep"].get("combine", "mean"),
+        norm_ord=get_nuc_dep_ord(),
+    threads: config["inference"]["num_workers"]
+    run:
+        from marin_dna.pipelines.evals.interpretation import compute_dependency_map
+
+        df = compute_dependency_map(
+            checkpoint_path=input.checkpoint,
+            # S3 URI; pyfaidx + fsspec/s3fs reads sequence by byte-range.
+            genome_path=config["genome_path"],
+            chrom=params.chrom,
+            start=int(params.start),
+            end=int(params.end),
+            strand=params.strand,
+            window_size=int(params.window_size),
+            combine=params.combine,
+            norm_ord=params.norm_ord,
+            batch_size=config["nuc_dep"].get("batch_size", 32),
+        )
+        n = int(params.end) - int(params.start)
+        assert df.shape == (n, n), f"expected {n}x{n} map, got {df.shape}"
+        df.to_parquet(output[0])
+        print(f"[nuc_dep] {wildcards.model} {wildcards.locus}: {df.shape[0]}x{df.shape[1]}")
+
+
+rule plot_nuc_dep:
+    input:
+        "results/interpretation/nuc_dep/{locus}/{model}.parquet",
+    output:
+        "results/plots/nuc_dep/{locus}/{model}.svg",
+    run:
+        from marin_dna.pipelines.evals.interpretation import plot_dependency_map
+
+        df = pd.read_parquet(input[0])
+        # parquet stringifies column names; restore int genomic coordinates.
+        df.columns = df.columns.astype(int)
+        df.index = df.index.astype(int)
+        plot_dependency_map(
+            df,
+            output[0],
+            chrom=str(config["nuc_dep"]["loci"][wildcards.locus]["chrom"]),
+            title=f"{wildcards.locus} — {wildcards.model}",
+        )
+
+
+rule nuc_dep:
+    """Aggregate convenience target: every (locus, model) dependency-map plot.
+    Not part of `rule all`."""
+    input:
+        [
+            f"results/plots/nuc_dep/{locus}/{model}.svg"
+            for model in NUC_DEP_MODELS
+            for locus in NUC_DEP_LOCI
+        ],

--- a/src/marin_dna/model/contact_metrics.py
+++ b/src/marin_dna/model/contact_metrics.py
@@ -1,0 +1,106 @@
+"""Contact-prediction metrics for nucleotide dependency maps (issue #237).
+
+Quantifies how well a (symmetric) dependency map recovers the known
+base-pairing of a structured ncRNA — the nuc-dep paper's Fig 7b benchmark
+(Tomaz da Silva et al., *Nat. Genet.* 2025; their
+``manuscript_code/fig7_benchmark_trna.ipynb``). Each position pair is scored by
+its dependency value and labelled by whether those two bases pair in the
+reference secondary structure; we report AUROC / AUPRC / top-L precision / PPV /
+MCC over the off-diagonal pairs.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def parse_trnascan_ss(ss: str) -> list[tuple[int, int]]:
+    """Parse a tRNAscan-SE nested-bp secondary structure into 0-indexed pairs.
+
+    The structure string uses ``>`` (open), ``<`` (close), ``.`` (unpaired);
+    pairs nest, so a stack matches each ``>`` to its partner ``<``. Returns a
+    sorted list of ``(i, j)`` with ``i < j``.
+    """
+    stack: list[int] = []
+    pairs: list[tuple[int, int]] = []
+    for k, c in enumerate(ss):
+        if c == ">":
+            stack.append(k)
+        elif c == "<":
+            assert stack, f"unbalanced structure: stray '<' at position {k}"
+            pairs.append((stack.pop(), k))
+        else:
+            assert c == ".", f"unexpected structure char {c!r} at position {k}"
+    assert not stack, f"unbalanced structure: {len(stack)} unclosed '>'"
+    return sorted(pairs)
+
+
+def base_pairs_to_contact_matrix(
+    base_pairs: list[tuple[int, int]], n: int
+) -> np.ndarray:
+    """Symmetric ``[n, n]`` boolean contact matrix from a base-pair list."""
+    contact = np.zeros((n, n), dtype=bool)
+    for i, j in base_pairs:
+        assert 0 <= i < n and 0 <= j < n, f"pair ({i},{j}) out of bounds for n={n}"
+        contact[i, j] = contact[j, i] = True
+    return contact
+
+
+def contact_prediction_metrics(
+    dep_map: np.ndarray,
+    base_pairs: list[tuple[int, int]],
+    *,
+    min_sep: int = 1,
+) -> dict[str, float]:
+    """Fig-7b-style contact-prediction metrics for a dependency map.
+
+    Candidate pairs are the strictly-lower triangle with separation
+    ``|i - j| >= min_sep`` (``min_sep=1`` = all off-diagonal, matching the
+    paper's active ``mask_diag=1``). Each candidate is scored by ``dep_map`` and
+    labelled by base-pair membership.
+
+    Args:
+        dep_map: Symmetric ``[n, n]`` dependency map (the map is symmetrized via
+            ``max(M, M.T)`` defensively, as in the reference).
+        base_pairs: 0-indexed ``(i, j)`` reference base pairs.
+        min_sep: Minimum sequence separation for a candidate pair.
+
+    Returns:
+        ``{auroc, auprc, top_L_precision, ppv, mcc, n_true_pairs, n_candidates}``.
+        ``top_L_precision`` = precision among the top ``L = n`` scored pairs;
+        ``ppv`` = precision among the top ``K = #true pairs``; ``mcc`` is at that
+        top-``K`` operating point.
+    """
+    from sklearn.metrics import (
+        auc,
+        matthews_corrcoef,
+        precision_recall_curve,
+        roc_auc_score,
+    )
+
+    dep_map = np.asarray(dep_map, dtype=float)
+    n = dep_map.shape[0]
+    assert dep_map.shape == (n, n), f"expected square map, got {dep_map.shape}"
+    dep_map = np.maximum(dep_map, dep_map.T)
+
+    contact = base_pairs_to_contact_matrix(base_pairs, n)
+    ii, jj = np.tril_indices(n, k=-min_sep)
+    scores = dep_map[ii, jj]
+    labels = contact[ii, jj]
+    assert labels.any(), "no reference base pairs fall within the candidate set"
+
+    prec, rec, _ = precision_recall_curve(labels, scores)
+    order = np.argsort(scores)[::-1]
+    n_true = int(labels.sum())
+    pred_topk = np.zeros_like(labels)
+    pred_topk[order[:n_true]] = True
+
+    return {
+        "auroc": float(roc_auc_score(labels, scores)),
+        "auprc": float(auc(rec, prec)),
+        "top_L_precision": float(labels[order[:n]].mean()),
+        "ppv": float(labels[order[:n_true]].mean()),
+        "mcc": float(matthews_corrcoef(labels, pred_topk)),
+        "n_true_pairs": n_true,
+        "n_candidates": int(labels.size),
+    }

--- a/src/marin_dna/model/interpretation.py
+++ b/src/marin_dna/model/interpretation.py
@@ -1,0 +1,236 @@
+"""Nucleotide dependency maps via the categorical Jacobian (issue #237).
+
+The categorical Jacobian measures how a single-nucleotide substitution at
+position ``i`` perturbs the model's predicted nucleotide distribution at every
+other position ``j``. Collapsing each ``4x4`` block to a scalar gives an
+``L x L`` *dependency map* (Tomaz da Silva et al., "Nucleotide dependency
+analysis of genomic language models detects functional elements",
+*Nat. Genet.* 2025), ported here from GPN-Star's ``interpretation/`` analysis.
+
+**Autoregressive twist.** GPN-Star is a masked LM, so its Jacobian is naturally
+two-sided. Our models are *causal* (``AutoModelForCausalLM``): the prediction
+for position ``t`` is ``P(x_t | x_{<t})`` and depends only on the left context.
+So the forward-strand Jacobian is **strictly upper-triangular** (perturbing
+``i`` cannot move any target ``m <= i``; the diagonal is structurally ~0). To
+recover the lower triangle we run the reverse-complemented window, flip it back
+to forward coordinates (now strictly lower-triangular), **stitch** the two
+disjoint triangles into one matrix ``A``, and **symmetrize** — ``(A + A.T)/2``
+(``combine="mean"``, the default) or ``max(A, A.T)`` (``combine="max"``, the
+paper's "max dependency within a pair"). See issue #237 for the full design.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from jaxtyping import Float, Int
+from torch import Tensor
+
+from marin_dna.data.dna import NUCLEOTIDES, reverse_complement
+from marin_dna.data.transforms import (
+    _get_nucleotide_token_ids,
+    _get_special_token_counts,
+)
+
+
+@torch.no_grad()
+def categorical_jacobian(
+    model: Any,
+    input_ids: Int[Tensor, " L"],
+    *,
+    nuc_token_ids: Int[Tensor, " 4"],
+    n_prefix: int,
+    window_size: int,
+    batch_size: int = 32,
+) -> Float[Tensor, "W 4 W 4"]:
+    """Categorical Jacobian of a causal LM over a window's DNA positions.
+
+    ``jac[i, a, m, b]`` is
+    ``log p(base b at DNA pos m | DNA pos i := nuc a)
+      - log p(base b at DNA pos m | wild-type)``,
+    computed in 4-nucleotide log-softmax space. For a causal LM ``jac`` is
+    strictly upper-triangular in ``(i, m)``.
+
+    Args:
+        model: HF-shaped causal LM — ``model(input_ids).logits`` must return
+            ``[B, L, V]`` (duck-typed; ``AutoModelForCausalLM`` satisfies it).
+        input_ids: One tokenized window, shape ``[L]`` (includes BOS / any
+            special tokens). Must already live on the model's device.
+        nuc_token_ids: Length-4 tensor of A/C/G/T token IDs in ``NUCLEOTIDES``
+            order.
+        n_prefix: Number of auto-prepended special tokens (BOS). Must be ``>= 1``
+            so DNA position 0 has a predictive context.
+        window_size: Number of DNA bases ``W`` in the window.
+        batch_size: Sequences per forward pass.
+
+    Returns:
+        ``[W, 4, W, 4]`` Jacobian on ``input_ids.device`` (fp32).
+    """
+    device = input_ids.device
+    W = window_size
+    L = int(input_ids.shape[0])
+    assert n_prefix >= 1, (
+        "categorical_jacobian needs a BOS token (n_prefix>=1): under a causal LM "
+        "with no left context, DNA position 0 has no predictive distribution. "
+        "exp135-style char tokenizers prepend BOS; a no-BOS model is unsupported."
+    )
+    assert L >= n_prefix + W, (
+        f"input_ids length {L} too short for window {W} + prefix {n_prefix}"
+    )
+    nuc_token_ids = nuc_token_ids.to(device)
+    # The logit that predicts DNA position m sits at index (n_prefix + m - 1):
+    # next-token logits[:, k] predict the token at input index k+1, and DNA
+    # position m lives at input index n_prefix + m.
+    readout_idx = torch.arange(W, device=device) + (n_prefix - 1)
+
+    def _readout(batch_ids: Int[Tensor, "B L"]) -> Float[Tensor, "B W 4"]:
+        logits = model(batch_ids).logits  # [B, L, V]
+        sel = logits[:, readout_idx][..., nuc_token_ids]  # [B, W, 4]
+        # fp32 log_softmax (biofoundation #21): bf16 rounding would otherwise
+        # leak into the near-zero lower triangle and break the causal assert.
+        return F.log_softmax(sel.float(), dim=-1)
+
+    base = _readout(input_ids.unsqueeze(0))[0]  # [W, 4]
+
+    # All single-position substitutions: pert[i, a] = input_ids with DNA pos i
+    # set to nucleotide a. Shape [W, 4, L].
+    pert = input_ids.view(1, 1, L).repeat(W, 4, 1)
+    for i in range(W):
+        pert[i, :, n_prefix + i] = nuc_token_ids
+    pert = pert.reshape(W * 4, L)
+
+    out = torch.empty((W * 4, W, 4), dtype=torch.float32, device=device)
+    for s in range(0, W * 4, batch_size):
+        out[s : s + batch_size] = _readout(pert[s : s + batch_size])
+
+    return out.reshape(W, 4, W, 4) - base.view(1, 1, W, 4)
+
+
+def dependency_matrix(jac: np.ndarray, norm_ord: float = np.inf) -> np.ndarray:
+    """Collapse each ``4x4`` block of a ``[W, 4, W, 4]`` Jacobian to a scalar
+    dependency via a vector norm over the 16 entries; zero the diagonal.
+
+    Returns a ``[W, W]`` matrix. For a forward (causal) Jacobian the result is
+    upper-triangular; the diagonal is zeroed explicitly (it is structurally ~0
+    for a causal LM but we zero it to match the masked-LM reference).
+    """
+    W = jac.shape[0]
+    assert jac.shape == (W, 4, W, 4), f"expected [W,4,W,4], got {jac.shape}"
+    x = jac.transpose(0, 2, 1, 3).reshape(W, W, -1)  # [W, W, 16]
+    D = np.linalg.norm(x, ord=norm_ord, axis=2)
+    np.fill_diagonal(D, 0.0)
+    return D
+
+
+def _stitch_and_symmetrize(
+    D_fwd: np.ndarray,
+    D_rc_flipped: np.ndarray,
+    combine: Literal["mean", "max"],
+) -> np.ndarray:
+    """Stitch the forward (upper-triangular) and reverse-complement
+    (lower-triangular, already flipped to forward coords) dependency matrices
+    into one matrix, then symmetrize.
+
+    The two triangles have disjoint support, so an elementwise **sum** stitches
+    them (this is *not* a per-strand average — that would halve every
+    off-diagonal value). The ``/2`` in ``mean`` is the symmetrization of the
+    stitched matrix: it averages the two *directed* dependencies ``i->j`` (from
+    the forward strand) and ``j->i`` (from RC) of each pair. See issue #237.
+    """
+    A = D_fwd + D_rc_flipped
+    if combine == "mean":
+        return (A + A.T) / 2.0
+    if combine == "max":
+        return np.maximum(A, A.T)
+    raise ValueError(f"combine must be 'mean' or 'max', got {combine!r}")
+
+
+@torch.no_grad()
+def nucleotide_dependency_map(
+    model: Any,
+    tokenizer: Any,
+    seq: str,
+    *,
+    rc: bool = True,
+    combine: Literal["mean", "max"] = "mean",
+    norm_ord: float = np.inf,
+    batch_size: int = 32,
+    atol: float = 1e-3,
+) -> np.ndarray:
+    """Nucleotide dependency map for one window, FWD+RC-stitched for causal LMs.
+
+    Args:
+        model: HF-shaped causal LM (see ``categorical_jacobian``).
+        tokenizer: Tokenizer for ``model`` (encodes ``seq``; supplies BOS count
+            and A/C/G/T token IDs).
+        seq: DNA window of length ``W``. The model receives the full window as
+            context.
+        rc: If True (default), also run the reverse-complemented window and
+            stitch FWD (upper) + RC (lower) before symmetrizing. If False,
+            return the forward-only map reflected via ``max`` — a one-sided
+            diagnostic, not a true dependency map (a causal LM sees only the
+            upper triangle on a single strand).
+        combine: Symmetrization of the stitched matrix when ``rc=True`` —
+            ``"mean"`` = ``(A + A.T)/2`` (default), ``"max"`` = ``max(A, A.T)``.
+        norm_ord: Vector-norm order collapsing each ``4x4`` block (``np.inf`` =
+            max-abs, as in GPN-Star).
+        batch_size: Sequences per forward pass.
+        atol: Tolerance for the causal-triangularity asserts.
+
+    Returns:
+        Symmetric ``[W, W]`` dependency map (numpy fp32/fp64).
+    """
+    try:
+        device = next(model.parameters()).device
+    except StopIteration:
+        device = torch.device("cpu")
+    n_prefix, _ = _get_special_token_counts(tokenizer)
+    nuc_ids = _get_nucleotide_token_ids(tokenizer)
+    nuc_token_ids = torch.tensor(
+        [nuc_ids[nuc] for nuc in NUCLEOTIDES], dtype=torch.long
+    )
+    W = len(seq)
+
+    def _strand_dependency(s: str) -> np.ndarray:
+        ids = torch.tensor(tokenizer.encode(s), dtype=torch.long, device=device)
+        jac = categorical_jacobian(
+            model,
+            ids,
+            nuc_token_ids=nuc_token_ids,
+            n_prefix=n_prefix,
+            window_size=W,
+            batch_size=batch_size,
+        )
+        return dependency_matrix(jac.cpu().numpy(), norm_ord=norm_ord)
+
+    D_fwd = _strand_dependency(seq)
+    # Causal invariant: the forward Jacobian is strictly upper-triangular.
+    # np.tril includes the (already-zeroed) diagonal; the strictly-lower part
+    # must be ~0 or our token/strand indexing is wrong.
+    lower_fwd = np.tril(D_fwd)
+    assert np.allclose(lower_fwd, 0.0, atol=atol), (
+        f"forward dependency map not upper-triangular (max |lower-tri| = "
+        f"{np.abs(lower_fwd).max():.2e} > atol={atol}); causal readout indexing "
+        f"is likely wrong"
+    )
+
+    if not rc:
+        return np.maximum(D_fwd, D_fwd.T)
+
+    D_rc = _strand_dependency(reverse_complement(seq))
+    # RC position k corresponds to forward position W-1-k; flip both axes to
+    # bring the RC map into forward coordinates. It is now lower-triangular.
+    D_rc_flipped = D_rc[::-1, ::-1]
+    upper_rc = np.triu(D_rc_flipped)
+    assert np.allclose(upper_rc, 0.0, atol=atol), (
+        f"reverse-complement dependency map not lower-triangular after flip "
+        f"(max |upper-tri| = {np.abs(upper_rc).max():.2e} > atol={atol}); the RC "
+        f"coordinate mapping is likely wrong"
+    )
+
+    M = _stitch_and_symmetrize(D_fwd, D_rc_flipped, combine)
+    assert np.allclose(M, M.T, atol=1e-6), "dependency map is not symmetric"
+    return M

--- a/src/marin_dna/model/interpretation.py
+++ b/src/marin_dna/model/interpretation.py
@@ -207,6 +207,7 @@ def nucleotide_dependency_map(
         return dependency_matrix(jac.cpu().numpy(), norm_ord=norm_ord)
 
     D_fwd = _strand_dependency(seq)
+    assert np.isfinite(D_fwd).all(), "forward dependency map has non-finite values"
     # Causal invariant: the forward Jacobian is strictly upper-triangular.
     # np.tril includes the (already-zeroed) diagonal; the strictly-lower part
     # must be ~0 or our token/strand indexing is wrong.
@@ -224,6 +225,7 @@ def nucleotide_dependency_map(
     # RC position k corresponds to forward position W-1-k; flip both axes to
     # bring the RC map into forward coordinates. It is now lower-triangular.
     D_rc_flipped = D_rc[::-1, ::-1]
+    assert np.isfinite(D_rc_flipped).all(), "RC dependency map has non-finite values"
     upper_rc = np.triu(D_rc_flipped)
     assert np.allclose(upper_rc, 0.0, atol=atol), (
         f"reverse-complement dependency map not lower-triangular after flip "

--- a/src/marin_dna/pipelines/evals/interpretation.py
+++ b/src/marin_dna/pipelines/evals/interpretation.py
@@ -59,6 +59,7 @@ def compute_dependency_map(
         map reads 5'->3' along the locus strand.
     """
     assert end > start, f"locus end {end} must exceed start {start}"
+    assert strand in ("+", "-"), f"strand must be '+' or '-', got {strand!r}"
     assert end - start <= window_size, (
         f"locus span {end - start} bp exceeds model window_size {window_size}; "
         f"pick a smaller locus or a longer-context model"
@@ -81,6 +82,13 @@ def compute_dependency_map(
     seq = genome(chrom, context_start, context_end, strand="+").upper()
     assert len(seq) == window_size, (
         f"extracted {len(seq)} bp, expected window_size={window_size}"
+    )
+    # Genome left/right-pads with N past chromosome ends (and assembly gaps
+    # carry N); such a window would build the map over non-genomic context while
+    # the length assert above still passes — fail loud rather than silently wrong.
+    assert "N" not in seq, (
+        f"window {chrom}:{context_start}-{context_end} contains N (near a chromosome "
+        f"boundary or assembly gap); pick a locus with full ACGT context"
     )
 
     M = nucleotide_dependency_map(
@@ -176,7 +184,9 @@ def plot_dependency_map(
         # blur) when the SVG is scaled — they read as sharp vector squares.
         svg = out.read_text()
         if "<image " in svg and "image-rendering" not in svg:
-            svg = svg.replace("<image ", '<image style="image-rendering:pixelated" ', 1)
+            # Replace every <image> (robust to a future colorbar / inset adding
+            # more than one rasterized layer), not just the first.
+            svg = svg.replace("<image ", '<image style="image-rendering:pixelated" ')
             out.write_text(svg)
         plt.savefig(out.with_suffix(".png"), bbox_inches="tight", dpi=dpi)
     plt.close()

--- a/src/marin_dna/pipelines/evals/interpretation.py
+++ b/src/marin_dna/pipelines/evals/interpretation.py
@@ -1,0 +1,161 @@
+"""Nucleotide dependency maps — pipeline glue + plotting (issue #237).
+
+Loads a checkpoint, extracts a ``window_size`` window centred on a locus,
+computes the FWD+RC-stitched dependency map via
+``marin_dna.model.interpretation.nucleotide_dependency_map``, and renders it as
+a heatmap. The categorical-Jacobian math lives in the model module; this is the
+thin orchestration layer the Snakemake rule calls.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+import pandas as pd
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from marin_dna.data.genome import Genome
+from marin_dna.model.interpretation import nucleotide_dependency_map
+
+
+def compute_dependency_map(
+    checkpoint_path: str | Path,
+    genome_path: str | Path,
+    chrom: str,
+    start: int,
+    end: int,
+    strand: Literal["+", "-"],
+    window_size: int,
+    *,
+    combine: Literal["mean", "max"] = "mean",
+    rc: bool = True,
+    norm_ord: float = np.inf,
+    batch_size: int = 32,
+) -> pd.DataFrame:
+    """Compute the nucleotide dependency map for a genomic locus.
+
+    A ``window_size`` window is centred on the locus midpoint and fed to the
+    model for context; the returned map is restricted to the locus
+    ``[start, end)``. Coordinates are 0-based half-open.
+
+    Args:
+        checkpoint_path: HF model directory (``AutoModelForCausalLM``).
+        genome_path: Reference FASTA (local path or ``s3://`` URI).
+        chrom, start, end, strand: Locus (0-based half-open). ``strand`` only
+            sets display orientation — the window is always extracted on ``+``
+            and reverse-complemented internally for the RC pass.
+        window_size: Model context window (bp); must be ``>= end - start``.
+        combine: Symmetrization of the stitched FWD/RC map (``mean`` | ``max``).
+        rc: Stitch forward + reverse-complement (the autoregressive fix).
+        norm_ord: Vector-norm order collapsing each ``4x4`` block.
+        batch_size: Sequences per forward pass.
+
+    Returns:
+        Symmetric ``[n, n]`` DataFrame (``n = end - start``) indexed and columned
+        by genomic position. For ``strand == "-"`` the axes are reversed so the
+        map reads 5'->3' along the locus strand.
+    """
+    assert end > start, f"locus end {end} must exceed start {start}"
+    assert end - start <= window_size, (
+        f"locus span {end - start} bp exceeds model window_size {window_size}; "
+        f"pick a smaller locus or a longer-context model"
+    )
+
+    # Duck-typed model/tokenizer throughout interpretation (see
+    # marin_dna.model.interpretation); annotate Any so HF stub overloads on
+    # `.to(device)` don't fight mypy.
+    tokenizer: Any = AutoTokenizer.from_pretrained(checkpoint_path)
+    model: Any = AutoModelForCausalLM.from_pretrained(
+        checkpoint_path, trust_remote_code=True
+    )
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model.to(device).eval()
+
+    genome = Genome(genome_path)
+    center = (start + end) // 2
+    context_start = center - window_size // 2
+    context_end = context_start + window_size
+    seq = genome(chrom, context_start, context_end, strand="+").upper()
+    assert len(seq) == window_size, (
+        f"extracted {len(seq)} bp, expected window_size={window_size}"
+    )
+
+    M = nucleotide_dependency_map(
+        model,
+        tokenizer,
+        seq,
+        rc=rc,
+        combine=combine,
+        norm_ord=norm_ord,
+        batch_size=batch_size,
+    )
+
+    start_idx = start - context_start
+    end_idx = end - context_start
+    assert 0 <= start_idx < end_idx <= window_size, (
+        f"locus window slice [{start_idx}:{end_idx}] out of bounds for "
+        f"window_size={window_size}"
+    )
+    sub = M[start_idx:end_idx, start_idx:end_idx]
+    coords = list(range(start, end))
+    df = pd.DataFrame(sub, index=coords, columns=coords)
+    if strand == "-":
+        df = df.iloc[::-1, ::-1]
+    return df
+
+
+def plot_dependency_map(
+    df: pd.DataFrame,
+    output_path: str | Path,
+    *,
+    chrom: str | None = None,
+    title: str | None = None,
+    tick_freq: int | None = None,
+) -> None:
+    """Render a dependency map as a ``coolwarm`` heatmap (SVG, plus a PNG
+    sibling for local visual sanity per repo convention).
+
+    Mirrors GPN-Star's nuc-dep plot: square aspect, robust color scaling,
+    rasterized cells, sparse genomic-coordinate ticks.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
+    coords = np.asarray(df.columns, dtype=int)
+    span = int(coords.max() - coords.min())
+    if tick_freq is None:
+        tick_freq = 50 if span > 100 else 10
+
+    plt.figure(figsize=(4, 4))
+    g = sns.heatmap(
+        df,
+        cmap="coolwarm",
+        square=True,
+        cbar=False,
+        xticklabels=False,
+        yticklabels=False,
+        robust=True,
+        rasterized=True,
+    )
+    tick_idx = np.where(coords % tick_freq == 0)[0]
+    g.set_xticks(tick_idx)
+    g.set_xticklabels(
+        [f"{coords[i]:,}" for i in tick_idx], rotation=0, ha="center", fontsize=8
+    )
+    if chrom is not None:
+        g.set_xlabel(f"Genomic position (chr{chrom})")
+    if title is not None:
+        g.set_title(title, fontsize=9)
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(out, bbox_inches="tight", dpi=200)
+    if out.suffix == ".svg":
+        plt.savefig(out.with_suffix(".png"), bbox_inches="tight", dpi=200)
+    plt.close()

--- a/src/marin_dna/pipelines/evals/interpretation.py
+++ b/src/marin_dna/pipelines/evals/interpretation.py
@@ -114,16 +114,24 @@ def plot_dependency_map(
     chrom: str | None = None,
     title: str | None = None,
     tick_freq: int | None = None,
+    dpi: int = 150,
 ) -> None:
     """Render a dependency map as a ``coolwarm`` heatmap (SVG, plus a PNG
     sibling for local visual sanity per repo convention).
 
     Mirrors GPN-Star's nuc-dep plot: square aspect, robust color scaling,
     rasterized cells, sparse genomic-coordinate ticks.
+
+    ``rasterized=True`` is essential: a dependency map is a dense ``L×L``
+    QuadMesh (e.g. 255×255 = 65k cells), which as pure SVG vector cells blows
+    up to ~12 MB. Rasterizing embeds the cells as a *single* PNG inside the
+    SVG (text/axes stay vector), so file size is governed by ``dpi`` — ~210 KB
+    at 150, ~130 KB at 72 for a 255 bp map. Lower ``dpi`` for smaller files.
     """
     import matplotlib
 
     matplotlib.use("Agg")
+    matplotlib.rcParams["svg.fonttype"] = "none"  # keep text as text, not paths
     import matplotlib.pyplot as plt
     import seaborn as sns
 
@@ -155,7 +163,7 @@ def plot_dependency_map(
 
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
-    plt.savefig(out, bbox_inches="tight", dpi=200)
+    plt.savefig(out, bbox_inches="tight", dpi=dpi)
     if out.suffix == ".svg":
-        plt.savefig(out.with_suffix(".png"), bbox_inches="tight", dpi=200)
+        plt.savefig(out.with_suffix(".png"), bbox_inches="tight", dpi=dpi)
     plt.close()

--- a/src/marin_dna/pipelines/evals/interpretation.py
+++ b/src/marin_dna/pipelines/evals/interpretation.py
@@ -114,7 +114,7 @@ def plot_dependency_map(
     chrom: str | None = None,
     title: str | None = None,
     tick_freq: int | None = None,
-    dpi: int = 150,
+    dpi: int = 100,
 ) -> None:
     """Render a dependency map as a ``coolwarm`` heatmap (SVG, plus a PNG
     sibling for local visual sanity per repo convention).
@@ -122,11 +122,17 @@ def plot_dependency_map(
     Mirrors GPN-Star's nuc-dep plot: square aspect, robust color scaling,
     rasterized cells, sparse genomic-coordinate ticks.
 
-    ``rasterized=True`` is essential: a dependency map is a dense ``L×L``
-    QuadMesh (e.g. 255×255 = 65k cells), which as pure SVG vector cells blows
-    up to ~12 MB. Rasterizing embeds the cells as a *single* PNG inside the
-    SVG (text/axes stay vector), so file size is governed by ``dpi`` — ~210 KB
-    at 150, ~130 KB at 72 for a 255 bp map. Lower ``dpi`` for smaller files.
+    **File size.** A dependency map is a dense, high-frequency ``L×L`` grid
+    (255×255 = 65k near-independent colored cells). As *pure* SVG vector it is
+    ~12 MB; even quantized to 11 colors + run-length-merged it is ~1.2 MB —
+    there are no long runs to merge, so true vector is never small for these
+    textured maps. ``rasterized=True`` instead embeds the cells as a *single*
+    PNG inside the SVG (axes/text stay vector); file size is then the embedded
+    raster, governed by ``dpi``. We post-process the embedded ``<image>`` with
+    ``image-rendering:pixelated`` so cells stay crisp (vector-like) at any zoom.
+    Keep ``dpi`` near the native cell count (≈ ``L`` px across the map, ~``dpi``
+    100 for a 255 bp window → ~125 KB); smaller maps come out far smaller. Going
+    well below native (``dpi`` < ~``L``/3 inch) starts dropping cells.
     """
     import matplotlib
 
@@ -165,5 +171,12 @@ def plot_dependency_map(
     out.parent.mkdir(parents=True, exist_ok=True)
     plt.savefig(out, bbox_inches="tight", dpi=dpi)
     if out.suffix == ".svg":
+        # The heatmap is one embedded raster (rasterized=True). Tag it
+        # image-rendering:pixelated so the cells stay crisp (no interpolation
+        # blur) when the SVG is scaled — they read as sharp vector squares.
+        svg = out.read_text()
+        if "<image " in svg and "image-rendering" not in svg:
+            svg = svg.replace("<image ", '<image style="image-rendering:pixelated" ', 1)
+            out.write_text(svg)
         plt.savefig(out.with_suffix(".png"), bbox_inches="tight", dpi=dpi)
     plt.close()

--- a/tests/model/test_contact_metrics.py
+++ b/tests/model/test_contact_metrics.py
@@ -1,0 +1,80 @@
+"""Tests for ``marin_dna.model.contact_metrics`` (Fig-7b contact prediction)."""
+
+import numpy as np
+import pytest
+
+from marin_dna.model.contact_metrics import (
+    base_pairs_to_contact_matrix,
+    contact_prediction_metrics,
+    parse_trnascan_ss,
+)
+
+# tRNA-Arg-TCT-4-1 (gtRNAdb GRCh38) tRNAscan-SE nested-bp structure, 74 nt.
+TRNA_SS = ">>>>>>>..>>>>.........<<<<.>>>>>.......<<<<<.....>>>>>.......<<<<<<<<<<<<."
+
+
+def test_parse_trnascan_ss_trna_cloverleaf():
+    pairs = parse_trnascan_ss(TRNA_SS)
+    assert len(TRNA_SS) == 74
+    # 7 acceptor + 4 D-arm + 5 anticodon + 5 T-arm = 21 base pairs.
+    assert len(pairs) == 21
+    # Outermost acceptor-stem pair: position 0 pairs with position 72.
+    assert (0, 72) in pairs
+    # All pairs are ordered and in range.
+    assert all(0 <= i < j < 74 for i, j in pairs)
+
+
+def test_parse_trnascan_ss_small_and_unbalanced():
+    assert parse_trnascan_ss(">>..<<") == [(0, 5), (1, 4)]
+    assert parse_trnascan_ss("") == []
+    with pytest.raises(AssertionError):
+        parse_trnascan_ss(">>.<")  # one unclosed '>'
+    with pytest.raises(AssertionError):
+        parse_trnascan_ss(">.<<")  # stray '<'
+
+
+def test_base_pairs_to_contact_matrix_symmetric():
+    c = base_pairs_to_contact_matrix([(0, 4), (1, 3)], 5)
+    assert c.shape == (5, 5)
+    assert c[0, 4] and c[4, 0] and c[1, 3] and c[3, 1]
+    assert np.array_equal(c, c.T)
+    assert c.sum() == 4  # two pairs, each counted twice
+
+
+def test_contact_metrics_perfect_ranking():
+    """A dependency map equal to the contact matrix ranks true pairs first →
+    AUROC = AUPRC = PPV = MCC = 1."""
+    pairs = [(0, 9), (1, 8), (2, 7)]
+    n = 10
+    dep = base_pairs_to_contact_matrix(pairs, n).astype(float)
+    # add a tiny diagonal-decaying background so non-contacts aren't all tied
+    dep = dep + 1e-3 * np.maximum(
+        0, 1 - np.abs(np.subtract.outer(range(n), range(n))) / n
+    )
+    m = contact_prediction_metrics(dep, pairs, min_sep=1)
+    assert m["n_true_pairs"] == 3
+    assert m["auroc"] == pytest.approx(1.0)
+    assert m["auprc"] == pytest.approx(1.0)
+    assert m["ppv"] == pytest.approx(1.0)
+    assert m["mcc"] == pytest.approx(1.0)
+
+
+def test_contact_metrics_random_is_chance():
+    rng = np.random.RandomState(0)
+    n = 40
+    pairs = [(i, n - 1 - i) for i in range(8)]  # 8 long-range pairs
+    A = rng.rand(n, n)
+    dep = (A + A.T) / 2
+    m = contact_prediction_metrics(dep, pairs, min_sep=1)
+    # A random map has no signal → AUROC near chance.
+    assert 0.3 < m["auroc"] < 0.7
+    assert m["n_true_pairs"] == 8
+
+
+def test_contact_metrics_min_sep_excludes_near_diagonal():
+    pairs = [(0, 1), (0, 9)]  # one adjacent, one long-range
+    n = 10
+    dep = base_pairs_to_contact_matrix(pairs, n).astype(float)
+    # min_sep=3 drops the (0,1) adjacent pair from the candidate set.
+    m = contact_prediction_metrics(dep, pairs, min_sep=3)
+    assert m["n_true_pairs"] == 1  # only (0,9) survives the separation filter

--- a/tests/model/test_interpretation.py
+++ b/tests/model/test_interpretation.py
@@ -1,0 +1,214 @@
+"""Tests for ``marin_dna.model.interpretation`` (nucleotide dependency maps, #237).
+
+Two flavors of model double:
+
+- ``_PrefixSumCausalLM`` — a genuinely *causal*, content-dependent test double
+  (logits at ``t`` depend only on a cumulative sum of inputs ``[0..t]``). It
+  produces a rich, strictly-upper-triangular Jacobian, exercising the
+  causal-invariant assert and the FWD/RC stitch with hand-checkable structure.
+- The real ``hf-internal-testing/tiny-random-GPTNeoXForCausalLM`` — validates
+  the actual HF ``.logits`` interface and that real causal attention zeroes the
+  lower triangle.
+"""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+from transformers import AutoModelForCausalLM
+
+from marin_dna.model.interpretation import (
+    _stitch_and_symmetrize,
+    categorical_jacobian,
+    dependency_matrix,
+    nucleotide_dependency_map,
+)
+from marin_dna.tokenizer.char import create_char_tokenizer
+
+TINY_CLM = "hf-internal-testing/tiny-random-GPTNeoXForCausalLM"
+
+
+class _PrefixSumCausalLM(nn.Module):
+    """Causal test double: ``logits[:, t]`` depend only on ``input_ids[:, :t+1]``
+    through a cumulative sum, so perturbing position ``i`` moves every readout
+    ``m > i`` and nothing at ``m <= i``. Nonlinear (``sin``) so the four
+    substitutions at a position give distinct effects. No parameters (the map
+    falls back to CPU device detection)."""
+
+    def __init__(self, vocab_size: int):
+        super().__init__()
+        self.vocab_size = vocab_size
+
+    def forward(self, input_ids, **kwargs):
+        x = input_ids.float()
+        prefix = torch.cumsum(x, dim=1)  # [B, L] — prefix[t] uses only [0..t]
+        v = torch.arange(self.vocab_size, dtype=torch.float)
+        logits = torch.sin(0.3 * prefix.unsqueeze(-1) + v)  # [B, L, V]
+        return SimpleNamespace(logits=logits)
+
+
+def _nuc_token_ids(tokenizer):
+    from marin_dna.data.dna import NUCLEOTIDES
+    from marin_dna.data.transforms import _get_nucleotide_token_ids
+
+    ids = _get_nucleotide_token_ids(tokenizer)
+    return torch.tensor([ids[n] for n in NUCLEOTIDES], dtype=torch.long)
+
+
+# --------------------------------------------------------------------------- #
+# categorical_jacobian
+# --------------------------------------------------------------------------- #
+def test_categorical_jacobian_shape_and_causal_upper_triangular():
+    tok = create_char_tokenizer(bos=True, eos=True)
+    model = _PrefixSumCausalLM(vocab_size=8).eval()
+    seq = "ACGTACGT"  # W = 8
+    W = len(seq)
+    input_ids = torch.tensor(tok.encode(seq), dtype=torch.long)
+
+    jac = categorical_jacobian(
+        model,
+        input_ids,
+        nuc_token_ids=_nuc_token_ids(tok),
+        n_prefix=1,
+        window_size=W,
+    )
+    assert jac.shape == (W, 4, W, 4)
+
+    # Causal: jac[i, :, m, :] must be exactly 0 for every target m <= i
+    # (cumsum up to the readout index does not include the perturbed position).
+    for i in range(W):
+        for m in range(i + 1):
+            assert torch.all(jac[i, :, m, :] == 0.0), f"non-causal at (i={i}, m={m})"
+    # ...and genuinely non-zero somewhere above the diagonal.
+    assert jac.abs().max() > 0
+
+
+def test_categorical_jacobian_requires_bos():
+    tok = create_char_tokenizer(bos=False, eos=False)  # n_prefix == 0
+    model = _PrefixSumCausalLM(vocab_size=8).eval()
+    seq = "ACGTACGT"
+    input_ids = torch.tensor(tok.encode(seq), dtype=torch.long)
+    with pytest.raises(AssertionError, match="BOS"):
+        categorical_jacobian(
+            model,
+            input_ids,
+            nuc_token_ids=_nuc_token_ids(tok),
+            n_prefix=0,
+            window_size=len(seq),
+        )
+
+
+def test_categorical_jacobian_batching_invariant():
+    """Result is independent of the forward batch size."""
+    tok = create_char_tokenizer(bos=True, eos=True)
+    model = _PrefixSumCausalLM(vocab_size=8).eval()
+    seq = "ACGTACGTAC"  # W = 10
+    input_ids = torch.tensor(tok.encode(seq), dtype=torch.long)
+    kw = dict(nuc_token_ids=_nuc_token_ids(tok), n_prefix=1, window_size=len(seq))
+    a = categorical_jacobian(model, input_ids, batch_size=4, **kw)
+    b = categorical_jacobian(model, input_ids, batch_size=40, **kw)
+    torch.testing.assert_close(a, b)
+
+
+# --------------------------------------------------------------------------- #
+# dependency_matrix
+# --------------------------------------------------------------------------- #
+def test_dependency_matrix_norm_inf_and_zero_diagonal():
+    W = 3
+    jac = np.zeros((W, 4, W, 4))
+    jac[0, 1, 2, 3] = -5.0  # block (i=0, m=2): max-abs 5
+    jac[2, 0, 0, 0] = 3.0  # block (i=2, m=0): max-abs 3
+    jac[1, :, 1, :] = 9.0  # diagonal block (1,1): must be zeroed out
+
+    D = dependency_matrix(jac, norm_ord=np.inf)
+    assert D.shape == (W, W)
+    assert D[0, 2] == 5.0
+    assert D[2, 0] == 3.0
+    assert D[1, 1] == 0.0  # diagonal explicitly zeroed
+    assert np.all(np.diag(D) == 0.0)
+
+
+# --------------------------------------------------------------------------- #
+# _stitch_and_symmetrize
+# --------------------------------------------------------------------------- #
+def test_stitch_and_symmetrize_mean_and_max():
+    D_fwd = np.array([[0, 2, 4], [0, 0, 6], [0, 0, 0]], dtype=float)  # upper
+    D_rc = np.array([[0, 0, 0], [1, 0, 0], [3, 5, 0]], dtype=float)  # lower
+
+    M_mean = _stitch_and_symmetrize(D_fwd, D_rc, "mean")
+    assert np.allclose(M_mean, M_mean.T)
+    # M[0,1] averages the two directed dependencies: (fwd 2 + rc 1)/2 = 1.5
+    assert M_mean[0, 1] == 1.5
+    assert M_mean[0, 2] == (4 + 3) / 2
+    assert M_mean[1, 2] == (6 + 5) / 2
+
+    M_max = _stitch_and_symmetrize(D_fwd, D_rc, "max")
+    assert np.allclose(M_max, M_max.T)
+    assert M_max[0, 1] == 2  # max(2, 1)
+    assert M_max[0, 2] == 4  # max(4, 3)
+
+    with pytest.raises(ValueError, match="combine"):
+        _stitch_and_symmetrize(D_fwd, D_rc, "median")  # type: ignore[arg-type]
+
+
+def test_stitch_mean_does_not_halve_offdiagonal_signal():
+    """Regression guard for the #237 trap: a true off-diagonal pair seen by
+    *one* strand keeps its magnitude (the /2 averages two real entries, it does
+    not halve a single-strand signal)."""
+    D_fwd = np.array([[0, 8], [0, 0]], dtype=float)  # fwd saw i=0 -> m=1 = 8
+    D_rc = np.array([[0, 0], [8, 0]], dtype=float)  # rc saw i=1 -> m=0 = 8
+    M = _stitch_and_symmetrize(D_fwd, D_rc, "mean")
+    assert M[0, 1] == 8.0 and M[1, 0] == 8.0  # not 4.0
+
+
+# --------------------------------------------------------------------------- #
+# nucleotide_dependency_map (end-to-end through a model)
+# --------------------------------------------------------------------------- #
+def test_nucleotide_dependency_map_stitched_symmetric():
+    tok = create_char_tokenizer(bos=True, eos=True)
+    model = _PrefixSumCausalLM(vocab_size=8).eval()
+    seq = "ACGTACGT"
+    W = len(seq)
+    M = nucleotide_dependency_map(model, tok, seq, rc=True, combine="mean")
+    assert M.shape == (W, W)
+    assert np.allclose(M, M.T)
+    assert np.all(np.diag(M) == 0.0)
+    # The model has genuine cross-position structure → non-trivial off-diagonal.
+    assert np.triu(M, 1).max() > 0
+
+
+def test_nucleotide_dependency_map_rc_false_is_forward_reflection():
+    tok = create_char_tokenizer(bos=True, eos=True)
+    model = _PrefixSumCausalLM(vocab_size=8).eval()
+    seq = "ACGTACGT"
+    M = nucleotide_dependency_map(model, tok, seq, rc=False)
+    assert np.allclose(M, M.T)  # forward-only map, reflected
+    # Differs from the stitched map (rc adds the lower triangle's real values).
+    M_rc = nucleotide_dependency_map(model, tok, seq, rc=True, combine="mean")
+    assert not np.allclose(M, M_rc)
+
+
+def test_nucleotide_dependency_map_mean_vs_max_differ():
+    tok = create_char_tokenizer(bos=True, eos=True)
+    model = _PrefixSumCausalLM(vocab_size=8).eval()
+    seq = "ACGTACGT"
+    M_mean = nucleotide_dependency_map(model, tok, seq, combine="mean")
+    M_max = nucleotide_dependency_map(model, tok, seq, combine="max")
+    assert not np.allclose(M_mean, M_max)
+    # max >= mean elementwise (max(a,b) >= (a+b)/2 for non-negative norms).
+    assert np.all(M_max + 1e-9 >= M_mean)
+
+
+def test_nucleotide_dependency_map_real_tiny_clm():
+    """Real HF causal LM: validates the ``.logits`` interface and that genuine
+    causal attention zeroes the lower triangle (the internal asserts fire)."""
+    tok = create_char_tokenizer(bos=True, eos=True)
+    model = AutoModelForCausalLM.from_pretrained(TINY_CLM).eval()
+    seq = "ACGTACGTACGT"  # W = 12
+    W = len(seq)
+    M = nucleotide_dependency_map(model, tok, seq, rc=True, combine="mean", atol=1e-4)
+    assert M.shape == (W, W)
+    assert np.allclose(M, M.T)
+    assert np.all(np.diag(M) == 0.0)

--- a/tests/pipelines/evals/test_interpretation.py
+++ b/tests/pipelines/evals/test_interpretation.py
@@ -12,9 +12,13 @@ from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pandas as pd
 import pytest
 
-from marin_dna.pipelines.evals.interpretation import compute_dependency_map
+from marin_dna.pipelines.evals.interpretation import (
+    compute_dependency_map,
+    plot_dependency_map,
+)
 
 _MOD = "marin_dna.pipelines.evals.interpretation"
 
@@ -82,6 +86,22 @@ def test_compute_dependency_map_strand_minus_flips_axes():
     np.testing.assert_array_equal(df.values, stub[2:8, 2:8][::-1, ::-1])
     assert list(df.index) == list(range(end - 1, start - 1, -1))
     assert list(df.columns) == list(range(end - 1, start - 1, -1))
+
+
+def test_plot_dependency_map_writes_svg_and_png(tmp_path):
+    coords = list(range(11089299, 11089309))
+    rng = np.random.RandomState(0)
+    M = np.abs(rng.randn(10, 10))
+    M = (M + M.T) / 2  # symmetric like a real map
+    np.fill_diagonal(M, 0.0)
+    df = pd.DataFrame(M, index=coords, columns=coords)
+
+    out = tmp_path / "nested" / "LDLR" / "map.svg"
+    plot_dependency_map(df, out, chrom="19", title="LDLR — test")
+
+    assert out.exists() and out.stat().st_size > 0
+    png = out.with_suffix(".png")
+    assert png.exists() and png.stat().st_size > 0
 
 
 def test_compute_dependency_map_rejects_oversized_locus():

--- a/tests/pipelines/evals/test_interpretation.py
+++ b/tests/pipelines/evals/test_interpretation.py
@@ -24,13 +24,16 @@ _MOD = "marin_dna.pipelines.evals.interpretation"
 
 
 @contextmanager
-def _mocked_compute(window_size: int, stub_map: np.ndarray):
+def _mocked_compute(
+    window_size: int, stub_map: np.ndarray, genome_seq: str | None = None
+):
     """Patch loaders + the Jacobian compute so the windowing logic runs alone.
 
-    ``Genome(...)`` returns a callable that yields a length-``window_size``
-    sequence; ``nucleotide_dependency_map`` returns ``stub_map``.
+    ``Genome(...)`` returns a callable that yields ``genome_seq`` (default a
+    length-``window_size`` all-A sequence); ``nucleotide_dependency_map``
+    returns ``stub_map``.
     """
-    genome_inst = MagicMock(return_value="A" * window_size)
+    genome_inst = MagicMock(return_value=genome_seq or "A" * window_size)
     with (
         patch(f"{_MOD}.AutoTokenizer"),
         patch(f"{_MOD}.AutoModelForCausalLM"),
@@ -116,3 +119,36 @@ def test_compute_dependency_map_rejects_oversized_locus():
             strand="+",
             window_size=10,
         )
+
+
+def test_compute_dependency_map_rejects_invalid_strand():
+    # Strand is validated near the top, before any model/genome load.
+    with pytest.raises(AssertionError, match="strand must be"):
+        compute_dependency_map(
+            checkpoint_path="/ckpt",
+            genome_path="/g.fa",
+            chrom="1",
+            start=1000,
+            end=1006,
+            strand="-1",  # typo for "-"
+            window_size=10,
+        )
+
+
+def test_compute_dependency_map_rejects_n_window():
+    """A window padded/gapped with N (e.g. near a chromosome boundary) must
+    fail loud rather than build the map over non-genomic context."""
+    window_size = 10
+    stub = np.zeros((6, 6))
+    n_seq = "N" + "A" * (window_size - 1)  # length OK, but contains N
+    with _mocked_compute(window_size, stub, genome_seq=n_seq):
+        with pytest.raises(AssertionError, match="contains N"):
+            compute_dependency_map(
+                checkpoint_path="/ckpt",
+                genome_path="/g.fa",
+                chrom="1",
+                start=1000,
+                end=1006,
+                strand="+",
+                window_size=window_size,
+            )

--- a/tests/pipelines/evals/test_interpretation.py
+++ b/tests/pipelines/evals/test_interpretation.py
@@ -1,0 +1,98 @@
+"""Tests for ``compute_dependency_map`` windowing / slicing / strand handling.
+
+The heavy compute (model load + categorical Jacobian) is mocked; these tests
+pin the coordinate arithmetic — the classic off-by-one footgun — by stubbing
+``nucleotide_dependency_map`` with an identifiable matrix and checking the
+locus slice, genomic-coordinate index, and reverse-strand flip.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from marin_dna.pipelines.evals.interpretation import compute_dependency_map
+
+_MOD = "marin_dna.pipelines.evals.interpretation"
+
+
+@contextmanager
+def _mocked_compute(window_size: int, stub_map: np.ndarray):
+    """Patch loaders + the Jacobian compute so the windowing logic runs alone.
+
+    ``Genome(...)`` returns a callable that yields a length-``window_size``
+    sequence; ``nucleotide_dependency_map`` returns ``stub_map``.
+    """
+    genome_inst = MagicMock(return_value="A" * window_size)
+    with (
+        patch(f"{_MOD}.AutoTokenizer"),
+        patch(f"{_MOD}.AutoModelForCausalLM"),
+        patch(f"{_MOD}.Genome", return_value=genome_inst),
+        patch(f"{_MOD}.torch.cuda.is_available", return_value=False),
+        patch(f"{_MOD}.nucleotide_dependency_map", return_value=stub_map),
+    ):
+        yield genome_inst
+
+
+def test_compute_dependency_map_windowing_and_coords():
+    window_size = 10
+    start, end = 1000, 1006  # span 6 <= 10
+    # Identifiable map: M[i, j] = 100*i + j.
+    stub = np.fromfunction(lambda i, j: 100 * i + j, (window_size, window_size))
+
+    with _mocked_compute(window_size, stub) as genome_inst:
+        df = compute_dependency_map(
+            checkpoint_path="/ckpt",
+            genome_path="/g.fa",
+            chrom="19",
+            start=start,
+            end=end,
+            strand="+",
+            window_size=window_size,
+        )
+
+    # center = (1000+1006)//2 = 1003; context_start = 1003 - 5 = 998.
+    genome_inst.assert_called_once_with("19", 998, 1008, strand="+")
+    assert list(df.index) == list(range(start, end))
+    assert list(df.columns) == list(range(start, end))
+    # start_idx = 1000-998 = 2; end_idx = 1006-998 = 8.
+    np.testing.assert_array_equal(df.values, stub[2:8, 2:8])
+
+
+def test_compute_dependency_map_strand_minus_flips_axes():
+    window_size = 10
+    start, end = 1000, 1006
+    stub = np.fromfunction(lambda i, j: 100 * i + j, (window_size, window_size))
+
+    with _mocked_compute(window_size, stub):
+        df = compute_dependency_map(
+            checkpoint_path="/ckpt",
+            genome_path="/g.fa",
+            chrom="11",
+            start=start,
+            end=end,
+            strand="-",
+            window_size=window_size,
+        )
+
+    # Reverse both axes for display; index/columns run high -> low.
+    np.testing.assert_array_equal(df.values, stub[2:8, 2:8][::-1, ::-1])
+    assert list(df.index) == list(range(end - 1, start - 1, -1))
+    assert list(df.columns) == list(range(end - 1, start - 1, -1))
+
+
+def test_compute_dependency_map_rejects_oversized_locus():
+    # Asserts before any model/genome load, so no mocks needed.
+    with pytest.raises(AssertionError, match="exceeds model window_size"):
+        compute_dependency_map(
+            checkpoint_path="/ckpt",
+            genome_path="/g.fa",
+            chrom="1",
+            start=0,
+            end=20,  # span 20 > window_size 10
+            strand="+",
+            window_size=10,
+        )


### PR DESCRIPTION
Implements v1 of #237 — nucleotide dependency maps (the **categorical Jacobian**) for our autoregressive gLMs, folded into `evals_v2`.

## What & why

Port GPN-Star's nucleotide dependency-map interpretation to our causal LMs. The map measures how a single-nucleotide substitution at position `i` shifts the model's predicted nucleotide distribution at every position `j` (each `4×4` block collapsed by a vector norm to an `L×L` map).

Our models are **causal**, so a single strand's Jacobian is **strictly upper-triangular** (perturbing `i` can't move any target `j ≤ i`; the diagonal is structurally ~0). We run forward **and** reverse-complement, **stitch** FWD→upper + RC→lower into one matrix, then symmetrize — `mean` by default (`max`, the paper's "max dependency within a pair", is a config flip). See #237 for the full design, including the "don't naively mean the two full per-strand matrices" trap (that halves every off-diagonal value).

## What's added

- **`src/marin_dna/model/interpretation.py`** — `categorical_jacobian`, `dependency_matrix`, `_stitch_and_symmetrize`, `nucleotide_dependency_map`, with causal-triangularity asserts on each strand.
- **`src/marin_dna/pipelines/evals/interpretation.py`** — `compute_dependency_map` (window centering + locus slice + `−` strand flip) and `plot_dependency_map` (seaborn `coolwarm`, SVG + PNG).
- **evals_v2 wiring** — `compute_nuc_dep` + `plot_nuc_dep` + a `nuc_dep` aggregate, **kept off the default metrics `rule all`** so they never perturb score/metric reruns; a `nuc_dep` config block (exp135-1B-m5.1 on LDLR / TH / GRIA4 / HBA1) + fail-fast asserts that every locus fits its model's window. Reuses the existing `download_model` rule and `sky/run.yaml` unchanged.
- **tests** — the causal upper-triangular invariant on a synthetic causal LM **and** a real tiny GPTNeoX; stitch/symmetrize mean+max + the no-halving guard; windowing/strand math; SVG+PNG rendering.

## Validation

- **14 unit tests** pass; ruff + mypy clean on the new modules.
- Dry-run: `nuc_dep` plans 4 compute + 4 plot (no checkpoint re-download); the default `all` target is unchanged.
- **Real run** on `exp135-1B-m5.1` (one A10G, ~6 min) produced four symmetric, structured maps — montage + writeup in [this #237 comment](https://github.com/Open-Athena/marin-dna/issues/237#issuecomment-4614231223). Symmetry + bilateral structure is the end-to-end confirmation that the FWD/RC stitch recovers both triangles; the per-strand causal-triangularity asserts also passed inside every run.

## Notes

- Interpretation targets are off the default DAG — build with `snakemake nuc_dep` (or one `…/plots/nuc_dep/<locus>/<model>.svg`).
- #237 stays open to track the listed follow-ups (max-vs-mean comparison, annotation overlays, longer-context models, UMAP / variant-deleteriousness).

## Update — further commits on this branch

- **`combine: [mean, max]`** parameterized into the output path; both computed. They're nearly identical — Spearman 0.97–0.99, max ~1.3× larger in magnitude ([details on #237](https://github.com/Open-Athena/marin-dna/issues/237#issuecomment-4614666131)).
- **SVG size**: native-resolution raster embedded in the SVG + `image-rendering:pixelated` + a `dpi` config knob (255² 256→190 KB; true vector is 1–12 MB, so raster-in-SVG is the right call).
- **tRNA-Arg-TCT-4-1** locus + a tested **`contact_metrics`** module (Fig-7b AUROC/AUPRC/top-L/PPV/MCC over base-pair contacts). exp135 does **not** recover this tRNA's base-pairing (AUROC ≈ chance) — verified not a bug; deferred follow-up.
- HBA1 cropped 256→255 to fit the 255 bp window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

