### PR TITLE
chrombpnet_eval: supervised VEP metric + ARSENAL one-hot baseline (M1a)

### DIFF
--- a/scripts/chrombpnet_eval/m1a_onehot_baseline.py
+++ b/scripts/chrombpnet_eval/m1a_onehot_baseline.py
@@ -73,7 +73,11 @@ def synapse_download(syn_id: str, dest: Path) -> Path:
     # S3 URL (which is exactly what we want).
     resp = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=120)
     resp.raise_for_status()
-    dest.write_bytes(resp.content)
+    # Write to a sibling .tmp then atomically rename, so an interrupted download
+    # never leaves a truncated file that the dest.exists() cache silently reuses.
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    tmp.write_bytes(resp.content)
+    tmp.replace(dest)
     return dest
 
 

--- a/scripts/chrombpnet_eval/m1a_onehot_baseline.py
+++ b/scripts/chrombpnet_eval/m1a_onehot_baseline.py
@@ -1,0 +1,146 @@
+"""M1a: validate the chrombpnet_eval harness against ARSENAL's precomputed
+one-hot ChromBPNet (GM12878 DNase, ENCODE ENCSR000EMT) on our caqtl/dsqtl splits.
+
+No training, no GPU. We pull ARSENAL's released ``variant_scores.tsv`` (signed
+``logfc``), align it to our split parquets (caQTL hg38 direct; dsQTL hg19→hg38
+lift), and compute the supervised metric set
+(:func:`compute_supervised_qtl_metrics`):
+
+- on **all** used variants (train+test) — cross-checks our harness against
+  ARSENAL's published one-hot numbers (caQTL AUROC≈0.750/Pearson≈0.633;
+  dsQTL AUROC≈0.883/Pearson≈0.720);
+- on our **train** split — the dev baseline (test held out).
+
+Run (needs ``SYNAPSE_AUTH_TOKEN`` in env; HF auth for the dataset repos):
+
+    uv run python scripts/chrombpnet_eval/m1a_onehot_baseline.py
+
+ARSENAL assets: https://www.synapse.org/Synapse:syn72351987 (ChromBPNet_Comparison
+/ ChromBPNet_Models / GM12878 / run_1). Design: GitHub issue #236.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import polars as pl
+import requests
+from huggingface_hub import hf_hub_download
+
+from marin_dna.pipelines.chrombpnet_eval.metrics import compute_supervised_qtl_metrics
+from marin_dna.pipelines.chrombpnet_eval.scores import (
+    align_scores_to_variants,
+    load_arsenal_scores,
+)
+
+# ARSENAL one-hot ChromBPNet GM12878 / run_1 variant_scores.tsv (Synapse).
+# african_variants = caQTL (hg38); yoruba_variants = dsQTL (hg19).
+DATASETS = {
+    "caqtl": {
+        "lift": False,
+        "flip_logfc": False,
+        "scores_syn": "syn73654973",
+        "hf_repo": "bolinas-dna/evals_caqtl",
+        "hf_rev": "9d004a21812c067b9ba1ebfe72f51b9095a5d0f8",
+        "published": {"AUROC": 0.750, "pearson": 0.633, "spearman": 0.656},
+    },
+    "dsqtl": {
+        "lift": True,
+        # ARSENAL's released dsQTL logfc is sign-flipped vs the study effect /
+        # DART-Eval convention our `effect` follows — see load_arsenal_scores.
+        "flip_logfc": True,
+        "scores_syn": "syn73655490",
+        "hf_repo": "bolinas-dna/evals_dsqtl",
+        "hf_rev": "b7e02a07beb831c7047286aacd3ddfd299d6f88f",
+        "published": {"AUROC": 0.883, "pearson": 0.720, "spearman": 0.744},
+    },
+}
+CACHE = Path(
+    os.environ.get("CHROMBPNET_EVAL_CACHE", Path.home() / ".cache/chrombpnet_eval")
+)
+
+
+def synapse_download(syn_id: str, dest: Path) -> Path:
+    """Download a Synapse FileEntity to ``dest`` (cached). Needs SYNAPSE_AUTH_TOKEN."""
+    if dest.exists():
+        return dest
+    token = os.environ.get("SYNAPSE_AUTH_TOKEN")
+    assert token, "set SYNAPSE_AUTH_TOKEN (a Synapse PAT with Download scope)"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    url = f"https://repo-prod.prod.sagebase.org/repo/v1/entity/{syn_id}/file"
+    # requests drops the auth header on the cross-host redirect to the presigned
+    # S3 URL (which is exactly what we want).
+    resp = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=120)
+    resp.raise_for_status()
+    dest.write_bytes(resp.content)
+    return dest
+
+
+def load_split(repo: str, rev: str, split: str) -> pl.DataFrame:
+    path = hf_hub_download(repo, f"{split}.parquet", revision=rev, repo_type="dataset")
+    return pl.read_parquet(path)
+
+
+def main() -> None:
+    rows: list[dict] = []
+    for name, cfg in DATASETS.items():
+        scores = load_arsenal_scores(
+            str(synapse_download(cfg["scores_syn"], CACHE / f"onehot_{name}_run1.tsv")),
+            flip_logfc=cfg["flip_logfc"],
+        )
+        train = load_split(cfg["hf_repo"], cfg["hf_rev"], "train")
+        test = load_split(cfg["hf_repo"], cfg["hf_rev"], "test")
+        splits = {"all (train+test)": pl.concat([train, test]), "train": train}
+        for split_name, variants in splits.items():
+            joined = align_scores_to_variants(
+                variants, scores, lift=cfg["lift"], min_coverage=0.9
+            )
+            cov = joined.height / variants.height
+            m = compute_supervised_qtl_metrics(joined.to_pandas(), score_col="score")
+            for _, r in m.iterrows():
+                rows.append(
+                    {
+                        "dataset": name,
+                        "split": split_name,
+                        "metric": r["metric"],
+                        "value": r["value"],
+                        "se": r["se"],
+                        "n_rows": int(r["n_rows"]),
+                        "n_pos": int(r["n_pos"]),
+                        "coverage": round(cov, 4),
+                        "published": cfg["published"].get(r["metric"]),
+                    }
+                )
+    res = pl.DataFrame(rows)
+    out = CACHE / "m1a_onehot_baseline.csv"
+    res.write_csv(out)
+
+    with pl.Config(tbl_rows=-1, tbl_cols=-1, float_precision=4, tbl_width_chars=200):
+        print(res)
+    print(f"\nwrote {out}")
+    # Cross-check: |ours_all − published| for the reproduced metrics. run_1 vs
+    # ARSENAL's 3-run average → expect a small (<~0.05) gap, same sign.
+    tol = 0.05
+    chk = (
+        res.filter(
+            (pl.col("split") == "all (train+test)") & pl.col("published").is_not_null()
+        )
+        .with_columns(
+            (pl.col("value") - pl.col("published")).abs().alias("abs_diff"),
+        )
+        .with_columns((pl.col("abs_diff") <= tol).alias("within_tol"))
+    )
+    print("\n=== cross-check vs ARSENAL published (all variants, run_1) ===")
+    with pl.Config(tbl_rows=-1, float_precision=4):
+        print(
+            chk.select(
+                ["dataset", "metric", "value", "published", "abs_diff", "within_tol"]
+            )
+        )
+    n_ok = int(chk["within_tol"].sum())
+    print(f"\n{n_ok}/{chk.height} reproduced within ±{tol} (same sign).")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/marin_dna/pipelines/chrombpnet_eval/__init__.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/__init__.py
@@ -1,0 +1,7 @@
+"""ChromBPNet-on-gLM-embeddings variant-effect eval (DART-Eval Task 5 / ARSENAL).
+
+Trains/uses a ChromBPNet-style supervised head over a genomic-LM representation
+(or one-hot) and scores caQTL/dsQTL variant effects on *our* train/test splits.
+See ``snakemake/evals`` for the QTL datasets and GitHub issue #236 for the
+overall design.
+"""

--- a/src/marin_dna/pipelines/chrombpnet_eval/metrics.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/metrics.py
@@ -116,7 +116,16 @@ def compute_supervised_qtl_metrics(
     for col in (score_col, label_col, effect_col):
         assert col in df.columns, f"df missing required column {col!r}"
 
-    label = np.asarray(df[label_col]).astype(int)
+    label_raw = np.asarray(df[label_col])
+    # Guard before astype(int): a NaN label would become INT_MIN (warning only)
+    # and a non-{0,1} float would silently miscount the positive mask / feed a
+    # spurious third class to roc_auc_score. bool is fine; else require {0,1}.
+    if label_raw.dtype != bool:
+        uniq = set(np.unique(label_raw).tolist())
+        assert uniq <= {0, 1}, (
+            f"{label_col!r} must be boolean or 0/1, got values {sorted(uniq)}"
+        )
+    label = label_raw.astype(int)
     score = np.asarray(df[score_col], dtype=float)
     effect = np.asarray(df[effect_col], dtype=float)
 

--- a/src/marin_dna/pipelines/chrombpnet_eval/metrics.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/metrics.py
@@ -1,0 +1,167 @@
+"""Supervised variant-effect metrics for the ChromBPNet-on-embeddings eval.
+
+These are the DART-Eval Task-5 / ARSENAL metrics for a **supervised** model that
+emits a *signed* allelic score (e.g. ``log2(alt_counts / ref_counts)`` from a
+trained ChromBPNet). They are deliberately **separate** from
+``marin_dna.pipelines.evals.metrics.compute_qtl_metrics`` (which serves the
+zero-shot/LLR leaderboard and correlates against the *unsigned* ``effect_size``):
+a supervised model's score is directional, so here we correlate the **signed**
+score against the **signed** study effect — exactly as ARSENAL's
+``supervised_variant_scoring_*.ipynb`` does.
+
+Two metric families, each over a different variant set (ARSENAL Methods §,
+verified against their notebook):
+
+- **AUROC / AUPRC on ``|score|``** over **all** used variants (significant QTL vs
+  control). Magnitude is what discriminates: a significant QTL perturbs
+  accessibility in *either* direction, so the sign carries no class information.
+- **Pearson / Spearman of the signed score vs the signed study ``effect``**, over
+  the **positive (significant) variants only** — "correlation metrics are only
+  calculated on variants with significant observed effect."
+
+Standard errors are nonparametric row-bootstrap (std of the bootstrap
+distribution, ``ddof=1``, NaN-tolerant). They are *marginal, single-scorer* SEs;
+comparing two scorers needs a paired-delta bootstrap, not overlapping ``±se``
+bars (same caveat as ``compute_qtl_metrics``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pandas as pd
+from scipy.stats import pearsonr, spearmanr
+from sklearn.metrics import average_precision_score, roc_auc_score
+
+
+def _binary_metric_bootstrap_se(
+    metric_fn: Callable[[np.ndarray, np.ndarray], float],
+    label: np.ndarray,
+    score: np.ndarray,
+    *,
+    n_bootstrap: int,
+    rng: np.random.Generator,
+) -> float:
+    """Row-bootstrap SE of a binary ranking metric (AUROC/AUPRC).
+
+    Resamples paired ``(label, score)`` rows with replacement. Resamples that
+    end up single-class leave the metric undefined → NaN, excluded from the std.
+    """
+    n = len(label)
+    boot = np.empty(n_bootstrap, dtype=float)
+    for b in range(n_bootstrap):
+        idx = rng.integers(0, n, size=n)
+        y = label[idx]
+        if y.min() == y.max():  # single class → AUROC/AUPRC undefined
+            boot[b] = np.nan
+            continue
+        boot[b] = metric_fn(y, score[idx])
+    return float(np.nanstd(boot, ddof=1))
+
+
+def _correlation_bootstrap_se(
+    corr_fn: Callable[[np.ndarray, np.ndarray], tuple[float, float]],
+    x: np.ndarray,
+    y: np.ndarray,
+    *,
+    n_bootstrap: int,
+    rng: np.random.Generator,
+) -> float:
+    """Row-bootstrap SE of a correlation. Resamples constant in either variable
+    leave the correlation undefined → NaN, excluded from the std."""
+    n = len(x)
+    boot = np.empty(n_bootstrap, dtype=float)
+    for b in range(n_bootstrap):
+        idx = rng.integers(0, n, size=n)
+        xb, yb = x[idx], y[idx]
+        if np.std(xb) == 0 or np.std(yb) == 0:
+            boot[b] = np.nan
+            continue
+        boot[b] = corr_fn(xb, yb)[0]
+    return float(np.nanstd(boot, ddof=1))
+
+
+def compute_supervised_qtl_metrics(
+    df: pd.DataFrame,
+    *,
+    score_col: str = "score",
+    label_col: str = "label",
+    effect_col: str = "effect",
+    n_bootstrap: int = 1000,
+    rng: np.random.Generator | int | None = 0,
+) -> pd.DataFrame:
+    """ARSENAL supervised-VEP metrics for one signed score column.
+
+    Args:
+        df: one row per variant, with:
+            - ``label_col``: bool / 0-1 — ``True`` = significant QTL (positive),
+              ``False`` = control (negative).
+            - ``score_col``: float — the model's **signed** allelic score
+              (e.g. ``log2(alt/ref)`` counts), oriented to ``alt``. No NaN.
+            - ``effect_col``: float — the **signed** study effect, oriented to
+              ``alt``. May be NaN for controls, but **must** be present for every
+              positive (asserted).
+        score_col / label_col / effect_col: column names.
+        n_bootstrap: bootstrap iterations per metric.
+        rng: ``numpy.random.Generator``, seed int, or ``None``. Default ``0`` for
+            bit-stable SEs across re-runs on identical inputs.
+
+    Returns:
+        Long-form ``DataFrame[metric, value, se, n_rows, n_pos]`` with ``metric``
+        in ``{AUROC, AUPRC, pearson, spearman}``. AUROC/AUPRC use ``|score|`` over
+        all rows (``n_rows`` = total); pearson/spearman use the signed score vs
+        signed effect over positives (``n_rows`` = ``n_pos``).
+    """
+    for col in (score_col, label_col, effect_col):
+        assert col in df.columns, f"df missing required column {col!r}"
+
+    label = np.asarray(df[label_col]).astype(int)
+    score = np.asarray(df[score_col], dtype=float)
+    effect = np.asarray(df[effect_col], dtype=float)
+
+    assert not np.isnan(score).any(), (
+        f"score column {score_col!r} has NaN — fill/align upstream before scoring"
+    )
+    n_rows = int(len(label))
+    pos_mask = label == 1
+    n_pos = int(pos_mask.sum())
+    assert 0 < n_pos < n_rows, (
+        f"binary metrics need both classes, got n_pos={n_pos} of n={n_rows}"
+    )
+    assert n_pos >= 2, f"correlation needs >=2 positives, got n_pos={n_pos}"
+    # Positives must carry a measured effect (controls legitimately may not —
+    # e.g. dsQTL controls have no measured effect). A NaN here means a positive
+    # is missing its effect → fail loud rather than silently drop it.
+    n_nan_pos = int(np.isnan(effect[pos_mask]).sum())
+    assert n_nan_pos == 0, (
+        f"{n_nan_pos} positive variants have NaN {effect_col!r} — expected a "
+        f"measured effect for every positive"
+    )
+
+    rng = np.random.default_rng(rng)
+    abs_score = np.abs(score)
+    rows: list[dict] = []
+
+    # Binary classification on |score| over all used variants.
+    for name, fn in (("AUROC", roc_auc_score), ("AUPRC", average_precision_score)):
+        value = float(fn(label, abs_score))
+        se = _binary_metric_bootstrap_se(
+            fn, label, abs_score, n_bootstrap=n_bootstrap, rng=rng
+        )
+        rows.append(
+            {"metric": name, "value": value, "se": se, "n_rows": n_rows, "n_pos": n_pos}
+        )
+
+    # Signed correlation over positives only.
+    score_pos, effect_pos = score[pos_mask], effect[pos_mask]
+    for name, fn in (("pearson", pearsonr), ("spearman", spearmanr)):
+        value = float(fn(score_pos, effect_pos)[0])
+        se = _correlation_bootstrap_se(
+            fn, score_pos, effect_pos, n_bootstrap=n_bootstrap, rng=rng
+        )
+        rows.append(
+            {"metric": name, "value": value, "se": se, "n_rows": n_pos, "n_pos": n_pos}
+        )
+
+    return pd.DataFrame(rows)

--- a/src/marin_dna/pipelines/chrombpnet_eval/scores.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/scores.py
@@ -53,7 +53,7 @@ def load_arsenal_scores(path: str, *, flip_logfc: bool = False) -> pl.DataFrame:
     missing = [c for c in ARSENAL_SCORE_COLUMNS if c not in df.columns]
     assert not missing, f"ARSENAL score TSV missing {missing}; got {df.columns}"
     sign = -1.0 if flip_logfc else 1.0
-    return df.select(
+    out = df.select(
         pl.col("chr").cast(pl.Utf8).str.replace(r"^chr", "").alias("chrom"),
         pl.col("pos").cast(pl.Int64),
         pl.col("allele1").cast(pl.Utf8).str.to_uppercase(),
@@ -61,6 +61,15 @@ def load_arsenal_scores(path: str, *, flip_logfc: bool = False) -> pl.DataFrame:
         pl.col("variant_id").cast(pl.Utf8),
         (pl.col("logfc").cast(pl.Float64) * sign).alias("logfc"),
     )
+    # SNP-only: a stray indel/N would build a malformed allele-pair key that
+    # silently fails to join later — fail loud at the boundary instead.
+    nuc = ["A", "C", "G", "T"]
+    bad = out.filter(~pl.col("allele1").is_in(nuc) | ~pl.col("allele2").is_in(nuc))
+    assert bad.height == 0, (
+        f"load_arsenal_scores: {bad.height} rows with non-ACGT alleles (SNP-only "
+        f"expected); e.g. {bad.select('chrom', 'pos', 'allele1', 'allele2').head(3)}"
+    )
+    return out
 
 
 def _unordered_pair(a: pl.Expr, b: pl.Expr) -> pl.Expr:
@@ -117,14 +126,31 @@ def align_scores_to_variants(
     v = variants.with_columns(
         _unordered_pair(pl.col("ref"), pl.col("alt")).alias("_pair")
     )
-    s = scores.with_columns(
+    s_paired = scores.with_columns(
         _unordered_pair(pl.col("allele1"), pl.col("allele2")).alias("_pair")
-    ).unique(subset=["chrom", "pos", "_pair"], keep="first")
+    )
+    # A (chrom,pos,pair) group with conflicting logfc would make the dedup below
+    # pick an arbitrary, order-dependent score — fail loud instead.
+    conflicts = (
+        s_paired.group_by(["chrom", "pos", "_pair"])
+        .agg(pl.col("logfc").n_unique().alias("_n"))
+        .filter(pl.col("_n") > 1)
+    )
+    assert conflicts.height == 0, (
+        f"{conflicts.height} (chrom,pos,pair) score groups have conflicting logfc; "
+        f"dedup would be arbitrary — e.g. {conflicts.head(3)}"
+    )
+    s = s_paired.unique(subset=["chrom", "pos", "_pair"], keep="first")
 
     joined = v.join(
-        s.select(["chrom", "pos", "_pair", "allele2", "logfc"]),
+        s.select(["chrom", "pos", "_pair", "allele1", "allele2", "logfc"]),
         on=["chrom", "pos", "_pair"],
         how="left",
+    )
+    # `s` is unique per (chrom,pos,_pair), so a left join cannot fan out — assert
+    # it (a weakened dedup would otherwise double-count rows into the metric).
+    assert joined.height == n_variants, (
+        f"join fan-out: {joined.height} rows from {n_variants} variants"
     )
     n_matched = joined.filter(pl.col("logfc").is_not_null()).height
     coverage = n_matched / n_variants
@@ -132,6 +158,17 @@ def align_scores_to_variants(
         f"score join coverage {coverage:.3f} < {min_coverage} "
         f"({n_matched}/{n_variants}) — suspect a coordinate/build mismatch "
         f"(lift={lift})"
+    )
+    # Orientation invariant: a matched variant's alt must be exactly one of the
+    # score's two alleles (guaranteed by the unordered-pair join). Assert so a
+    # future join-key change can't silently route rows through the -logfc branch.
+    bad_orient = joined.filter(
+        pl.col("logfc").is_not_null()
+        & (pl.col("alt") != pl.col("allele1"))
+        & (pl.col("alt") != pl.col("allele2"))
+    )
+    assert bad_orient.height == 0, (
+        f"{bad_orient.height} matched rows whose alt is neither ARSENAL allele"
     )
 
     # Orient to our alt: +logfc if our alt is allele2, -logfc if our alt is
@@ -145,5 +182,5 @@ def align_scores_to_variants(
             .alias(score_out)
         )
         .filter(pl.col("logfc").is_not_null())
-        .drop("_pair", "allele2", "logfc")
+        .drop("_pair", "allele1", "allele2", "logfc")
     )

--- a/src/marin_dna/pipelines/chrombpnet_eval/scores.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/scores.py
@@ -1,0 +1,149 @@
+"""Load ARSENAL ChromBPNet variant scores and align them to our QTL parquets.
+
+ARSENAL's ``snp_score`` output (``variant_scores.tsv``) is one row per scored
+variant carrying the study's ``allele1`` / ``allele2`` and a signed
+``logfc = log2(allele2_pred_counts / allele1_pred_counts)``. To evaluate on
+*our* caqtl/dsqtl splits we join those scores onto our variant parquets and
+re-orient the score so it is signed to *our* ``alt`` — matching the orientation
+of our signed ``effect`` so the signed correlation is meaningful.
+
+Coordinate systems:
+
+- **caQTL** is native hg38 on both sides → join directly on ``(chrom, pos)``.
+- **dsQTL** ARSENAL scores are **hg19** (scored against ``male.hg19.fa``) while
+  our parquet is hg38-lifted → lift the ARSENAL coords hg19→hg38 with the same
+  ``lift_hg19_to_hg38`` used to build our parquet before joining.
+
+The join is keyed on ``(chrom, pos, {ref,alt} as an unordered pair)`` so it is
+robust to ref/alt-orientation differences (``check_ref_alt`` may have swapped our
+ref/alt to match the reference) and to multi-allelic sites.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from marin_dna.pipelines.evals.variants import lift_hg19_to_hg38
+
+ARSENAL_SCORE_COLUMNS = ["chr", "pos", "allele1", "allele2", "variant_id", "logfc"]
+
+
+def load_arsenal_scores(path: str, *, flip_logfc: bool = False) -> pl.DataFrame:
+    """Read an ARSENAL ``variant_scores.tsv``.
+
+    Returns ``[chrom, pos, allele1, allele2, variant_id, logfc]`` with ``chrom``
+    stripped of any ``chr`` prefix and alleles upper-cased.
+
+    Args:
+        path: TSV path.
+        flip_logfc: negate ``logfc`` on load. **Needed for ARSENAL's released
+            dsQTL (yoruban) scores**, whose ``logfc`` sign convention is the
+            opposite of the study effect (``obs.estimate``) / DART-Eval — verified
+            two ways: (1) ARSENAL's own ``supervised_variant_scoring_yoruba.ipynb``
+            correlates ``-1 * obs.estimate`` against their ``logfc`` (the african
+            caQTL notebook does *not* negate), and (2) the released dsQTL ``logfc``
+            anti-correlates (r≈-0.97) with the in-benchmark
+            ``pred.chrombpnet.encsr000emt.varscore.logfc`` despite identical
+            allele order. Our ``effect`` follows the DART-Eval convention
+            (``obs.estimate`` as-is), so we negate ARSENAL's released dsQTL
+            ``logfc`` here to put both on the same axis. (Not needed for caQTL,
+            nor for M2 where we score with our own model and control the sign.)
+    """
+    df = pl.read_csv(path, separator="\t")
+    missing = [c for c in ARSENAL_SCORE_COLUMNS if c not in df.columns]
+    assert not missing, f"ARSENAL score TSV missing {missing}; got {df.columns}"
+    sign = -1.0 if flip_logfc else 1.0
+    return df.select(
+        pl.col("chr").cast(pl.Utf8).str.replace(r"^chr", "").alias("chrom"),
+        pl.col("pos").cast(pl.Int64),
+        pl.col("allele1").cast(pl.Utf8).str.to_uppercase(),
+        pl.col("allele2").cast(pl.Utf8).str.to_uppercase(),
+        pl.col("variant_id").cast(pl.Utf8),
+        (pl.col("logfc").cast(pl.Float64) * sign).alias("logfc"),
+    )
+
+
+def _unordered_pair(a: pl.Expr, b: pl.Expr) -> pl.Expr:
+    """An orientation-independent ``"X/Y"`` key for an allele pair (sorted)."""
+    return (
+        pl.when(a <= b)
+        .then(pl.concat_str([a, pl.lit("/"), b]))
+        .otherwise(pl.concat_str([b, pl.lit("/"), a]))
+    )
+
+
+def align_scores_to_variants(
+    variants: pl.DataFrame,
+    scores: pl.DataFrame,
+    *,
+    lift: bool,
+    score_out: str = "score",
+    min_coverage: float = 0.95,
+) -> pl.DataFrame:
+    """Join ARSENAL ``scores`` onto our ``variants``, re-oriented to our ``alt``.
+
+    Args:
+        variants: our QTL parquet, with at least ``chrom, pos, ref, alt``.
+        scores: output of :func:`load_arsenal_scores`.
+        lift: if True, lift ``scores`` hg19→hg38 before joining (dsQTL). caQTL
+            is already hg38 → pass ``False``.
+        score_out: name of the appended signed-score column.
+        min_coverage: assert at least this fraction of ``variants`` receive a
+            score (a loud guard against a coordinate/build mismatch).
+
+    Returns:
+        ``variants`` (unmatched rows dropped) plus a ``score_out`` column equal
+        to ``logfc`` when our ``alt`` is ARSENAL's ``allele2`` and ``-logfc``
+        when our ``alt`` is ARSENAL's ``allele1`` — i.e. the model's signed
+        allelic score oriented to our ``alt``.
+    """
+    assert {"chrom", "pos", "ref", "alt"} <= set(variants.columns), (
+        f"variants missing coordinate columns; got {variants.columns}"
+    )
+    n_variants = variants.height
+
+    if lift:
+        # lift_hg19_to_hg38 transforms chrom/pos/ref/alt (RCing alleles on the
+        # minus strand) and preserves all other columns; map allele1/allele2 to
+        # ref/alt around the call so the alleles are lifted consistently.
+        lifted = (
+            scores.rename({"allele1": "ref", "allele2": "alt"})
+            .pipe(lift_hg19_to_hg38)
+            .filter(pl.col("pos") != -1)
+            .rename({"ref": "allele1", "alt": "allele2"})
+        )
+        scores = lifted
+
+    v = variants.with_columns(
+        _unordered_pair(pl.col("ref"), pl.col("alt")).alias("_pair")
+    )
+    s = scores.with_columns(
+        _unordered_pair(pl.col("allele1"), pl.col("allele2")).alias("_pair")
+    ).unique(subset=["chrom", "pos", "_pair"], keep="first")
+
+    joined = v.join(
+        s.select(["chrom", "pos", "_pair", "allele2", "logfc"]),
+        on=["chrom", "pos", "_pair"],
+        how="left",
+    )
+    n_matched = joined.filter(pl.col("logfc").is_not_null()).height
+    coverage = n_matched / n_variants
+    assert coverage >= min_coverage, (
+        f"score join coverage {coverage:.3f} < {min_coverage} "
+        f"({n_matched}/{n_variants}) — suspect a coordinate/build mismatch "
+        f"(lift={lift})"
+    )
+
+    # Orient to our alt: +logfc if our alt is allele2, -logfc if our alt is
+    # allele1. The unordered-pair join guarantees {ref,alt}=={allele1,allele2},
+    # so a matched row's alt is always exactly one of them.
+    return (
+        joined.with_columns(
+            pl.when(pl.col("alt") == pl.col("allele2"))
+            .then(pl.col("logfc"))
+            .otherwise(-pl.col("logfc"))
+            .alias(score_out)
+        )
+        .filter(pl.col("logfc").is_not_null())
+        .drop("_pair", "allele2", "logfc")
+    )

--- a/tests/pipelines/chrombpnet_eval/test_metrics.py
+++ b/tests/pipelines/chrombpnet_eval/test_metrics.py
@@ -1,0 +1,107 @@
+"""Tests for the supervised QTL metric (signed correlation + |score| binary)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from marin_dna.pipelines.chrombpnet_eval.metrics import compute_supervised_qtl_metrics
+
+
+def _val(m: pd.DataFrame, metric: str) -> float:
+    return float(m.loc[m.metric == metric, "value"].iloc[0])
+
+
+def _toy() -> pd.DataFrame:
+    """4 positives (signed score == signed effect, perfectly aligned) + 4
+    controls with small |score| and no measured effect (NaN, as for dsQTL)."""
+    return pd.DataFrame(
+        {
+            "label": [True, True, True, True, False, False, False, False],
+            "score": [1.0, -2.0, 3.0, -0.5, 0.01, -0.02, 0.0, 0.03],
+            "effect": [1.0, -2.0, 3.0, -0.5, np.nan, np.nan, np.nan, np.nan],
+        }
+    )
+
+
+def test_output_shape_and_metric_names():
+    m = compute_supervised_qtl_metrics(_toy(), n_bootstrap=50)
+    assert set(m["metric"]) == {"AUROC", "AUPRC", "pearson", "spearman"}
+    assert list(m.columns) == ["metric", "value", "se", "n_rows", "n_pos"]
+    # binary metrics span all rows; correlations span positives only.
+    assert _row(m, "AUROC")["n_rows"] == 8
+    assert _row(m, "pearson")["n_rows"] == 4
+    assert (m["n_pos"] == 4).all()
+
+
+def _row(m: pd.DataFrame, metric: str) -> pd.Series:
+    return m.loc[m.metric == metric].iloc[0]
+
+
+def test_perfect_signed_correlation():
+    m = compute_supervised_qtl_metrics(_toy(), n_bootstrap=50)
+    assert _val(m, "pearson") == pytest.approx(1.0)
+    assert _val(m, "spearman") == pytest.approx(1.0)
+
+
+def test_binary_separates_by_magnitude():
+    # positives have large |score|, controls ~0 → perfect separation.
+    m = compute_supervised_qtl_metrics(_toy(), n_bootstrap=50)
+    assert _val(m, "AUROC") == pytest.approx(1.0)
+    assert _val(m, "AUPRC") == pytest.approx(1.0)
+
+
+def test_sign_flips_correlation_but_not_binary():
+    """|score| binary metrics are sign-invariant; signed correlation flips."""
+    df = _toy()
+    m1 = compute_supervised_qtl_metrics(df, n_bootstrap=50)
+    df2 = df.assign(score=-df["score"])
+    m2 = compute_supervised_qtl_metrics(df2, n_bootstrap=50)
+    for metric in ("AUROC", "AUPRC"):
+        assert _val(m1, metric) == pytest.approx(_val(m2, metric))
+    assert _val(m1, "pearson") == pytest.approx(-_val(m2, "pearson"))
+    assert _val(m1, "spearman") == pytest.approx(-_val(m2, "spearman"))
+
+
+def test_anticorrelated_model_is_negative():
+    # model score is the negation of the true effect on positives.
+    df = pd.DataFrame(
+        {
+            "label": [True, True, True, False, False, False],
+            "score": [-1.0, 2.0, -3.0, 0.0, 0.1, -0.1],
+            "effect": [1.0, -2.0, 3.0, np.nan, np.nan, np.nan],
+        }
+    )
+    m = compute_supervised_qtl_metrics(df, n_bootstrap=20)
+    assert _val(m, "pearson") == pytest.approx(-1.0)
+
+
+def test_controls_may_lack_effect():
+    # NaN effect on controls must not raise (correlation is positives-only).
+    compute_supervised_qtl_metrics(_toy(), n_bootstrap=10)
+
+
+def test_nan_score_raises():
+    df = _toy()
+    df.loc[0, "score"] = np.nan
+    with pytest.raises(AssertionError, match="has NaN"):
+        compute_supervised_qtl_metrics(df, n_bootstrap=10)
+
+
+def test_positive_missing_effect_raises():
+    df = _toy()
+    df.loc[0, "effect"] = np.nan  # a positive with no measured effect
+    with pytest.raises(AssertionError, match="NaN"):
+        compute_supervised_qtl_metrics(df, n_bootstrap=10)
+
+
+def test_single_class_raises():
+    df = _toy()
+    df["label"] = True
+    with pytest.raises(AssertionError, match="both classes"):
+        compute_supervised_qtl_metrics(df, n_bootstrap=10)
+
+
+def test_se_is_nonnegative_and_finite():
+    m = compute_supervised_qtl_metrics(_toy(), n_bootstrap=100)
+    assert (m["se"] >= 0).all()
+    assert np.isfinite(m["se"]).all()

--- a/tests/pipelines/chrombpnet_eval/test_scores.py
+++ b/tests/pipelines/chrombpnet_eval/test_scores.py
@@ -1,0 +1,112 @@
+"""Tests for ARSENAL score loading + orientation-aware join (non-lift path).
+
+The dsQTL ``lift=True`` path is exercised end-to-end by the M1a driver (it needs
+the hg19→hg38 liftover chain); here we test the orientation/sign logic and the
+coverage guard with synthetic hg38 variants.
+"""
+
+import polars as pl
+import pytest
+
+from marin_dna.pipelines.chrombpnet_eval.scores import (
+    align_scores_to_variants,
+    load_arsenal_scores,
+)
+
+
+def _variants() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "chrom": ["1", "1", "1"],
+            "pos": [100, 200, 300],
+            "ref": ["C", "A", "T"],  # row 3: our ref/alt swapped vs the study
+            "alt": ["T", "G", "C"],
+            "label": [True, False, True],
+            "effect": [0.5, None, -0.2],
+        }
+    )
+
+
+def _scores() -> pl.DataFrame:
+    # row1: alt(T)==allele2 -> +logfc; row2: alt(G)==allele1 -> -logfc;
+    # row3: study alleles in the opposite order from our ref/alt; alt(C)==allele1 -> -logfc
+    return pl.DataFrame(
+        {
+            "chrom": ["1", "1", "1"],
+            "pos": [100, 200, 300],
+            "allele1": ["C", "G", "C"],
+            "allele2": ["T", "A", "T"],
+            "variant_id": ["rs1", "rs2", "rs3"],
+            "logfc": [0.3, 0.4, 0.5],
+        }
+    )
+
+
+def test_orientation_to_our_alt():
+    out = align_scores_to_variants(_variants(), _scores(), lift=False).sort("pos")
+    got = dict(zip(out["pos"].to_list(), out["score"].to_list()))
+    assert got[100] == pytest.approx(0.3)  # alt == allele2
+    assert got[200] == pytest.approx(-0.4)  # alt == allele1
+    assert got[300] == pytest.approx(-0.5)  # alt == allele1 (study order flipped)
+
+
+def test_preserves_variant_columns_and_drops_helpers():
+    out = align_scores_to_variants(_variants(), _scores(), lift=False)
+    assert {"chrom", "pos", "ref", "alt", "label", "effect", "score"} <= set(
+        out.columns
+    )
+    for helper in ("_pair", "allele2", "logfc", "allele1", "variant_id"):
+        assert helper not in out.columns
+
+
+def test_low_coverage_raises():
+    # add a variant with no matching score → coverage 3/4 < 0.95
+    variants = _variants().vstack(
+        pl.DataFrame(
+            {
+                "chrom": ["2"],
+                "pos": [999],
+                "ref": ["A"],
+                "alt": ["G"],
+                "label": [False],
+                "effect": [None],
+            }
+        )
+    )
+    with pytest.raises(AssertionError, match="coverage"):
+        align_scores_to_variants(variants, _scores(), lift=False)
+
+
+def test_unmatched_dropped_when_coverage_ok():
+    variants = _variants().vstack(
+        pl.DataFrame(
+            {
+                "chrom": ["2"],
+                "pos": [999],
+                "ref": ["A"],
+                "alt": ["G"],
+                "label": [False],
+                "effect": [None],
+            }
+        )
+    )
+    out = align_scores_to_variants(variants, _scores(), lift=False, min_coverage=0.5)
+    assert out.height == 3  # the unmatched row 999 is dropped
+    assert out.filter(pl.col("score").is_null()).height == 0
+
+
+def test_load_arsenal_scores(tmp_path):
+    p = tmp_path / "variant_scores.tsv"
+    p.write_text(
+        "chr\tpos\tallele1\tallele2\tvariant_id\tlogfc\tabs_logfc\n"
+        "chr1\t100\tc\tt\trs1\t0.3\t0.3\n"
+        "chr1\t200\tG\tA\trs2\t-0.4\t0.4\n"
+    )
+    df = load_arsenal_scores(str(p))
+    assert df.columns == ["chrom", "pos", "allele1", "allele2", "variant_id", "logfc"]
+    assert df["chrom"].to_list() == ["1", "1"]  # 'chr' stripped
+    assert df["allele1"].to_list() == ["C", "G"]  # upper-cased
+    assert df["logfc"].to_list() == [pytest.approx(0.3), pytest.approx(-0.4)]
+    # flip_logfc negates the score (needed for ARSENAL's released dsQTL scores).
+    flipped = load_arsenal_scores(str(p), flip_logfc=True)
+    assert flipped["logfc"].to_list() == [pytest.approx(-0.3), pytest.approx(0.4)]


### PR DESCRIPTION
Part of #236, split out of the M2 training pipeline in #239 so the done part can land on its own. Adds the supervised variant-effect metric (signed Pearson/Spearman over positives + AUROC/AUPRC on the absolute score) and the ARSENAL-score harness (load variant_scores.tsv + an orientation-aware join onto our caqtl/dsqtl parquets, including the dsQTL hg19->hg38 lift and the released-dsQTL sign flip). The driver reproduces ARSENAL's published one-hot ChromBPNet numbers within +/-0.05 on our splits (caQTL AUROC 0.765 / Pearson 0.664; dsQTL 0.893 / 0.725). Self-contained, no training or GPU; 15 unit tests.

Tracks #236.

Generated with Claude Code.