### PR TITLE
chrombpnet_eval: one-hot ChromBPNet training + online caQTL/dsQTL metric (M1b)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,17 @@ marin = [
     # check needs (`qwen3_0_6b_hd128`, `default_tokenize`) are vendored at
     # the bottom of `experiments/parity/exp160_parity.py`.
 ]
+# Vendored ChromBPNet (arsenal-chrombpnet) for the supervised caQTL/dsQTL VEP
+# eval (issue #236). Opt in with `uv sync --extra chrombpnet`; snakemake / eval
+# contributors who don't train ChromBPNet skip the PyTorch Lightning install.
+# `pooch` is a top-level import in the vendored `genome.py`; `h5py` loads the
+# `.h5` bias model. (deepdish/weasyprint are lazy in unused functions; tensorflow
+# /deeplift/tangermeme live only in modules we don't import.)
+chrombpnet = [
+    "lightning",
+    "h5py",
+    "pooch",
+]
 
 [dependency-groups]
 dev = [
@@ -194,6 +205,11 @@ allow-direct-references = true
 [tool.hatch.build.targets.wheel]
 packages = ["src/marin_dna"]
 
+[tool.ruff]
+# The vendored ChromBPNet (third-party, src/.../chrombpnet_eval/_vendor) is not
+# ours to lint or format — exclude it from ruff entirely.
+extend-exclude = ["src/marin_dna/pipelines/chrombpnet_eval/_vendor"]
+
 [tool.ruff.lint]
 # jaxtyping uses string annotations like ``Int[Tensor, "B L"]`` that ruff's
 # F722 parser rejects; suppress for the whole project.
@@ -211,5 +227,7 @@ ignore = ["F722"]
 # on missing stubs. `strict_optional` off matches the existing code's
 # implicit-None tolerance — tighten incrementally.
 files = "src/marin_dna"
+# Don't type-check the vendored third-party ChromBPNet.
+exclude = ['src/marin_dna/pipelines/chrombpnet_eval/_vendor/']
 ignore_missing_imports = true
 strict_optional = false

--- a/scripts/chrombpnet_eval/README.md
+++ b/scripts/chrombpnet_eval/README.md
@@ -33,6 +33,13 @@ ChromBPNet objective), `alpha = median_count / 10`. Early-stops + checkpoints on
 pass `val_count_pearson` + `val_count_spearman` (predicted vs observed log counts,
 the ChromBPNet accessibility metrics) + the val losses.
 
+With `--qtl-eval`, also logs the **online QTL metric** each validation —
+`qtl_caqtl_pearson`/`_spearman` and `qtl_dsqtl_pearson`/`_spearman`: the signed
+correlation of the model's predicted `log2 FC` of counts vs the observed QTL
+effect, over the train-split **positives** (caqtl 3,173 + dsqtl 309). This is the
+eval *target* (does it rank QTL effects?), distinct from `val_count_pearson` (the
+accessibility-count fit). It reuses the staged fasta via `--qtl-chrom-prefix chr`.
+
 ### Data (ARSENAL Synapse `syn72513540` + a chr-prefixed hg38 fasta)
 
 `filtered.peaks.bed` (`syn73665410`), `filtered.nonpeaks.bed` (`syn73665411`),
@@ -51,10 +58,13 @@ sky exec cbp-onehot scripts/chrombpnet_eval/sky/run_onehot.yaml \
     --env SYNAPSE_AUTH_TOKEN --env WANDB_API_KEY --env SMOKE=0
 ```
 
-Tuning knobs (the script defaults match official one-hot ChromBPNet —
-`Adam(lr=1e-3)`, no scheduler): `--lr`, `--lr-scheduler {none,plateau}`,
-`--precision {32,bf16-mixed}`, `--batch-size`, `--patience`,
-`--val-check-interval`, `--log-every-n-steps`.
+Stability + tuning knobs: full fp32 by default (`--matmul-precision highest`),
+with `--seed`, `--warmup-steps` (linear LR warmup, default 100) and `--grad-clip`
+(global-norm, default 1000) taming an early gradient spike that can diverge to
+NaN (see #247). Plus `--lr` (default 1e-3, official), `--lr-scheduler
+{none,plateau}`, `--precision {32,bf16-mixed}` (the forward is bf16-safe),
+`--batch-size`, `--patience`, `--val-check-interval`, `--log-every-n-steps`,
+`--compile`.
 
 ### Local (synthetic) smoke
 

--- a/scripts/chrombpnet_eval/README.md
+++ b/scripts/chrombpnet_eval/README.md
@@ -1,0 +1,64 @@
+# chrombpnet_eval — supervised ChromBPNet VEP eval (issue #236)
+
+Train a ChromBPNet-style accessibility head and score caQTL/dsQTL variant
+effects, following the [ARSENAL](https://www.biorxiv.org/content/10.64898/2026.02.05.703637v1.full)
+recipe. Library code lives in `src/marin_dna/pipelines/chrombpnet_eval/`
+(`_vendor/` is the pinned `arsenal-chrombpnet` fork — see its `PROVENANCE.md`);
+these scripts are thin drivers.
+
+The `chrombpnet` dependency extra is opt-in: `uv sync --extra chrombpnet`
+(PyTorch Lightning etc.; eval contributors who don't train ChromBPNet skip it).
+
+## Scripts
+
+| Script | What it does |
+|---|---|
+| `m1a_onehot_baseline.py` | **M1a** (no training/GPU): validate the metric+scoring harness against ARSENAL's *precomputed* one-hot ChromBPNet scores on our caqtl/dsqtl splits. |
+| `train_onehot.py` | **M1b** (#241): train our own one-hot ChromBPNet on GM12878 DNase and validate the whole training pipeline + W&B instrumentation. |
+| `sky/run_onehot.yaml` | SkyPilot launch for `train_onehot.py` (stages the GM12878 data + hg38 fasta). |
+
+## One-hot ChromBPNet training (`train_onehot.py`)
+
+Faithful one-hot ChromBPNet (vendored `ChromBPNet`, 4-channel one-hot input, a
+frozen pretrained Tn5/DNase bias model), fp32. ChromBPNet trains on its **regular
+DART-Eval chrom splits** (`val = chr6, chr21`; `test = chr5, 10, 14, 18, 20, 22`),
+which are orthogonal to the caqtl/dsqtl variant splits.
+
+Loss = `beta * multinomial_nll(profile) + alpha * mse(log_counts)` (the vendored
+ChromBPNet objective), `alpha = median_count / 10`. Early-stops + checkpoints on
+`val_count_pearson`.
+
+**Logged to W&B** (`chrombpnet-eval` project): per-step `train_loss` /
+`train_profile_loss` / `train_count_loss` / `grad_norm` / `lr`; per validation
+pass `val_count_pearson` + `val_count_spearman` (predicted vs observed log counts,
+the ChromBPNet accessibility metrics) + the val losses.
+
+### Data (ARSENAL Synapse `syn72513540` + a chr-prefixed hg38 fasta)
+
+`filtered.peaks.bed` (`syn73665410`), `filtered.nonpeaks.bed` (`syn73665411`),
+`GM12878_unstranded.bw` (`syn73665418`), `bias_model_scaled.h5` (`syn73665413`),
+hg38 fasta (`syn60756064`) + `.fai` (`syn62284997`), `hg38.chrom.sizes` (UCSC).
+Needs `SYNAPSE_AUTH_TOKEN`. The sky launch stages all of these.
+
+### Run on SkyPilot (recommended — real data is large)
+
+```bash
+# Smoke: logs every step, validates often, online W&B — confirm the pipeline works
+sky launch -c cbp-onehot scripts/chrombpnet_eval/sky/run_onehot.yaml \
+    --env SYNAPSE_AUTH_TOKEN --env WANDB_API_KEY -i 60 --down
+# Full early-stopped run on the same cluster
+sky exec cbp-onehot scripts/chrombpnet_eval/sky/run_onehot.yaml \
+    --env SYNAPSE_AUTH_TOKEN --env WANDB_API_KEY --env SMOKE=0
+```
+
+Tuning knobs (the script defaults match official one-hot ChromBPNet —
+`Adam(lr=1e-3)`, no scheduler): `--lr`, `--lr-scheduler {none,plateau}`,
+`--precision {32,bf16-mixed}`, `--batch-size`, `--patience`,
+`--val-check-interval`, `--log-every-n-steps`.
+
+### Local (synthetic) smoke
+
+The training loop + instrumentation are covered on CPU/synthetic data by
+`tests/pipelines/chrombpnet_eval/test_lit.py` and `test_onehot.py`
+(`uv run --extra chrombpnet pytest tests/pipelines/chrombpnet_eval/`). A real
+data run needs a GPU + the staged GM12878 data, so use the sky launch above.

--- a/scripts/chrombpnet_eval/sky/run_onehot.yaml
+++ b/scripts/chrombpnet_eval/sky/run_onehot.yaml
@@ -2,7 +2,7 @@
 #
 # Stages the GM12878 DNase inputs (ARSENAL Synapse syn72513540) + a chr-prefixed
 # hg38 fasta (DART-Eval Synapse), then runs scripts/chrombpnet_eval/train_onehot.py.
-# No gLM checkpoint — this is the fast, data-loading-bound one-hot arm (fp32).
+# No gLM checkpoint — just the one-hot arm (fp32 default).
 #
 # SMOKE=1 (default): logs EVERY step (per-step loss + grad_norm), validates every
 # 50 train batches on 50 val batches (several val_count_pearson/spearman points),
@@ -20,7 +20,7 @@ name: cbp-onehot
 
 resources:
     infra: aws/us-east-2
-    accelerators: A10G:1        # 24 GB; one-hot ChromBPNet is tiny + CPU-bound
+    accelerators: A10G:1        # 24 GB; ~11 GB used at batch 64 fp32 (GPU-bound)
     disk_size: 200
     labels:
         project: dna
@@ -30,7 +30,7 @@ workdir: .
 envs:
     SMOKE: "1"
     BATCH: "64"                 # official ChromBPNet batch size; fp32 fits easily
-    PRECISION: "32"             # one-hot is data-loading-bound; bf16 buys nothing
+    PRECISION: "32"             # faithful default; bf16-mixed may speed it up (GPU-bound)
     WANDB_MODE: "online"        # the point of the smoke is to see logging work
     WANDB_API_KEY: ""           # pass via `sky launch --env WANDB_API_KEY`
     SYNAPSE_AUTH_TOKEN: ""      # pass via `sky launch --env SYNAPSE_AUTH_TOKEN`
@@ -48,9 +48,15 @@ run: |
     cd ~/sky_workdir
     mkdir -p data
 
-    # GM12878 DNase inputs (ARSENAL Synapse) + chr-prefixed hg38 fasta (DART-Eval)
-    syn() { test -s "$2" || curl -fsSL -H "Authorization: Bearer $SYNAPSE_AUTH_TOKEN" \
-        "https://repo-prod.prod.sagebase.org/repo/v1/entity/$1/file" -o "$2"; }
+    # GM12878 DNase inputs (ARSENAL Synapse) + chr-prefixed hg38 fasta (DART-Eval).
+    # `set +x` around the curl so `set -x` doesn't echo the bearer token to logs.
+    syn() {
+        test -s "$2" && return 0
+        { set +x; } 2>/dev/null
+        curl -fsSL -H "Authorization: Bearer $SYNAPSE_AUTH_TOKEN" \
+            "https://repo-prod.prod.sagebase.org/repo/v1/entity/$1/file" -o "$2"
+        set -x
+    }
     syn syn73665410 data/gm12878_peaks.bed
     syn syn73665411 data/gm12878_nonpeaks.bed
     syn syn73665418 data/GM12878_unstranded.bw

--- a/scripts/chrombpnet_eval/sky/run_onehot.yaml
+++ b/scripts/chrombpnet_eval/sky/run_onehot.yaml
@@ -1,0 +1,77 @@
+# SkyPilot task: train the one-hot ChromBPNet baseline on GM12878 DNase (#241).
+#
+# Stages the GM12878 DNase inputs (ARSENAL Synapse syn72513540) + a chr-prefixed
+# hg38 fasta (DART-Eval Synapse), then runs scripts/chrombpnet_eval/train_onehot.py.
+# No gLM checkpoint — this is the fast, data-loading-bound one-hot arm (fp32).
+#
+# SMOKE=1 (default): logs EVERY step (per-step loss + grad_norm), validates every
+# 50 train batches on 50 val batches (several val_count_pearson/spearman points),
+# caps the epoch — a few minutes to confirm the whole pipeline + W&B logging work.
+# SMOKE=0: the full early-stopped run.
+#
+# Launch (smoke, online W&B so you can watch the curves):
+#   sky launch -c cbp-onehot scripts/chrombpnet_eval/sky/run_onehot.yaml \
+#     --env SYNAPSE_AUTH_TOKEN --env WANDB_API_KEY -i 60 --down
+# Full run on the same cluster:
+#   sky exec cbp-onehot scripts/chrombpnet_eval/sky/run_onehot.yaml \
+#     --env SYNAPSE_AUTH_TOKEN --env WANDB_API_KEY --env SMOKE=0
+
+name: cbp-onehot
+
+resources:
+    infra: aws/us-east-2
+    accelerators: A10G:1        # 24 GB; one-hot ChromBPNet is tiny + CPU-bound
+    disk_size: 200
+    labels:
+        project: dna
+
+workdir: .
+
+envs:
+    SMOKE: "1"
+    BATCH: "64"                 # official ChromBPNet batch size; fp32 fits easily
+    PRECISION: "32"             # one-hot is data-loading-bound; bf16 buys nothing
+    WANDB_MODE: "online"        # the point of the smoke is to see logging work
+    WANDB_API_KEY: ""           # pass via `sky launch --env WANDB_API_KEY`
+    SYNAPSE_AUTH_TOKEN: ""      # pass via `sky launch --env SYNAPSE_AUTH_TOKEN`
+
+setup: |
+    set -euxo pipefail
+    command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="$HOME/.local/bin:$PATH"
+    uv sync --extra chrombpnet
+
+run: |
+    set -euxo pipefail
+    export PATH="$HOME/.local/bin:$PATH"
+    export WANDB_MODE="${WANDB_MODE:-online}"
+    cd ~/sky_workdir
+    mkdir -p data
+
+    # GM12878 DNase inputs (ARSENAL Synapse) + chr-prefixed hg38 fasta (DART-Eval)
+    syn() { test -s "$2" || curl -fsSL -H "Authorization: Bearer $SYNAPSE_AUTH_TOKEN" \
+        "https://repo-prod.prod.sagebase.org/repo/v1/entity/$1/file" -o "$2"; }
+    syn syn73665410 data/gm12878_peaks.bed
+    syn syn73665411 data/gm12878_nonpeaks.bed
+    syn syn73665418 data/GM12878_unstranded.bw
+    syn syn73665413 data/bias_model_scaled.h5
+    syn syn60756064 data/GRCh38.fasta
+    syn syn62284997 data/GRCh38.fasta.fai
+    test -s data/hg38.chrom.sizes || curl -fsSL \
+        "https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.chrom.sizes" -o data/hg38.chrom.sizes
+
+    nvidia-smi
+    if [ "$SMOKE" = "1" ]; then
+        # log every step; ~6 validation passes across the capped epoch
+        EXTRA_ARGS="--log-every-n-steps 1 --val-check-interval 50 \
+            --limit-train-batches 300 --limit-val-batches 50 --max-epochs 1"
+    else
+        # full run: validate ~every 1000 train batches on a 200-batch val subset
+        EXTRA_ARGS="--val-check-interval 1000 --limit-val-batches 200"
+    fi
+    uv run --extra chrombpnet python scripts/chrombpnet_eval/train_onehot.py \
+        --peaks data/gm12878_peaks.bed --nonpeaks data/gm12878_nonpeaks.bed \
+        --bigwig data/GM12878_unstranded.bw --bias data/bias_model_scaled.h5 \
+        --fasta data/GRCh38.fasta --chrom-sizes data/hg38.chrom.sizes \
+        --batch-size "$BATCH" --num-workers 4 --precision "$PRECISION" \
+        --wandb-name dna-exp236-onehot-chrombpnet --out-dir runs/onehot $EXTRA_ARGS

--- a/scripts/chrombpnet_eval/sky/run_onehot.yaml
+++ b/scripts/chrombpnet_eval/sky/run_onehot.yaml
@@ -77,8 +77,9 @@ run: |
         EXTRA_ARGS="--log-every-n-steps 1 --val-check-interval 50 \
             --limit-train-batches 300 --limit-val-batches 50 --max-epochs 1"
     else
-        # full run: validate ~every 1000 train batches on a 200-batch val subset
-        EXTRA_ARGS="--val-check-interval 1000 --limit-val-batches 200"
+        # full run: validate twice per epoch (fraction → robust to epoch length;
+        # batch 128 ≈ 886 train batches/epoch) on a 200-batch val subset
+        EXTRA_ARGS="--val-check-interval 0.5 --limit-val-batches 200"
     fi
     uv run --extra chrombpnet python scripts/chrombpnet_eval/train_onehot.py \
         --peaks data/gm12878_peaks.bed --nonpeaks data/gm12878_nonpeaks.bed \

--- a/scripts/chrombpnet_eval/sky/run_onehot.yaml
+++ b/scripts/chrombpnet_eval/sky/run_onehot.yaml
@@ -9,12 +9,16 @@
 # caps the epoch — a few minutes to confirm the whole pipeline + W&B logging work.
 # SMOKE=0: the full early-stopped run.
 #
+# Logs the online QTL metric too (signed Pearson/Spearman of predicted log2FC vs
+# observed effect over caqtl/dsqtl train-split positives) — reusing the staged
+# hg38 fasta with --qtl-chrom-prefix chr; needs HF access to the variant parquets.
+#
 # Launch (smoke, online W&B so you can watch the curves):
 #   sky launch -c cbp-onehot scripts/chrombpnet_eval/sky/run_onehot.yaml \
-#     --env SYNAPSE_AUTH_TOKEN --env WANDB_API_KEY -i 60 --down
+#     --env SYNAPSE_AUTH_TOKEN --env WANDB_API_KEY --env HF_TOKEN -i 60 --down
 # Full run on the same cluster:
 #   sky exec cbp-onehot scripts/chrombpnet_eval/sky/run_onehot.yaml \
-#     --env SYNAPSE_AUTH_TOKEN --env WANDB_API_KEY --env SMOKE=0
+#     --env SYNAPSE_AUTH_TOKEN --env WANDB_API_KEY --env HF_TOKEN --env SMOKE=0
 
 name: cbp-onehot
 
@@ -34,6 +38,7 @@ envs:
     WANDB_MODE: "online"        # the point of the smoke is to see logging work
     WANDB_API_KEY: ""           # pass via `sky launch --env WANDB_API_KEY`
     SYNAPSE_AUTH_TOKEN: ""      # pass via `sky launch --env SYNAPSE_AUTH_TOKEN`
+    HF_TOKEN: ""                # pass via `--env HF_TOKEN` (caqtl/dsqtl parquets)
 
 setup: |
     set -euxo pipefail
@@ -80,4 +85,5 @@ run: |
         --bigwig data/GM12878_unstranded.bw --bias data/bias_model_scaled.h5 \
         --fasta data/GRCh38.fasta --chrom-sizes data/hg38.chrom.sizes \
         --batch-size "$BATCH" --num-workers 4 --precision "$PRECISION" \
+        --qtl-eval --qtl-genome data/GRCh38.fasta --qtl-chrom-prefix chr \
         --wandb-name dna-exp236-onehot-chrombpnet --out-dir runs/onehot $EXTRA_ARGS

--- a/scripts/chrombpnet_eval/train_onehot.py
+++ b/scripts/chrombpnet_eval/train_onehot.py
@@ -117,9 +117,10 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--log-every-n-steps", type=int, default=10)
     p.add_argument(
         "--val-check-interval",
-        type=int,
+        type=float,
         default=None,
-        help="validate every N train batches (default: epoch end)",
+        help="validate every N train batches (int >=1) or every fraction of an "
+        "epoch (0<f<1, robust to epoch length); default: epoch end",
     )
     p.add_argument("--wandb-name", default="dna-exp236-onehot-chrombpnet")
     p.add_argument("--wandb-project", default="chrombpnet-eval")
@@ -232,6 +233,12 @@ def main() -> None:
         )
         callbacks.append(QTLEvalCallback(specs, batch_size=args.qtl_batch_size))
 
+    # int >=1 -> validate every N batches; float in (0,1) -> fraction of an epoch
+    # (robust to epoch length); None/0 -> once per epoch.
+    vci: int | float = args.val_check_interval or 1.0
+    if vci >= 1:
+        vci = int(vci)
+
     trainer = L.Trainer(
         max_epochs=args.max_epochs,
         reload_dataloaders_every_n_epochs=1,  # resample train negatives each epoch
@@ -240,7 +247,7 @@ def main() -> None:
         precision=args.precision,
         gradient_clip_val=args.grad_clip or None,
         log_every_n_steps=args.log_every_n_steps,
-        val_check_interval=args.val_check_interval or 1.0,
+        val_check_interval=vci,
         limit_train_batches=args.limit_train_batches,
         limit_val_batches=args.limit_val_batches,
         logger=logger,

--- a/scripts/chrombpnet_eval/train_onehot.py
+++ b/scripts/chrombpnet_eval/train_onehot.py
@@ -189,6 +189,12 @@ def main() -> None:
         model = torch.compile(model)
         print("[train] torch.compile enabled")
 
+    if args.warmup_steps > 0 and args.lr_scheduler == "plateau":
+        print(
+            "[train] WARNING: --lr-scheduler plateau is ignored while "
+            "--warmup-steps > 0 (warmup takes precedence); pass --warmup-steps 0 "
+            "to use the plateau scheduler."
+        )
     lit = ChromBPNetLit(
         model,
         alpha=alpha,
@@ -233,11 +239,15 @@ def main() -> None:
         )
         callbacks.append(QTLEvalCallback(specs, batch_size=args.qtl_batch_size))
 
-    # int >=1 -> validate every N batches; float in (0,1) -> fraction of an epoch
-    # (robust to epoch length); None/0 -> once per epoch.
-    vci: int | float = args.val_check_interval or 1.0
-    if vci >= 1:
-        vci = int(vci)
+    # value >=1 -> validate every N batches (int); float in (0,1) -> fraction of
+    # an epoch (robust to epoch length); None/0 -> once per epoch. NB: keep the
+    # default as float 1.0 — int(1.0)==1 would mean "every batch" in Lightning.
+    if not args.val_check_interval:
+        vci: int | float = 1.0
+    elif args.val_check_interval >= 1:
+        vci = int(args.val_check_interval)
+    else:
+        vci = args.val_check_interval
 
     trainer = L.Trainer(
         max_epochs=args.max_epochs,

--- a/scripts/chrombpnet_eval/train_onehot.py
+++ b/scripts/chrombpnet_eval/train_onehot.py
@@ -5,8 +5,9 @@ counts+profile loss, early-stopping on ``val_count_pearson``, and the W&B
 instrumentation (per-step losses + ``grad_norm``, per-epoch ``val_count_pearson``
 / ``val_count_spearman``, ``lr``) — before the slow gLM arm (#243). Faithful
 one-hot ChromBPNet (vendored class, 4-channel one-hot, frozen pretrained bias),
-fp32 (one-hot ChromBPNet is data-loading-bound, so bf16 buys nothing; a
-``--precision bf16-mixed`` knob is exposed for experiments anyway).
+fp32 by default (faithful to official one-hot ChromBPNet). A ``--precision
+bf16-mixed`` knob is exposed for tuning — on an A10G this arm is GPU-compute-bound
+(~97% util at batch 64), so bf16 can actually speed it up.
 
 Data (stage locally first; from ARSENAL Synapse syn72513540 + a hg38 fasta):
   --peaks    filtered.peaks.bed      (syn73665410)

--- a/scripts/chrombpnet_eval/train_onehot.py
+++ b/scripts/chrombpnet_eval/train_onehot.py
@@ -77,6 +77,22 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument("--patience", type=int, default=5, help="early-stop patience")
     p.add_argument(
+        "--seed", type=int, default=0, help="seed_everything (reproducibility)"
+    )
+    p.add_argument(
+        "--warmup-steps",
+        type=int,
+        default=100,
+        help="linear LR warmup steps (0=off); tames the early NaN-prone step (#247)",
+    )
+    p.add_argument(
+        "--grad-clip",
+        type=float,
+        default=1000.0,
+        help="global-norm gradient clip (0=off); a generous safety net above the "
+        "normal grad_norm (~tens-hundreds) to kill spikes (#247)",
+    )
+    p.add_argument(
         "--precision",
         default="32",
         help="'32' (default) or 'bf16-mixed'. The model has a bf16-safe forward "
@@ -86,9 +102,10 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--matmul-precision",
         choices=["highest", "high", "medium"],
-        default="high",
-        help="torch.set_float32_matmul_precision; 'high' enables TF32 matmuls "
-        "(convs already use TF32 via cuDNN, so this is marginal for a conv net)",
+        default="highest",
+        help="torch.set_float32_matmul_precision; 'highest' = full fp32 matmuls "
+        "(default — TF32 'high' contributed to a NaN divergence, see #247). Convs "
+        "still use TF32 via cuDNN regardless.",
     )
     p.add_argument(
         "--compile",
@@ -137,7 +154,9 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
 
-    # TF32 matmuls (Ampere+); convs already use TF32 via cuDNN's default.
+    L.seed_everything(args.seed, workers=True)
+    # matmul precision: 'highest' = full fp32 (default; TF32 contributed to a NaN
+    # divergence, #247). Convs use TF32 via cuDNN regardless.
     torch.set_float32_matmul_precision(args.matmul_precision)
 
     data_config = DataConfig(
@@ -174,6 +193,7 @@ def main() -> None:
         alpha=alpha,
         beta=1.0,
         lr=args.lr,
+        warmup_steps=args.warmup_steps,
         lr_scheduler=None if args.lr_scheduler == "none" else args.lr_scheduler,
     )
 
@@ -218,6 +238,7 @@ def main() -> None:
         accelerator="gpu",
         devices=args.devices,
         precision=args.precision,
+        gradient_clip_val=args.grad_clip or None,
         log_every_n_steps=args.log_every_n_steps,
         val_check_interval=args.val_check_interval or 1.0,
         limit_train_batches=args.limit_train_batches,

--- a/scripts/chrombpnet_eval/train_onehot.py
+++ b/scripts/chrombpnet_eval/train_onehot.py
@@ -1,0 +1,167 @@
+"""Train the one-hot ChromBPNet baseline on GM12878 DNase (M1b, issue #241).
+
+The fast path that validates the whole training pipeline — data loading, the
+counts+profile loss, early-stopping on ``val_count_pearson``, and the W&B
+instrumentation (per-step losses + ``grad_norm``, per-epoch ``val_count_pearson``
+/ ``val_count_spearman``, ``lr``) — before the slow gLM arm (#243). Faithful
+one-hot ChromBPNet (vendored class, 4-channel one-hot, frozen pretrained bias),
+fp32 (one-hot ChromBPNet is data-loading-bound, so bf16 buys nothing; a
+``--precision bf16-mixed`` knob is exposed for experiments anyway).
+
+Data (stage locally first; from ARSENAL Synapse syn72513540 + a hg38 fasta):
+  --peaks    filtered.peaks.bed      (syn73665410)
+  --nonpeaks filtered.nonpeaks.bed   (syn73665411)
+  --bigwig   GM12878_unstranded.bw   (syn73665418)
+  --bias     bias_model_scaled.h5    (syn73665413)
+  --fasta    GRCh38...fasta (chr-prefixed; DART-Eval syn60756064)
+  --chrom-sizes hg38.chrom.sizes
+
+Example (1 GPU, full early-stopped run):
+  uv run --extra chrombpnet python scripts/chrombpnet_eval/train_onehot.py \
+    --peaks gm12878_peaks.bed --nonpeaks gm12878_nonpeaks.bed \
+    --bigwig GM12878_unstranded.bw --bias bias_model_scaled.h5 \
+    --fasta GRCh38.fasta --chrom-sizes hg38.chrom.sizes \
+    --wandb-name dna-exp236-onehot-chrombpnet --out-dir runs/onehot
+
+Smoke (log every step, validate often, cap batches):
+  ... --log-every-n-steps 1 --val-check-interval 50 --limit-train-batches 200 \
+      --limit-val-batches 50 --max-epochs 1
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import lightning as L
+
+from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.data_config import (
+    DataConfig,
+)
+from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.dataset import DataModule
+from marin_dna.pipelines.chrombpnet_eval.lit import ChromBPNetLit
+from marin_dna.pipelines.chrombpnet_eval.onehot import (
+    build_onehot_chrombpnet,
+    count_trainable_params,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    # data
+    p.add_argument("--peaks", required=True)
+    p.add_argument("--nonpeaks", required=True)
+    p.add_argument("--bigwig", required=True)
+    p.add_argument("--bias", required=True, help="Keras .h5 pretrained bias model")
+    p.add_argument("--fasta", required=True, help="hg38 fasta (chr-prefixed)")
+    p.add_argument("--chrom-sizes", required=True)
+    p.add_argument("--out-dir", default="runs/onehot")
+    # training
+    p.add_argument("--max-epochs", type=int, default=100)
+    p.add_argument("--batch-size", type=int, default=64)
+    p.add_argument("--num-workers", type=int, default=4)
+    p.add_argument("--lr", type=float, default=1e-3, help="Adam LR (official: 1e-3)")
+    p.add_argument(
+        "--lr-scheduler",
+        choices=["none", "plateau"],
+        default="none",
+        help="'plateau' = ReduceLROnPlateau on val_count_pearson (ChromBPNet's "
+        "commented-out config)",
+    )
+    p.add_argument("--patience", type=int, default=5, help="early-stop patience")
+    p.add_argument(
+        "--precision", default="32", help="'32' or 'bf16-mixed' (experimental)"
+    )
+    p.add_argument("--devices", type=int, default=1)
+    # logging cadence
+    p.add_argument("--log-every-n-steps", type=int, default=10)
+    p.add_argument(
+        "--val-check-interval",
+        type=int,
+        default=None,
+        help="validate every N train batches (default: epoch end)",
+    )
+    p.add_argument("--wandb-name", default="dna-exp236-onehot-chrombpnet")
+    p.add_argument("--wandb-project", default="chrombpnet-eval")
+    p.add_argument("--no-wandb", action="store_true", help="CSVLogger instead of W&B")
+    # smoke knobs (cap batches per epoch so a 1-epoch run finishes fast)
+    p.add_argument("--limit-train-batches", type=int, default=None)
+    p.add_argument("--limit-val-batches", type=int, default=None)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    data_config = DataConfig(
+        peaks=args.peaks,
+        negatives=args.nonpeaks,
+        bigwig=args.bigwig,
+        fasta=args.fasta,
+        chrom_sizes=args.chrom_sizes,
+        in_window=2114,
+        out_window=1000,
+        genome="hg38",
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+    )
+    datamodule = DataModule(data_config)
+    # ChromBPNet's scale-balancing heuristic for the counts-loss weight.
+    alpha = datamodule.median_count / 10
+    print(f"[train] median_count={datamodule.median_count:.1f} -> alpha={alpha:.3f}")
+
+    model = build_onehot_chrombpnet(bias_h5=args.bias)
+    n_trainable = count_trainable_params(model)
+    n_bias = sum(p.numel() for p in model.bias.parameters())
+    print(
+        f"[train] one-hot ChromBPNet: {n_trainable:,} trainable params; "
+        f"bias frozen ({n_bias:,} params, requires_grad="
+        f"{any(p.requires_grad for p in model.bias.parameters())})"
+    )
+
+    lit = ChromBPNetLit(
+        model,
+        alpha=alpha,
+        beta=1.0,
+        lr=args.lr,
+        lr_scheduler=None if args.lr_scheduler == "none" else args.lr_scheduler,
+    )
+
+    logger: object
+    if args.no_wandb:
+        logger = L.pytorch.loggers.CSVLogger(args.out_dir, name=args.wandb_name)
+    else:
+        logger = L.pytorch.loggers.WandbLogger(
+            name=args.wandb_name, project=args.wandb_project, save_dir=args.out_dir
+        )
+    trainer = L.Trainer(
+        max_epochs=args.max_epochs,
+        reload_dataloaders_every_n_epochs=1,  # resample train negatives each epoch
+        accelerator="gpu",
+        devices=args.devices,
+        precision=args.precision,
+        log_every_n_steps=args.log_every_n_steps,
+        val_check_interval=args.val_check_interval or 1.0,
+        limit_train_batches=args.limit_train_batches,
+        limit_val_batches=args.limit_val_batches,
+        logger=logger,
+        callbacks=[
+            L.pytorch.callbacks.LearningRateMonitor(logging_interval="step"),
+            L.pytorch.callbacks.EarlyStopping(
+                monitor="val_count_pearson", patience=args.patience, mode="max"
+            ),
+            L.pytorch.callbacks.ModelCheckpoint(
+                dirpath=f"{args.out_dir}/checkpoints",
+                monitor="val_count_pearson",
+                mode="max",
+                save_top_k=1,
+                filename="best_model",
+                save_last=True,
+            ),
+        ],
+    )
+    trainer.fit(lit, datamodule)
+    print(f"[train] done; best checkpoint under {args.out_dir}/checkpoints")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chrombpnet_eval/train_onehot.py
+++ b/scripts/chrombpnet_eval/train_onehot.py
@@ -39,11 +39,17 @@ import torch
 from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.data_config import (
     DataConfig,
 )
+from marin_dna.data.genome import Genome
 from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.dataset import DataModule
 from marin_dna.pipelines.chrombpnet_eval.lit import ChromBPNetLit
 from marin_dna.pipelines.chrombpnet_eval.onehot import (
     build_onehot_chrombpnet,
     count_trainable_params,
+)
+from marin_dna.pipelines.chrombpnet_eval.qtl_eval import (
+    QTL_DATASETS,
+    QTLEvalCallback,
+    build_qtl_specs,
 )
 
 
@@ -101,6 +107,27 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--wandb-name", default="dna-exp236-onehot-chrombpnet")
     p.add_argument("--wandb-project", default="chrombpnet-eval")
     p.add_argument("--no-wandb", action="store_true", help="CSVLogger instead of W&B")
+    # online QTL metric: signed Pearson/Spearman of predicted log2FC vs the
+    # observed effect, over positives only, logged each validation (the eval
+    # target — distinct from val_count_pearson, the accessibility-count fit).
+    p.add_argument(
+        "--qtl-eval",
+        action="store_true",
+        help="log live caqtl/dsqtl Pearson/Spearman over positives each val",
+    )
+    p.add_argument(
+        "--qtl-genome",
+        default=None,
+        help="reference fasta for QTL window extraction — e.g. the staged hg38 "
+        "fasta with --qtl-chrom-prefix chr, or the canonical s3:// GRCh38",
+    )
+    p.add_argument(
+        "--qtl-chrom-prefix",
+        default="",
+        help="prefix prepended to the variant chrom ('chr' for a chr-prefixed fasta)",
+    )
+    p.add_argument("--qtl-batch-size", type=int, default=256)
+    p.add_argument("--qtl-split", default="train", help="QTL split (dev = train)")
     # smoke knobs (cap batches per epoch so a 1-epoch run finishes fast)
     p.add_argument("--limit-train-batches", type=int, default=None)
     p.add_argument("--limit-val-batches", type=int, default=None)
@@ -157,6 +184,34 @@ def main() -> None:
         logger = L.pytorch.loggers.WandbLogger(
             name=args.wandb_name, project=args.wandb_project, save_dir=args.out_dir
         )
+
+    callbacks: list[L.Callback] = [
+        L.pytorch.callbacks.LearningRateMonitor(logging_interval="step"),
+        L.pytorch.callbacks.EarlyStopping(
+            monitor="val_count_pearson", patience=args.patience, mode="max"
+        ),
+        L.pytorch.callbacks.ModelCheckpoint(
+            dirpath=f"{args.out_dir}/checkpoints",
+            monitor="val_count_pearson",
+            mode="max",
+            save_top_k=1,
+            filename="best_model",
+            save_last=True,
+        ),
+    ]
+    if args.qtl_eval:
+        assert args.qtl_genome, "--qtl-eval requires --qtl-genome"
+        # Pre-extract the positives' ref/alt windows once; the callback re-scores
+        # the cached one-hots each validation.
+        specs = build_qtl_specs(
+            Genome(args.qtl_genome),
+            QTL_DATASETS,
+            split=args.qtl_split,
+            window=2114,
+            chrom_prefix=args.qtl_chrom_prefix,
+        )
+        callbacks.append(QTLEvalCallback(specs, batch_size=args.qtl_batch_size))
+
     trainer = L.Trainer(
         max_epochs=args.max_epochs,
         reload_dataloaders_every_n_epochs=1,  # resample train negatives each epoch
@@ -168,20 +223,7 @@ def main() -> None:
         limit_train_batches=args.limit_train_batches,
         limit_val_batches=args.limit_val_batches,
         logger=logger,
-        callbacks=[
-            L.pytorch.callbacks.LearningRateMonitor(logging_interval="step"),
-            L.pytorch.callbacks.EarlyStopping(
-                monitor="val_count_pearson", patience=args.patience, mode="max"
-            ),
-            L.pytorch.callbacks.ModelCheckpoint(
-                dirpath=f"{args.out_dir}/checkpoints",
-                monitor="val_count_pearson",
-                mode="max",
-                save_top_k=1,
-                filename="best_model",
-                save_last=True,
-            ),
-        ],
+        callbacks=callbacks,
     )
     trainer.fit(lit, datamodule)
     print(f"[train] done; best checkpoint under {args.out_dir}/checkpoints")

--- a/scripts/chrombpnet_eval/train_onehot.py
+++ b/scripts/chrombpnet_eval/train_onehot.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import argparse
 
 import lightning as L
+import torch
 
 from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.data_config import (
     DataConfig,
@@ -70,7 +71,23 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument("--patience", type=int, default=5, help="early-stop patience")
     p.add_argument(
-        "--precision", default="32", help="'32' or 'bf16-mixed' (experimental)"
+        "--precision",
+        default="32",
+        help="'32' (default) or 'bf16-mixed'. The model has a bf16-safe forward "
+        "(fp32 count-combine), so bf16 won't NaN; it's GPU-bound, so bf16 speeds "
+        "it up.",
+    )
+    p.add_argument(
+        "--matmul-precision",
+        choices=["highest", "high", "medium"],
+        default="high",
+        help="torch.set_float32_matmul_precision; 'high' enables TF32 matmuls "
+        "(convs already use TF32 via cuDNN, so this is marginal for a conv net)",
+    )
+    p.add_argument(
+        "--compile",
+        action="store_true",
+        help="torch.compile the model (experimental; may fuse the conv tower)",
     )
     p.add_argument("--devices", type=int, default=1)
     # logging cadence
@@ -92,6 +109,9 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
+
+    # TF32 matmuls (Ampere+); convs already use TF32 via cuDNN's default.
+    torch.set_float32_matmul_precision(args.matmul_precision)
 
     data_config = DataConfig(
         peaks=args.peaks,
@@ -118,6 +138,9 @@ def main() -> None:
         f"bias frozen ({n_bias:,} params, requires_grad="
         f"{any(p.requires_grad for p in model.bias.parameters())})"
     )
+    if args.compile:
+        model = torch.compile(model)
+        print("[train] torch.compile enabled")
 
     lit = ChromBPNetLit(
         model,

--- a/scripts/chrombpnet_eval/vram_probe.py
+++ b/scripts/chrombpnet_eval/vram_probe.py
@@ -1,0 +1,78 @@
+"""Probe peak GPU memory for a one-hot ChromBPNet training step (#241).
+
+Sweeps batch sizes × precisions and reports peak reserved VRAM (the number that
+actually OOMs) so we can pick a batch that fits — especially for bf16, which
+roughly halves the activation memory and so admits a bigger batch. Diagnostic,
+synthetic data, no real inputs:
+
+    uv run --extra chrombpnet python scripts/chrombpnet_eval/vram_probe.py
+
+Mirrors the real training step: bf16-autocast conv towers + the fp32 count-combine
+(OneHotChromBPNet) + the fp32 counts/profile loss + an Adam step, with the bias
+frozen (as in a real run).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+import torch.nn.functional as F
+
+from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.model_wrappers import (
+    multinomial_nll,
+)
+from marin_dna.pipelines.chrombpnet_eval.onehot import build_onehot_chrombpnet
+
+
+def _train_step(model: torch.nn.Module, batch_size: int, bf16: bool) -> None:
+    dev = "cuda"
+    x = torch.zeros(batch_size, 4, 2114, device=dev)
+    x[:, torch.randint(0, 4, (2114,)), torch.arange(2114)] = 1.0
+    true_profile = torch.randint(0, 5, (batch_size, 1000), device=dev).float()
+    true_counts = torch.log1p(true_profile.sum(dim=-1))
+    opt = torch.optim.Adam([p for p in model.parameters() if p.requires_grad], lr=1e-3)
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=bf16):
+        y_profile, y_count = model(x)
+    with torch.autocast(device_type="cuda", enabled=False):
+        loss = multinomial_nll(y_profile.float(), true_profile.float()) + F.mse_loss(
+            y_count.squeeze(-1).float(), true_counts.float()
+        )
+    loss.backward()
+    opt.step()
+    opt.zero_grad(set_to_none=True)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--batches", type=int, nargs="+", default=[64, 128, 192, 256, 384, 512]
+    )
+    ap.add_argument("--precisions", nargs="+", default=["fp32", "bf16"])
+    args = ap.parse_args()
+
+    assert torch.cuda.is_available(), "need a GPU"
+    torch.set_float32_matmul_precision("highest")
+    total = torch.cuda.get_device_properties(0).total_memory / 1e9
+    print(f"GPU: {torch.cuda.get_device_name(0)}  total {total:.1f} GB")
+    print(f"{'batch':>6} {'precision':>10} {'peak_GB':>8}  status")
+    for prec in args.precisions:
+        for bs in args.batches:
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats()
+            model = build_onehot_chrombpnet(bias_h5=None).cuda()
+            for p in model.bias.parameters():  # bias is frozen in a real run
+                p.requires_grad = False
+            try:
+                _train_step(model, bs, bf16=(prec == "bf16"))
+                peak = torch.cuda.max_memory_reserved() / 1e9
+                print(f"{bs:>6} {prec:>10} {peak:>8.1f}  OK")
+            except RuntimeError as e:
+                status = "OOM" if "out of memory" in str(e).lower() else str(e)[:40]
+                print(f"{bs:>6} {prec:>10} {'-':>8}  {status}")
+            del model
+            torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/PROVENANCE.md
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/PROVENANCE.md
@@ -1,0 +1,18 @@
+# Vendored: chrombpnet_pytorch (arsenal-chrombpnet)
+
+Source: https://github.com/amanpatel101/arsenal-chrombpnet
+Commit: dcfa42b1786713e131bb113f4c6d20acc046185d (2026-02-08)
+
+A PyTorch ChromBPNet (forked from jsxlei/chrombpnet-pytorch) extended by the
+ARSENAL authors to train a ChromBPNet head on language-model embeddings.
+
+Local modifications (see git history / issue #236, PR #239):
+- Absolute intra-package imports (`from chrombpnet.X`) -> relative (`from .X`).
+- ARSENAL `from modeling.model import *` (regulatory_lm) removed; the embedding
+  input is supplied by `marin_dna.pipelines.chrombpnet_eval.embedding` (our HF
+  causal adapter).
+- interpret.py / snp_scoring.py / snp_utils.py are removed (they pull
+  tensorflow / deeplift / tangermeme); we use our own variant scoring + the M1a
+  metric harness instead.
+- Heavy/irrelevant top-level imports (weasyprint, pooch, deepdish) made lazy or
+  trimmed on the training path.

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/__init__.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/__init__.py
@@ -1,0 +1,24 @@
+"""
+ChromBPNet - Chromatin Binding Prediction Network
+
+A PyTorch implementation of ChromBPNet for chromatin binding prediction.
+"""
+
+__version__ = "0.0.1"
+__author__ = "Lei Xiong"
+__email__ = "jsxlei@gmail.com"
+
+# Import main modules
+from . import data_utils
+from . import chrombpnet
+from . import bpnet
+from . import model_wrappers
+from . import dataset
+
+__all__ = [
+    "data_utils",
+    "chrombpnet",
+    "bpnet",
+    "model_wrappers",
+    "dataset",
+]

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/bpnet.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/bpnet.py
@@ -1,0 +1,587 @@
+# Author: Lei Xiong <jsxlei@gmail.com>
+
+import torch
+import torch.nn.functional as F
+
+# adapted from BPNet in bpnet-lite, credit goes to Jacob Schreiber <jmschreiber91@gmail.com>
+
+
+class BPNet(torch.nn.Module):
+    """A basic BPNet model with stranded profile and total count prediction.
+
+    This is a reference implementation for BPNet. The model takes in
+    one-hot encoded sequence, runs it through:
+
+    (1) a single wide convolution operation
+
+    THEN
+
+    (2) a user-defined number of dilated residual convolutions
+
+    THEN
+
+    (3a) profile predictions done using a very wide convolution layer
+    that also takes in stranded control tracks
+
+    AND
+
+    (3b) total count prediction done using an average pooling on the output
+    from 2 followed by concatenation with the log1p of the sum of the
+    stranded control tracks and then run through a dense layer.
+
+    This implementation differs from the original BPNet implementation in
+    two ways:
+
+
+    (1) The model concatenates stranded control tracks for profile
+    prediction as opposed to adding the two strands together and also then
+    smoothing that track
+
+    (2) The control input for the count prediction task is the log1p of
+    the strand-wise sum of the control tracks, as opposed to the raw
+    counts themselves.
+
+    (3) A single log softmax is applied across both strands such that
+    the logsumexp of both strands together is 0. Put another way, the
+    two strands are concatenated together, a log softmax is applied,
+    and the MNLL loss is calculated on the concatenation.
+
+    (4) The count prediction task is predicting the total counts across
+    both strands. The counts are then distributed across strands according
+    to the single log softmax from 3.
+
+    Note that this model is also used as components in the ChromBPNet model,
+    as both the bias model and the accessibility model. Both components are
+    the same BPNet architecture but trained on different loci.
+
+
+    Parameters
+    ----------
+    n_filters: int, optional
+        The number of filters to use per convolution. Default is 64.
+
+    n_layers: int, optional
+        The number of dilated residual layers to include in the model.
+        Default is 8.
+
+    n_outputs: int, optional
+        The number of profile outputs from the model. Generally either 1 or 2
+        depending on if the data is unstranded or stranded. Default is 2.
+
+    n_control_tracks: int, optional
+        The number of control tracks to feed into the model. When predicting
+        TFs, this is usually 2. When predicting accessibility, this is usualy
+        0. When 0, this input is removed from the model. Default is 2.
+
+    alpha: float, optional
+        The weight to put on the count loss.
+
+    profile_output_bias: bool, optional
+        Whether to include a bias term in the final profile convolution.
+        Removing this term can help with attribution stability and will usually
+        not affect performance. Default is True.
+
+    count_output_bias: bool, optional
+        Whether to include a bias term in the linear layer used to predict
+        counts. Removing this term can help with attribution stability but
+        may affect performance. Default is True.
+
+    name: str or None, optional
+        The name to save the model to during training.
+
+    trimming: int or None, optional
+        The amount to trim from both sides of the input window to get the
+        output window. This value is removed from both sides, so the total
+        number of positions removed is 2*trimming.
+
+    verbose: bool, optional
+        Whether to display statistics during training. Setting this to False
+        will still save the file at the end, but does not print anything to
+        screen during training. Default is True.
+    """
+
+    def __init__(
+        self,
+        out_dim=1000,
+        n_filters=64,
+        n_layers=8,
+        rconvs_kernel_size=3,
+        conv1_kernel_size=21,
+        profile_kernel_size=75,
+        n_outputs=1,
+        n_control_tracks=0,
+        profile_output_bias=True,
+        count_output_bias=True,
+        name=None,
+        verbose=False,
+        custom_dilations=False
+    ):
+        super().__init__()
+
+        self.out_dim = out_dim
+        self.n_filters = n_filters
+        self.n_layers = n_layers
+        self.n_outputs = n_outputs
+        self.n_control_tracks = n_control_tracks
+        self.verbose = verbose
+        self.name = name or "bpnet.{}.{}".format(n_filters, n_layers)
+
+        # first convolution without dilation
+        self.iconv = torch.nn.Conv1d(4, n_filters, kernel_size=conv1_kernel_size, padding='valid')
+        self.irelu = torch.nn.ReLU()
+
+        if custom_dilations:
+            rconvs_kernel_size = 5
+            dilation_sched = [2,8,32,64,128]
+            # dilation_sched = [8,16,32,64,128,256]
+            self.rconvs = torch.nn.ModuleList([
+                torch.nn.Conv1d(n_filters, n_filters, kernel_size=rconvs_kernel_size, padding='valid',
+                    dilation=dilation_sched[i-1]) for i in range(1, self.n_layers+1)
+            ])
+
+        # residual dilated convolutions
+        else:
+            self.rconvs = torch.nn.ModuleList([
+                torch.nn.Conv1d(n_filters, n_filters, kernel_size=rconvs_kernel_size, padding='valid',
+                    dilation=2**i) for i in range(1, self.n_layers+1)
+            ])
+
+        self.rrelus = torch.nn.ModuleList([
+			torch.nn.ReLU() for i in range(1, self.n_layers+1)
+		])
+
+        # profile prediction
+        self.fconv = torch.nn.Conv1d(n_filters+n_control_tracks, n_outputs,
+            kernel_size=profile_kernel_size, padding='valid', bias=profile_output_bias)
+
+        # count prediction
+        n_count_control = 1 if n_control_tracks > 0 else 0
+        self.global_avg_pool = torch.nn.AdaptiveAvgPool1d(1)
+        self.linear = torch.nn.Linear(n_filters+n_count_control, 1,
+            bias=count_output_bias)
+
+
+    def forward(self, x, x_ctl=None):
+        """A forward pass of the model.
+
+        This method takes in a nucleotide sequence x, a corresponding
+        per-position value from a control track, and a per-locus value
+        from the control track and makes predictions for the profile
+        and for the counts. This per-locus value is usually the
+        log(sum(X_ctl_profile)+1) when the control is an experimental
+        read track but can also be the -output from another model.
+
+        Parameters
+        ----------
+        x: torch.tensor, shape=(batch_size, 4, length)
+            The one-hot encoded batch of sequences.
+
+        X_ctl: torch.tensor or None, shape=(batch_size, n_strands, length)
+            A value representing the signal of the control at each position in
+            the sequence. If no controls, pass in None. Default is None.
+
+        Returns
+        -------
+        pred_profile: torch.tensor, shape=(batch_size, n_strands, out_length)
+            The output predictions for each strand trimmed to the output
+            length.
+        pred_count: torch.tensor, shape=(batch_size, 1)
+        """
+        if x.shape[1] != 4:
+            x = x.permute(0, 2, 1)
+        x = self.get_embs_after_crop(x)
+
+        if self.verbose: print(f'trunk shape: {x.shape}')
+
+        if x_ctl is not None:
+            crop_size = (x_ctl.shape[2] - x.shape[2]) // 2
+            if self.verbose: print(f'crop_size: {crop_size}')
+            if crop_size > 0:
+                x_ctl = x_ctl[:, :, crop_size:-crop_size]
+            else:
+                x_ctl = F.pad(x_ctl, (-crop_size, -crop_size))
+
+        pred_profile = self.profile_head(x, x_ctl=x_ctl) # before log_softmax
+        pred_count = self.count_head(x, x_ctl=x_ctl) #.squeeze(-1) # (batch_size, 1)
+
+        return pred_profile, pred_count
+
+
+    def get_embs_after_crop(self, x):
+        x = self.irelu(self.iconv(x))
+        for i in range(self.n_layers):
+            conv_x = self.rrelus[i](self.rconvs[i](x))
+            crop_len = (x.shape[2] - conv_x.shape[2]) // 2
+            if crop_len > 0:
+                x = x[:, :, crop_len:-crop_len]
+            x = torch.add(x, conv_x)
+
+        return x
+
+    def profile_head(self, x, x_ctl=None):
+        """
+        Profile head of the model.
+        output: (batch_size, n_outputs, out_window)
+        """
+
+        if x_ctl is not None:
+            x = torch.cat([x, x_ctl], dim=1)
+
+        pred_profile = self.fconv(x)
+
+        crop_size = (pred_profile.shape[2] - self.out_dim) // 2
+        if crop_size > 0:
+            pred_profile = pred_profile[:, :, crop_size:-crop_size]
+        else:
+            pred_profile = F.pad(pred_profile, (-crop_size, -crop_size)) # pad if out_window > in_window
+
+        return pred_profile
+
+
+    def count_head(self, x, x_ctl=None):
+
+        # pred_count = torch.mean(x, dim=2)
+        pred_count = self.global_avg_pool(x).squeeze(-1)
+        if x_ctl is not None:
+            x_ctl = torch.sum(x_ctl, dim=(1, 2)).unsqueeze(-1)
+            pred_count = torch.cat([pred_count, torch.log1p(x_ctl)], dim=-1)
+        pred_count = self.linear(pred_count)
+        return pred_count
+
+
+    @classmethod
+    def from_keras(cls, filename, name='chrombpnet'):
+        """Loads a model from ChromBPNet TensorFlow format.
+
+        This method will load one of the components of a ChromBPNet model
+        from TensorFlow format. Note that a full ChromBPNet model is made up
+        of an accessibility model and a bias model and that this will load
+        one of the two. Use `ChromBPNet.from_chrombpnet` to end up with the
+        entire ChromBPNet model.
+
+
+        Parameters
+        ----------
+        filename: str
+            The name of the h5 file that stores the trained model parameters.
+
+
+        Returns
+        -------
+        model: BPNet
+            A BPNet model compatible with this repository in PyTorch.
+        """
+        if filename.endswith('.h5'):
+            import h5py
+
+            h5 = h5py.File(filename, "r")
+            w = h5['model_weights']
+        else:
+            import os
+            os.system('conda activate chrombpnet')
+            import tensorflow as tf
+
+            model = tf.keras.models.load_model(filename)
+            w = model.get_weights()
+            os.system('conda deactivate')
+
+        if 'bpnet_1conv' in w.keys():
+            prefix = ""
+        else:
+            prefix = "wo_bias_"
+        # print(f"Loading {name} model from {filename}", flush=True)
+
+        namer = lambda prefix, suffix: '{0}{1}/{0}{1}'.format(prefix, suffix)
+        k, b = 'kernel:0', 'bias:0'
+
+        n_layers = 0
+        for layer_name in w.keys():
+            try:
+                idx = int(layer_name.split("_")[-1].replace("conv", ""))
+                n_layers = max(n_layers, idx)
+            except:
+                pass
+
+        name = namer(prefix, "bpnet_1conv")
+        n_filters = w[name][k].shape[2]
+
+        model = BPNet(n_layers=n_layers, n_filters=n_filters, n_outputs=1,
+            n_control_tracks=0)
+
+        convert_w = lambda x: torch.nn.Parameter(torch.tensor(
+            x[:]).permute(2, 1, 0))
+        convert_b = lambda x: torch.nn.Parameter(torch.tensor(x[:]))
+
+        iname = namer(prefix, 'bpnet_1st_conv')
+
+        model.iconv.weight = convert_w(w[iname][k])
+        model.iconv.bias = convert_b(w[iname][b])
+
+        for i in range(1, n_layers+1):
+            lname = namer(prefix, 'bpnet_{}conv'.format(i))
+
+            model.rconvs[i-1].weight = convert_w(w[lname][k])
+            model.rconvs[i-1].bias = convert_b(w[lname][b])
+
+        prefix = prefix + "bpnet_" if prefix != "" else ""
+
+        fname = namer(prefix, 'prof_out_precrop')
+        model.fconv.weight = convert_w(w[fname][k])
+        model.fconv.bias = convert_b(w[fname][b])
+
+        name = namer(prefix, "logcount_predictions")
+        model.linear.weight = torch.nn.Parameter(torch.tensor(w[name][k][:].T))
+        model.linear.bias = convert_b(w[name][b])
+        return model
+
+    @classmethod
+    def to_keras(cls, filename):
+        import tensorflow as tf
+        from tensorflow.keras.layers import Input, Conv1D, Cropping1D, Add, GlobalAveragePooling1D, Dense, ReLU
+        from tensorflow.keras.models import Model
+        import numpy as np
+
+        def build_keras_bpnet(sequence_len, n_dil_layers, filters, conv1_kernel_size, profile_kernel_size, num_tasks, out_pred_len):
+            inp = Input(shape=(sequence_len, 4), name='sequence')
+
+            # First convolution without dilation
+            x = Conv1D(filters, kernel_size=conv1_kernel_size, padding='valid', activation='relu', name='conv1')(inp)
+
+            for i in range(1, n_dil_layers + 1):
+                conv_x = Conv1D(filters, kernel_size=3, padding='valid', activation='relu', dilation_rate=2**i, name=f'dilated_conv_{i}')(x)
+                x_len = x.shape[1]
+                conv_x_len = conv_x.shape[1]
+                assert (x_len - conv_x_len) % 2 == 0
+                crop_len = (x_len - conv_x_len) // 2
+                x = Cropping1D(cropping=(crop_len, crop_len), name=f'crop_{i}')(x)
+                x = Add(name=f'add_{i}')([conv_x, x])
+
+            # Profile prediction
+            prof_out_precrop = Conv1D(num_tasks, kernel_size=profile_kernel_size, padding='valid', name='profile_conv')(x)
+            cropsize = (prof_out_precrop.shape[1] - out_pred_len) // 2
+            prof = Cropping1D(cropping=(cropsize, cropsize), name='profile_crop')(prof_out_precrop)
+            profile_out = tf.reshape(prof, (tf.shape(prof)[0], -1), name='profile_out')
+
+            # Counts prediction
+            gap_combined_conv = GlobalAveragePooling1D(name='gap')(x)
+            count_out = Dense(num_tasks, name='count_out')(gap_combined_conv)
+
+            model = Model(inputs=[inp], outputs=[profile_out, count_out])
+            return model
+
+        # # Build the Keras model
+        keras_model = build_keras_bpnet(sequence_len=2114, n_dil_layers=8, filters=512, conv1_kernel_size=21, profile_kernel_size=75, num_tasks=1, out_pred_len=1000)
+
+        # # Summary of the model
+        # keras_model.summary()
+
+        def transfer_weights(pytorch_model, keras_model):
+            # Transfer conv1 weights
+            keras_model.get_layer('conv1').set_weights([
+                pytorch_model.conv1.weight.detach().numpy().transpose(2, 1, 0),
+                pytorch_model.conv1.bias.detach().numpy()
+            ])
+
+            # Transfer dilated conv layers' weights
+            for i, layer in enumerate(pytorch_model.dilated_convs):
+                keras_layer = keras_model.get_layer(f'dilated_conv_{i + 1}')
+                keras_layer.set_weights([
+                    layer.weight.detach().numpy().transpose(2, 1, 0),
+                    layer.bias.detach().numpy()
+                ])
+
+            # Transfer profile conv weights
+            keras_model.get_layer('profile_conv').set_weights([
+                pytorch_model.profile_conv.weight.detach().numpy().transpose(2, 1, 0),
+                pytorch_model.profile_conv.bias.detach().numpy()
+            ])
+
+            # Transfer dense layer weights
+            keras_model.get_layer('count_out').set_weights([
+                pytorch_model.dense.weight.detach().numpy().transpose(1, 0),
+                pytorch_model.dense.bias.detach().numpy()
+            ])
+
+        transfer_weights(self, keras_model)
+        keras_model.save(filename)
+
+
+
+
+
+class DoubleBPNet(BPNet):
+
+    def __init__(
+        self,
+        out_dim=1000,
+        n_filters=64,
+        n_layers=8,
+        rconvs_kernel_size=3,
+        conv1_kernel_size=21,
+        profile_kernel_size=75,
+        n_outputs=1,
+        n_control_tracks=0,
+        input_sizes=[4,768],
+        profile_output_bias=True,
+        count_output_bias=True,
+        name=None,
+        verbose=False,
+        dropout=False
+    ):
+        super().__init__()
+
+        self.out_dim = out_dim
+        self.n_filters = n_filters
+        self.n_layers = n_layers
+        self.n_outputs = n_outputs
+        self.n_control_tracks = n_control_tracks
+        self.verbose = verbose
+        self.name = name or "bpnet.{}.{}".format(n_filters, n_layers)
+        self.input_sizes = input_sizes
+
+        # first convolution without dilation
+        self.iconv1 = torch.nn.Conv1d(input_sizes[0], n_filters, kernel_size=conv1_kernel_size, padding='valid')
+        self.irelu1 = torch.nn.ReLU()
+
+        self.iconv2 = torch.nn.Conv1d(input_sizes[1], n_filters, kernel_size=conv1_kernel_size, padding='valid')
+        self.irelu2 = torch.nn.ReLU()
+
+
+        # residual dilated convolutions
+        self.rconvs1 = torch.nn.ModuleList([
+            torch.nn.Conv1d(n_filters, n_filters, kernel_size=rconvs_kernel_size, padding='valid',
+                dilation=2**i) for i in range(1, self.n_layers+1)
+        ])
+
+        self.rrelus1 = torch.nn.ModuleList([
+			torch.nn.ReLU() for i in range(1, self.n_layers+1)
+		])
+
+        self.rconvs2 = torch.nn.ModuleList([
+            torch.nn.Conv1d(n_filters, n_filters, kernel_size=rconvs_kernel_size, padding='valid',
+                dilation=2**i) for i in range(1, self.n_layers+1)
+        ])
+
+        self.rrelus2 = torch.nn.ModuleList([
+			torch.nn.ReLU() for i in range(1, self.n_layers+1)
+		])
+
+
+        # profile prediction
+        self.fconv = torch.nn.Conv1d(n_filters * 2, n_outputs,
+            kernel_size=profile_kernel_size, padding='valid', bias=profile_output_bias)
+
+        # count prediction
+        n_count_control = 1 if n_control_tracks > 0 else 0
+        self.global_avg_pool = torch.nn.AdaptiveAvgPool1d(1)
+        self.linear = torch.nn.Linear(n_filters * 2, 1,
+            bias=count_output_bias)
+
+    def get_embs_after_crop(self, x):
+        assert x.shape[1] == self.input_sizes[0] + self.input_sizes[1]
+        x_onehot = x[:,:self.input_sizes[0],:]
+        x_lm = x[:,self.input_sizes[0]:,:]
+
+        x_onehot = self.irelu1(self.iconv1(x_onehot))
+        for i in range(self.n_layers):
+            conv_x = self.rrelus1[i](self.rconvs1[i](x_onehot))
+            crop_len = (x_onehot.shape[2] - conv_x.shape[2]) // 2
+            if crop_len > 0:
+                x_onehot = x_onehot[:, :, crop_len:-crop_len]
+            x_onehot = torch.add(x_onehot, conv_x)
+
+        x_lm = self.irelu2(self.iconv2(x_lm))
+        for i in range(self.n_layers):
+            conv_x = self.rrelus2[i](self.rconvs2[i](x_lm))
+            crop_len = (x_lm.shape[2] - conv_x.shape[2]) // 2
+            if crop_len > 0:
+                x_lm = x_lm[:, :, crop_len:-crop_len]
+            x_lm = torch.add(x_lm, conv_x)
+
+        x = torch.cat([x_onehot, x_lm], dim=1)
+        return x
+
+
+
+class ConvBlock(torch.nn.Module):
+    """
+    Basic convolutional block.
+    Consists of a convolutional layer, a max pooling layer and a dropout layer.
+    """
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        pool_size: int,
+        dropout: float
+    ):
+        super().__init__()
+        self.conv = torch.nn.Conv1d(in_channels=in_channels, out_channels=out_channels, kernel_size=kernel_size, padding='same')
+        self.mp = torch.nn.MaxPool1d(kernel_size=pool_size, stride=pool_size)
+        self.do = torch.nn.Dropout(dropout)
+
+    def forward(self, x):
+        # x: (batch_size, in_channels, seq_len)
+        x = F.relu(self.conv(x))  # (batch_size, out_channels, seq_len)
+        x = self.mp(x)  # (batch_size, out_channels, seq_len // pool_size)
+        x = self.do(x)  # (batch_size, out_channels, seq_len // pool_size)
+        return x
+
+class DreamRNN(BPNet):
+
+    def __init__(
+        self,
+        out_dim=1000,
+        n_filters=64,
+        n_layers=8,
+        rconvs_kernel_size=3,
+        conv1_kernel_size=21,
+        profile_kernel_size=75,
+        n_outputs=1,
+        n_control_tracks=0,
+        profile_output_bias=True,
+        count_output_bias=True,
+        name=None,
+        verbose=False,
+        dropout=False
+    ):
+        super().__init__()
+        in_channels = 512
+        out_channels = 320
+        lstm_hidden_channels = 320
+        kernel_sizes = [9, 15]
+        pool_size = 1
+        dropout1 = 0.2
+        dropout2 = 0.2
+        self.do = torch.nn.Dropout(dropout2)
+        self.lstm = torch.nn.LSTM(input_size=in_channels, hidden_size=lstm_hidden_channels, batch_first=True, bidirectional=True)
+        self.conv_list1 = torch.nn.ModuleList([
+            ConvBlock(8, in_channels // len(kernel_sizes), k, pool_size, dropout1) for k in kernel_sizes
+        ])
+        self.conv_list2 = torch.nn.ModuleList([
+            ConvBlock(2 * lstm_hidden_channels, out_channels // len(kernel_sizes), k, pool_size, dropout1) for k in kernel_sizes
+        ])
+
+        self.fconv = torch.nn.Conv1d(out_channels, n_outputs,
+            kernel_size=profile_kernel_size, padding='valid', bias=profile_output_bias)
+
+        # count prediction
+        self.linear = torch.nn.Linear(out_channels, 1,
+            bias=count_output_bias)
+
+
+    def get_embs_after_crop(self, x):
+        conv_outputs = [conv(x) for conv in self.conv_list1]  # [(batch_size, each_out_channels, seq_len // pool_size), ...]
+        # concatenate the outputs along the channel dimension
+        x = torch.cat(conv_outputs, dim=1)  # (batch_size, out_channels, seq_len // pool_size)
+        x = x.permute(0, 2, 1)  # (batch_size, seq_len, in_channels)
+        x, _ = self.lstm(x)  # (batch_size, seq_len, 2 * lstm_hidden_channels)
+        x = x.permute(0, 2, 1)  # (batch_size, 2 * lstm_hidden_channels, seq_len)
+        conv_outputs = [conv(x) for conv in self.conv_list2]  # [(batch_size, each_conv_out_channels, seq_len // pool_size), ...]
+
+        # concatenate the outputs along the channel dimension
+        x = torch.cat(conv_outputs, dim=1)  # (batch_size, conv_out_channels, seq_len // pool_size)
+        x = self.do(x)
+
+        return x

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/chrombpnet.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/chrombpnet.py
@@ -1,0 +1,549 @@
+# Author: Lei Xiong <jsxlei@gmail.com>
+
+import torch
+import torch.nn as nn
+
+from .bpnet import BPNet, DoubleBPNet, DreamRNN
+import os
+import sys
+arsenal_dir = os.environ.get("ARSENAL_MODEL_DIR", "")
+sys.path.append(f"{arsenal_dir}/src/regulatory_lm/")
+# [vendored] removed ARSENAL `from modeling.model import *` (replaced by HF adapter)
+
+
+class _Exp(nn.Module):
+	def __init__(self):
+		super(_Exp, self).__init__()
+
+	def forward(self, X):
+		return torch.exp(X)
+
+
+class _Log(nn.Module):
+	def __init__(self):
+		super(_Log, self).__init__()
+
+	def forward(self, X):
+		return torch.log(X)
+
+
+def _to_numpy(tensor):
+	return tensor.detach().cpu().numpy()
+
+# adapt from BPNet in bpnet-lite, credit goes to Jacob Schreiber <jmschreiber91@gmail.com>
+class ChromBPNet(nn.Module):
+	"""A ChromBPNet model.
+
+	ChromBPNet is an extension of BPNet to handle chromatin accessibility data,
+	in contrast to the protein binding data that BPNet handles. The distinction
+	between these data types is that an enzyme used in DNase-seq and ATAC-seq
+	experiments itself has a soft sequence preference, meaning that the
+	strength of the signal is driven by real biology but that the exact read
+	mapping locations are driven by the soft sequence bias of the enzyme.
+
+	ChromBPNet handles this by treating the data using two models: a bias
+	model that is initially trained on background (non-peak) regions where
+	the bias dominates, and an accessibility model that is subsequently trained
+	using a frozen version of the bias model. The bias model learns to remove
+	the enzyme bias so that the accessibility model can learn real motifs.
+
+
+	Parameters
+	----------
+	bias: torch.nn.Module
+		This model takes in sequence and outputs the shape one would expect in
+		ATAC-seq data due to Tn5 bias alone. This is usually a BPNet model
+		from the bpnet-lite repo that has been trained on GC-matched non-peak
+		regions.
+
+	accessibility: torch.nn.Module
+		This model takes in sequence and outputs the accessibility one would
+		expect due to the components of the sequence, but also takes in a cell
+		representation which modifies the parameters of the model, hence,
+		"dynamic." This model is usually a DynamicBPNet model, defined below.
+
+	name: str
+		The name to prepend when saving the file.
+	"""
+
+	def __init__(self,
+		config,
+		**kwargs
+		):
+		super().__init__()
+
+		self.model = BPNet(
+			out_dim=config.out_dim,
+			n_filters=config.n_filters,
+			n_layers=config.n_layers,
+			conv1_kernel_size=config.conv1_kernel_size,
+			profile_kernel_size=config.profile_kernel_size,
+			n_outputs=config.n_outputs,
+			n_control_tracks=config.n_control_tracks,
+			profile_output_bias=config.profile_output_bias,
+			count_output_bias=config.count_output_bias,
+		)
+
+		self.bias = BPNet(out_dim=config.out_dim, n_layers=4, n_filters=128)
+
+		self._log = _Log()
+		self._exp1 = _Exp()
+		self._exp2 = _Exp()
+
+		self.n_control_tracks = config.n_control_tracks
+
+		self.tf_style_reinit()
+
+	def tf_style_reinit(self):
+		"""
+		Re-initializes model weights for Linear and Conv1d layers using
+		TensorFlow's default: Xavier/Glorot uniform for weights, zeros for bias.
+		Operates in-place!
+		"""
+		print("Reinitializing with TF strategy")
+		for m in self.model.modules():
+			if isinstance(m, nn.Conv1d) or isinstance(m, nn.Linear):
+				if hasattr(m, 'weight') and m.weight is not None:
+					nn.init.xavier_uniform_(m.weight)
+				if hasattr(m, 'bias') and m.bias is not None:
+					nn.init.zeros_(m.bias)
+
+	def forward(self, x, **kwargs):
+		"""A forward pass through the network.
+
+		This function is usually accessed through calling the model, e.g.
+		doing `model(x)`. The method defines how inputs are transformed into
+		the outputs through interactions with each of the layers.
+
+
+		Parameters
+		----------
+		x: torch.tensor, shape=(-1, 4, 2114)
+			A one-hot encoded sequence tensor.
+
+		X_ctl: ignore
+			An ignored parameter for consistency with attribution functions.
+
+
+		Returns
+		-------
+		y_profile: torch.tensor, shape=(-1, 1000)
+			The predicted logit profile for each example. Note that this is not
+			a normalized value.
+		"""
+		acc_profile, acc_counts = self.model(x)
+		bias_profile, bias_counts = self.bias(x)
+
+		y_profile = acc_profile + bias_profile
+		y_counts = self._log(self._exp1(acc_counts) + self._exp2(bias_counts))
+		# counts_cat = torch.cat((acc_counts, bias_counts), dim=-1)
+		# y_counts = torch.logsumexp(counts_cat, dim=-1)
+
+		# DO NOT SQUEEZE y_counts, as it is needed for running deep_lift_shap
+		return y_profile.squeeze(1), y_counts #.squeeze()
+
+
+class ArsenalChromBPNet(nn.Module):
+	"""A ChromBPNet model.
+
+	ChromBPNet is an extension of BPNet to handle chromatin accessibility data,
+	in contrast to the protein binding data that BPNet handles. The distinction
+	between these data types is that an enzyme used in DNase-seq and ATAC-seq
+	experiments itself has a soft sequence preference, meaning that the
+	strength of the signal is driven by real biology but that the exact read
+	mapping locations are driven by the soft sequence bias of the enzyme.
+
+	ChromBPNet handles this by treating the data using two models: a bias
+	model that is initially trained on background (non-peak) regions where
+	the bias dominates, and an accessibility model that is subsequently trained
+	using a frozen version of the bias model. The bias model learns to remove
+	the enzyme bias so that the accessibility model can learn real motifs.
+
+
+	Parameters
+	----------
+	bias: torch.nn.Module
+		This model takes in sequence and outputs the shape one would expect in
+		ATAC-seq data due to Tn5 bias alone. This is usually a BPNet model
+		from the bpnet-lite repo that has been trained on GC-matched non-peak
+		regions.
+
+	accessibility: torch.nn.Module
+		This model takes in sequence and outputs the accessibility one would
+		expect due to the components of the sequence, but also takes in a cell
+		representation which modifies the parameters of the model, hence,
+		"dynamic." This model is usually a DynamicBPNet model, defined below.
+
+	name: str
+		The name to prepend when saving the file.
+	"""
+
+	def __init__(self,
+		config,
+		arsenal_model,
+		**kwargs
+		):
+		super().__init__()
+
+		self.finetune = config.finetune_arsenal
+		self.arsenal_output_type = config.arsenal_output_type
+		####ADD FINETUNE LOGIC HERE########
+		self.arsenal_model = arsenal_model
+		if not self.finetune:
+			for param in self.arsenal_model.parameters():
+				param.requires_grad = False
+			self.arsenal_model.eval()
+
+		self.seq_input_size = config.input_len
+		self.arsenal_input_size = config.arsenal_input_size
+		self.num_layers_avg = config.num_layers_avg
+		self.softmax = torch.nn.Softmax(dim=-1)
+
+		# Store category as buffer so it moves with .to()
+		if config.category is not None:
+			category_tensor = torch.tensor([config.category], dtype=torch.long)
+			# register buffer named 'category'; access via self.category
+			self.register_buffer("category", category_tensor)
+		else:
+			# no category provided
+			self.category = None
+		#Need to adjust first convolutional layer
+		self.model = BPNet(
+			out_dim=config.out_dim,
+			n_filters=config.n_filters,
+			n_layers=config.n_layers,
+			conv1_kernel_size=config.conv1_kernel_size,
+			profile_kernel_size=config.profile_kernel_size,
+			n_outputs=config.n_outputs,
+			n_control_tracks=config.n_control_tracks,
+			profile_output_bias=config.profile_output_bias,
+			count_output_bias=config.count_output_bias,
+		)
+
+		self.model.iconv = torch.nn.Conv1d(config.input_embedding_dim, config.n_filters, kernel_size=config.conv1_kernel_size, padding='valid')
+
+		self.bias = BPNet(out_dim=config.out_dim, n_layers=4, n_filters=128)
+
+		self._log = _Log()
+		self._exp1 = _Exp()
+		self._exp2 = _Exp()
+
+		self.n_control_tracks = config.n_control_tracks
+
+		self.tf_style_reinit()
+
+	def tf_style_reinit(self):
+		"""
+		Re-initializes model weights for Linear and Conv1d layers using
+		TensorFlow's default: Xavier/Glorot uniform for weights, zeros for bias.
+		Operates in-place!
+		"""
+		print("Reinitializing with TF strategy")
+		for m in self.model.modules():
+			if isinstance(m, nn.Conv1d) or isinstance(m, nn.Linear):
+				if hasattr(m, 'weight') and m.weight is not None:
+					nn.init.xavier_uniform_(m.weight)
+				if hasattr(m, 'bias') and m.bias is not None:
+					nn.init.zeros_(m.bias)
+
+
+	def one_hot_to_tokens(self, X):
+		tokens = torch.argmax(X, dim=-1)
+		n_mask = (X.sum(dim=-1) == 0)
+		tokens[n_mask] = 4
+		return tokens
+
+	def get_avg_embeddings(self, X, n=4):
+		'''
+		This function gets predictions for the last n embeddings of the ARSENAL model and averages them
+		Intended to be used as part of the model's forward pass
+		'''
+		layers = [m for m in self.arsenal_model.modules() if type(m) in [TransformerROPEEncoderLayer, torch.nn.TransformerEncoderLayer]]
+		# Pick last n layers (or adjust layer-type filter as needed)
+		# target_layers = layers[-n-4:-n]
+		target_layers = layers[-n:]
+		# target_layers = layers[-10:-4]
+		activations = []
+		hooks = []
+
+		def hook_fn(module, input, output):
+			activations.append(output)
+
+		# Register hooks
+		hooks = [layer.register_forward_hook(hook_fn) for layer in target_layers]
+
+		# Do inference (forward pass)
+		_ = self.arsenal_model(X, self.category)
+
+		# Remove hooks to avoid memory leaks
+		for h in hooks:
+			h.remove()
+
+		return sum(activations) / len(activations)
+
+
+	def normalize_probs(self, probs, tokens):
+		#Calculate entropy-weighted probabilities
+		# keep last dim so it broadcasts over the 4-class channel; clamp for numerical stability
+		# entropy_metric = 2 + (probs * torch.log2(probs)).sum(-1, keepdim=True)
+		# probs_norm = entropy_metric * probs
+		probs_norm = probs
+		onehot_start = torch.ones_like(probs)
+		#Zero out everywhere except true indices
+		idx = tokens.unsqueeze(-1)
+		clamped = idx.clamp(0, 3)
+		valid = (tokens >= 0) & (tokens < 4)
+		kept = onehot_start.gather(2, clamped)
+		kept = kept.masked_fill(~valid.unsqueeze(-1), 0)
+		onehot_final = torch.zeros_like(onehot_start)
+		onehot_final.scatter_(2, clamped, kept)
+		probs_out = torch.cat((onehot_final, probs_norm), dim=-1)
+		# probs_out = probs_norm
+		return probs_out
+
+	def combine_embeddings_onehot(self, embs, tokens):
+		#Calculate entropy-weighted probabilities
+		# keep last dim so it broadcasts over the 4-class channel; clamp for numerical stability
+		# entropy_metric = 2 + (probs * torch.log2(probs)).sum(-1, keepdim=True)
+		# probs_norm = entropy_metric * probs
+		# onehot_start = torch.ones(size=[embs.shape[0], embs.shape[1], 4], device=embs.device)
+		onehot_start = self.projection_layer(embs) / torch.exp(self.temperature)
+		#Zero out everywhere except true indices
+		idx = tokens.unsqueeze(-1)
+		clamped = idx.clamp(0, 3)
+		valid = (tokens >= 0) & (tokens < 4)
+		kept = onehot_start.gather(2, clamped)
+		kept = kept.masked_fill(~valid.unsqueeze(-1), 0)
+		onehot_final = torch.zeros_like(onehot_start)
+		onehot_final.scatter_(2, clamped, kept)
+		# embs_out = torch.cat((onehot_final, embs), dim=-1)
+		# probs_out = probs_norm
+		return onehot_final
+
+
+	def get_likelihoods(self, tokens):
+		if self.seq_input_size == self.arsenal_input_size:
+			logits = self.arsenal_model(tokens, self.category)
+			probs = self.softmax(logits)
+			return self.normalize_probs(probs, tokens)
+		else:
+			# Calculate center-aligned chunking
+			seq_len = self.seq_input_size
+			chunk_size = self.arsenal_input_size
+			center = seq_len // 2
+
+			# Position the first chunk centered on the sequence center
+			first_start = center - chunk_size // 2
+			first_end = first_start + chunk_size
+
+			# Get center chunk first
+			center_tokens = tokens[:, first_start:first_end]
+			center_logits = self.arsenal_model(center_tokens, self.category)
+			probs = self.normalize_probs(self.softmax(center_logits), center_tokens)
+
+			# Expand outward from center
+			# Right side chunks
+			right_start = first_end
+			while right_start < seq_len:
+				if right_start + chunk_size <= seq_len:
+					# Full chunk fits
+					curr_tokens = tokens[:, right_start:right_start + chunk_size]
+					curr_logits = self.arsenal_model(curr_tokens, self.category)
+					curr_probs = self.normalize_probs(self.softmax(curr_logits), curr_tokens)
+					probs = torch.cat((probs, curr_probs), dim=1)
+					right_start += chunk_size
+				else:
+					# Partial chunk - predict from end and take only stragglers
+					remainder = seq_len - right_start
+					end_tokens = tokens[:, -chunk_size:]
+					end_logits = self.arsenal_model(end_tokens, self.category)
+					end_probs = self.normalize_probs(self.softmax(end_logits), end_tokens)
+					probs = torch.cat((probs, end_probs[:, -remainder:]), dim=1)
+					break
+
+			# Left side chunks (prepend, so reverse order)
+			left_end = first_start
+			left_chunks = []
+			while left_end > 0:
+				if left_end - chunk_size >= 0:
+					# Full chunk fits
+					curr_tokens = tokens[:, left_end - chunk_size:left_end]
+					curr_logits = self.arsenal_model(curr_tokens, self.category)
+					curr_probs = self.normalize_probs(self.softmax(curr_logits), curr_tokens)
+					left_chunks.insert(0, curr_probs)
+					left_end -= chunk_size
+				else:
+					# Partial chunk - predict from start and take only stragglers
+					remainder = left_end
+					start_tokens = tokens[:, :chunk_size]
+					start_logits = self.arsenal_model(start_tokens, self.category)
+					start_probs = self.normalize_probs(self.softmax(start_logits), start_tokens)
+					left_chunks.insert(0, start_probs[:, :remainder])
+					break
+
+			# Concatenate all: left stragglers + left chunks + center + right chunks + right stragglers
+			if left_chunks:
+				probs = torch.cat(left_chunks + [probs], dim=1)
+
+		return probs
+
+
+	def get_embeddings(self, tokens):
+		'''
+		This function takes in tokens and gets ARSENAL embeddings from them.
+		Usually, ARSENAL's input size is smaller than the sequence length. In that case, we chunk the sequence.
+		We start at the center and extend out in both directions.
+		If there are stragglers at either end, we get their embeddings using predictions from the beginning/end of the sequence.
+		'''
+		if self.seq_input_size == self.arsenal_input_size:
+			embs = self.get_avg_embeddings(tokens, self.num_layers_avg)
+		else:
+			# Calculate center-aligned chunking
+			seq_len = self.seq_input_size
+			chunk_size = self.arsenal_input_size
+			center = seq_len // 2
+
+			# Position the first chunk centered on the sequence center
+			first_start = center - chunk_size // 2
+			first_end = first_start + chunk_size
+
+			# Get center chunk first
+			center_tokens = tokens[:, first_start:first_end]
+			embs = self.get_avg_embeddings(center_tokens, self.num_layers_avg)
+
+			# Expand outward from center
+			# Right side chunks
+			right_start = first_end
+			while right_start < seq_len:
+				if right_start + chunk_size <= seq_len:
+					# Full chunk fits
+					curr_tokens = tokens[:, right_start:right_start + chunk_size]
+					curr_embs = self.get_avg_embeddings(curr_tokens, self.num_layers_avg)
+					embs = torch.cat((embs, curr_embs), dim=1)
+					right_start += chunk_size
+				else:
+					# Partial chunk - predict from end and take only stragglers
+					remainder = seq_len - right_start
+					end_tokens = tokens[:, -chunk_size:]
+					end_embs = self.get_avg_embeddings(end_tokens, self.num_layers_avg)
+					embs = torch.cat((embs, end_embs[:, -remainder:]), dim=1)
+					break
+
+			# Left side chunks (prepend, so reverse order)
+			left_end = first_start
+			left_chunks = []
+			while left_end > 0:
+				if left_end - chunk_size >= 0:
+					# Full chunk fits
+					curr_tokens = tokens[:, left_end - chunk_size:left_end]
+					curr_embs = self.get_avg_embeddings(curr_tokens, self.num_layers_avg)
+					left_chunks.insert(0, curr_embs)
+					left_end -= chunk_size
+				else:
+					# Partial chunk - predict from start and take only stragglers
+					remainder = left_end
+					start_tokens = tokens[:, :chunk_size]
+					start_embs = self.get_avg_embeddings(start_tokens, self.num_layers_avg)
+					left_chunks.insert(0, start_embs[:, :remainder])
+					break
+
+			# Concatenate all: left stragglers + left chunks + center + right chunks + right stragglers
+			if left_chunks:
+				embs = torch.cat(left_chunks + [embs], dim=1)
+
+		return embs
+
+	def forward(self, x, **kwargs):
+		"""A forward pass through the network.
+
+		This function is usually accessed through calling the model, e.g.
+		doing `model(x)`. The method defines how inputs are transformed into
+		the outputs through interactions with each of the layers.
+
+
+		Parameters
+		----------
+		x: torch.tensor, shape=(-1, 4, 2114)
+			A one-hot encoded sequence tensor.
+
+		X_ctl: ignore
+			An ignored parameter for consistency with attribution functions.
+
+
+		Returns
+		-------
+		y_profile: torch.tensor, shape=(-1, 1000)
+			The predicted logit profile for each example. Note that this is not
+			a normalized value.
+		"""
+
+		tokens = self.one_hot_to_tokens(x.transpose(1,2))
+		if self.arsenal_output_type == "embedding":
+			x_embs = self.get_embeddings(tokens) #We don't transpose because bpnet code does it for us if dimension is not 4
+		elif self.arsenal_output_type == "likelihood":
+			x_embs = self.get_likelihoods(tokens)
+			if x_embs.shape[-1] == 4:
+				x_embs = x_embs.transpose(1,2)
+
+
+		acc_profile, acc_counts = self.model(x_embs)
+		bias_profile, bias_counts = self.bias(x)
+
+		y_profile = acc_profile + bias_profile
+		y_counts = self._log(self._exp1(acc_counts) + self._exp2(bias_counts))
+		# counts_cat = torch.cat((acc_counts, bias_counts), dim=-1)
+		# y_counts = torch.logsumexp(counts_cat, dim=-1)
+
+		# DO NOT SQUEEZE y_counts, as it is needed for running deep_lift_shap
+		return y_profile.squeeze(1), y_counts #.squeeze()
+
+
+class ArsenalChromBPNetNoBias(ArsenalChromBPNet):
+	def __init__(self,
+		config,
+		arsenal_model,
+		**kwargs
+		):
+		super().__init__(config, arsenal_model, **kwargs)
+
+	def forward(self, x, **kwargs):
+		"""A forward pass through the network.
+
+		This function is usually accessed through calling the model, e.g.
+		doing `model(x)`. The method defines how inputs are transformed into
+		the outputs through interactions with each of the layers.
+
+
+		Parameters
+		----------
+		x: torch.tensor, shape=(-1, 4, 2114)
+			A one-hot encoded sequence tensor.
+
+		X_ctl: ignore
+			An ignored parameter for consistency with attribution functions.
+
+
+		Returns
+		-------
+		y_profile: torch.tensor, shape=(-1, 1000)
+			The predicted logit profile for each example. Note that this is not
+			a normalized value.
+		"""
+
+		tokens = self.one_hot_to_tokens(x.transpose(1,2))
+		if self.arsenal_output_type == "embedding":
+			x_embs = self.get_embeddings(tokens) #We don't transpose because bpnet code does it for us if dimension is not 4
+		elif self.arsenal_output_type == "likelihood":
+			x_embs = self.get_likelihoods(tokens)
+			if x_embs.shape[-1] == 4:
+				x_embs = x_embs.transpose(1,2)
+
+
+
+		acc_profile, acc_counts = self.model(x_embs)
+
+		y_profile = acc_profile
+		y_counts = acc_counts
+
+		# DO NOT SQUEEZE y_counts, as it is needed for running deep_lift_shap
+		return y_profile.squeeze(1), y_counts #.squeeze()

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/data_config.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/data_config.py
@@ -1,0 +1,200 @@
+# Author: Lei Xiong <jsxlei@gmail.com>
+
+"""
+Data configuration classes for the RegNet project.
+
+This module provides configuration classes for different data types and processing steps.
+It includes parameter validation and default values for common configurations.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Dict, Any, Union, Tuple
+from argparse import ArgumentParser, Namespace
+import os
+import json
+from .parse_utils import add_argparse_args, from_argparse_args, parse_argparser, get_init_arguments_and_types
+from .genome import hg38, hg38_datasets, mm10, mm10_datasets
+
+
+class DataConfig:
+	"""Base configuration class for data handling.
+
+	This class defines the common parameters used across different data types
+	and provides validation for these parameters.
+	"""
+
+	def __init__(
+			self,
+			data_dir: str = None,
+			peaks: str = None, #'{}/peaks.bed',
+			negatives: str = None, #'{}/negatives.bed',
+			bigwig: str = None, #'{}/unstranded.bw',
+			# background: str = None,
+			negative_sampling_ratio: float = 0.1,
+			saved_data: str = None,
+			fasta: str = None,
+			chrom_sizes: str = None,
+			in_window: int = 2114,
+			out_window: int = 1000,
+			shift: int = 500,
+			rc: float = 0.5,
+			outlier_threshold: float = 0.999,
+			data_type: str = 'profile',
+			training_chroms: List = [
+				"chr1",
+				"chr2",
+				"chr3",
+				"chr4",
+				"chr7",
+				"chr8",
+				"chr9",
+				"chr11",
+				"chr12",
+				"chr13",
+				"chr15",
+				"chr16",
+				"chr17",
+				"chr19",
+				"chrX",
+				"chrY"
+			],
+			validation_chroms: List = ['chr6', 'chr21'],
+			test_chroms: List = [
+				"chr5",
+				"chr10",
+				"chr14",
+				"chr18",
+				"chr20",
+				"chr22"
+			],
+			exclude_chroms: list = [],
+			fold: int = 0,
+			genome: str = 'hg38',
+			batch_size: int = 64,
+			num_workers: int = 32,
+			debug: bool = False,
+			**kwargs,
+		):
+
+			_genome = hg38 if genome == 'hg38' else mm10 if genome == 'mm10' else None
+			_datasets = hg38_datasets() if genome == 'hg38' else mm10_datasets() if genome == 'mm10' else None
+			self.data_dir = data_dir
+			self.peaks = peaks if peaks is not None else f'{data_dir}/peaks.bed'
+			self.negatives = negatives if negatives is not None else f'{data_dir}/negatives.bed' if data_dir is not None else None
+			self.bigwig = bigwig if bigwig is not None else f'{data_dir}/unstranded.bw'
+			# self.background = background if background is not None else f'{data_dir}/background.bw'
+			self.negative_sampling_ratio = negative_sampling_ratio
+			self.saved_data = saved_data
+			self.fasta = fasta if fasta is not None else _genome.fasta
+			self.chrom_sizes = chrom_sizes if chrom_sizes is not None else _genome.chrom_sizes
+			self.in_window = in_window
+			self.out_window = out_window
+			self.shift = shift
+			self.rc = rc
+			self.outlier_threshold = outlier_threshold
+			self.data_type = data_type
+			self.training_chroms = training_chroms
+			self.validation_chroms = validation_chroms
+			self.test_chroms = test_chroms
+			self.exclude_chroms = exclude_chroms
+			self.fold = fold
+			self.batch_size = batch_size
+			self.num_workers = num_workers
+			self.debug = debug
+
+			fold_file_path = _datasets.fetch(f'fold_{fold}.json', progressbar=False)
+			splits_dict = json.load(open(fold_file_path))
+			# training_chroms, validation_chroms, test_chroms = None, None, None
+			self.training_chroms = splits_dict['train'] if training_chroms is None else training_chroms
+			self.validation_chroms = splits_dict['valid'] if validation_chroms is None else validation_chroms
+			self.test_chroms = splits_dict['test'] if test_chroms is None else test_chroms
+			print(self.test_chroms)
+
+	def __post_init__(self):
+		"""Validate configuration parameters after initialization."""
+		self._validate_paths()
+		self._validate_windows()
+		self._validate_chromosomes()
+		self._validate_data_type()
+
+	def _validate_paths(self):
+		"""Validate that all required files exist."""
+		required_files = {
+			'FASTA': self.fasta,
+			'BigWig': self.bigwig,
+			'Peaks': self.peaks
+		}
+
+		for name, path in required_files.items():
+			if not os.path.exists(path):
+				raise FileNotFoundError(f"{name} file not found: {path}")
+
+	def _validate_windows(self):
+		"""Validate window size parameters."""
+		if self.in_window <= 0:
+			raise ValueError("Input window size must be positive")
+		if self.out_window <= 0:
+			raise ValueError("Output window size must be positive")
+		if self.in_window < self.out_window:
+			raise ValueError("Input window must be larger than output window")
+
+	def _validate_chromosomes(self):
+		"""Validate chromosome configuration."""
+		all_chroms = set(self.training_chroms + self.validation_chroms + self.test_chroms)
+		excluded = set(self.exclude_chroms)
+
+		if not all_chroms:
+			raise ValueError("No chromosomes specified for training, validation, or testing")
+
+		if excluded.intersection(all_chroms) != excluded:
+			raise ValueError("Some excluded chromosomes are not in the training/validation/test sets")
+
+	def _validate_data_type(self):
+		"""Validate data type parameter."""
+		if self.data_type not in ['profile', 'longrange']:
+			raise ValueError("Data type must be either 'profile' or 'longrange'")
+
+	@classmethod
+	def add_argparse_args(cls, parent_parser: ArgumentParser, **kwargs: Any):
+		"""Extends existing argparse by default `LightningDataModule` attributes.
+
+		Example::
+
+			parser = ArgumentParser(add_help=False)
+			parser = LightningDataModule.add_argparse_args(parser)
+		"""
+		return add_argparse_args(cls, parent_parser, **kwargs)
+
+
+	@classmethod
+	def from_argparse_args(
+		cls, args: Union[Namespace, ArgumentParser], **kwargs: Any
+	) -> Union["pl.LightningDataModule", "pl.Trainer"]:
+		"""Create an instance from CLI arguments.
+
+		Args:
+			args: The parser or namespace to take arguments from. Only known arguments will be
+				parsed and passed to the :class:`~pytorch_lightning.core.datamodule.LightningDataModule`.
+			**kwargs: Additional keyword arguments that may override ones in the parser or namespace.
+				These must be valid DataModule arguments.
+
+		Example::
+
+			module = LightningDataModule.from_argparse_args(args)
+		"""
+		return from_argparse_args(cls, args, **kwargs)
+
+
+	@classmethod
+	def parse_argparser(cls, arg_parser: Union[ArgumentParser, Namespace]) -> Namespace:
+		return parse_argparser(cls, arg_parser)
+
+	@classmethod
+	def get_init_arguments_and_types(cls) -> List[Tuple[str, Tuple, Any]]:
+		r"""Scans the DataModule signature and returns argument names, types and default values.
+
+		Returns:
+			List with tuples of 3 values:
+			(argument name, set with argument types, argument default value).
+		"""
+		return get_init_arguments_and_types(cls)

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/data_utils.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/data_utils.py
@@ -1,0 +1,488 @@
+# Author: Lei Xiong <jsxlei@gmail.com>
+
+import numpy as np
+import pandas as pd
+import pyBigWig
+import pyfaidx
+import os
+
+def dna_to_one_hot(seqs):
+    """
+    Converts a list of DNA ("ACGT") sequences to one-hot encodings, where the
+    position of 1s is ordered alphabetically by "ACGT". `seqs` must be a list
+    of N strings, where every string is the same length L. Returns an N x L x 4
+    NumPy array of one-hot encodings, in the same order as the input sequences.
+    All bases will be converted to upper-case prior to performing the encoding.
+    Any bases that are not "ACGT" will be given an encoding of all 0s.
+    """
+    seq_len = len(seqs[0])
+    assert np.all(np.array([len(s) for s in seqs]) == seq_len)
+
+    # Join all sequences together into one long string, all uppercase
+    seq_concat = "".join(seqs).upper() + "ACGT"
+    # Add one example of each base, so np.unique doesn't miss indices later
+
+    one_hot_map = np.identity(5)[:, :-1].astype(np.int8)
+
+    # Convert string into array of ASCII character codes;
+    base_vals = np.frombuffer(bytearray(seq_concat, "utf8"), dtype=np.int8)
+
+    # Anything that's not an A, C, G, or T gets assigned a higher code
+    base_vals[~np.isin(base_vals, np.array([65, 67, 71, 84]))] = 85
+
+    # Convert the codes into indices in [0, 4], in ascending order by code
+    _, base_inds = np.unique(base_vals, return_inverse=True)
+
+    # Get the one-hot encoding for those indices, and reshape back to separate
+    return one_hot_map[base_inds[:-4]].reshape((len(seqs), seq_len, 4))
+
+
+# def one_hot_to_dna(one_hot):
+#     """
+#     Converts a one-hot encoding into a list of DNA ("ACGT") sequences, where the
+#     position of 1s is ordered alphabetically by "ACGT". `one_hot` must be an
+#     N x L x 4 array of one-hot encodings. Returns a lits of N "ACGT" strings,
+#     each of length L, in the same order as the input array. The returned
+#     sequences will only consist of letters "A", "C", "G", "T", or "N" (all
+#     upper-case). Any encodings that are all 0s will be translated to "N".
+#     """
+#     bases = np.array(["A", "C", "G", "T", "N"])
+#     # Create N x L array of all 5s
+#     one_hot_inds = np.tile(one_hot.shape[2], one_hot.shape[:2])
+
+#     # Get indices of where the 1s are
+#     batch_inds, seq_inds, base_inds = np.where(one_hot)
+
+#     # In each of the locations in the N x L array, fill in the location of the 1
+#     one_hot_inds[batch_inds, seq_inds] = base_inds
+
+#     # Fetch the corresponding base for each position using indexing
+#     seq_array = bases[one_hot_inds]
+#     return ["".join(seq) for seq in seq_array]
+import numpy as np
+
+def one_hot_to_dna(one_hot):
+    """
+    Converts one-hot encoded DNA (N, 4) or (N, L, 4) to sequences of ACGT/N.
+    Automatically handles dimensionality and avoids hardcoded constants.
+    """
+    bases = np.array(["A", "C", "G", "T", "N"])
+    n_bases = one_hot.shape[-1]
+    n_index = len(bases) - 1  # index for 'N'
+
+    # Expand (N, 4) to (N, 1, 4)
+    if one_hot.ndim == 2 and one_hot.shape[1] == n_bases:
+        one_hot = one_hot[:, np.newaxis, :]
+
+    assert one_hot.ndim == 3 and one_hot.shape[2] == n_bases, "Expected shape (N, L, 4) or (N, 4)"
+
+    N, L = one_hot.shape[:2]
+
+    # Initialize with index for 'N'
+    one_hot_inds = np.full((N, L), n_index, dtype=int)
+
+    # Fill in valid base indices
+    batch_inds, seq_inds, base_inds = np.where(one_hot)
+    one_hot_inds[batch_inds, seq_inds] = base_inds
+
+    # Convert to DNA strings
+    return ''.join(["".join(bases[idxs]) for idxs in one_hot_inds])
+
+
+
+# https://stackoverflow.com/questions/46091111/python-slice-array-at-different-position-on-every-row
+def take_per_row(A, indx, num_elem):
+    """
+    Matrix A, indx is a vector for each row which specifies
+    slice beginning for that row. Each has width num_elem.
+    """
+
+    all_indx = indx[:,None] + np.arange(num_elem)
+    return A[np.arange(all_indx.shape[0])[:,None], all_indx]
+
+
+def random_crop(seqs, labels, seq_crop_width, label_crop_width, coords):
+    """
+    Takes sequences and corresponding counts labels. They should have the same
+    #examples. The widths would correspond to inputlen and outputlen respectively,
+    and any additional flanking width for jittering which should be the same
+    for seqs and labels. Each example is cropped starting at a random offset.
+
+    seq_crop_width - label_crop_width should be equal to seqs width - labels width,
+    essentially implying they should have the same flanking width.
+    """
+
+    assert(seqs.shape[1]>=seq_crop_width)
+    assert(labels.shape[1]>=label_crop_width)
+    assert(seqs.shape[1] - seq_crop_width == labels.shape[1] - label_crop_width)
+
+    max_start = seqs.shape[1] - seq_crop_width # This should be the same for both input and output
+
+    starts = np.random.choice(range(max_start+1), size=seqs.shape[0], replace=True)
+
+    new_coords = coords.copy()
+    new_coords[:,1] = new_coords[:,1].astype(int) - (seqs.shape[1]//2) + starts
+
+    return take_per_row(seqs, starts, seq_crop_width), take_per_row(labels, starts, label_crop_width), new_coords
+
+def random_rev_comp(seqs, labels, coords, frac=0.5):
+    """
+    Data augmentation: applies reverse complement randomly to a fraction of
+    sequences and labels.
+
+    Assumes seqs are arranged in ACGT. Then ::-1 gives TGCA which is revcomp.
+
+    NOTE: Performs in-place modification.
+    """
+
+    pos_to_rc = np.random.choice(range(seqs.shape[0]),
+            size=int(seqs.shape[0]*frac),
+            replace=False)
+
+    seqs[pos_to_rc] = seqs[pos_to_rc, ::-1, ::-1]
+    labels[pos_to_rc] = labels[pos_to_rc, ::-1]
+    coords[pos_to_rc,2] =  "r"
+
+    return seqs, labels, coords
+
+def crop_revcomp_augment(seqs, labels, coords, seq_crop_width, label_crop_width, add_revcomp, rc_frac=0.5, shuffle=False):
+    """
+    seqs: B x IL x 4
+    labels: B x OL
+
+    Applies random crop to seqs and labels and reverse complements rc_frac.
+    """
+
+    assert(seqs.shape[0]==labels.shape[0])
+
+    # this does not modify seqs and labels
+    #mod_seqs, mod_labels, mod_coords = random_crop(seqs, labels, seq_crop_width, label_crop_width, coords)
+    mod_seqs, mod_labels, mod_coords = seqs, labels, coords
+
+    # this modifies mod_seqs, mod_labels in-place
+    if add_revcomp:
+        mod_seqs, mod_labels, mod_coords = random_rev_comp(mod_seqs, mod_labels, mod_coords, frac=rc_frac)
+
+
+    if shuffle:
+        perm = np.random.permutation(mod_seqs.shape[0])
+        mod_seqs = mod_seqs[perm]
+        mod_labels = mod_labels[perm]
+        mod_coords = mod_coords[perm]
+
+
+    return mod_seqs, mod_labels, mod_coords
+
+
+def read_chrom_sizes(fname):
+    with open(fname) as f:
+        gs = [x.strip().split('\t') for x in f]
+    gs = {x[0]: int(x[1]) for x in gs if len(x)==2}
+
+    return gs
+
+
+def format_region(df, width=500):
+    df.loc[:, 'start'] = df.loc[:, 'start'].astype(np.int64) + df.loc[:, 'summit'] - width // 2
+    df.loc[:, 'end'] = df.loc[:, 'start'] + width
+    df.loc[:, 'summit'] = width // 2
+    return df
+
+
+def expand_3col_to_10col(df):
+    if df.shape[1] != 3:
+        df = df.iloc[:, :3].copy()
+    for i in ['name', 'score', 'strand', 'signalValue', 'pValue', 'qValue']: #range(4, 10):
+        df[f'{i}'] = '.'
+    df.iloc[:, 1] = df.iloc[:, 1].astype(int)
+    df.iloc[:, 2] = df.iloc[:, 2].astype(int)
+    df['summit'] = (df.iloc[:, 2] - df.iloc[:, 1]) // 2
+    df.columns = ['chr', 'start', 'end', 'name', 'score', 'strand', 'signalValue', 'pValue', 'qValue', 'summit']
+    df['start'] = df['start'].astype(int)
+    df['end'] = df['end'].astype(int)
+    df['summit'] = df['summit'].astype(int)
+    return df
+
+
+def load_region_df(peak_bed, chrom_sizes=None, in_window=2114, shift=0, width=500, is_peak=True):
+    """
+    Filters regions in the DataFrame that exceed defined chromosome sizes.
+
+    Parameters:
+    - df (pd.DataFrame): DataFrame with columns 'chr', 'start', and 'end'.
+    - chrom_sizes (dict): Dictionary with chromosome names as keys and sizes as values.
+
+    Returns:
+    - pd.DataFrame: Filtered DataFrame where no region exceeds the chromosome boundaries.
+    """
+    # Apply filter to check each row
+    # Assume column0 is chr, column 9 is the summit
+    if isinstance(peak_bed, pd.DataFrame):
+        df = peak_bed
+    else:
+        if not os.path.exists(peak_bed) and os.path.exists(peak_bed+'.gz'):
+            peak_bed = peak_bed+'.gz'
+
+        df = pd.read_csv(peak_bed, sep='\t', header=None)
+
+    if isinstance(chrom_sizes, str):
+        chrom_sizes = read_chrom_sizes(chrom_sizes)
+    else:
+        # print(chrom_sizes)
+        pass
+
+    if df.shape[1] < 10:
+        df = expand_3col_to_10col(df)
+    # print(peak_bed, df.head())
+    df['is_peak'] = is_peak
+    if chrom_sizes is not None:
+        flank_length = in_window // 2 + shift
+        if df.shape[1] < 10:
+            filtered_df = df[df.apply(
+                lambda row: (row.iloc[1] + row.iloc[2]) // 2 - flank_length > 0
+                        and (row.iloc[1] + row.iloc[2]) // 2 + flank_length <= int(chrom_sizes.get(row.iloc[0], float('inf'))), axis=1)]
+        else:
+            filtered_df = df[df.apply(
+                lambda row: row.iloc[9] + row.iloc[1] -  flank_length > 0
+                        and row.iloc[9] + row.iloc[1] + flank_length <= int(chrom_sizes.get(row.iloc[0], float('inf'))), axis=1)]
+    else:
+        filtered_df = df
+
+    filtered_df.columns = ['chr', 'start', 'end', 'name', 'score', 'strand', 'signalValue', 'pValue', 'qValue', 'summit', 'is_peak']
+    filtered_df = format_region(filtered_df, width=500)
+    return filtered_df.reset_index(drop=True) # Reset index to avoid index errors
+
+
+def get_seq(peaks_df, genome, width):
+    """
+    Same as get_cts, but fetches sequence from a given genome.
+    """
+    vals = []
+
+    for i, r in peaks_df.iterrows():
+        sequence = str(genome[r['chr']][(r['start']+r['summit'] - width//2):(r['start'] + r['summit'] + width//2)])
+        vals.append(sequence)
+
+    return dna_to_one_hot(vals)
+
+
+def get_cts(peaks_df, bw, width):
+    """
+    Fetches values from a bigwig bw, given a df with minimally
+    chr, start and summit columns. Summit is relative to start.
+    Retrieves values of specified width centered at summit.
+
+    "cts" = per base counts across a region
+    """
+    vals = []
+    for i, r in peaks_df.iterrows():
+        vals.append(np.nan_to_num(bw.values(r['chr'],
+                                            r['start'] + r['summit'] - width//2,
+                                            r['start'] + r['summit'] + width//2)))
+
+    return np.array(vals)
+
+def get_coords(peaks_df, peaks_bool):
+    """
+    Fetch the co-ordinates of the regions in bed file
+    returns a list of tuples with (chrom, summit)
+    """
+    vals = []
+    for i, r in peaks_df.iterrows():
+        vals.append([r['chr'], r['start']+r['summit'], "f", peaks_bool])
+
+    return np.array(vals)
+
+def get_seq_cts_coords(peaks_df, genome, bw, input_width, output_width, peaks_bool):
+
+    seq = get_seq(peaks_df, genome, input_width)
+    cts = get_cts(peaks_df, bw, output_width)
+    coords = get_coords(peaks_df, peaks_bool)
+    return seq, cts, coords
+
+def load_data(bed_regions, nonpeak_regions, genome_fasta, cts_bw_file, inputlen, outputlen, max_jitter):
+    """
+    Load sequences and corresponding base resolution counts for training,
+    validation regions in peaks and nonpeaks (2 x 2 x 2 = 8 matrices).
+
+    For training peaks/nonpeaks, values for inputlen + 2*max_jitter and outputlen + 2*max_jitter
+    are returned centered at peak summit. This allows for jittering examples by randomly
+    cropping. Data of width inputlen/outputlen is returned for validation
+    data.
+
+    If outliers is not None, removes training examples with counts > outlier%ile
+    """
+
+    cts_bw = pyBigWig.open(cts_bw_file)
+    genome = pyfaidx.Fasta(genome_fasta)
+
+    train_peaks_seqs=None
+    train_peaks_cts=None
+    train_peaks_coords=None
+    train_nonpeaks_seqs=None
+    train_nonpeaks_cts=None
+    train_nonpeaks_coords=None
+
+    if bed_regions is not None:
+        if not set(['chr', 'start', 'summit']).issubset(bed_regions.columns):
+            bed_regions = expand_3col_to_10col(bed_regions)
+        train_peaks_seqs, train_peaks_cts, train_peaks_coords = get_seq_cts_coords(bed_regions,
+                                            genome,
+                                            cts_bw,
+                                            inputlen+2*max_jitter,
+                                            outputlen+2*max_jitter,
+                                            peaks_bool=1)
+
+    if nonpeak_regions is not None:
+        if not set(['chr', 'start', 'summit']).issubset(nonpeak_regions.columns):
+            nonpeak_regions = expand_3col_to_10col(nonpeak_regions)
+        train_nonpeaks_seqs, train_nonpeaks_cts, train_nonpeaks_coords = get_seq_cts_coords(nonpeak_regions,
+                                            genome,
+                                            cts_bw,
+                                            inputlen,
+                                            outputlen,
+                                            peaks_bool=0)
+
+
+
+    cts_bw.close()
+    genome.close()
+
+    return (train_peaks_seqs, train_peaks_cts, train_peaks_coords,
+            train_nonpeaks_seqs, train_nonpeaks_cts, train_nonpeaks_coords)
+
+
+def write_bigwig(data, regions, gs, bw_out, debug_chr=None, use_tqdm=False, outstats_file=None):
+    # regions may overlap but as we go in sorted order, at a given position,
+    # we will pick the value from the interval whose summit is closest to
+    # current position
+    chr_to_idx = {}
+    for i,x in enumerate(gs):
+        chr_to_idx[x[0]] = i
+
+    bw = pyBigWig.open(bw_out, 'w')
+    bw.addHeader(gs)
+
+    # regions may not be sorted, so get their sorted order
+    order_of_regs = sorted(range(len(regions)), key=lambda x:(chr_to_idx[regions[x][0]], regions[x][1]))
+
+    all_entries = []
+    cur_chr = ""
+    cur_end = 0
+
+    iterator = range(len(order_of_regs))
+    if use_tqdm:
+        from tqdm import tqdm
+        iterator = tqdm(iterator)
+
+    for itr in iterator:
+        # subset to chromosome (debugging)
+        if debug_chr and regions[i][0]!=debug_chr:
+            continue
+
+        i = order_of_regs[itr]
+        i_chr, i_start, i_end, i_mid = regions[i]
+
+        if i_chr != cur_chr:
+            cur_chr = i_chr
+            cur_end = 0
+
+        # bring current end to at least start of current region
+        if cur_end < i_start:
+            cur_end = i_start
+
+        assert(regions[i][2]>=cur_end)
+
+        # figure out where to stop for this region, get next region
+        # which may partially overlap with this one
+        next_end = i_end
+
+        if itr+1 != len(order_of_regs):
+            n = order_of_regs[itr+1]
+            next_chr, next_start, _, next_mid = regions[n]
+
+            if next_chr == i_chr and next_start < i_end:
+                # if next region overlaps with this, end between their midpoints
+                next_end = (i_mid+next_mid)//2
+
+        vals = data[i][cur_end - i_start:next_end - i_start]
+
+        bw.addEntries([i_chr]*(next_end-cur_end),
+                       list(range(cur_end,next_end)),
+                       ends = list(range(cur_end+1, next_end+1)),
+                       values=[float(x) for x in vals])
+
+        all_entries.append(vals)
+
+        cur_end = next_end
+
+    bw.close()
+
+    all_entries = np.hstack(all_entries)
+    if outstats_file != None:
+        with open(outstats_file, 'w') as f:
+            f.write("Min\t{:.6f}\n".format(np.min(all_entries)))
+            f.write(".1%\t{:.6f}\n".format(np.quantile(all_entries, 0.001)))
+            f.write("1%\t{:.6f}\n".format(np.quantile(all_entries, 0.01)))
+            f.write("50%\t{:.6f}\n".format(np.quantile(all_entries, 0.5)))
+            f.write("99%\t{:.6f}\n".format(np.quantile(all_entries, 0.99)))
+            f.write("99.9%\t{:.6f}\n".format(np.quantile(all_entries, 0.999)))
+            f.write("99.95%\t{:.6f}\n".format(np.quantile(all_entries, 0.9995)))
+            f.write("99.99%\t{:.6f}\n".format(np.quantile(all_entries, 0.9999)))
+            f.write("Max\t{:.6f}\n".format(np.max(all_entries)))
+
+
+def get_regions(regions_file, seqlen, regions_used=None):
+    # regions file is assumed to be centered at summit (2nd + 10th column)
+    # it is adjusted to be of length seqlen centered at summit
+
+    assert(seqlen%2==0)
+
+    #with open(regions_file) as r:
+    #    regions = [x.strip().split('\t') for x in r]
+
+    regions = pd.read_csv(regions_file,sep='\t',header=None)
+    #print(regions)
+    if regions_used is None:
+        regions = [[x[0], int(x[1])+int(x[9])-seqlen//2, int(x[1])+int(x[9])+seqlen//2, int(x[1])+int(x[9])] for x in np.array(regions.values)]
+    else:
+        regions = [[x[0], int(x[1])+int(x[9])-seqlen//2, int(x[1])+int(x[9])+seqlen//2, int(x[1])+int(x[9])] for x in np.array(regions.values)[regions_used]]
+
+    return regions
+
+def hdf5_to_bigwig(hdf5, regions, chrom_sizes, output_prefix, output_prefix_stats=None, debug_chr=None, tqdm=False):
+    import deepdish
+
+    d = deepdish.io.load(hdf5, '/projected_shap/seq')
+
+    SEQLEN = d.shape[2]
+    assert(SEQLEN%2==0)
+
+    # gs = bigwig_helper.read_chrom_sizes(chrom_sizes)
+    # gs = chrom_sizes
+    regions = get_regions(regions, SEQLEN)
+    chr_list = set([region[0] for region in regions])
+    chrom_sizes = read_chrom_sizes(chrom_sizes)
+    chrom_sizes = [(x, v) for x, v in chrom_sizes.items() if x in chr_list]
+
+    assert(d.shape[0] == len(regions))
+
+    write_bigwig(d.sum(1),
+                        regions,
+                        chrom_sizes,
+                        output_prefix+".bw",
+                        outstats_file=output_prefix_stats,
+                        debug_chr=debug_chr,
+                        use_tqdm=tqdm)
+
+
+
+def html_to_pdf(input_html, output_pdf):
+    from weasyprint import HTML, CSS
+    css = CSS(string='''
+        @page {
+            size: 1800mm 1300mm;
+            margin: 0in 0in 0in 0in;
+        }
+    ''')
+    HTML(input_html).write_pdf(output_pdf, stylesheets=[css])

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/dataset.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/dataset.py
@@ -1,0 +1,498 @@
+# Author: Lei Xiong <jsxlei@gmail.com>
+
+
+"""
+Data loading and processing module for genomic data.
+
+This module provides classes for loading and processing genomic data for training and evaluation.
+It handles the loading of genomic regions, their corresponding sequences, and various data augmentation techniques.
+"""
+
+from functools import cached_property
+from time import time
+
+# Third-party imports
+import torch
+import numpy as np
+import pandas as pd
+import lightning as L
+
+
+from .data_utils import load_region_df, load_data, random_crop, crop_revcomp_augment, get_cts
+
+
+class DataModule(L.LightningDataModule):
+    """DataModule for loading and processing genomic data for training and evaluation.
+
+    This module handles the loading of genomic regions, their corresponding sequences,
+    and various data augmentation techniques. It supports different data types:
+    - Profile data: For single-region analysis
+    - Long-range data: For analyzing interactions between regions
+
+    The module implements different sampling strategies for training, validation and testing:
+    - Train: peaks + negative_sampling_ratio (0.1) of negatives, sampled each epoch
+    - Val: peaks + negatives_sampling_ratio (1) of negatives, sampled once and fixed
+    - Test: peaks + negatives, no sampling
+
+    Attributes:
+        config: Configuration object containing data loading parameters
+        dataset_class: The dataset class to use (ChromBPNetBatchGenerator or LongRangeDataset)
+        peaks: DataFrame containing peak regions
+        negatives: DataFrame containing negative regions
+        data: Combined DataFrame of peaks and negatives
+        train_chroms: List of chromosomes used for training
+        val_chroms: List of chromosomes used for validation
+        test_chroms: List of chromosomes used for testing
+    """
+
+    def __init__(self, config):
+        """Initialize the DataModule.
+
+        Args:
+            config: Configuration object containing data loading parameters
+        """
+        super().__init__()
+        self.config = config
+
+        # Set dataset class based on data type
+        if self.config.data_type == 'profile':
+            self.dataset_class = ChromBPNetDataset
+        else:
+            raise ValueError(f'Invalid data type: {self.config.data_type}')
+
+        # Load and process data
+        self._load_regions()
+        self._setup_chromosomes()
+        self._split_data()
+
+    def _load_regions(self):
+        """Load peak and negative regions from files."""
+        self.peaks = load_region_df(
+            self.config.peaks,
+            chrom_sizes=self.config.chrom_sizes,
+            in_window=self.config.in_window,
+            shift=self.config.shift,
+            is_peak=True
+        )
+
+        if self.config.negatives is not None:
+            self.negatives = load_region_df(
+                self.config.negatives,
+                chrom_sizes=self.config.chrom_sizes,
+                in_window=self.config.in_window,
+                shift=self.config.shift,
+                is_peak=False
+            )
+            self.data = pd.concat([self.peaks, self.negatives], ignore_index=True)
+        else:
+            self.negatives = None
+            self.data = self.peaks
+
+
+
+    def _setup_chromosomes(self):
+        """Setup chromosome lists for training, validation and testing."""
+        self.train_chroms = [i for i in self.config.training_chroms if i not in self.config.exclude_chroms]
+        self.val_chroms = [i for i in self.config.validation_chroms if i not in self.config.exclude_chroms]
+        self.test_chroms = [i for i in self.config.test_chroms if i not in self.config.exclude_chroms]
+        self.chroms = self.train_chroms + self.val_chroms + self.test_chroms
+
+    def _split_data(self):
+        """Split data into training, validation and testing sets."""
+        self.train_val = self.data[self.data.iloc[:, 0].isin(self.val_chroms+self.train_chroms)].reset_index(drop=True)
+        self.train_data = self.data[self.data.iloc[:, 0].isin(self.train_chroms)].reset_index(drop=True)
+
+        self.val_data = self.data[self.data.iloc[:, 0].isin(self.val_chroms)].reset_index(drop=True)
+        self.test_data = self.data[self.data.iloc[:, 0].isin(self.test_chroms)].reset_index(drop=True)
+
+    def setup(self, stage='fit'):
+        print('Setting up data...'); t0 = time()
+
+        config = self.config
+
+        if stage == 'fit':
+            train_peaks, train_nonpeaks = split_peak_and_nonpeak(self.train_data)
+            val_peaks, val_nonpeaks = split_peak_and_nonpeak(self.val_data)
+
+            self.train_dataset = self.dataset_class(
+                peak_regions=train_peaks,
+                nonpeak_regions=train_nonpeaks,
+                genome_fasta=config.fasta,
+                inputlen=config.in_window,
+                outputlen=config.out_window,
+                max_jitter=config.shift,
+                negative_sampling_ratio=config.negative_sampling_ratio,
+                cts_bw_file=config.bigwig,
+                add_revcomp=True,
+                return_coords=False, #return_coords,
+                shuffle_at_epoch_start=False, #shuffle_at_epoch_start
+            )
+            self.val_dataset = self.dataset_class(
+                peak_regions=val_peaks,
+                nonpeak_regions=val_nonpeaks,
+                genome_fasta=config.fasta,
+                inputlen=config.in_window,
+                outputlen=config.out_window,
+                max_jitter=0,
+                negative_sampling_ratio=config.negative_sampling_ratio,
+                cts_bw_file=config.bigwig,
+                add_revcomp=False,
+                return_coords=False,
+                shuffle_at_epoch_start=False,
+            )
+        elif stage == 'test':
+            test_peaks, test_nonpeaks = split_peak_and_nonpeak(self.test_data)
+            self.test_dataset = self.dataset_class(
+                peak_regions=test_peaks,
+                nonpeak_regions=test_nonpeaks,
+                genome_fasta=config.fasta,
+                inputlen=config.in_window,
+                outputlen=config.out_window,
+                max_jitter=0,
+                negative_sampling_ratio=-1,
+                cts_bw_file=config.bigwig,
+                add_revcomp=False,
+                return_coords=False,
+                shuffle_at_epoch_start=False,
+            )
+
+        print(f'Data setup complete in {time() - t0:.2f} seconds')
+
+    @cached_property
+    def median_count(self):
+        import pyBigWig
+        ## Calculate median count to get weight of count loss
+        self.train_val_subsampled = concat_peaks_and_subsampled_negatives(self.train_val, negative_sampling_ratio=self.config.negative_sampling_ratio)
+        counts_subsampled = get_cts(self.train_val_subsampled, pyBigWig.open(self.config.bigwig), self.config.out_window).sum(-1)
+        # counts_subsampled = extract_loci(self.train_val_subsampled, self.config.bigwig, width=self.config.out_windo, w, out='bigwig', shift=0, pool_size=64).sum(-1)
+        return np.median(counts_subsampled)
+
+
+
+    def train_dataloader(self):
+        self.train_dataset.crop_revcomp_data()
+
+        return torch.utils.data.DataLoader(
+            self.train_dataset,
+            batch_size=self.config.batch_size,
+            shuffle=True,
+            drop_last=False,
+            num_workers=self.config.num_workers,
+            # pin_memory=True,
+        )
+
+    def val_dataloader(self):
+        return torch.utils.data.DataLoader(
+            self.val_dataset,
+            batch_size=self.config.batch_size,
+            shuffle=False,
+            num_workers=self.config.num_workers,
+            # pin_memory=True
+        )
+
+    def test_dataloader(self):
+        return torch.utils.data.DataLoader(
+            self.test_dataset,
+            batch_size=self.config.batch_size,
+            shuffle=False,
+            num_workers=self.config.num_workers,
+        )
+
+    def negative_dataloader(self):
+        self.negative_dataset = self.dataset_class(
+            peak_regions=self.negatives,
+            nonpeak_regions=None,
+            genome_fasta=self.config.fasta,
+            batch_size=self.config.batch_size,
+            inputlen=self.config.in_window,
+            outputlen=self.config.out_window,
+            max_jitter=0,
+            negative_sampling_ratio=-1,
+            cts_bw_file=self.config.bigwig,
+            add_revcomp=False,
+            return_coords=False,
+            shuffle_at_epoch_start=False,
+        )
+        return torch.utils.data.DataLoader(
+            self.negative_dataset,
+            batch_size=self.config.batch_size,
+            shuffle=False,
+            num_workers=self.config.num_workers,
+        )
+
+    def chrom_dataloader(self, chrom='chr1', negative_sampling_ratio=-1):
+
+        dataset = self.chrom_dataset(chrom=chrom, negative_sampling_ratio=negative_sampling_ratio)
+
+        return torch.utils.data.DataLoader(
+            dataset,
+            batch_size=self.config.batch_size,
+            shuffle=False,
+            num_workers=self.config.num_workers,
+        ), dataset
+
+
+    def chrom_dataset(self, chrom='chr1', negative_sampling_ratio=-1):
+        if isinstance(chrom, str):
+            if chrom in ['train', 'val', 'test']:
+                chrom = getattr(self, f'{chrom}_chroms')
+
+            elif chrom == 'all':
+                chrom = self.chroms
+            else:
+                chrom = [chrom]
+
+        regions = self.data[self.data.iloc[:, 0].isin(chrom)].reset_index(drop=True)
+        peaks, nonpeaks = split_peak_and_nonpeak(regions)
+
+        dataset = self.dataset_class(
+            peak_regions=peaks,
+            nonpeak_regions=nonpeaks,
+            genome_fasta=self.config.fasta,
+            inputlen=self.config.in_window,
+            outputlen=self.config.out_window,
+            max_jitter=0,
+            negative_sampling_ratio=-1,
+            cts_bw_file=self.config.bigwig,
+            add_revcomp=False,
+            return_coords=False,
+            shuffle_at_epoch_start=False,
+            debug=self.config.debug,
+        )
+        return dataset
+
+
+
+
+
+def split_peak_and_nonpeak(data):
+    data['is_peak'] = data['is_peak'].astype(int).astype(bool)
+    non_peaks = data[~data['is_peak']].copy()
+    if not len(non_peaks) > 0:
+        non_peaks = None
+    peaks = data[data['is_peak']].copy()
+    return peaks, non_peaks
+
+
+def subsample_nonpeak_data(nonpeak_seqs, nonpeak_cts, nonpeak_coords, peak_data_size, negative_sampling_ratio):
+    #Randomly samples a portion of the non-peak data to use in training
+    num_nonpeak_samples = int(negative_sampling_ratio * peak_data_size)
+    nonpeak_indices_to_keep = np.random.choice(len(nonpeak_seqs), size=min(num_nonpeak_samples, len(nonpeak_seqs)), replace=False)
+    nonpeak_seqs = nonpeak_seqs[nonpeak_indices_to_keep]
+    nonpeak_cts = nonpeak_cts[nonpeak_indices_to_keep]
+    nonpeak_coords = nonpeak_coords[nonpeak_indices_to_keep]
+    return nonpeak_seqs, nonpeak_cts, nonpeak_coords
+
+
+def concat_peaks_and_subsampled_negatives(peaks, negatives=None, negative_sampling_ratio=0.1):
+    if negatives is None:
+        peaks, negatives = split_peak_and_nonpeak(peaks)
+        # print(peaks.shape, negatives.shape)
+
+    if negatives is not None and len(negatives) > len(peaks) * negative_sampling_ratio and negative_sampling_ratio > 0:
+        negatives = negatives.sample(n=int(negative_sampling_ratio * len(peaks)), replace=False)
+
+        data = pd.concat([peaks, negatives], ignore_index=True)
+    else:
+        data = peaks
+    return data
+
+
+def crop_revcomp_data(
+    peak_seqs, peak_cts, peak_coords,
+    nonpeak_seqs=None, nonpeak_cts=None, nonpeak_coords=None,
+    inputlen=2114, outputlen=1000, add_revcomp=False, negative_sampling_ratio=0.1, shuffle=False):
+    """Apply random cropping and reverse complement augmentation to the data.
+
+        This method:
+        1. Randomly crops peak data to inputlen and outputlen
+        2. Samples negative examples according to negative_sampling_ratio
+        3. Applies reverse complement augmentation if enabled
+        4. Shuffles data if shuffle_at_epoch_start is True
+    """
+    if (peak_seqs is not None) and (nonpeak_seqs is not None):
+        # Crop peak data
+        cropped_peaks, cropped_cnts, cropped_coords = random_crop(
+            peak_seqs, peak_cts, inputlen, outputlen, peak_coords
+        )
+
+        # Sample negative examples
+        if negative_sampling_ratio > 0:
+            sampled_nonpeak_seqs, sampled_nonpeak_cts, sampled_nonpeak_coords = subsample_nonpeak_data(
+                nonpeak_seqs, nonpeak_cts, nonpeak_coords,
+                len(peak_seqs), negative_sampling_ratio
+            )
+            seqs = np.vstack([cropped_peaks, sampled_nonpeak_seqs])
+            cts = np.vstack([cropped_cnts, sampled_nonpeak_cts])
+            coords = np.vstack([cropped_coords, sampled_nonpeak_coords])
+        else:
+            seqs = np.vstack([cropped_peaks, nonpeak_seqs])
+            cts = np.vstack([cropped_cnts, nonpeak_cts])
+            coords = np.vstack([cropped_coords, nonpeak_coords])
+
+    elif peak_seqs is not None:
+        # Only peak data
+        cropped_peaks, cropped_cnts, cropped_coords = random_crop(
+            peak_seqs, peak_cts, inputlen, outputlen, peak_coords
+        )
+        seqs = cropped_peaks
+        cts = cropped_cnts
+        coords = cropped_coords
+
+    elif nonpeak_seqs is not None:
+        # Only non-peak data
+        seqs = nonpeak_seqs
+        cts = nonpeak_cts
+        coords = nonpeak_coords
+    else:
+        raise ValueError("Both peak and non-peak arrays are empty")
+
+    # Apply augmentation
+    seqs, cts, coords = crop_revcomp_augment(
+        seqs, cts, coords, inputlen, outputlen,
+        add_revcomp, shuffle=shuffle
+    )
+    # self.regions = pd.DataFrame(self.cur_coords, columns=['chrom', 'start', 'forward_or_reverse', 'is_peak'])
+    # print('Regions', self.regions['is_peak'].value_counts())
+    return seqs, cts, coords
+
+
+def debug_subsample(peak_regions, chrom=None):
+    if peak_regions is None:
+        return None
+
+    if chrom is None:
+        chrom = peak_regions['chr'].unique()[0]
+
+
+    peak_regions = peak_regions[peak_regions['chr'] == chrom]
+    print('debugging on ', chrom, 'shape', peak_regions.shape)
+    return peak_regions.reset_index(drop=True)
+
+class ChromBPNetDataset(torch.utils.data.Dataset):
+    """Generator for genomic sequence data with random cropping and reverse complement augmentation.
+
+    This generator randomly crops (=jitter) and applies reverse complement augmentation to training examples
+    for every epoch. It handles both peak and non-peak regions, with configurable sampling ratios.
+
+    Attributes:
+        peak_seqs: Array of peak sequences
+        nonpeak_seqs: Array of non-peak sequences
+        peak_cts: Array of peak counts
+        nonpeak_cts: Array of non-peak counts
+        peak_coords: Array of peak coordinates
+        nonpeak_coords: Array of non-peak coordinates
+        negative_sampling_ratio: Ratio of negative samples to use
+        inputlen: Length of input sequences
+        outputlen: Length of output sequences
+        batch_size: Size of batches
+        add_revcomp: Whether to add reverse complement augmentation
+        return_coords: Whether to return coordinates
+        shuffle_at_epoch_start: Whether to shuffle at epoch start
+    """
+
+    def __init__(
+            self,
+            peak_regions,
+            nonpeak_regions,
+            genome_fasta,
+            inputlen=2114,
+            outputlen=1000,
+            max_jitter=0,
+            negative_sampling_ratio=0.1,
+            cts_bw_file=None,
+            add_revcomp=False,
+            return_coords=False,
+            shuffle_at_epoch_start=False,
+            debug=False,
+            **kwargs
+    ):
+        """Initialize the generator.
+
+        Args:
+            peak_regions: DataFrame containing peak regions
+            nonpeak_regions: DataFrame containing non-peak regions
+            genome_fasta: Path to genome FASTA file
+            batch_size: Size of batches
+            inputlen: Length of input sequences
+            outputlen: Length of output sequences
+            max_jitter: Maximum jitter for random cropping
+            negative_sampling_ratio: Ratio of negative samples to use
+            cts_bw_file: Path to bigwig file containing counts
+            add_revcomp: Whether to add reverse complement augmentation
+            return_coords: Whether to return coordinates
+            shuffle_at_epoch_start: Whether to shuffle at epoch start
+            **kwargs: Additional keyword arguments
+        """
+        if debug:
+            peak_regions = debug_subsample(peak_regions)
+            nonpeak_regions = debug_subsample(nonpeak_regions)
+
+
+        # Load data
+        peak_seqs, peak_cts, peak_coords, nonpeak_seqs, nonpeak_cts, nonpeak_coords = load_data(
+            peak_regions, nonpeak_regions, genome_fasta, cts_bw_file, inputlen, outputlen, max_jitter
+        )
+
+        # Store data
+        self.peak_seqs, self.nonpeak_seqs = peak_seqs, nonpeak_seqs
+        self.peak_cts, self.nonpeak_cts = peak_cts, nonpeak_cts
+        self.peak_coords, self.nonpeak_coords = peak_coords, nonpeak_coords
+
+        # Store parameters
+        self.negative_sampling_ratio = negative_sampling_ratio
+        self.inputlen = inputlen
+        self.outputlen = outputlen
+        self.add_revcomp = add_revcomp
+        self.return_coords = return_coords
+        self.shuffle_at_epoch_start = shuffle_at_epoch_start
+        self.max_jitter = max_jitter
+        self.genome_fasta = genome_fasta
+        self.cts_bw_file = cts_bw_file
+
+        if nonpeak_regions is not None:
+            self.regions = pd.concat([peak_regions, nonpeak_regions], ignore_index=True)
+        else:
+            self.regions = peak_regions
+        # Initialize data
+        self.crop_revcomp_data()
+
+    def __len__(self):
+        """Return the number of samples in the dataset."""
+        return len(self.cur_seqs)
+
+    def crop_revcomp_data(self):
+        """Apply random cropping and reverse complement augmentation to the data.
+
+        This method:
+        1. Randomly crops peak data to inputlen and outputlen
+        2. Samples negative examples according to negative_sampling_ratio
+        3. Applies reverse complement augmentation if enabled
+        4. Shuffles data if shuffle_at_epoch_start is True
+        """
+        self.cur_seqs, self.cur_cts, self.cur_coords = crop_revcomp_data(
+            self.peak_seqs, self.peak_cts, self.peak_coords,
+            self.nonpeak_seqs, self.nonpeak_cts, self.nonpeak_coords,
+            self.inputlen, self.outputlen, self.add_revcomp, self.negative_sampling_ratio, self.shuffle_at_epoch_start
+        )
+
+    def _get_adj(self):
+        """Get adjacency matrix for the data."""
+        pass
+
+
+    def __getitem__(self, idx):
+        """Get a sample from the dataset.
+
+        Args:
+            idx: Index of the sample to get
+
+        Returns:
+            Dictionary containing:
+                - onehot_seq: One-hot encoded sequence
+                - profile: Profile data
+        """
+        return {
+            'onehot_seq': self.cur_seqs[idx].astype(np.float32).transpose(),
+            'profile': self.cur_cts[idx].astype(np.float32),
+        }

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/genome.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/genome.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+from collections.abc import Callable
+
+from pathlib import Path
+from pooch import Decompress
+import pandas as pd
+import os
+import logging
+
+import pooch
+
+# Set up logging
+logger = logging.getLogger(__name__)
+
+class EnhancedDataset:
+    """
+    Enhanced dataset class that provides better caching and error handling.
+    """
+
+    def __init__(self, dataset_func):
+        self.dataset_func = dataset_func
+        self._dataset = None
+
+    @property
+    def dataset(self):
+        """Lazy load the dataset."""
+        if self._dataset is None:
+            self._dataset = self.dataset_func()
+        return self._dataset
+
+    def check_file_exists(self, filename):
+        """
+        Check if a file is already downloaded and valid.
+
+        Parameters
+        ----------
+        filename : str
+            Name of the file to check
+
+        Returns
+        -------
+        bool
+            True if file exists and is valid, False otherwise
+        """
+        try:
+            file_path = self.dataset.abspath / filename
+            return file_path.exists() and self.dataset.is_available(filename)
+        except Exception as e:
+            logger.warning(f"Error checking file {filename}: {e}")
+            return False
+
+    def fetch(self, filename, processor=None, progressbar=True):
+        """
+        Safely fetch a file with better error handling and logging.
+
+        Parameters
+        ----------
+        filename : str
+            Name of the file to fetch
+        processor : callable, optional
+            Processor to apply to the downloaded file
+        progressbar : bool
+            Whether to show progress bar
+
+        Returns
+        -------
+        str
+            Path to the downloaded file
+        """
+        # Check if file already exists
+        if self.check_file_exists(filename):
+            logger.info(f"File {filename} already exists and is valid, skipping download")
+            return str(self.dataset.abspath / filename)
+
+        logger.info(f"Downloading {filename}...")
+        try:
+            result = self.dataset.fetch(filename, processor=processor, progressbar=progressbar)
+            logger.info(f"Successfully downloaded {filename}")
+            return result
+        except Exception as e:
+            logger.error(f"Failed to download {filename}: {e}")
+            raise
+
+    def get_cache_info(self):
+        """
+        Get information about the cache directory and available files.
+
+        Returns
+        -------
+        dict
+            Dictionary with cache information
+        """
+        info = {
+            'cache_directory': str(self.dataset.abspath),
+            'base_url': self.dataset.base_url,
+            'available_files': list(self.dataset.registry.keys()),
+            'downloaded_files': []
+        }
+
+        for filename in self.dataset.registry.keys():
+            if self.check_file_exists(filename):
+                file_path = self.dataset.abspath / filename
+                file_size = file_path.stat().st_size if file_path.exists() else 0
+                info['downloaded_files'].append({
+                    'filename': filename,
+                    'size_bytes': file_size,
+                    'size_mb': file_size / (1024**2)
+                })
+
+        return info
+
+# Legacy functions for backward compatibility
+def check_file_exists(dataset_func, filename):
+    """Legacy function - use EnhancedDataset.check_file_exists instead."""
+    dataset = EnhancedDataset(dataset_func)
+    return dataset.check_file_exists(filename)
+
+def safe_fetch(dataset_func, filename, processor=None, progressbar=True):
+    """Legacy function - use EnhancedDataset.safe_fetch instead."""
+    dataset = EnhancedDataset(dataset_func)
+    return dataset.safe_fetch(filename, processor, progressbar)
+
+def motifs_datasets():
+    """Get enhanced motifs dataset."""
+    def _create_dataset():
+        return pooch.create(
+            path=pooch.os_cache("genome/motifs"),
+            base_url="https://zenodo.org/records/7445373/files/",
+            env="GENOME_DATA_DIR",
+            registry={
+                "motifs.meme.txt": "md5:21b0d5f5496efe677567db04304ed0de",
+            },
+            urls={
+                "motifs.meme.txt": "https://zenodo.org/records/7445373/files/motifs.meme.txt?download=1",
+            },
+        )
+    return EnhancedDataset(_create_dataset)
+
+def hg38_datasets():
+    """Get enhanced hg38 dataset."""
+    def _create_dataset():
+        return pooch.create(
+                path=pooch.os_cache("genome/hg38"),
+                base_url="https://zenodo.org/records/12193595/files/",
+                env="GENOME_DATA_DIR",  # The user can overwrite the storage path by setting this environment variable.
+                # The registry specifies the files that can be fetched
+                registry={
+                    # TF motifs
+                    # Genome files
+                    "hg38.chrom.sizes": "md5:c95303fb77cc3e11d50e3c3a4b93b3fb",
+                    "hg38.fa": "md5:a6da8681616c05eb542f1d91606a7b2f",
+                    "hg38.gtf.gz": "md5:16fcae8ca8e488cd8056cf317d963407",
+                    "fold_0.json": "md5:88bab8abe271c9ebb6655a0332b74998",
+                    "fold_1.json": "md5:426f117b2d4e5885fb10ef7a3b7e593e",
+                    "fold_2.json": "md5:b603378ebfcd8954aecd4ae60c4ce9b4",
+                    "fold_3.json": "md5:8e70574ae38b7314c09cfc7db6194486",
+                    "fold_4.json": "md5:eab6e147532e3cb5c8e6860b2e24da3b",
+                },
+                urls={
+                    "hg38.fa": "https://zenodo.org/records/12193595/files/hg38.fa",
+                    "hg38.gtf.gz": "https://zenodo.org/records/12193595/files/gencode.v38.annotation.gtf.gz",
+                    "hg38.chrom.sizes": "https://zenodo.org/records/12193595/files/hg38.chrom.sizes",
+                    "fold_0.json": "https://zenodo.org/records/12193595/files/fold_0.json",
+                    "fold_1.json": "https://zenodo.org/records/12193595/files/fold_1.json",
+                    "fold_2.json": "https://zenodo.org/records/12193595/files/fold_2.json",
+                    "fold_3.json": "https://zenodo.org/records/12193595/files/fold_3.json",
+                    "fold_4.json": "https://zenodo.org/records/12193595/files/fold_4.json",
+                },
+            )
+    return EnhancedDataset(_create_dataset)
+
+def mm10_datasets():
+    """Get enhanced mm10 dataset."""
+    def _create_dataset():
+        return pooch.create(
+            path=pooch.os_cache("genome/mm10"),
+            base_url="https://zenodo.org/records/12193429/files/",
+            env="GENOME_DATA_DIR",
+            registry={
+                "mm10.gtf.gz": "md5:5a103c9a15dd660c295a089ef5035672",
+                "mm10.fa": "md5:7e329b2bf419a9f5a7dc42c625c884ac",
+                "mm10.chrom.sizes": "md5:5a103c9a15dd660c295a089ef5035672",
+                "fold_0.json": "md5:32f25d53ba1270fe2acd15b31bc4789d",
+                "fold_1.json": "md5:b07be1148b1e81399436c985c0647999",
+                "fold_2.json": "md5:fccbd2d245aca6433ad6f729a2e5d9a8",
+                "fold_3.json": "md5:c74f9221fc7f0d5984368c4cf594a071",
+                "fold_4.json": "md5:f3eaf62e8a013db9de19f606a46dba04",
+            },
+            urls={
+                "mm10.gtf.gz": "https://zenodo.org/records/12193429/files/mm10.gtf.gz",
+                "mm10.fa": "https://zenodo.org/records/12193429/files/mm10.fa",
+                "mm10.chrom.sizes": "https://zenodo.org/records/12193429/files/mm10.chrom.sizes",
+                "fold_0.json": "https://zenodo.org/records/12193429/files/fold_0.json",
+                "fold_1.json": "https://zenodo.org/records/12193429/files/fold_1.json",
+                "fold_2.json": "https://zenodo.org/records/12193429/files/fold_2.json",
+                "fold_3.json": "https://zenodo.org/records/12193429/files/fold_3.json",
+                "fold_4.json": "https://zenodo.org/records/12193429/files/fold_4.json",
+            },
+        )
+    return EnhancedDataset(_create_dataset)
+
+def hg19_datasets():
+    """Get enhanced hg19 dataset."""
+    def _create_dataset():
+        return pooch.create(
+            path=pooch.os_cache("genome/hg19"),
+            base_url="https://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/",
+            env="GENOME_DATA_DIR",  # The user can overwrite the storage path by setting this environment variable.
+            registry={
+                "hg19.fa.gz": "md5:806c02398f5ac5da8ffd6da2d1d5d1a9",
+                "hg19.gtf.gz": "md5:bd83e28270e595d3bde6bfcb21c9748f",
+                "hg19.chrom.sizes": "md5:b3b0fcf79b5477ab0b3af02e81eac8dc",
+                "hg19.fa": "md5:530d89d3ef07fdb2a9b3c701fb4ca486",
+                "fold_0.json": "md5:88bab8abe271c9ebb6655a0332b74998",
+                "fold_1.json": "md5:426f117b2d4e5885fb10ef7a3b7e593e",
+                "fold_2.json": "md5:b603378ebfcd8954aecd4ae60c4ce9b4",
+                "fold_3.json": "md5:8e70574ae38b7314c09cfc7db6194486",
+                "fold_4.json": "md5:eab6e147532e3cb5c8e6860b2e24da3b",
+            },
+            urls={
+                "hg19.fa": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.fa.gz",
+                "hg19.gtf.gz": "https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_19/gencode.v19.annotation.gtf.gz",
+                "hg19.chrom.sizes": "https://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.chrom.sizes",
+                "fold_0.json": "https://zenodo.org/records/12193595/files/fold_0.json",
+                "fold_1.json": "https://zenodo.org/records/12193595/files/fold_1.json",
+                "fold_2.json": "https://zenodo.org/records/12193595/files/fold_2.json",
+                "fold_3.json": "https://zenodo.org/records/12193595/files/fold_3.json",
+                "fold_4.json": "https://zenodo.org/records/12193595/files/fold_4.json",
+            },
+        )
+    return EnhancedDataset(_create_dataset)
+
+class Genome:
+    """
+    A class that encapsulates information about a genome, including its FASTA sequence,
+    its annotation, and chromosome sizes.
+
+    Attributes
+    ----------
+    fasta
+        The path to the FASTA file.
+    annotation
+        The path to the annotation file.
+    chrom_sizes
+        A dictionary containing chromosome names and sizes.
+
+    Raises
+    ------
+    ValueError
+        If `fasta` or `annotation` are not a Path, a string, or a callable.
+    """
+
+    def __init__(
+        self,
+        *,
+        fasta: Path | Callable[[], Path],
+        annotation: Path | Callable[[], Path],
+        chrom_sizes: Path | Callable[[], Path],
+        # chrom_sizes: dict[str, int] | None = None,
+    ):
+        """
+        Initializes the Genome object with paths or callables for FASTA and annotation files,
+        and optionally, chromosome sizes.
+
+        Parameters
+        ----------
+        fasta
+            A Path or callable that returns a Path to the FASTA file.
+        annotation
+            A Path or callable that returns a Path to the annotation file.
+        chrom_sizes
+            Optional chromosome sizes. If not provided, chromosome sizes will
+            be inferred from the FASTA file.
+        """
+        if callable(fasta):
+            self._fetch_fasta = fasta
+            self._fasta = None
+        elif isinstance(fasta, Path) or isinstance(fasta, str):
+            self._fasta = Path(fasta)
+            self._fetch_fasta = None
+        else:
+            raise ValueError("fasta must be a Path or Callable")
+
+        if callable(annotation):
+            self._fetch_annotation = annotation
+            self._annotation = None
+        elif isinstance(annotation, Path) or isinstance(annotation, str):
+            self._annotation = Path(annotation)
+            self._fetch_annotation = None
+        else:
+            raise ValueError("annotation must be a Path or Callable")
+
+        self._chrom_sizes = chrom_sizes
+        self.chrom_sizes = chrom_sizes
+
+    @property
+    def fasta(self):
+        """
+        The Path to the FASTA file.
+
+        Returns
+        -------
+        Path
+            The path to the FASTA file.
+        """
+        if self._fasta is None:
+            self._fasta = Path(self._fetch_fasta())
+        return str(self._fasta)
+
+    @property
+    def annotation(self):
+        """
+        The Path to the annotation file.
+
+        Returns
+        -------
+        Path
+            The path to the annotation file.
+        """
+        if self._annotation is None:
+            self._annotation = Path(self._fetch_annotation())
+        return str(self._annotation)
+
+    # @property
+    # def chrom_sizes(self):
+    #     """
+    #     A dictionary with chromosome names as keys and their lengths as values.
+
+    #     Returns
+    #     -------
+    #     dict[str, int]
+    #         A dictionary of chromosome sizes.
+    #     """
+    #     if self._chrom_sizes is None:
+    #         from pyfaidx import Fasta
+    #         fasta = Fasta(self.fasta)
+    #         self._chrom_sizes = {chr: len(fasta[chr]) for chr in fasta.keys()}
+    #     return self._chrom_sizes
+
+
+GRCh38 = Genome(
+    fasta=lambda : hg38_datasets().fetch(
+        "hg38.fa",
+        # processor=Decompress(method="gzip", name="hg38.fa"),
+        progressbar=True
+    ),
+    annotation=lambda : hg38_datasets().fetch(
+        "hg38.gtf.gz",
+        progressbar=True
+    ),
+    chrom_sizes= hg38_datasets().fetch(
+        "hg38.chrom.sizes",
+        progressbar=True
+    ),
+    )
+hg38 = GRCh38
+
+GRCh37 = Genome(
+    fasta=lambda : hg19_datasets().fetch(
+        "hg19.fa",
+        progressbar=True, processor=Decompress(method="gzip", name="hg19.fa")
+    ),
+    annotation=lambda : hg19_datasets().fetch(
+        "hg19.gtf.gz",
+        progressbar=True
+    ),
+    chrom_sizes= hg19_datasets().fetch(
+        "hg19.chrom.sizes",
+        progressbar=True
+    ),
+)
+hg19 = GRCh37
+
+GRCm38 = Genome(
+    fasta=lambda : mm10_datasets().fetch(
+        "mm10.fa",
+        # processor=Decompress(method="gzip", name="mm10.fa"),
+        progressbar=True
+    ),
+    annotation=lambda : mm10_datasets().fetch(
+        "mm10.gtf.gz",
+        progressbar=True
+    ),
+    chrom_sizes= mm10_datasets().fetch(
+        "mm10.chrom.sizes",
+        progressbar=True
+    ),
+
+    )
+mm10 = GRCm38
+
+
+def strand_specific_start_site(df):
+    df = df.copy()
+    if set(df["Strand"]) != set(["+", "-"]):
+        raise ValueError("Not all features are strand specific!")
+
+    pos_strand = df.query("Strand == '+'").index
+    neg_strand = df.query("Strand == '-'").index
+    df.loc[pos_strand, "End"] = df.loc[pos_strand, "Start"] + 1
+    df.loc[neg_strand, "Start"] = df.loc[neg_strand, "End"] - 1
+    return df

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/logger.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/logger.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+# Author: Lei Xiong <jsxlei@gmail.com>
+
+import logging
+
+def create_logger(name='', ch=True, fh=False, levelname=logging.INFO, overwrite=False):
+    logger = logging.getLogger(name)
+    logger.setLevel(levelname)
+
+    if overwrite:
+        for h in logger.handlers:
+            logger.removeHandler(h)
+
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    # handler
+    if ch:
+        ch = logging.StreamHandler()
+        ch.setLevel(logging.INFO)
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
+    if fh:
+        fh = logging.FileHandler(fh, mode='w')
+        fh.setLevel(logging.DEBUG)
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
+    return logger

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/metrics.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/metrics.py
@@ -1,0 +1,346 @@
+# Author: Lei Xiong <jsxlei@gmail.com>
+
+import numpy as np
+import argparse
+from scipy.stats import spearmanr, pearsonr
+from scipy.spatial.distance import jensenshannon
+import matplotlib
+# matplotlib.use('Agg')
+from matplotlib import pyplot as plt
+# from matplotlib import cm
+# from matplotlib.colors import Normalize
+from scipy.interpolate import interpn
+from .metrics_utils import *
+from .data_utils import write_bigwig, read_chrom_sizes, expand_3col_to_10col
+from .genome import hg38_datasets
+
+plt.rcParams["figure.figsize"]=10,5
+font = {'weight' : 'bold',
+        'size'   : 10}
+matplotlib.rc('font', **font)
+
+import os
+import h5py
+import pandas as pd
+import json
+
+def softmax(x, temp=1):
+    norm_x = x - np.mean(x,axis=1, keepdims=True)
+    return np.exp(temp*norm_x)/np.sum(np.exp(temp*norm_x), axis=1, keepdims=True)
+
+def get_regions(regions, seqlen, regions_used=None):
+    # regions file is assumed to be centered at summit (2nd + 10th column)
+    # it is adjusted to be of length seqlen centered at summit
+
+    assert(seqlen%2==0)
+
+    #with open(regions_file) as r:
+    #    regions = [x.strip().split('\t') for x in r]
+
+    # regions = pd.read_csv(regions_file,sep='\t',header=None)
+    #print(regions)
+    if regions_used is None:
+        regions = [[x[0], int(x[1])+int(x[9])-seqlen//2, int(x[1])+int(x[9])+seqlen//2, int(x[1])+int(x[9])] for x in np.array(regions.values)]
+    else:
+        regions = [[x[0], int(x[1])+int(x[9])-seqlen//2, int(x[1])+int(x[9])+seqlen//2, int(x[1])+int(x[9])] for x in np.array(regions.values)[regions_used]]
+
+    return regions
+
+
+def write_predictions_h5py(profile, logcts, coords, out_dir='.'):
+    # open h5 file for writing predictions
+    os.makedirs(out_dir, exist_ok=True)
+    output_h5_fname = os.path.join(out_dir, "predictions.h5")
+    h5_file = h5py.File(output_h5_fname, "w")
+    # create groups
+    coord_group = h5_file.create_group("coords")
+    pred_group = h5_file.create_group("predictions")
+
+    num_examples=len(coords)
+
+    coords_chrom_dset =  [str(coords[i][0]) for i in range(num_examples)]
+    coords_center_dset =  [int(coords[i][1]) for i in range(num_examples)]
+    coords_peak_dset =  [int(coords[i][3]) for i in range(num_examples)]
+
+    dt = h5py.special_dtype(vlen=str)
+
+    # create the "coords" group datasets
+    coords_chrom_dset = coord_group.create_dataset(
+        "coords_chrom", data=np.array(coords_chrom_dset, dtype=dt),
+        dtype=dt, compression="gzip")
+    coords_start_dset = coord_group.create_dataset(
+        "coords_center", data=coords_center_dset, dtype=int, compression="gzip")
+    coords_end_dset = coord_group.create_dataset(
+        "coords_peak", data=coords_peak_dset, dtype=int, compression="gzip")
+
+    # create the "predictions" group datasets
+    profs_dset = pred_group.create_dataset(
+        "profs",
+        data=profile,
+        dtype=float, compression="gzip")
+    logcounts_dset = pred_group.create_dataset(
+        "logcounts", data=logcts,
+        dtype=float, compression="gzip")
+
+    # close hdf5 file
+    h5_file.close()
+
+
+def save_predictions(output, regions, chrom_sizes, out_dir='./'):
+    """
+    Save the predictions to an HDF5 file and write regions to a CSV file.
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    with open(chrom_sizes) as f:
+        gs = [x.strip().split('\t') for x in f]
+    gs = [(x[0], int(x[1])) for x in gs if len(x)==2]
+    if regions.shape[1] < 10:
+        regions = expand_3col_to_10col(regions)
+    # gs = read_chrom_sizes(chrom_sizes); print(gs)
+
+    seqlen = 1000
+    regions_array = [[x[0], int(x[1])+int(x[9])-seqlen//2, int(x[1])+int(x[9])+seqlen//2, int(x[1])+int(x[9])] for x in np.array(regions.values)]
+
+    # parse output
+    parsed_output = {key: np.concatenate([batch[key] for batch in output]) for key in output[0]}
+
+    data = softmax(parsed_output['pred_profile']) * (np.expand_dims(np.exp(parsed_output['pred_count']), axis=1))
+
+    write_bigwig(
+        data,
+        regions_array,
+        gs,
+        os.path.join(out_dir, "pred.bw"),
+        outstats_file=None,
+        debug_chr=None,
+        use_tqdm=True)
+
+    # save predictions into h5py file
+    # write_predictions_h5py(parsed_output['pred_profile'], parsed_output['pred_count'], regions_array, out_dir)
+
+    return
+
+def load_output_to_regions(output, regions, out_dir='./'):
+    """
+    Load the output to regions
+    """
+    regions = regions.reset_index(drop=True).copy()
+    os.makedirs(out_dir, exist_ok=True)
+    parsed_output = {key: np.concatenate([batch[key] for batch in output]) for key in output[0]}
+    if 'is_peak' in regions.columns:
+        regions['is_peak'] = regions['is_peak'].astype(int)
+    regions['pred_count'] = parsed_output['pred_count']
+    regions['true_count'] = parsed_output['true_count']
+    regions.to_csv(os.path.join(out_dir, 'regions.csv'), sep='\t', index=False)
+    return regions, parsed_output
+
+def compare_with_observed(regions, parsed_output, out_dir='./', tag='all_regions'):
+    """
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    # chrom_sizes = os.path.expanduser('~/.cache/regnet/hg38.chrom.sizes')
+    # gs = bigwig_helper.read_chrom_sizes(chrom_sizes) #list(chrom_sizes.items())
+
+    # #gs = bigwig_helper.read_chrom_sizes(chrom_sizes)
+    # seqlen = 1000
+    # regions_array = [[x[0], int(x[1])+int(x[9])-seqlen//2, int(x[1])+int(x[9])+seqlen//2, int(x[1])+int(x[9])] for x in np.array(regions.values)]
+
+    # # parse output
+    # parsed_output = {key: np.concatenate([batch[key] for batch in output]) for key in output[0]}
+
+    # data = softmax(parsed_output['pred_profile']) * (np.expand_dims(np.exp(parsed_output['pred_count']),axis=1))
+
+    # bigwig_helper.write_bigwig(
+    #                     data,
+    #                     regions_array,
+    #                     gs,
+    #                     os.path.join(out_dir, "pred.bw"),
+    #                     outstats_file=None,
+    #                     debug_chr=None,
+    #                     use_tqdm=True)
+
+    # save predictions into h5py file
+    # write_predictions_h5py(parsed_output['pred_profile_prob'], parsed_output['true_profile'], coords, out_dir)
+
+    # regions = pd.DataFrame(coords, columns=['chrom', 'summit', 'forward_reverse', 'is_peak'])
+    # regions['is_peak'] = regions['is_peak'].astype(int)
+    # regions['pred_count'] = parsed_output['pred_count']
+    # regions['true_count'] = parsed_output['true_count']
+    # regions.to_csv(os.path.join(out_dir, 'regions.csv'), sep='\t', index=False)
+
+    # print(peak_regions.head())
+
+    metrics_dictionary={}
+    metrics_dictionary["counts_metrics"] = {}
+    # save count metrics
+    spearman_cor, pearson_cor, mse = counts_metrics(regions['true_count'], regions['pred_count'], os.path.join(out_dir, 'all_regions'))
+    metrics_dictionary["counts_metrics"]["peaks_and_nonpeaks"] = {}
+    metrics_dictionary["counts_metrics"]["peaks_and_nonpeaks"]["spearmanr"] = spearman_cor
+    metrics_dictionary["counts_metrics"]["peaks_and_nonpeaks"]["pearsonr"] = pearson_cor
+    metrics_dictionary["counts_metrics"]["peaks_and_nonpeaks"]["mse"] = mse
+
+    metrics_dictionary["profile_metrics"] = {}
+    mnll_pw, mnll_norm, jsd_pw, jsd_norm, jsd_rnd, jsd_rnd_norm, mnll_rnd, mnll_rnd_norm = profile_metrics(parsed_output['true_profile'], softmax(parsed_output['pred_profile']))
+    plot_histogram(jsd_pw, jsd_rnd, os.path.join(out_dir, 'all_regions_jsd'), '')
+    metrics_dictionary["profile_metrics"]["peaks_and_nonpeaks"] = {}
+    metrics_dictionary["profile_metrics"]["peaks_and_nonpeaks"]["median_jsd"] = np.nanmedian(jsd_pw)
+    metrics_dictionary["profile_metrics"]["peaks_and_nonpeaks"]["median_norm_jsd"] = np.nanmedian(jsd_norm)
+
+
+    if 'is_peak' in regions.columns:
+        peak_regions = regions[regions['is_peak']==1].copy()
+        peak_index = peak_regions.index
+        peak_regions = peak_regions.reset_index(drop=True)
+        print('peak_regions', peak_regions.head())
+
+        spearman_cor, pearson_cor, mse = counts_metrics(peak_regions['true_count'], peak_regions['pred_count'], os.path.join(out_dir, 'peaks'))
+        metrics_dictionary["counts_metrics"]["peaks"] = {}
+        metrics_dictionary["counts_metrics"]["peaks"]["spearmanr"] = spearman_cor
+        metrics_dictionary["counts_metrics"]["peaks"]["pearsonr"] = pearson_cor
+        metrics_dictionary["counts_metrics"]["peaks"]["mse"] = mse
+
+        mnll_pw, mnll_norm, jsd_pw, jsd_norm, jsd_rnd, jsd_rnd_norm, mnll_rnd, mnll_rnd_norm = profile_metrics(parsed_output['true_profile'][peak_index], softmax(parsed_output['pred_profile'])[peak_index])
+        plot_histogram(jsd_pw, jsd_rnd, os.path.join(out_dir, 'peaks_jsd'), '')
+        metrics_dictionary["profile_metrics"]["peaks"] = {}
+        metrics_dictionary["profile_metrics"]["peaks"]["median_jsd"] = np.nanmedian(jsd_pw)
+        metrics_dictionary["profile_metrics"]["peaks"]["median_norm_jsd"] = np.nanmedian(jsd_norm)
+
+        nonpeak_regions = regions[regions['is_peak']==0].copy()
+        nonpeak_index = nonpeak_regions.index
+        nonpeak_regions = nonpeak_regions.reset_index(drop=True)
+        print('nonpeak_regions', nonpeak_regions.head())
+
+        spearman_cor, pearson_cor, mse = counts_metrics(nonpeak_regions['true_count'], nonpeak_regions['pred_count'], os.path.join(out_dir, 'nonpeaks'))
+        metrics_dictionary["counts_metrics"]["nonpeaks"] = {}
+        metrics_dictionary["counts_metrics"]["nonpeaks"]["spearmanr"] = spearman_cor
+        metrics_dictionary["counts_metrics"]["nonpeaks"]["pearsonr"] = pearson_cor
+        metrics_dictionary["counts_metrics"]["nonpeaks"]["mse"] = mse
+        mnll_pw, mnll_norm, jsd_pw, jsd_norm, jsd_rnd, jsd_rnd_norm, mnll_rnd, mnll_rnd_norm = profile_metrics(parsed_output['true_profile'][nonpeak_index], softmax(parsed_output['pred_profile'])[nonpeak_index])
+        plot_histogram(jsd_pw, jsd_rnd, os.path.join(out_dir, 'nonpeaks_jsd'), '')
+        metrics_dictionary["profile_metrics"]["nonpeaks"] = {}
+        metrics_dictionary["profile_metrics"]["nonpeaks"]["median_jsd"] = np.nanmedian(jsd_pw)
+        metrics_dictionary["profile_metrics"]["nonpeaks"]["median_norm_jsd"] = np.nanmedian(jsd_norm)
+
+    print(json.dumps(metrics_dictionary, indent=4, default=lambda o: float(o)))
+
+    # os.makedirs(out_dir, exist_ok=True)
+    with open(os.path.join(out_dir, f'metrics_{tag}.json'), 'w') as fp:
+        json.dump(metrics_dictionary, fp,  indent=4, default=lambda x: float(x))
+    return metrics_dictionary
+
+def counts_metrics(labels,preds,outf=None,title='',fontsize=20, xlab='Log Count Labels', ylab='Log Count Predictions'):
+    '''
+    Get count metrics
+    '''
+    spearman_cor=spearmanr(labels,preds)[0]
+    pearson_cor=pearsonr(labels,preds)[0]
+    mse=((labels - preds)**2).mean(axis=0)
+
+    #print("spearman:"+str(spearman_cor))
+    #print("pearson:"+str(pearson_cor))
+    #print("mse:"+str(mse))
+
+    plt.rcParams["figure.figsize"]=8,8
+    # fig=plt.figure()
+    ax = density_scatter(labels,
+                    preds,
+                    xlab=xlab,
+                    ylab=ylab,
+                    fontsize=fontsize
+                    )
+    plt.suptitle("count: spearman R="+str(round(spearman_cor,3))+"\nPearson R="+str(round(pearson_cor,3))+"\nmse="+str(round(mse,3)), y=0.9, fontsize=20)
+    # plt.legend(loc='best')
+
+    if outf is not None:
+        plt.savefig(outf+'.counts_pearsonr.png',format='png',dpi=300)
+    plt.show()
+    plt.close()
+
+    return spearman_cor, pearson_cor, mse
+
+def profile_metrics(true_counts,pred_probs,pseudocount=0.001):
+    '''
+    Get profile metrics
+    '''
+    mnll_pw = []
+    mnll_norm = []
+
+    jsd_pw = []
+    jsd_norm = []
+    jsd_rnd = []
+    jsd_rnd_norm = []
+    mnll_rnd = []
+    mnll_rnd_norm = []
+
+    num_regions = true_counts.shape[0]
+    for idx in range(num_regions):
+        # mnll
+        #curr_mnll = mnll(true_counts[idx,:],  probs=pred_probs[idx,:])
+        #mnll_pw.append(curr_mnll)
+        # normalized mnll
+        #min_mnll, max_mnll = mnll_min_max_bounds(true_counts[idx,:])
+        #curr_mnll_norm = get_min_max_normalized_value(curr_mnll, min_mnll, max_mnll)
+        #mnll_norm.append(curr_mnll_norm)
+
+        # jsd
+        cur_jsd=jensenshannon(true_counts[idx,:]/(pseudocount+np.nansum(true_counts[idx,:])),pred_probs[idx,:])
+        jsd_pw.append(cur_jsd)
+        # normalized jsd
+        min_jsd, max_jsd = jsd_min_max_bounds(true_counts[idx,:])
+        curr_jsd_norm = get_min_max_normalized_value(cur_jsd, min_jsd, max_jsd)
+        jsd_norm.append(curr_jsd_norm)
+
+        # get random shuffling on labels for a worst case performance on metrics - labels versus shuffled labels
+        shuffled_labels=np.random.permutation(true_counts[idx,:])
+        shuffled_labels_prob=shuffled_labels/(pseudocount+np.nansum(shuffled_labels))
+
+        # mnll random
+        #curr_rnd_mnll = mnll(true_counts[idx,:],  probs=shuffled_labels_prob)
+        #mnll_rnd.append(curr_rnd_mnll)
+        # normalized mnll random
+        #curr_rnd_mnll_norm = get_min_max_normalized_value(curr_rnd_mnll, min_mnll, max_mnll)
+        #mnll_rnd_norm.append(curr_rnd_mnll_norm)
+
+        # jsd random
+        curr_jsd_rnd=jensenshannon(true_counts[idx,:]/(pseudocount+np.nansum(true_counts[idx,:])),shuffled_labels_prob)
+        jsd_rnd.append(curr_jsd_rnd)
+        # normalized jsd random
+        curr_rnd_jsd_norm = get_min_max_normalized_value(curr_jsd_rnd, min_jsd, max_jsd)
+        jsd_rnd_norm.append(curr_rnd_jsd_norm)
+
+    return np.array(mnll_pw), np.array(mnll_norm), np.array(jsd_pw), np.array(jsd_norm), np.array(jsd_rnd), np.array(jsd_rnd_norm), np.array(mnll_rnd), np.array(mnll_rnd_norm)
+
+def plot_histogram(region_jsd, shuffled_labels_jsd, output_prefix, title):
+
+    #generate histogram distributions
+    num_bins=100
+    plt.rcParams["figure.figsize"]=8,8
+
+    #plot mnnll histogram
+    #plt.figure()
+    #n,bins,patches=plt.hist(mnnll_vals,num_bins,facecolor='blue',alpha=0.5,label="Predicted vs Labels")
+    #n1,bins1,patches1=plt.hist(shuffled_labels_mnll,num_bins,facecolor='black',alpha=0.5,label='Shuffled Labels vs Labels')
+    #plt.xlabel('Multinomial Negative LL Profile Labels and Predictions in Probability Space')
+    #plt.title("MNNLL: "+ tile)
+    #plt.legend(loc='best')
+    #plt.savefig(output_prefix+".mnnll.png",format='png',dpi=300)
+
+    #plot jsd histogram
+    plt.figure()
+    n,bins,patches=plt.hist(region_jsd,num_bins,facecolor='blue',alpha=0.5,label="Predicted vs Labels")
+    n1,bins1,patches1=plt.hist(shuffled_labels_jsd,num_bins,facecolor='black',alpha=0.5,label='Shuffled Labels vs Labels')
+    plt.xlabel('Jensen Shannon Distance Profile Labels and Predictions in Probability Space')
+    plt.title("JSD Dist: "+title)
+    plt.legend(loc='best')
+    plt.savefig(output_prefix+".profile_jsd.png",format='png',dpi=300)
+    plt.close()
+
+def flatten_dict(d, parent_key='', sep='/'):
+    items = []
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.extend(flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/metrics_utils.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/metrics_utils.py
@@ -1,0 +1,215 @@
+
+import numpy as np
+import matplotlib
+from matplotlib import pyplot as plt
+from matplotlib import cm
+from matplotlib.colors import Normalize
+from scipy.interpolate import interpn
+from scipy.stats import multinomial
+import math
+from scipy.spatial.distance import jensenshannon
+
+
+plt.rcParams["figure.figsize"]=10,5
+font = {
+    # 'family' : 'normal',
+        'weight' : 'bold',
+        'size'   : 10}
+matplotlib.rc('font', **font)
+
+
+def _fix_sum_to_one(probs):
+    """
+      Fix probability arrays whose sum is fractinally above or
+      below 1.0
+
+      Args:
+          probs (numpy.ndarray): An array whose sum is almost equal
+              to 1.0
+
+      Returns:
+          np.ndarray: array that sums to 1
+    """
+
+    _probs = np.copy(probs)
+
+    if np.sum(_probs) > 1.0:
+        _probs[np.argmax(_probs)] -= np.sum(_probs) - 1.0
+
+    if np.sum(_probs) < 1.0:
+        _probs[np.argmin(_probs)] += 1.0 - np.sum(_probs)
+
+    return _probs
+
+
+def density_scatter(x, y, xlab, ylab, ax = None, sort = True, bins = 20, fontsize=20):
+    """
+    Scatter plot colored by 2d histogram
+    """
+    bad_indices=np.where(np.isnan(x))+np.where(np.isnan(y))
+    x=x[~np.isin(np.arange(x.size),bad_indices)]
+    y=y[~np.isin(np.arange(y.size),bad_indices)]
+
+    if ax is None :
+        fig , ax = plt.subplots()
+    data , x_e, y_e = np.histogram2d( x, y, bins = bins, density = True )
+    z = interpn( ( 0.5*(x_e[1:] + x_e[:-1]) , 0.5*(y_e[1:]+y_e[:-1]) ) , data , np.vstack([x,y]).T , method = "splinef2d", bounds_error = False)
+
+    #To be sure to plot all data
+    z[np.where(np.isnan(z))] = 0.0
+    # Sort the points by density, so that the densest points are plotted last
+    if sort :
+        idx = z.argsort()
+        x, y, z = x[idx], y[idx], z[idx]
+
+    ax.scatter( x, y, c=z )
+    plt.subplots_adjust(left=0.2, right=0.8, top=0.8, bottom=0.2)
+    ax.spines['top'].set_visible(False)
+    ax.spines['right'].set_visible(False)
+
+    vmin = min(np.min(x), np.min(y)) - 0.1
+    vmax = max(np.max(x), np.max(y)) + 0.1
+    plt.xlim(vmin, vmax)
+    plt.ylim(vmin, vmax)
+    plt.xlabel(xlab, fontsize=fontsize)
+    plt.ylabel(ylab, fontsize=fontsize)
+
+    norm = Normalize(vmin = np.min(z), vmax = np.max(z))
+    cax = fig.add_axes([0.85, 0.4, 0.02, 0.2])
+    cbar = fig.colorbar(cm.ScalarMappable(norm = norm), cax=cax)
+    cbar.ax.set_ylabel('Density', rotation=0, y=1.2, labelpad=-15, fontsize=16)
+
+    return ax
+
+#https://github.com/kundajelab/basepairmodels/blob/cf8e346e9df1bad9e55bd459041976b41207e6e5/basepairmodels/cli/metrics.py#L18
+# replacing TracebackExceptions with assertions
+def mnll(true_counts, logits=None, probs=None):
+    """
+        Compute the multinomial negative log-likelihood between true
+        counts and predicted values of a BPNet-like profile model
+
+        One of `logits` or `probs` must be given. If both are
+        given `logits` takes preference.
+        Args:
+            true_counts (numpy.array): observed counts values
+
+            logits (numpy.array): predicted logits values
+
+            probs (numpy.array): predicted values as probabilities
+
+        Returns:
+            float: cross entropy
+
+    """
+
+    dist = None
+
+    if logits is not None:
+
+        # check for length mismatch
+        assert (len(logits) == len(true_counts))
+
+        # convert logits to softmax probabilities
+        probs = logits - logsumexp(logits)
+        probs = np.exp(probs)
+
+    elif probs is not None:
+
+        # check for length mistmatch
+        assert(len(probs) == len(true_counts))
+
+        # check if probs sums to 1
+        # why is this nans sometimes
+        assert( abs(1.0 - np.sum(probs)) < 1e-1)
+
+    else:
+
+        # both 'probs' and 'logits' are None
+         print(
+            "At least one of probs or logits must be provided. "
+            "Both are None.")
+
+    # compute the nmultinomial distribution
+    mnom = multinomial(np.sum(true_counts), probs)
+    return -(mnom.logpmf(true_counts) / len(true_counts))
+
+#https://github.com/kundajelab/basepairmodels/blob/cf8e346e9df1bad9e55bd459041976b41207e6e5/basepairmodels/cli/metrics.py#L129
+def get_min_max_normalized_value(val, minimum, maximum):
+    ret_val = (val - maximum) / (minimum - maximum)
+
+    if ret_val < 0:
+        return 0
+
+    if ret_val > 1:
+        return 1
+    return ret_val
+
+#https://github.com/kundajelab/basepairmodels/blob/cf8e346e9df1bad9e55bd459041976b41207e6e5/basepairmodels/cli/fastpredict.py#L59
+def mnll_min_max_bounds(profile):
+    """
+        Min Max bounds for the mnll metric
+
+        Args:
+            profile (numpy.ndarray): true profile
+        Returns:
+            tuple: (min, max) bounds values
+    """
+
+    # uniform distribution profile
+    uniform_profile = np.ones(len(profile)) * (1.0 / len(profile))
+
+    # profile as probabilities
+    profile = profile.astype(np.float64)
+
+    # profile as probabilities
+    profile_prob = profile / np.sum(profile)
+
+    # the scipy.stats.multinomial function is very sensitive to
+    # profile_prob summing to exactly 1.0, if not you get NaN as the
+    # resuls. In majority of the cases we can fix that problem by
+    # adding or substracting the difference (but unfortunately it
+    # doesnt always and there are cases where we still see NaNs, and
+    # those we'll set to 0)
+    profile_prob = _fix_sum_to_one(profile_prob)
+    #print(profile, profile_prob)
+
+    # mnll of profile with itself
+    min_mnll = mnll(profile, probs=profile_prob)
+
+    # if we still find a NaN, even after the above fix, set it to zero
+    if math.isnan(min_mnll):
+        min_mnll = 0.0
+
+    if math.isinf(min_mnll):
+        min_mnll = 0.0
+
+    # mnll of profile with uniform profile
+    max_mnll = mnll(profile, probs=uniform_profile)
+
+    return (min_mnll, max_mnll)
+
+#https://github.com/kundajelab/basepairmodels/blob/cf8e346e9df1bad9e55bd459041976b41207e6e5/basepairmodels/cli/fastpredict.py#L131
+def jsd_min_max_bounds(profile):
+    """
+        Min Max bounds for the jsd metric
+
+        Args:
+            profile (numpy.ndarray): true profile
+
+        Returns:
+            tuple: (min, max) bounds values
+    """
+
+    # uniform distribution profile
+    uniform_profile = np.ones(len(profile)) * (1.0 / len(profile))
+
+    # profile as probabilities
+    profile_prob = profile / np.sum(profile)
+
+    # jsd of profile with uniform profile
+    max_jsd = jensenshannon(profile_prob, uniform_profile)
+
+    # jsd of profile with itself (upper bound)
+    min_jsd = 0.0
+
+    return (min_jsd, max_jsd)

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/model_config.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/model_config.py
@@ -1,0 +1,136 @@
+# Author: Lei Xiong <jsxlei@gmail.com>
+from .parse_utils import add_argparse_args, from_argparse_args, parse_argparser, get_init_arguments_and_types
+from argparse import ArgumentParser, Namespace
+from typing import Any, List, Tuple, Union
+
+class BaseConfig:
+
+    model_type = "base"
+
+    @classmethod
+    def add_argparse_args(cls, parent_parser: ArgumentParser, **kwargs: Any):
+        """Extends existing argparse by default `LightningDataModule` attributes.
+
+        Example::
+
+            parser = ArgumentParser(add_help=False)
+            parser = LightningDataModule.add_argparse_args(parser)
+        """
+        return add_argparse_args(cls, parent_parser, **kwargs)
+
+
+    @classmethod
+    def from_argparse_args(
+        cls, args: Union[Namespace, ArgumentParser], **kwargs: Any
+    ) -> Union["pl.LightningDataModule", "pl.Trainer"]:
+        """Create an instance from CLI arguments.
+
+        Args:
+            args: The parser or namespace to take arguments from. Only known arguments will be
+                parsed and passed to the :class:`~pytorch_lightning.core.datamodule.LightningDataModule`.
+            **kwargs: Additional keyword arguments that may override ones in the parser or namespace.
+                These must be valid DataModule arguments.
+
+        Example::
+
+            module = LightningDataModule.from_argparse_args(args)
+        """
+        return from_argparse_args(cls, args, **kwargs)
+
+
+    @classmethod
+    def parse_argparser(cls, arg_parser: Union[ArgumentParser, Namespace]) -> Namespace:
+        return parse_argparser(cls, arg_parser)
+
+    @classmethod
+    def get_init_arguments_and_types(cls) -> List[Tuple[str, Tuple, Any]]:
+        r"""Scans the DataModule signature and returns argument names, types and default values.
+
+        Returns:
+            List with tuples of 3 values:
+            (argument name, set with argument types, argument default value).
+        """
+        return get_init_arguments_and_types(cls)
+
+
+
+class ChromBPNetConfig(BaseConfig):
+    r"""
+
+    ```"""
+
+    model_type = "chrombpnet"
+
+    def __init__(
+        self,
+
+        out_dim:int=1000,
+        n_filters:int=512,
+        n_layers:int=8,
+        conv1_kernel_size:int=21,
+        profile_kernel_size:int=75,
+        n_outputs:int=1,
+        n_control_tracks:int=0,
+        profile_output_bias:int=True,
+        count_output_bias:int=True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.out_dim = out_dim
+        self.n_filters = n_filters
+        self.n_layers = n_layers
+        self.conv1_kernel_size = conv1_kernel_size
+        self.profile_kernel_size = profile_kernel_size
+        self.n_outputs = n_outputs
+        self.n_control_tracks = n_control_tracks
+        self.profile_output_bias = profile_output_bias
+        self.count_output_bias = count_output_bias
+
+
+
+class ArsenalChromBPNetConfig(BaseConfig):
+    r"""
+
+    ```"""
+
+    model_type = "arsenal-chrombpnet"
+
+    def __init__(
+        self,
+        input_len:int=2114,
+        out_dim:int=1000,
+        n_filters:int=512,
+        n_layers:int=8,
+        conv1_kernel_size:int=21,
+        profile_kernel_size:int=75,
+        n_outputs:int=1,
+        n_control_tracks:int=0,
+        profile_output_bias:int=True,
+        count_output_bias:int=True,
+        finetune_arsenal: bool = False,
+        arsenal_output_type: str = "embedding",
+        input_embedding_dim: int = 512,
+        arsenal_input_size: int = 2114,
+        num_layers_avg: int = 4,
+        category : int = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.input_len = input_len
+        self.out_dim = out_dim
+        self.n_filters = n_filters
+        self.n_layers = n_layers
+        self.conv1_kernel_size = conv1_kernel_size
+        self.profile_kernel_size = profile_kernel_size
+        self.n_outputs = n_outputs
+        self.n_control_tracks = n_control_tracks
+        self.profile_output_bias = profile_output_bias
+        self.count_output_bias = count_output_bias
+        self.finetune_arsenal = finetune_arsenal
+        self.arsenal_output_type = arsenal_output_type
+        self.input_embedding_dim = input_embedding_dim
+        self.arsenal_input_size = arsenal_input_size
+        self.num_layers_avg = num_layers_avg
+        self.category = category

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/model_wrappers.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/model_wrappers.py
@@ -1,0 +1,812 @@
+# Author: Lei Xiong <jsxlei@gmail.com>
+
+"""
+Model-specific wrappers for different architectures.
+
+This module provides specialized wrappers for BPNet, ChromBPNet, and RegNet models,
+extending the base ModelWrapper class with model-specific functionality.
+"""
+
+from typing import Dict, Any, Optional, Union, List
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import lightning as L
+from lightning import LightningModule
+from lightning.pytorch.utilities.types import STEP_OUTPUT
+import numpy as np
+import argparse
+from torch.distributions.multinomial import Multinomial
+from .chrombpnet import BPNet, ChromBPNet, ArsenalChromBPNet, ArsenalChromBPNetNoBias
+from .model_config import ChromBPNetConfig, ArsenalChromBPNetConfig
+import os
+import sys
+arsenal_dir = os.environ.get("ARSENAL_MODEL_DIR", "")
+sys.path.append(f"{arsenal_dir}/src/regulatory_lm/")
+# [vendored] removed ARSENAL `from modeling.model import *` (replaced by HF adapter)
+
+
+# def multinomial_nll(logits, true_counts):
+# 	dist = Multinomial(logits=logits, validate_args=False)
+# 	log_probs = dist.log_prob(true_counts.long())
+# 	return -log_probs.mean()
+
+def multinomial_nll(logits, true_counts):
+	"""Compute the multinomial negative log-likelihood in PyTorch.
+
+	Args:
+	  true_counts: Tensor of observed counts (batch_size, num_classes) (integer counts)
+	  logits: Tensor of predicted logits (batch_size, num_classes)
+
+	Returns:
+	  Mean negative log-likelihood across the batch.
+	"""
+	# Ensure true_counts is an integer tensor
+	true_counts = true_counts.to(torch.float)  # Keep as float to prevent conversion issues
+
+	# Compute total counts per example (should already be integer-like)
+	counts_per_example = true_counts.sum(dim=-1, keepdim=True)
+
+	# Convert logits to log probabilities (Softmax + Log)
+	log_probs = F.log_softmax(logits, dim=-1)
+
+	# Compute log-probability of the observed counts
+	log_likelihood = (true_counts * log_probs).sum(dim=-1)
+
+	# Compute multinomial coefficient (log factorial term)
+	log_factorial_counts = torch.lgamma(counts_per_example + 1) - torch.lgamma(true_counts + 1).sum(dim=-1)
+
+	# Compute final NLL
+	nll = -(log_factorial_counts + log_likelihood).mean()
+
+	return nll
+
+
+def pearson_corr(x: torch.Tensor, y: torch.Tensor, dim: int = -1) -> torch.Tensor:
+	"""
+	Compute the Pearson correlation coefficient along a given dimension for multi-dimensional tensors.
+
+	Args:
+		x (torch.Tensor): Input tensor of shape (..., N).
+		y (torch.Tensor): Input tensor of shape (..., N).
+		dim (int): The dimension along which to compute the Pearson correlation. Default is -1 (last dimension).
+
+	Returns:
+		torch.Tensor: Pearson correlation coefficients along the specified dimension.
+	"""
+	# Ensure x and y have the same shape
+	assert x.shape == y.shape, "Input tensors must have the same shape"
+
+	# Step 1: Center the data (subtract the mean along the given dimension)
+	x_centered = x - torch.mean(x, dim=dim, keepdim=True)
+	y_centered = y - torch.mean(y, dim=dim, keepdim=True)
+
+	# Step 2: Compute covariance (sum of element-wise products of centered tensors)
+	cov = torch.sum(x_centered * y_centered, dim=dim)
+
+	# Step 3: Compute standard deviations for each tensor along the specified dimension
+	std_x = torch.sqrt(torch.sum(x_centered ** 2, dim=dim))
+	std_y = torch.sqrt(torch.sum(y_centered ** 2, dim=dim))
+
+	# Step 4: Compute Pearson correlation (with numerical stability)
+	eps = 1e-8  # Small constant to prevent division by zero
+	corr = cov / (std_x * std_y + eps)
+
+	return corr
+
+def _to_numpy(tensor: torch.Tensor) -> np.ndarray:
+	"""Convert tensor to numpy array.
+
+	Args:
+		tensor: Input tensor
+
+	Returns:
+		Numpy array
+	"""
+	return tensor.detach().cpu().numpy()
+
+
+def adjust_bias_model_logcounts(bias_model, dataloader, verbose=False, device=1):
+	"""
+	Given a bias model, sequences and associated counts, the function adds a
+	constant to the output of the bias_model's logcounts that minimises squared
+	error between predicted logcounts and observed logcounts (infered from
+	cts). This simply reduces to adding the average difference between observed
+	and predicted to the "bias" (constant additive term) of the Dense layer.
+	Typically the seqs and counts would correspond to training nonpeak regions.
+	ASSUMES model_bias's last layer is a dense layer that outputs logcounts.
+	This would change if you change the model.
+	"""
+
+	print("Predicting within adjust counts")
+	bias_model.eval()
+	with torch.no_grad():
+		output = L.Trainer(logger=False, devices=device).predict(bias_model, dataloader)
+		parsed_output = {key: np.concatenate([batch[key] for batch in output]) for key in output[0]}
+		try:
+			delta = parsed_output['true_count'].mean(-1) - parsed_output['pred_count'].mean(-1)
+		except:
+			import pdb; pdb.set_trace()
+			# delta = parsed_output['true_count'].mean(dim=-1) - parsed_output['pred_count'].mean(dim=-1)
+		# delta = torch.cat([predictions['delta'] for predictions in predictions], dim=0)
+
+		bias_model.linear.bias += torch.Tensor(delta).to(bias_model.linear.bias.device)
+
+	if verbose:
+		print('### delta', delta.mean(), flush=True)
+	return bias_model
+
+def init_bias(bias, dataloader=None, verbose=False, device=1):
+		print(f"Loading bias model from {bias}")
+		bias_model = BPNet.from_keras(bias, name='bias')
+		bias_model.eval()  # Freeze the sub-model
+		for param in bias_model.parameters():
+			param.requires_grad = False
+
+		if dataloader is not None:
+			bias_model = adjust_bias_model_logcounts(bias_model, dataloader, verbose=verbose, device=device)
+		return bias_model
+
+def load_bpnet_checkpoint(filename):
+	model = torch.load(filename, weights_only=False)
+	model["state_dict"] = {x: model["state_dict"][x] for x in model["state_dict"].keys() if "model.model" in x}
+	model["state_dict"] = {x[12:]:model["state_dict"][x] for x in model["state_dict"].keys()}
+	bpnet = BPNet(n_filters=512, n_layers=8)
+	bpnet.load_state_dict(model["state_dict"])
+	return bpnet
+
+def init_chrombpnet_wo_bias(chrombpnet_wo_bias, freeze=True):
+	print(f"Loading chrombpnet_wo_bias model from {chrombpnet_wo_bias}")
+	if chrombpnet_wo_bias.endswith('.h5'):
+		model = BPNet.from_keras(chrombpnet_wo_bias)
+	elif chrombpnet_wo_bias.endswith('.pt'):
+		model = BPNet(n_filters=512, n_layers=8)
+		model.load_state_dict(torch.load(chrombpnet_wo_bias, map_location='cpu'))
+	elif chrombpnet_wo_bias.endswith('.ckpt'):
+		# model = BPNet.load_from_checkpoint(chrombpnet_wo_bias)
+		model = load_bpnet_checkpoint(chrombpnet_wo_bias)
+
+	if freeze:
+		for param in model.parameters():
+			param.requires_grad = False
+
+	return model
+
+def init_arsenal_wo_bias(model_path, freeze=True):
+	print(f"Loading arsenal_wo_bias model from {model_path}")
+	model = ArsenalChromBPNetNoBiasWrapper.load_from_checkpoint(model_path)
+
+	if freeze:
+		for param in model.parameters():
+			param.requires_grad = False
+
+	return model
+
+
+class ControlWrapper(torch.nn.Module):
+	"""This wrapper automatically creates a control track of all zeroes.
+
+	This wrapper will check to see whether the model is expecting a control
+	track (e.g., most BPNet-style models) and will create one with the expected
+	shape. If no control track is expected then it will provide the normal
+	output from the model.
+	"""
+
+	def __init__(self, model):
+		super(ControlWrapper, self).__init__()
+		self.model = model
+
+	def forward(self, X, X_ctl=None):
+		if X_ctl != None:
+			return self.model(X, X_ctl)
+
+		if self.model.n_control_tracks == 0:
+			return self.model(X)
+
+		X_ctl = torch.zeros(X.shape[0], self.model.n_control_tracks,
+			X.shape[-1], dtype=X.dtype, device=X.device)
+		return self.model(X, X_ctl)
+
+
+
+class _ProfileLogitScaling(torch.nn.Module):
+	"""This ugly class is necessary because of Captum.
+
+	Captum internally registers classes as linear or non-linear. Because the
+	profile wrapper performs some non-linear operations, those operations must
+	be registered as such. However, the inputs to the wrapper are not the
+	logits that are being modified in a non-linear manner but rather the
+	original sequence that is subsequently run through the model. Hence, this
+	object will contain all of the operations performed on the logits and
+	can be registered.
+
+
+	Parameters
+	----------
+	logits: torch.Tensor, shape=(-1, -1)
+		The logits as they come out of a Chrom/BPNet model.
+	"""
+
+	def __init__(self):
+		super(_ProfileLogitScaling, self).__init__()
+		self.softmax = torch.nn.Softmax(dim=-1)
+
+	def forward(self, logits):
+		y_softmax = self.softmax(logits)
+		y = logits * y_softmax
+		return y
+		#print("a")
+		#y_lsm = torch.nn.functional.log_softmax(logits, dim=-1)
+		#return torch.sign(logits) * torch.exp(torch.log(abs(logits)) + y_lsm)
+
+
+class _Exp(torch.nn.Module):
+	def __init__(self):
+		super(_Exp, self).__init__()
+
+	def forward(self, X):
+		return torch.exp(X)
+
+
+class _Log(torch.nn.Module):
+	def __init__(self):
+		super(_Log, self).__init__()
+
+	def forward(self, X):
+		return torch.log(X)
+
+
+class ProfileWrapper(torch.nn.Module):
+	"""A wrapper class that returns transformed profiles.
+
+	This class takes in a trained model and returns the weighted softmaxed
+	outputs of the first dimension. Specifically, it takes the predicted
+	"logits" and takes the dot product between them and the softmaxed versi
+	ons
+	of those logits. This is for convenience when using captum to calculate
+	attribution scores.
+
+	Parameters
+	----------
+	model: torch.nn.Module
+		A torch model to be wrapped.
+	"""
+
+	def __init__(self, model):
+		super(ProfileWrapper, self).__init__()
+		self.model = model
+		self.flatten = torch.nn.Flatten()
+		self.scaling = _ProfileLogitScaling()
+
+	def forward(self, x, x_ctl=None, **kwargs):
+		logits = self.model(x, x_ctl=x_ctl, **kwargs)[0]
+		logits = self.flatten(logits)
+		logits = logits - torch.mean(logits, dim=-1, keepdims=True)
+		return self.scaling(logits).sum(dim=-1, keepdims=True)
+
+
+class CountWrapper(torch.nn.Module):
+	"""A wrapper class that only returns the predicted counts.
+
+	This class takes in a trained model and returns only the second output.
+	For BPNet models, this means that it is only returning the count
+	predictions. This is for convenience when using captum to calculate
+	attribution scores.
+
+	Parameters
+	----------
+	model: torch.nn.Module
+		A torch model to be wrapped.
+	"""
+
+	def __init__(self, model):
+			super(CountWrapper, self).__init__()
+			self.model = model
+
+	def forward(self, x, x_ctl=None, **kwargs):
+		return self.model(x, x_ctl=x_ctl, **kwargs)[1]
+
+
+class ModelWrapper(LightningModule):
+	"""A generic wrapper for different model architectures to be used with PyTorch Lightning.
+
+	This wrapper provides a flexible interface for training, validation, and testing different model architectures
+	while maintaining consistent logging and optimization strategies.
+
+	Attributes:
+		model (nn.Module): The underlying model architecture
+		learning_rate (float): Learning rate for optimization
+		weight_decay (float): Weight decay for optimization
+		warmup_steps (int): Number of warmup steps for learning rate scheduling
+		finetune (bool): Whether to use fine-tuning mode
+		alpha (float): Weight for count loss
+		beta (float): Weight for profile loss
+		metrics (Dict[str, List[float]]): Dictionary to store metrics during training
+	"""
+
+	def __init__(
+		self,
+		args,
+		**kwargs
+	):
+		"""Initialize the model wrapper.
+
+		Args:
+			model: The underlying model architecture
+			learning_rate: Learning rate for optimization
+			weight_decay: Weight decay for optimization
+			warmup_steps: Number of warmup steps for learning rate scheduling
+			finetune: Whether to use fine-tuning mode
+			alpha: Weight for count loss
+			beta: Weight for profile loss
+			**kwargs: Additional arguments to be passed to the model
+		"""
+
+
+		super().__init__()
+		self.alpha = args.alpha
+		self.beta = args.beta
+		self.verbose = args.verbose
+
+		self.metrics = {
+			'train': {'preds': [], 'targets': []},
+			'val': {'preds': [], 'targets': []},
+			'test': {'preds': [], 'targets': []},
+			'predict': {'preds': [], 'targets': []}
+		}
+
+		for k, v in kwargs.items():
+			setattr(self, k, v)
+
+		# Save hyperparameters
+		self.save_hyperparameters(ignore=['model'])
+
+	def forward(self, x: torch.Tensor, **kwargs) -> torch.Tensor:
+		"""Forward pass through the model.
+
+		Args:
+			x: Input tensor
+			**kwargs: Additional arguments to be passed to the model's forward method
+
+		Returns:
+			Model output
+		"""
+		return self.model(x, **kwargs)
+
+	def _step(self, batch, batch_idx, mode='train'):
+		raise NotImplementedError("Subclasses must implement this method")
+
+	def init_bias(self, bias, dataloader=None, verbose=False, device=1):
+		# print(f"Loading bias model from {bias}")
+		return init_bias(bias, dataloader=dataloader, verbose=verbose, device=device)
+
+	def init_chrombpnet_wo_bias(self, chrombpnet_wo_bias, freeze=True):
+		# print(f"Initializing chrombpnet_wo_bias model from {chrombpnet_wo_bias}")
+		return init_chrombpnet_wo_bias(chrombpnet_wo_bias, freeze=freeze)
+
+	def _predict_on_dataloader(self, dataloader, func, **kwargs):
+		outs = []
+		for batch in dataloader:
+			out = func(self, batch, **kwargs)
+			outs.append(out.detach().cpu())
+		return torch.cat(outs, dim=0)
+
+
+	def training_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> STEP_OUTPUT:
+		"""Training step.
+
+		Args:
+			batch: Dictionary containing batch data
+			batch_idx: Index of the current batch
+
+		Returns:
+			Loss value
+		"""
+		return self._step(batch, batch_idx, 'train')
+
+	def validation_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> STEP_OUTPUT:
+		"""Validation step.
+
+		Args:
+			batch: Dictionary containing batch data
+			batch_idx: Index of the current batch
+
+		Returns:
+			Loss value
+		"""
+		return self._step(batch, batch_idx, 'val')
+
+	def test_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> STEP_OUTPUT:
+		"""Test step.
+
+		Args:
+			batch: Dictionary containing batch data
+			batch_idx: Index of the current batch
+
+		Returns:
+			Loss value
+		"""
+		return self._step(batch, batch_idx, 'test')
+
+	def predict_step(self, batch: Dict[str, torch.Tensor], batch_idx: int) -> Dict[str, np.ndarray]:
+		"""Prediction step.
+
+		Args:
+			batch: Dictionary containing batch data
+			batch_idx: Index of the current batch
+
+		Returns:
+			Dictionary containing predictions and true values
+		"""
+		return self._step(batch, batch_idx, 'predict')
+
+	def _epoch_end(self, mode: str) -> None:
+		"""Handle end of epoch operations.
+
+		Args:
+			mode: Mode of operation ('train', 'val', or 'test')
+		"""
+		# Concatenate predictions and targets
+		all_preds = torch.cat(self.metrics[mode]['preds']).reshape(-1)
+		all_targets = torch.cat(self.metrics[mode]['targets']).reshape(-1)
+
+		# Calculate and log correlation
+		pr = self._pearson_corr(all_preds, all_targets)
+		self.log(f"{mode}_count_pearson", pr, prog_bar=True, logger=True, sync_dist=True)
+
+		# Reset metrics storage
+		self.metrics[mode]['preds'] = []
+		self.metrics[mode]['targets'] = []
+
+	def on_train_epoch_end(self) -> None:
+		"""Handle end of training epoch."""
+		self._epoch_end('train')
+
+	def on_validation_epoch_end(self) -> None:
+		"""Handle end of validation epoch."""
+		self._epoch_end('val')
+
+	def on_test_epoch_end(self) -> None:
+		"""Handle end of test epoch."""
+		self._epoch_end('test')
+
+	def configure_optimizers(self) -> Union[torch.optim.Optimizer, Dict[str, Any]]:
+		raise NotImplementedError("Subclasses must implement this method")
+
+	@staticmethod
+	def _to_numpy(tensor: torch.Tensor) -> np.ndarray:
+		"""Convert tensor to numpy array.
+
+		Args:
+			tensor: Input tensor
+
+		Returns:
+			Numpy array
+		"""
+		return tensor.detach().cpu().numpy()
+
+	@staticmethod
+	def _pearson_corr(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+		"""Calculate Pearson correlation coefficient.
+
+		Args:
+			x: First tensor
+			y: Second tensor
+
+		Returns:
+			Pearson correlation coefficient
+		"""
+		x_centered = x - x.mean(dim=-1, keepdim=True)
+		y_centered = y - y.mean(dim=-1, keepdim=True)
+		numerator = (x_centered * y_centered).sum(dim=-1)
+		denominator = torch.sqrt(
+			(x_centered ** 2).sum(dim=-1) * (y_centered ** 2).sum(dim=-1)
+		)
+		return numerator / denominator
+
+	@staticmethod
+	def _multinomial_nll(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+		"""Calculate multinomial negative log likelihood loss.
+
+		Args:
+			pred: Predicted probabilities
+			target: Target probabilities
+
+		Returns:
+			Loss value
+		"""
+		return -torch.sum(target * torch.log(pred + 1e-10), dim=-1).mean()
+
+
+
+
+class BPNetWrapper(ModelWrapper):
+	"""Wrapper for BPNet model with specific configurations and loss functions.
+
+	This wrapper extends the base ModelWrapper to handle BPNet-specific features
+	such as profile and count predictions, and appropriate loss calculations.
+	"""
+	def __init__(self, args):
+		super().__init__(args)
+		self.model = BPNet(
+				out_dim=args.out_dim,
+				n_filters=args.n_filters,
+				n_layers=args.n_layers,
+				conv1_kernel_size=args.conv1_kernel_size,
+				profile_kernel_size=args.profile_kernel_size,
+				n_outputs=args.n_outputs,
+				n_control_tracks=args.n_control_tracks,
+				profile_output_bias=args.profile_output_bias,
+				count_output_bias=args.count_output_bias,
+			)
+
+	def _step(self, batch, batch_idx, mode='train'):
+		x = batch['onehot_seq'] # batch_size x 4 x seq_length
+		true_profile = batch['profile'] # batch_size x seq_length
+		true_counts = torch.log1p(true_profile.sum(dim=-1))
+
+		y_profile, y_count = self(x)
+		y_count = y_count.squeeze(-1) # batch_size x 1
+
+		if mode == 'predict':
+			return {
+				'pred_count': _to_numpy(y_count),
+				'true_count': _to_numpy(true_counts),
+				'pred_profile': _to_numpy(y_profile), #.softmax(-1)),
+				'true_profile': _to_numpy(true_profile),
+			}
+
+		self.metrics[mode]['preds'].append(y_count)
+		self.metrics[mode]['targets'].append(true_counts)
+		with torch.no_grad():
+			# count_pearson = pearson_corr(y_count, true_counts).mean()
+			profile_pearson = pearson_corr(y_profile.softmax(-1), true_profile).mean()
+			self.log_dict({f"{mode}_profile_pearson": profile_pearson}, on_step=False, on_epoch=True, prog_bar=True, logger=True, sync_dist=True)
+
+		profile_loss = multinomial_nll(y_profile, true_profile)
+		count_loss = F.mse_loss(y_count, true_counts)
+		loss = self.beta * profile_loss + self.alpha * count_loss
+
+		dict_show = {
+			f'{mode}_loss': loss,
+			f'{mode}_profile_loss': profile_loss,
+			f'{mode}_count_loss': count_loss,
+		}
+
+		self.log_dict(dict_show, on_step=False, on_epoch=True, prog_bar=False, logger=True, sync_dist=True)
+
+		return loss
+
+	def configure_optimizers(self):
+		optimizer = torch.optim.Adam(self.model.parameters(), lr=0.001, eps=1e-7)
+		# scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, factor=0.4, patience=3, min_lr=1e-8)
+		# schedule_info = {"scheduler": scheduler, "monitor": "val_loss", "interval": "epoch", "frequency": 1}
+		# return {"optimizer": optimizer, "scheduler": schedule_info}
+		return optimizer
+
+
+	def predict(self, x, forward_only=True):
+		y_profile, y_count = self(x)
+		y_count = torch.exp(y_count)
+
+		if not forward_only:
+			y_profile_revcomp, y_count_revcomp = self(x[:, ::-1, ::-1])
+			y_count_revcomp = torch.exp(y_count_revcomp)
+			y_profile = (y_profile + y_profile_revcomp) / 2
+			y_count = (y_count + y_count_revcomp) / 2
+
+		return y_profile.cpu().numpy(), y_count.cpu().numpy()
+
+
+
+
+class ChromBPNetWrapper(BPNetWrapper):
+	"""Wrapper for ChromBPNet model with specific configurations and loss functions.
+
+	This wrapper extends the base ModelWrapper to handle ChromBPNet-specific features
+	such as chromatin accessibility predictions and appropriate loss calculations.
+	"""
+
+	def __init__(
+		self,
+		args,
+	):
+		"""Initialize ChromBPNet wrapper.
+
+		Args:
+			model: ChromBPNet model instance
+			alpha: Weight for count loss
+			beta: Weight for profile loss
+			bias_scaled: Path to bias model if using scaled bias
+			**kwargs: Additional arguments to be passed to the model
+		"""
+		super().__init__(args)
+
+		config = ChromBPNetConfig.from_argparse_args(args)
+		self.model = ChromBPNet(config)
+
+class ArsenalChromBPNetWrapper(BPNetWrapper):
+	"""Wrapper for ArsenalChromBPNet model with specific configurations and loss functions.
+
+	This wrapper extends the base ModelWrapper to handle ChromBPNet-specific features
+	such as chromatin accessibility predictions and appropriate loss calculations.
+	"""
+
+	def __init__(
+		self,
+		args,
+	):
+		"""Initialize ChromBPNet wrapper.
+
+		Args:
+			model: ChromBPNet model instance
+			alpha: Weight for count loss
+			beta: Weight for profile loss
+			bias_scaled: Path to bias model if using scaled bias
+			**kwargs: Additional arguments to be passed to the model
+		"""
+		super().__init__(args)
+
+		config = ArsenalChromBPNetConfig.from_argparse_args(args)
+		arsenal_model = torch.load(args.arsenal_model, weights_only=False)
+		self.model = ArsenalChromBPNet(config, arsenal_model)
+		self.arsenal_output_type = args.arsenal_output_type
+
+	def configure_optimizers(self):
+		if self.arsenal_output_type == "likelihood":
+			optimizer = torch.optim.Adam(self.model.parameters(), lr=0.001, eps=1e-7)
+		elif self.arsenal_output_type == "embedding":
+			optimizer = torch.optim.Adam(self.model.parameters(), lr=0.0001, eps=1e-7)
+		return optimizer
+
+
+	def _step(self, batch, batch_idx, mode='train'):
+		if (mode != "train") or (not self.model.finetune):
+			self.model.arsenal_model.eval()
+		x = batch['onehot_seq'] # batch_size x 4 x seq_length
+		true_profile = batch['profile'] # batch_size x seq_length
+		true_counts = torch.log1p(true_profile.sum(dim=-1))
+
+		y_profile, y_count = self(x)
+		y_count = y_count.squeeze(-1) # batch_size x 1
+
+		if mode == 'predict':
+			return {
+				'pred_count': _to_numpy(y_count),
+				'true_count': _to_numpy(true_counts),
+				'pred_profile': _to_numpy(y_profile), #.softmax(-1)),
+				'true_profile': _to_numpy(true_profile),
+			}
+
+		self.metrics[mode]['preds'].append(y_count)
+		self.metrics[mode]['targets'].append(true_counts)
+		with torch.no_grad():
+			# count_pearson = pearson_corr(y_count, true_counts).mean()
+			profile_pearson = pearson_corr(y_profile.softmax(-1), true_profile).mean()
+			self.log_dict({f"{mode}_profile_pearson": profile_pearson}, on_step=False, on_epoch=True, prog_bar=True, logger=True, sync_dist=True)
+
+		profile_loss = multinomial_nll(y_profile, true_profile)
+		count_loss = F.mse_loss(y_count, true_counts)
+		loss = self.beta * profile_loss + self.alpha * count_loss
+
+		dict_show = {
+			f'{mode}_loss': loss,
+			f'{mode}_profile_loss': profile_loss,
+			f'{mode}_count_loss': count_loss,
+		}
+
+		self.log_dict(dict_show, on_step=False, on_epoch=True, prog_bar=False, logger=True, sync_dist=True)
+
+		return loss
+
+class ArsenalChromBPNetNoBiasWrapper(ArsenalChromBPNetWrapper):
+	"""Wrapper for ArsenalChromBPNet model with specific configurations and loss functions.
+
+	This wrapper extends the base ModelWrapper to handle ChromBPNet-specific features
+	such as chromatin accessibility predictions and appropriate loss calculations.
+	"""
+
+	def __init__(
+		self,
+		args,
+	):
+
+		super().__init__(args)
+
+		config = ArsenalChromBPNetConfig.from_argparse_args(args)
+		arsenal_model = torch.load(args.arsenal_model, weights_only=False)
+		self.model = ArsenalChromBPNetNoBias(config, arsenal_model)
+
+
+def create_model_wrapper(
+	args,
+	**kwargs
+) -> ModelWrapper:
+	"""Factory function to create appropriate model wrapper.
+
+	Args:
+		model_type: Type of model ('bpnet', 'chrombpnet')
+		config: Model configuration
+		**kwargs: Additional arguments to be passed to the wrapper
+
+	Returns:
+		Appropriate model wrapper instance
+
+	Raises:
+		ValueError: If model_type is not recognized
+	"""
+	model_type = args.model_type.lower()
+	if model_type == 'bpnet':
+		return BPNetWrapper(args)
+	elif model_type == 'chrombpnet':
+		model_wrapper = ChromBPNetWrapper(args)
+		if args.bias_scaled:
+			model_wrapper.model.bias = model_wrapper.init_bias(args.bias_scaled)
+		if args.chrombpnet_wo_bias:
+			model_wrapper.model.model = model_wrapper.init_chrombpnet_wo_bias(args.chrombpnet_wo_bias, freeze=False)
+		return model_wrapper
+	elif model_type == 'arsenal-chrombpnet':
+		model_wrapper = ArsenalChromBPNetWrapper(args)
+		if args.bias_scaled:
+			model_wrapper.model.bias = model_wrapper.init_bias(args.bias_scaled)
+		if args.chrombpnet_wo_bias:
+			model_wrapper.model.model = model_wrapper.init_chrombpnet_wo_bias(args.chrombpnet_wo_bias, freeze=False)
+		return model_wrapper
+
+	else:
+		raise ValueError(f"Unknown model type: {model_type}")
+
+
+def load_pretrained_model(args, checkpoint):
+	import os
+	wrapper_class = ArsenalChromBPNetWrapper if args.model_type == "arsenal-chrombpnet" else ChromBPNetWrapper
+	if args.bias_scaled is None and os.path.exists(os.path.join(args.data_dir, 'bias_scaled.h5')):
+		args.bias_scaled = os.path.join(args.data_dir, 'bias_scaled.h5')
+	if checkpoint is not None:
+		if checkpoint.endswith('.ckpt'):
+			model_wrapper = wrapper_class.load_from_checkpoint(checkpoint, map_location='cpu')
+			if args.bias_scaled:
+				model_wrapper.model.bias = model_wrapper.init_bias(args.bias_scaled)
+			else:
+				print(f"No bias model found")
+			return model_wrapper
+
+		elif checkpoint.endswith('.pt'):
+			model_wrapper = wrapper_class(args)
+			model_wrapper.model.model.load_state_dict(torch.load(checkpoint, map_location='cpu'))
+			if args.bias_scaled:
+				model_wrapper.model.bias = model_wrapper.init_bias(args.bias_scaled)
+			else:
+				print(f"No bias model found")
+			return model_wrapper
+		elif checkpoint.endswith('.h5'):
+			model_wrapper = wrapper_class(args)
+			# For Keras H5 files, load using the from_keras method
+			print(f"Loading chrombpnet_wo_bias model from {checkpoint}")
+			model_wrapper.model.model = BPNet.from_keras(checkpoint)
+			if args.bias_scaled:
+				print(f"Loading bias model from {args.bias_scaled}")
+				model_wrapper.model.bias = model_wrapper.init_bias(args.bias_scaled)
+			else:
+				print(f"No bias model found")
+			return model_wrapper
+	else:
+		model_wrapper = wrapper_class(args)
+
+	return model_wrapper
+
+if __name__ == '__main__':
+
+	args = argparse.ArgumentParser()
+	args.add_argument('--model_type', type=str, default='chrombpnet')
+	args.add_argument('--alpha', type=float, default=1.0)
+	args = args.parse_args()
+
+	model_wrapper = create_model_wrapper(args.model_type, args)
+	x = torch.randn(1, 4, 2114)
+	batch = {
+		'onehot_seq': x,
+		'profile': torch.randn(1, 1000),
+	}
+	loss = model_wrapper._step(batch, 0, mode='train')
+	print(loss)

--- a/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/parse_utils.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/_vendor/chrombpnet/parse_utils.py
@@ -1,0 +1,410 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for Argument Parsing within Lightning Components."""
+
+import inspect
+import os
+from argparse import _ArgumentGroup, ArgumentParser, Namespace
+from ast import literal_eval
+from contextlib import suppress
+from functools import wraps
+from typing import Any, Callable, cast, Dict, List, Tuple, Type, TypeVar, Union
+
+# from pytorch_lightning.utilities.types import _ADD_ARGPARSE_RETURN
+
+_T = TypeVar("_T", bound=Callable[..., Any])
+#_ARGPARSE_CLS = Union[Type[]]
+
+from ast import literal_eval
+from contextlib import suppress
+
+
+def str_to_bool_or_str(val: str) -> Union[str, bool]:
+    """Possibly convert a string representation of truth to bool. Returns the input otherwise. Based on the python
+    implementation distutils.utils.strtobool.
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values are 'n', 'no', 'f', 'false', 'off', and '0'.
+    """
+    lower = val.lower()
+    if lower in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    if lower in ("n", "no", "f", "false", "off", "0"):
+        return False
+    return val
+
+
+
+def str_to_bool(val: str) -> bool:
+    """Convert a string representation of truth to bool.
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.
+
+    Raises:
+        ValueError:
+            If ``val`` isn't in one of the aforementioned true or false values.
+
+    >>> str_to_bool('YES')
+    True
+    >>> str_to_bool('FALSE')
+    False
+    """
+    val_converted = str_to_bool_or_str(val)
+    if isinstance(val_converted, bool):
+        return val_converted
+    raise ValueError(f"invalid truth value {val_converted}")
+
+
+
+def str_to_bool_or_int(val: str) -> Union[bool, int, str]:
+    """Convert a string representation to truth of bool if possible, or otherwise try to convert it to an int.
+
+    >>> str_to_bool_or_int("FALSE")
+    False
+    >>> str_to_bool_or_int("1")
+    True
+    >>> str_to_bool_or_int("2")
+    2
+    >>> str_to_bool_or_int("abc")
+    'abc'
+    """
+    val_converted = str_to_bool_or_str(val)
+    if isinstance(val_converted, bool):
+        return val_converted
+    try:
+        return int(val_converted)
+    except ValueError:
+        return val_converted
+
+
+def from_argparse_args(
+    cls,
+    args: Union[Namespace, ArgumentParser],
+    **kwargs: Any,
+) -> Union["pl.LightningDataModule", "pl.Trainer"]:
+    """Create an instance from CLI arguments. Eventually use variables from OS environment which are defined as
+    ``"PL_<CLASS-NAME>_<CLASS_ARUMENT_NAME>"``.
+
+    Args:
+        cls: Lightning class
+        args: The parser or namespace to take arguments from. Only known arguments will be
+            parsed and passed to the :class:`Trainer`.
+        **kwargs: Additional keyword arguments that may override ones in the parser or namespace.
+            These must be valid Trainer arguments.
+
+    Examples:
+
+        >>> from pytorch_lightning import Trainer
+        >>> parser = ArgumentParser(add_help=False)
+        >>> parser = Trainer.add_argparse_args(parser)
+        >>> parser.add_argument('--my_custom_arg', default='something')  # doctest: +SKIP
+        >>> args = Trainer.parse_argparser(parser.parse_args(""))
+        >>> trainer = Trainer.from_argparse_args(args, logger=False)
+    """
+    if isinstance(args, ArgumentParser):
+        args = cls.parse_argparser(args)
+
+    params = vars(args)
+
+    # we only want to pass in valid Trainer args, the rest may be user specific
+    valid_kwargs = inspect.signature(cls.__init__).parameters
+    trainer_kwargs = {name: params[name] for name in valid_kwargs if name in params}
+    trainer_kwargs.update(**kwargs)
+
+    return cls(**trainer_kwargs)
+
+
+
+
+def parse_argparser(cls, arg_parser: Union[ArgumentParser, Namespace]) -> Namespace:
+    """Parse CLI arguments, required for custom bool types."""
+    args = arg_parser.parse_args() if isinstance(arg_parser, ArgumentParser) else arg_parser
+
+    types_default = {arg: (arg_types, arg_default) for arg, arg_types, arg_default in get_init_arguments_and_types(cls)}
+
+    modified_args = {}
+    for k, v in vars(args).items():
+        if k in types_default and v is None:
+            # We need to figure out if the None is due to using nargs="?" or if it comes from the default value
+            arg_types, arg_default = types_default[k]
+            if bool in arg_types and isinstance(arg_default, bool):
+                # Value has been passed as a flag => It is currently None, so we need to set it to True
+                # We always set to True, regardless of the default value.
+                # Users must pass False directly, but when passing nothing True is assumed.
+                # i.e. the only way to disable something that defaults to True is to use the long form:
+                # "--a_default_true_arg False" becomes False, while "--a_default_false_arg" becomes None,
+                # which then becomes True here.
+
+                v = True
+
+        modified_args[k] = v
+    return Namespace(**modified_args)
+
+
+
+
+def parse_env_variables(cls, template: str = "PL_%(cls_name)s_%(cls_argument)s") -> Namespace:
+    """Parse environment arguments if they are defined.
+
+    Examples:
+
+        >>> from pytorch_lightning import Trainer
+        >>> parse_env_variables(Trainer)
+        Namespace()
+        >>> import os
+        >>> os.environ["PL_TRAINER_GPUS"] = '42'
+        >>> os.environ["PL_TRAINER_BLABLABLA"] = '1.23'
+        >>> parse_env_variables(Trainer)
+        Namespace(gpus=42)
+        >>> del os.environ["PL_TRAINER_GPUS"]
+    """
+    cls_arg_defaults = get_init_arguments_and_types(cls)
+
+    env_args = {}
+    for arg_name, _, _ in cls_arg_defaults:
+        env = template % {"cls_name": cls.__name__.upper(), "cls_argument": arg_name.upper()}
+        val = os.environ.get(env)
+        if not (val is None or val == ""):
+            # todo: specify the possible exception
+            with suppress(Exception):
+                # converting to native types like int/float/bool
+                val = literal_eval(val)
+            env_args[arg_name] = val
+    return Namespace(**env_args)
+
+
+
+
+def get_init_arguments_and_types(cls) -> List[Tuple[str, Tuple, Any]]:
+    r"""Scans the class signature and returns argument names, types and default values.
+
+    Returns:
+        List with tuples of 3 values:
+        (argument name, set with argument types, argument default value).
+
+    Examples:
+
+        >>> from pytorch_lightning import Trainer
+        >>> args = get_init_arguments_and_types(Trainer)
+
+    """
+    cls_default_params = inspect.signature(cls).parameters
+    name_type_default = []
+    for arg in cls_default_params:
+        arg_type = cls_default_params[arg].annotation
+        arg_default = cls_default_params[arg].default
+        try:
+            arg_types = tuple(arg_type.__args__)
+        except (AttributeError, TypeError):
+            arg_types = (arg_type,)
+
+        name_type_default.append((arg, arg_types, arg_default))
+
+    return name_type_default
+
+
+
+def _get_abbrev_qualified_cls_name(cls) -> str:
+    assert isinstance(cls, type), repr(cls)
+    if cls.__module__.startswith("pytorch_lightning."):
+        # Abbreviate.
+        return f"pl.{cls.__name__}"
+    # Fully qualified.
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+
+def add_argparse_args(
+    cls,
+    parent_parser: ArgumentParser,
+    *,
+    use_argument_group: bool = True,
+):
+    r"""Extends existing argparse by default attributes for ``cls``.
+
+    Args:
+        cls: Lightning class
+        parent_parser:
+            The custom cli arguments parser, which will be extended by
+            the class's default arguments.
+        use_argument_group:
+            By default, this is True, and uses ``add_argument_group`` to add
+            a new group.
+            If False, this will use old behavior.
+
+    Returns:
+        If use_argument_group is True, returns ``parent_parser`` to keep old
+        workflows. If False, will return the new ArgumentParser object.
+
+    Only arguments of the allowed types (str, float, int, bool) will
+    extend the ``parent_parser``.
+
+    Raises:
+        RuntimeError:
+            If ``parent_parser`` is not an ``ArgumentParser`` instance
+
+    Examples:
+
+        >>> # Option 1: Default usage.
+        >>> import argparse
+        >>> from pytorch_lightning import Trainer
+        >>> parser = argparse.ArgumentParser()
+        >>> parser = Trainer.add_argparse_args(parser)
+        >>> args = parser.parse_args([])
+
+        >>> # Option 2: Disable use_argument_group (old behavior).
+        >>> import argparse
+        >>> from pytorch_lightning import Trainer
+        >>> parser = argparse.ArgumentParser()
+        >>> parser = Trainer.add_argparse_args(parser, use_argument_group=False)
+        >>> args = parser.parse_args([])
+    """
+    if isinstance(parent_parser, _ArgumentGroup):
+        raise RuntimeError("Please only pass an `ArgumentParser` instance.")
+    if use_argument_group:
+        group_name = _get_abbrev_qualified_cls_name(cls)
+        parser: _ADD_ARGPARSE_RETURN = parent_parser.add_argument_group(group_name)
+    else:
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+
+    ignore_arg_names = ["self", "args", "kwargs"]
+
+    allowed_types = (str, int, float, bool)
+
+    # Get symbols from cls or init function.
+    for symbol in (cls, cls.__init__):
+        args_and_types = get_init_arguments_and_types(symbol)  # type: ignore[arg-type]
+        args_and_types = [x for x in args_and_types if x[0] not in ignore_arg_names]
+        if len(args_and_types) > 0:
+            break
+
+    args_help = _parse_args_from_docstring(cls.__init__.__doc__ or cls.__doc__ or "")
+
+    for arg, arg_types, arg_default in args_and_types:
+        arg_types = tuple(at for at in allowed_types if at in arg_types)
+        if not arg_types:
+            # skip argument with not supported type
+            continue
+        arg_kwargs: Dict[str, Any] = {}
+        if bool in arg_types:
+            arg_kwargs.update(nargs="?", const=True)
+            # if the only arg type is bool
+            if len(arg_types) == 1:
+                use_type: Callable[[str], Union[bool, int, float, str]] = str_to_bool
+            elif int in arg_types:
+                use_type = str_to_bool_or_int
+            elif str in arg_types:
+                use_type = str_to_bool_or_str
+            else:
+                # filter out the bool as we need to use more general
+                use_type = [at for at in arg_types if at is not bool][0]
+        else:
+            use_type = arg_types[0]
+
+        if arg == "gpus" or arg == "tpu_cores":
+            use_type = _gpus_allowed_type
+
+        # hack for types in (int, float)
+        if len(arg_types) == 2 and int in set(arg_types) and float in set(arg_types):
+            use_type = _int_or_float_type
+
+        # hack for track_grad_norm
+        if arg == "track_grad_norm":
+            use_type = float
+
+        # hack for precision
+        if arg == "precision":
+            use_type = _precision_allowed_type
+
+        parser.add_argument(
+            f"--{arg}",
+            dest=arg,
+            default=arg_default,
+            type=use_type,
+            help=args_help.get(arg),
+            required=(arg_default == inspect._empty),
+            **arg_kwargs,
+        )
+
+    if use_argument_group:
+        return parent_parser
+    return parser
+
+
+
+def _parse_args_from_docstring(docstring: str) -> Dict[str, str]:
+    arg_block_indent = None
+    current_arg = ""
+    parsed = {}
+    for line in docstring.split("\n"):
+        stripped = line.lstrip()
+        if not stripped:
+            continue
+        line_indent = len(line) - len(stripped)
+        if stripped.startswith(("Args:", "Arguments:", "Parameters:")):
+            arg_block_indent = line_indent + 4
+        elif arg_block_indent is None:
+            continue
+        elif line_indent < arg_block_indent:
+            break
+        elif line_indent == arg_block_indent:
+            current_arg, arg_description = stripped.split(":", maxsplit=1)
+            parsed[current_arg] = arg_description.lstrip()
+        elif line_indent > arg_block_indent:
+            parsed[current_arg] += f" {stripped}"
+    return parsed
+
+
+def _gpus_allowed_type(x: str) -> Union[int, str]:
+    if "," in x:
+        return str(x)
+    return int(x)
+
+
+def _int_or_float_type(x: Union[int, float, str]) -> Union[int, float]:
+    if "." in str(x):
+        return float(x)
+    return int(x)
+
+
+def _precision_allowed_type(x: Union[int, str]) -> Union[int, str]:
+    """
+    >>> _precision_allowed_type("32")
+    32
+    >>> _precision_allowed_type("bf16")
+    'bf16'
+    """
+    try:
+        return int(x)
+    except ValueError:
+        return x
+
+
+def _defaults_from_env_vars(fn: _T) -> _T:
+    @wraps(fn)
+    def insert_env_defaults(self: Any, *args: Any, **kwargs: Any) -> Any:
+        cls = self.__class__  # get the class
+        if args:  # in case any args passed move them to kwargs
+            # parse only the argument names
+            cls_arg_names = [arg[0] for arg in get_init_arguments_and_types(cls)]
+            # convert args to kwargs
+            kwargs.update(dict(zip(cls_arg_names, args)))
+        env_variables = vars(parse_env_variables(cls))
+        # update the kwargs by env variables
+        kwargs = dict(list(env_variables.items()) + list(kwargs.items()))
+
+        # all args were already moved to kwargs
+        return fn(self, **kwargs)
+
+    return cast(_T, insert_env_defaults)

--- a/src/marin_dna/pipelines/chrombpnet_eval/lit.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/lit.py
@@ -52,9 +52,13 @@ class ChromBPNetLit(L.LightningModule):
         beta: profile-loss weight (1.0).
         lr: Adam learning rate. Default ``1e-3`` matches official one-hot
             ChromBPNet (the embedding arm drops to ``1e-4``).
+        warmup_steps: linear LR warmup over this many optimizer steps (0 = off).
+            Ramps from ``0.01*lr`` to ``lr`` then holds constant — tames the
+            early large-gradient step that can diverge to NaN (#247). Takes
+            precedence over ``lr_scheduler``.
         lr_scheduler: ``None`` (constant LR, official one-hot default) or
             ``"plateau"`` (``ReduceLROnPlateau`` on ``val_count_pearson`` —
-            ChromBPNet's commented-out config, exposed here for tuning).
+            ChromBPNet's commented-out config). Ignored when ``warmup_steps>0``.
     """
 
     def __init__(
@@ -64,6 +68,7 @@ class ChromBPNetLit(L.LightningModule):
         alpha: float = 1.0,
         beta: float = 1.0,
         lr: float = 1e-3,
+        warmup_steps: int = 0,
         lr_scheduler: str | None = None,
     ) -> None:
         super().__init__()
@@ -74,6 +79,7 @@ class ChromBPNetLit(L.LightningModule):
         self.alpha = alpha
         self.beta = beta
         self.lr = lr
+        self.warmup_steps = warmup_steps
         self.lr_scheduler = lr_scheduler
         self._val_pred: list[torch.Tensor] = []
         self._val_true: list[torch.Tensor] = []
@@ -153,6 +159,17 @@ class ChromBPNetLit(L.LightningModule):
         opt = torch.optim.Adam(
             [p for p in self.parameters() if p.requires_grad], lr=self.lr, eps=1e-7
         )
+        # Warmup takes precedence: a step-wise linear ramp from 0.01*lr to lr over
+        # warmup_steps, then constant (LinearLR holds at end_factor) — keeps the
+        # first (huge-gradient) steps tiny so they can't diverge.
+        if self.warmup_steps > 0:
+            warmup = torch.optim.lr_scheduler.LinearLR(
+                opt, start_factor=0.01, end_factor=1.0, total_iters=self.warmup_steps
+            )
+            return {
+                "optimizer": opt,
+                "lr_scheduler": {"scheduler": warmup, "interval": "step"},
+            }
         if self.lr_scheduler == "plateau":
             sched = torch.optim.lr_scheduler.ReduceLROnPlateau(
                 opt, mode="max", factor=0.4, patience=3, min_lr=1e-8

--- a/src/marin_dna/pipelines/chrombpnet_eval/lit.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/lit.py
@@ -86,10 +86,10 @@ class ChromBPNetLit(L.LightningModule):
         true_counts = torch.log1p(true_profile.sum(dim=-1))
         y_profile, y_count = self(batch["onehot_seq"])
         y_count = y_count.squeeze(-1)
-        # Compute the loss in fp32. One-hot ChromBPNet trains in fp32 by default
-        # (data-loading-bound, so bf16 buys nothing), but the multinomial NLL and
-        # the count combine are bf16-unstable — disabling autocast here keeps a
-        # future ``--precision bf16-mixed`` experiment from NaN-ing on the loss.
+        # Compute the loss in fp32 even under a bf16 autocast: the multinomial
+        # NLL and the exp/log count-combine are bf16-unstable (→ NaN). Disabling
+        # autocast here keeps a ``--precision bf16-mixed`` run (this arm is
+        # GPU-compute-bound, so bf16 can speed it up) from NaN-ing on the loss.
         with torch.autocast(device_type=y_count.device.type, enabled=False):
             profile_loss = multinomial_nll(y_profile.float(), true_profile.float())
             count_loss = F.mse_loss(y_count.float(), true_counts.float())

--- a/src/marin_dna/pipelines/chrombpnet_eval/lit.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/lit.py
@@ -1,0 +1,168 @@
+"""Lightning training module for the one-hot ChromBPNet baseline (issue #241).
+
+Replicates the vendored ChromBPNet training step — a weighted sum of the
+base-resolution **profile** multinomial NLL and the **counts** MSE — as our own
+``LightningModule`` so we own the optimizer and the logger (W&B) and can add the
+instrumentation we want while validating the pipeline:
+
+- **counts Pearson + Spearman** on the validation set, computed once per
+  validation epoch over the pooled predictions (scipy, matching the vendored
+  ``counts_metrics``). ``val_count_pearson`` is the early-stopping / checkpoint
+  monitor (the ChromBPNet convention); ``val_count_spearman`` is logged
+  alongside it. Official ChromBPNet logs only Pearson in its train loop — the
+  Spearman is the extra signal we surface here.
+- the **gradient L2 norm** per optimizer step (a basic exploding/vanishing-grad
+  health signal), which official ChromBPNet does not log.
+
+The profile loss reuses the vendored ``multinomial_nll`` so the objective is
+bit-identical to ChromBPNet's. ``model`` only has to satisfy the ChromBPNet
+forward contract (``onehot[B,4,L] -> (profile[B,out], counts[B,1])``), so the
+gLM-embedding arm (#243) can reuse this module unchanged; its separate LR group
+for the LM is layered on there, not here.
+
+Batch contract (matches the vendored ``DataModule``): ``onehot_seq`` ``[B,4,L]``
+and ``profile`` ``[B,out]`` (observed per-bp counts over the central window).
+``alpha`` (counts weight) is set to ``median_count/10`` by the driver (the
+ChromBPNet scale-balancing heuristic); ``beta`` (profile weight) is 1.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import lightning as L
+import torch
+import torch.nn.functional as F
+from scipy.stats import pearsonr, spearmanr
+
+from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.model_wrappers import (
+    multinomial_nll,
+)
+
+
+class ChromBPNetLit(L.LightningModule):
+    """Train a ChromBPNet-style model with the counts+profile loss.
+
+    Args:
+        model: a module obeying the ChromBPNet forward contract — ``forward(
+            onehot[B,4,L]) -> (profile_logits[B,out], log_counts[B,1])``. For
+            #241 this is the vendored one-hot ``ChromBPNet`` (built by
+            :func:`marin_dna.pipelines.chrombpnet_eval.onehot.build_onehot_chrombpnet`).
+        alpha: counts-loss weight (the driver sets ``median_count/10``).
+        beta: profile-loss weight (1.0).
+        lr: Adam learning rate. Default ``1e-3`` matches official one-hot
+            ChromBPNet (the embedding arm drops to ``1e-4``).
+        lr_scheduler: ``None`` (constant LR, official one-hot default) or
+            ``"plateau"`` (``ReduceLROnPlateau`` on ``val_count_pearson`` —
+            ChromBPNet's commented-out config, exposed here for tuning).
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        *,
+        alpha: float = 1.0,
+        beta: float = 1.0,
+        lr: float = 1e-3,
+        lr_scheduler: str | None = None,
+    ) -> None:
+        super().__init__()
+        assert lr_scheduler in (None, "plateau"), (
+            f"lr_scheduler must be None or 'plateau', got {lr_scheduler!r}"
+        )
+        self.model = model
+        self.alpha = alpha
+        self.beta = beta
+        self.lr = lr
+        self.lr_scheduler = lr_scheduler
+        self._val_pred: list[torch.Tensor] = []
+        self._val_true: list[torch.Tensor] = []
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.model(x)
+
+    def _step(self, batch: dict, mode: str) -> torch.Tensor:
+        true_profile = batch["profile"]
+        true_counts = torch.log1p(true_profile.sum(dim=-1))
+        y_profile, y_count = self(batch["onehot_seq"])
+        y_count = y_count.squeeze(-1)
+        # Compute the loss in fp32. One-hot ChromBPNet trains in fp32 by default
+        # (data-loading-bound, so bf16 buys nothing), but the multinomial NLL and
+        # the count combine are bf16-unstable — disabling autocast here keeps a
+        # future ``--precision bf16-mixed`` experiment from NaN-ing on the loss.
+        with torch.autocast(device_type=y_count.device.type, enabled=False):
+            profile_loss = multinomial_nll(y_profile.float(), true_profile.float())
+            count_loss = F.mse_loss(y_count.float(), true_counts.float())
+            loss = self.beta * profile_loss + self.alpha * count_loss
+        self.log_dict(
+            {
+                f"{mode}_loss": loss,
+                f"{mode}_profile_loss": profile_loss,
+                f"{mode}_count_loss": count_loss,
+            },
+            on_step=(mode == "train"),  # live per-step train curve; val per-epoch
+            on_epoch=True,
+            prog_bar=(mode == "train"),
+            sync_dist=True,
+        )
+        if mode == "val":
+            self._val_pred.append(y_count.detach())
+            self._val_true.append(true_counts.detach())
+        return loss
+
+    def training_step(self, batch: dict, batch_idx: int) -> torch.Tensor:
+        return self._step(batch, "train")
+
+    def validation_step(self, batch: dict, batch_idx: int) -> torch.Tensor:
+        return self._step(batch, "val")
+
+    def on_validation_epoch_end(self) -> None:
+        if not self._val_pred:
+            return
+        # Pool over the whole val set, then correlate predicted vs observed log
+        # counts. Single-device exact; with >1 device `sync_dist` averages the
+        # per-rank scalars (we train on 1 GPU, so this is exact for our runs).
+        pred = torch.cat(self._val_pred).float().cpu().numpy().ravel()
+        true = torch.cat(self._val_true).float().cpu().numpy().ravel()
+        if pred.size > 1 and pred.std() > 0 and true.std() > 0:
+            pearson = float(pearsonr(pred, true).statistic)
+            spearman = float(spearmanr(pred, true).statistic)
+        else:
+            # Too few / constant predictions (e.g. an early smoke val pass) —
+            # correlation is undefined; log 0 so early-stopping has a number.
+            pearson = spearman = 0.0
+        self.log("val_count_pearson", pearson, prog_bar=True, sync_dist=True)
+        self.log("val_count_spearman", spearman, prog_bar=True, sync_dist=True)
+        self._val_pred.clear()
+        self._val_true.clear()
+
+    def on_before_optimizer_step(self, optimizer: torch.optim.Optimizer) -> None:
+        # Total L2 norm of the gradients (post-unscale, pre-clip) over trainable
+        # params — frozen-bias params have grad None and are skipped.
+        norms = [
+            p.grad.detach().norm(2) for p in self.parameters() if p.grad is not None
+        ]
+        total = (
+            torch.norm(torch.stack(norms), 2)
+            if norms
+            else torch.zeros((), device=self.device)
+        )
+        self.log("grad_norm", total, on_step=True, on_epoch=False, prog_bar=True)
+
+    def configure_optimizers(self) -> Any:
+        opt = torch.optim.Adam(
+            [p for p in self.parameters() if p.requires_grad], lr=self.lr, eps=1e-7
+        )
+        if self.lr_scheduler == "plateau":
+            sched = torch.optim.lr_scheduler.ReduceLROnPlateau(
+                opt, mode="max", factor=0.4, patience=3, min_lr=1e-8
+            )
+            return {
+                "optimizer": opt,
+                "lr_scheduler": {
+                    "scheduler": sched,
+                    "monitor": "val_count_pearson",
+                    "interval": "epoch",
+                },
+            }
+        return opt

--- a/src/marin_dna/pipelines/chrombpnet_eval/onehot.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/onehot.py
@@ -10,6 +10,8 @@ the supervised baseline (cf. the embedding arm, #243).
 
 from __future__ import annotations
 
+from typing import Any
+
 import torch
 
 from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.bpnet import BPNet
@@ -17,6 +19,32 @@ from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.chrombpnet import Ch
 from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.model_config import (
     ChromBPNetConfig,
 )
+
+
+class OneHotChromBPNet(ChromBPNet):
+    """One-hot ChromBPNet with a bf16-safe forward.
+
+    Identical to the vendored ``ChromBPNet`` in fp32, but the **count-combine**
+    (``log(exp(acc) + exp(bias))``) and the profile sum run in **fp32** even
+    under a bf16 autocast — that ``exp``/``log`` is bf16-unstable (→ NaN loss),
+    the same reason :class:`GLMChromBPNet` guards its forward. The dilated-CNN
+    towers still run under the outer autocast, so ``--precision bf16-mixed``
+    keeps the faster bf16 convs without NaN-ing the combine. In fp32 mode the
+    ``autocast(enabled=False)`` block is a no-op, so behaviour is byte-identical
+    to the vendored forward.
+    """
+
+    def forward(
+        self, x: torch.Tensor, **kwargs: Any
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        acc_profile, acc_counts = self.model(x)  # bf16 convs under outer autocast
+        bias_profile, bias_counts = self.bias(x)
+        with torch.autocast(device_type=x.device.type, enabled=False):
+            y_profile = acc_profile.float() + bias_profile.float()
+            y_counts = self._log(
+                self._exp1(acc_counts.float()) + self._exp2(bias_counts.float())
+            )
+        return y_profile.squeeze(1), y_counts
 
 
 def load_frozen_bias(model: ChromBPNet, bias_h5: str) -> None:
@@ -42,8 +70,8 @@ def build_onehot_chrombpnet(
     n_layers: int = 8,
     conv1_kernel_size: int = 21,
     profile_kernel_size: int = 75,
-) -> ChromBPNet:
-    """Construct a one-hot ChromBPNet.
+) -> OneHotChromBPNet:
+    """Construct a one-hot ChromBPNet (bf16-safe forward, see OneHotChromBPNet).
 
     Args:
         bias_h5: path to ARSENAL's ``bias_model_scaled.h5``. When given, the
@@ -68,7 +96,7 @@ def build_onehot_chrombpnet(
         n_outputs=1,
         n_control_tracks=0,
     )
-    model = ChromBPNet(config)
+    model = OneHotChromBPNet(config)
     if bias_h5 is not None:
         load_frozen_bias(model, bias_h5)
     return model

--- a/src/marin_dna/pipelines/chrombpnet_eval/onehot.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/onehot.py
@@ -1,0 +1,80 @@
+"""Build the one-hot ChromBPNet baseline (issue #241).
+
+A thin, testable constructor around the vendored ChromBPNet: an accessibility
+``BPNet`` (dilated CNN over 4-channel one-hot, official 512-filter / 8-layer
+config) plus a **frozen, pretrained** Tn5/DNase bias ``BPNet`` loaded from
+ARSENAL's ``bias_model_scaled.h5``. This is the faithful one-hot ChromBPNet —
+no gLM, no architectural change — used to validate the training pipeline and as
+the supervised baseline (cf. the embedding arm, #243).
+"""
+
+from __future__ import annotations
+
+import torch
+
+from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.bpnet import BPNet
+from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.chrombpnet import ChromBPNet
+from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.model_config import (
+    ChromBPNetConfig,
+)
+
+
+def load_frozen_bias(model: ChromBPNet, bias_h5: str) -> None:
+    """Replace ``model.bias`` with the pretrained bias from a Keras ``.h5`` and
+    freeze it.
+
+    ``ChromBPNet.__init__`` builds a *fresh, untrained* bias ``BPNet``; real
+    training needs the GC-matched bias model trained on non-peak regions, held
+    frozen so the accessibility tower learns motifs rather than enzyme bias.
+    ``BPNet.from_keras`` reconstructs the bias architecture from the stored
+    weights (h5py-only; no TensorFlow).
+    """
+    model.bias = BPNet.from_keras(bias_h5, name="bias")
+    for p in model.bias.parameters():
+        p.requires_grad = False
+
+
+def build_onehot_chrombpnet(
+    *,
+    bias_h5: str | None = None,
+    out_dim: int = 1000,
+    n_filters: int = 512,
+    n_layers: int = 8,
+    conv1_kernel_size: int = 21,
+    profile_kernel_size: int = 75,
+) -> ChromBPNet:
+    """Construct a one-hot ChromBPNet.
+
+    Args:
+        bias_h5: path to ARSENAL's ``bias_model_scaled.h5``. When given, the
+            pretrained bias is loaded and frozen (see :func:`load_frozen_bias`).
+            ``None`` keeps ChromBPNet's fresh untrained bias — only for code-path
+            smoke tests on synthetic data, **never** a real training run.
+        out_dim: profile output width (central window, 1000 bp).
+        n_filters / n_layers / conv1_kernel_size / profile_kernel_size: the
+            accessibility-tower architecture. Defaults are official one-hot
+            ChromBPNet (512 filters, 8 dilated layers); shrink for fast tests.
+
+    Returns:
+        A ``ChromBPNet`` whose ``forward(onehot[B,4,2114])`` returns
+        ``(profile_logits[B,out_dim], log_counts[B,1])``.
+    """
+    config = ChromBPNetConfig(
+        out_dim=out_dim,
+        n_filters=n_filters,
+        n_layers=n_layers,
+        conv1_kernel_size=conv1_kernel_size,
+        profile_kernel_size=profile_kernel_size,
+        n_outputs=1,
+        n_control_tracks=0,
+    )
+    model = ChromBPNet(config)
+    if bias_h5 is not None:
+        load_frozen_bias(model, bias_h5)
+    return model
+
+
+def count_trainable_params(model: torch.nn.Module) -> int:
+    """Number of trainable (``requires_grad``) parameters — used by the driver
+    to print model size and to assert the bias is frozen."""
+    return sum(p.numel() for p in model.parameters() if p.requires_grad)

--- a/src/marin_dna/pipelines/chrombpnet_eval/qtl_eval.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/qtl_eval.py
@@ -170,12 +170,16 @@ def score_log2fc(
 
 
 def signed_correlations(scores: np.ndarray, effect: np.ndarray) -> tuple[float, float]:
-    """Signed (Pearson, Spearman) of ``scores`` vs ``effect``; ``(0, 0)`` if
-    either is constant or there are <2 points (an early smoke pass)."""
+    """Signed (Pearson, Spearman) of ``scores`` vs ``effect``; ``(0.0, 0.0)`` if
+    degenerate — either input constant, fewer than 2 points (an early smoke
+    pass), or a **non-finite** result (e.g. a diverged model emitting
+    overflowing scores, so ``pearsonr`` returns NaN). The metric never emits NaN.
+    """
     if len(scores) > 1 and np.std(scores) > 0 and np.std(effect) > 0:
-        return float(pearsonr(scores, effect).statistic), float(
-            spearmanr(scores, effect).statistic
-        )
+        pearson = float(pearsonr(scores, effect).statistic)
+        spearman = float(spearmanr(scores, effect).statistic)
+        if np.isfinite(pearson) and np.isfinite(spearman):
+            return pearson, spearman
     return 0.0, 0.0
 
 

--- a/src/marin_dna/pipelines/chrombpnet_eval/qtl_eval.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/qtl_eval.py
@@ -1,0 +1,235 @@
+"""Online caQTL/dsQTL variant-effect metric for ChromBPNet training (#241).
+
+A **light, continuous** live-validation signal: score each QTL **positive**
+variant by the model's predicted ``log2`` fold-change of accessibility counts
+(alt vs ref 2114 bp windows) and correlate — signed **Pearson + Spearman** —
+against the observed study ``effect``. Positives-only and correlation-only by
+design, so it runs every validation cheaply (caqtl ~3,173 + dsqtl ~309
+positives). The binary AUROC/AUPRC need the full negative set (~10–50× larger)
+and belong to the heavier final/test eval, not this callback.
+
+This tracks the **eval target** (does the model rank QTL effects?), which is
+distinct from ``val_count_pearson`` — that's the accessibility-count fit on the
+held-out chromosome split, a training-health proxy, not a QTL metric.
+
+The score is oriented to ``alt`` (``pred(alt) - pred(ref)``) and the parquet
+``effect`` is signed to ``alt``, so the signed correlation is meaningful — the
+same convention as the M1a supervised metric.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import cast
+
+import lightning as L
+import numpy as np
+import torch
+from scipy.stats import pearsonr, spearmanr
+
+from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.data_utils import (
+    dna_to_one_hot,
+)
+
+_NUC = frozenset("ACGT")
+
+# caqtl/dsqtl variant parquets (HF), pinned to the same revisions M1a uses.
+QTL_DATASETS: list[tuple[str, str, str]] = [
+    ("caqtl", "bolinas-dna/evals_caqtl", "9d004a21812c067b9ba1ebfe72f51b9095a5d0f8"),
+    ("dsqtl", "bolinas-dna/evals_dsqtl", "b7e02a07beb831c7047286aacd3ddfd299d6f88f"),
+]
+
+
+@dataclass
+class QTLSpec:
+    """Pre-extracted positives for one QTL dataset (ready for repeated scoring).
+
+    ``ref_oh`` / ``alt_oh`` are ``[N, 4, window]`` float32 one-hots; ``effect``
+    is the ``[N]`` signed study effect oriented to ``alt`` (positives only).
+    """
+
+    name: str
+    ref_oh: np.ndarray
+    alt_oh: np.ndarray
+    effect: np.ndarray
+
+
+def extract_ref_alt_onehot(
+    chroms: Sequence[str],
+    positions: Sequence[int],
+    refs: Sequence[str],
+    alts: Sequence[str],
+    genome: Callable[[str, int, int, str], str],
+    *,
+    window: int = 2114,
+    chrom_prefix: str = "",
+    min_ref_match: float = 0.99,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Extract ref/alt one-hot windows centered on each (SNP) variant.
+
+    Args:
+        chroms / positions / refs / alts: parallel arrays; ``positions`` are
+            **1-based** (parquet convention), ``refs``/``alts`` single ACGT bases.
+        genome: callable ``(chrom, start, end, strand) -> seq`` over 0-based
+            half-open coords (the ``marin_dna.data.genome.Genome`` interface).
+        window: window length (2114 for ChromBPNet); the variant sits at the
+            center index ``window // 2``.
+        chrom_prefix: prepended to ``chrom`` before the genome lookup — pass
+            ``"chr"`` to read a chr-prefixed fasta with our non-prefixed
+            ("1".."22") variant chroms.
+        min_ref_match: assert at least this fraction of variants have the genome
+            base at the center equal to ``ref`` — a loud guard against a
+            reference-build / chrom-prefix mismatch (the parquets were built with
+            ``ref`` oriented to the genome, so a match near 1.0 is expected).
+
+    Returns:
+        ``(ref_oh, alt_oh)`` each ``[N, 4, window]`` float32 (channels A,C,G,T).
+    """
+    half = window // 2
+    ref_seqs: list[str] = []
+    alt_seqs: list[str] = []
+    mismatches: list[tuple[str, int, str, str]] = []
+    for chrom, pos, ref, alt in zip(chroms, positions, refs, alts, strict=True):
+        ref, alt = ref.upper(), alt.upper()
+        assert ref in _NUC and alt in _NUC, (
+            f"SNP-only expected; got ref={ref!r} alt={alt!r} at {chrom}:{pos}"
+        )
+        center0 = int(pos) - 1  # 1-based parquet pos -> 0-based genome coord
+        start = center0 - half
+        seq = genome(f"{chrom_prefix}{chrom}", start, start + window, "+").upper()
+        assert len(seq) == window, f"{chrom}:{pos} got {len(seq)} bp, want {window}"
+        if seq[half] != ref:
+            mismatches.append((chrom, int(pos), seq[half], ref))
+        ref_seqs.append(seq)
+        alt_seqs.append(seq[:half] + alt + seq[half + 1 :])
+
+    n = len(ref_seqs)
+    assert n > 0, "no variants to extract"
+    match = 1.0 - len(mismatches) / n
+    assert match >= min_ref_match, (
+        f"genome base == ref for only {match:.3f} of {n} variants (< "
+        f"{min_ref_match}); suspect a reference-build / chrom-prefix mismatch "
+        f"(chrom_prefix={chrom_prefix!r}). e.g. {mismatches[:3]}"
+    )
+    ref_oh = dna_to_one_hot(ref_seqs).astype(np.float32).transpose(0, 2, 1)
+    alt_oh = dna_to_one_hot(alt_seqs).astype(np.float32).transpose(0, 2, 1)
+    return np.ascontiguousarray(ref_oh), np.ascontiguousarray(alt_oh)
+
+
+@torch.no_grad()
+def score_log2fc(
+    model: torch.nn.Module,
+    ref_oh: np.ndarray,
+    alt_oh: np.ndarray,
+    *,
+    batch_size: int = 256,
+    device: torch.device | str | None = None,
+) -> np.ndarray:
+    """Predicted ``log2(counts(alt) / counts(ref))`` per variant.
+
+    The model's count head outputs (natural-)log counts, so the alt−ref
+    difference divided by ``ln 2`` is the log2 fold-change (and the constant is
+    irrelevant to the rank/Pearson correlation anyway). Runs in eval mode and
+    restores the prior train/eval state.
+    """
+    assert len(ref_oh) == len(alt_oh)
+    if device is None:
+        device = next(model.parameters()).device
+    was_training = model.training
+    model.eval()
+    out: list[np.ndarray] = []
+    for i in range(0, len(ref_oh), batch_size):
+        r = torch.from_numpy(ref_oh[i : i + batch_size]).to(device)
+        a = torch.from_numpy(alt_oh[i : i + batch_size]).to(device)
+        _, ref_counts = model(r)
+        _, alt_counts = model(a)
+        fc = (alt_counts.squeeze(-1) - ref_counts.squeeze(-1)) / math.log(2)
+        out.append(fc.float().cpu().numpy())
+    if was_training:
+        model.train()
+    return np.concatenate(out)
+
+
+def signed_correlations(scores: np.ndarray, effect: np.ndarray) -> tuple[float, float]:
+    """Signed (Pearson, Spearman) of ``scores`` vs ``effect``; ``(0, 0)`` if
+    either is constant or there are <2 points (an early smoke pass)."""
+    if len(scores) > 1 and np.std(scores) > 0 and np.std(effect) > 0:
+        return float(pearsonr(scores, effect).statistic), float(
+            spearmanr(scores, effect).statistic
+        )
+    return 0.0, 0.0
+
+
+class QTLEvalCallback(L.Callback):
+    """Log signed Pearson/Spearman of predicted log2FC vs observed ``effect``
+    over the QTL positives, once per validation.
+
+    Single-device exact (we train on 1 GPU); each rank would recompute the same
+    rank-local scalar, so it's logged with ``sync_dist=False``.
+    """
+
+    def __init__(self, specs: Sequence[QTLSpec], *, batch_size: int = 256) -> None:
+        super().__init__()
+        self.specs = list(specs)
+        self.batch_size = batch_size
+
+    def on_validation_epoch_end(
+        self, trainer: L.Trainer, pl_module: L.LightningModule
+    ) -> None:
+        for spec in self.specs:
+            scores = score_log2fc(
+                cast(torch.nn.Module, pl_module.model),
+                spec.ref_oh,
+                spec.alt_oh,
+                batch_size=self.batch_size,
+                device=pl_module.device,
+            )
+            pearson, spearman = signed_correlations(scores, spec.effect)
+            pl_module.log(
+                f"qtl_{spec.name}_pearson", pearson, prog_bar=True, sync_dist=False
+            )
+            pl_module.log(f"qtl_{spec.name}_spearman", spearman, sync_dist=False)
+
+
+def build_qtl_specs(
+    genome: Callable[[str, int, int, str], str],
+    datasets: Sequence[tuple[str, str, str]] = tuple(QTL_DATASETS),
+    *,
+    split: str = "train",
+    window: int = 2114,
+    chrom_prefix: str = "",
+) -> list[QTLSpec]:
+    """Load the QTL **positive** variants (one split) and pre-extract their
+    ref/alt one-hot windows — done once before training; the callback then just
+    re-scores the cached arrays each validation.
+
+    ``datasets`` is ``[(name, hf_repo, revision), ...]`` (defaults to
+    :data:`QTL_DATASETS`). Develop on ``split="train"`` (test held out).
+    """
+    import polars as pl
+    from huggingface_hub import hf_hub_download
+
+    specs: list[QTLSpec] = []
+    for name, repo, rev in datasets:
+        path = hf_hub_download(
+            repo, f"{split}.parquet", revision=rev, repo_type="dataset"
+        )
+        df = pl.read_parquet(path).filter(
+            pl.col("label") & pl.col("effect").is_not_null()
+        )
+        assert df.height > 0, f"{name}: no positive variants with an effect in {split}"
+        ref_oh, alt_oh = extract_ref_alt_onehot(
+            df["chrom"].to_list(),
+            df["pos"].to_list(),
+            df["ref"].to_list(),
+            df["alt"].to_list(),
+            genome,
+            window=window,
+            chrom_prefix=chrom_prefix,
+        )
+        effect = df["effect"].to_numpy().astype(np.float64)
+        print(f"[qtl] {name}: {df.height} positives ({split} split)")
+        specs.append(QTLSpec(name=name, ref_oh=ref_oh, alt_oh=alt_oh, effect=effect))
+    return specs

--- a/src/marin_dna/pipelines/chrombpnet_eval/qtl_eval.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/qtl_eval.py
@@ -36,9 +36,24 @@ from marin_dna.pipelines.chrombpnet_eval._vendor.chrombpnet.data_utils import (
 _NUC = frozenset("ACGT")
 
 # caqtl/dsqtl variant parquets (HF), pinned to the same revisions M1a uses.
-QTL_DATASETS: list[tuple[str, str, str]] = [
-    ("caqtl", "bolinas-dna/evals_caqtl", "9d004a21812c067b9ba1ebfe72f51b9095a5d0f8"),
-    ("dsqtl", "bolinas-dna/evals_dsqtl", "b7e02a07beb831c7047286aacd3ddfd299d6f88f"),
+# (name, hf_repo, revision, flip_effect). dsQTL's study effect (``obs.estimate``,
+# our parquet ``effect``) is sign-flipped vs alt-oriented accessibility log2FC —
+# the same convention M1a handles with ``flip_logfc=True`` (ARSENAL's notebook
+# correlates ``-obs.estimate`` against ChromBPNet's logfc). Flip the effect so a
+# model that agrees with the study reads as a POSITIVE correlation. caQTL: no flip.
+QTL_DATASETS: list[tuple[str, str, str, bool]] = [
+    (
+        "caqtl",
+        "bolinas-dna/evals_caqtl",
+        "9d004a21812c067b9ba1ebfe72f51b9095a5d0f8",
+        False,
+    ),
+    (
+        "dsqtl",
+        "bolinas-dna/evals_dsqtl",
+        "b7e02a07beb831c7047286aacd3ddfd299d6f88f",
+        True,
+    ),
 ]
 
 
@@ -195,7 +210,7 @@ class QTLEvalCallback(L.Callback):
 
 def build_qtl_specs(
     genome: Callable[[str, int, int, str], str],
-    datasets: Sequence[tuple[str, str, str]] = tuple(QTL_DATASETS),
+    datasets: Sequence[tuple[str, str, str, bool]] = tuple(QTL_DATASETS),
     *,
     split: str = "train",
     window: int = 2114,
@@ -212,7 +227,7 @@ def build_qtl_specs(
     from huggingface_hub import hf_hub_download
 
     specs: list[QTLSpec] = []
-    for name, repo, rev in datasets:
+    for name, repo, rev, flip_effect in datasets:
         path = hf_hub_download(
             repo, f"{split}.parquet", revision=rev, repo_type="dataset"
         )
@@ -230,6 +245,11 @@ def build_qtl_specs(
             chrom_prefix=chrom_prefix,
         )
         effect = df["effect"].to_numpy().astype(np.float64)
-        print(f"[qtl] {name}: {df.height} positives ({split} split)")
+        if flip_effect:
+            effect = -effect  # align dsQTL obs.estimate to alt-oriented log2FC
+        print(
+            f"[qtl] {name}: {df.height} positives ({split} split)"
+            + (" [effect sign-flipped]" if flip_effect else "")
+        )
         specs.append(QTLSpec(name=name, ref_oh=ref_oh, alt_oh=alt_oh, effect=effect))
     return specs

--- a/src/marin_dna/pipelines/chrombpnet_eval/qtl_eval.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/qtl_eval.py
@@ -150,6 +150,8 @@ def score_log2fc(
     restores the prior train/eval state.
     """
     assert len(ref_oh) == len(alt_oh)
+    if len(ref_oh) == 0:
+        return np.zeros(0, dtype=np.float32)
     if device is None:
         device = next(model.parameters()).device
     was_training = model.training
@@ -220,7 +222,7 @@ def build_qtl_specs(
     ref/alt one-hot windows — done once before training; the callback then just
     re-scores the cached arrays each validation.
 
-    ``datasets`` is ``[(name, hf_repo, revision), ...]`` (defaults to
+    ``datasets`` is ``[(name, hf_repo, revision, flip_effect), ...]`` (defaults to
     :data:`QTL_DATASETS`). Develop on ``split="train"`` (test held out).
     """
     import polars as pl

--- a/src/marin_dna/pipelines/chrombpnet_eval/scores.py
+++ b/src/marin_dna/pipelines/chrombpnet_eval/scores.py
@@ -46,8 +46,10 @@ def load_arsenal_scores(path: str, *, flip_logfc: bool = False) -> pl.DataFrame:
             ``pred.chrombpnet.encsr000emt.varscore.logfc`` despite identical
             allele order. Our ``effect`` follows the DART-Eval convention
             (``obs.estimate`` as-is), so we negate ARSENAL's released dsQTL
-            ``logfc`` here to put both on the same axis. (Not needed for caQTL,
-            nor for M2 where we score with our own model and control the sign.)
+            ``logfc`` here to put both on the same axis. (Not needed for caQTL.
+            The supervised scorer hits the *same* dsQTL flip — its predicted
+            alt-log2FC anti-correlates with this ``effect`` — so it applies the
+            equivalent per-dataset flip; see ``qtl_eval.QTL_DATASETS``.)
     """
     df = pl.read_csv(path, separator="\t")
     missing = [c for c in ARSENAL_SCORE_COLUMNS if c not in df.columns]

--- a/tests/pipelines/chrombpnet_eval/test_lit.py
+++ b/tests/pipelines/chrombpnet_eval/test_lit.py
@@ -1,0 +1,65 @@
+"""Smoke test: the one-hot ChromBPNet training loop runs end-to-end and logs the
+instrumentation we added (val_count_pearson + val_count_spearman, grad_norm).
+
+Synthetic data, CPU, no GPU — validates forward -> counts/profile loss ->
+backward -> optimizer step, plus the validation-epoch correlation hook and the
+gradient-norm hook, without real GM12878 data.
+"""
+
+import lightning as L
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from marin_dna.pipelines.chrombpnet_eval.lit import ChromBPNetLit
+from marin_dna.pipelines.chrombpnet_eval.onehot import build_onehot_chrombpnet
+
+
+class _ToyDS(Dataset):
+    def __init__(self, n: int = 8):
+        self.n = n
+
+    def __len__(self) -> int:
+        return self.n
+
+    def __getitem__(self, i: int) -> dict:
+        oh = torch.zeros(4, 2114)
+        oh[torch.randint(0, 4, (2114,)), torch.arange(2114)] = 1.0
+        profile = torch.randint(0, 5, (1000,)).float()
+        return {"onehot_seq": oh, "profile": profile}
+
+
+def _fit(lr_scheduler=None):
+    model = build_onehot_chrombpnet(bias_h5=None, n_filters=8, n_layers=2)
+    lit = ChromBPNetLit(model, alpha=1.0, beta=1.0, lr=1e-3, lr_scheduler=lr_scheduler)
+    dl = DataLoader(_ToyDS(8), batch_size=4)
+    trainer = L.Trainer(
+        max_epochs=1,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        accelerator="cpu",
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        num_sanity_val_steps=0,
+    )
+    trainer.fit(lit, dl, dl)
+    return trainer
+
+
+def test_train_loop_and_instrumentation():
+    trainer = _fit()
+    metrics = {**trainer.callback_metrics, **trainer.logged_metrics}
+    # The validation-epoch correlation hook logged both counts metrics ...
+    for key in ("val_count_pearson", "val_count_spearman"):
+        assert key in metrics, f"{key} not logged; got {sorted(metrics)}"
+        assert torch.isfinite(torch.as_tensor(float(metrics[key]))), key
+    # ... and the per-step gradient-norm hook fired (a positive, finite norm).
+    assert "grad_norm" in metrics, sorted(metrics)
+    gn = float(metrics["grad_norm"])
+    assert gn > 0 and torch.isfinite(torch.as_tensor(gn)), gn
+
+
+def test_plateau_scheduler_configures():
+    # The opt-in ReduceLROnPlateau path builds a valid optimizer+scheduler dict.
+    trainer = _fit(lr_scheduler="plateau")
+    assert trainer.lr_scheduler_configs, "plateau scheduler not configured"

--- a/tests/pipelines/chrombpnet_eval/test_lit.py
+++ b/tests/pipelines/chrombpnet_eval/test_lit.py
@@ -28,9 +28,16 @@ class _ToyDS(Dataset):
         return {"onehot_seq": oh, "profile": profile}
 
 
-def _fit(lr_scheduler=None):
+def _fit(lr_scheduler=None, warmup_steps=0):
     model = build_onehot_chrombpnet(bias_h5=None, n_filters=8, n_layers=2)
-    lit = ChromBPNetLit(model, alpha=1.0, beta=1.0, lr=1e-3, lr_scheduler=lr_scheduler)
+    lit = ChromBPNetLit(
+        model,
+        alpha=1.0,
+        beta=1.0,
+        lr=1e-3,
+        warmup_steps=warmup_steps,
+        lr_scheduler=lr_scheduler,
+    )
     dl = DataLoader(_ToyDS(8), batch_size=4)
     trainer = L.Trainer(
         max_epochs=1,
@@ -63,3 +70,10 @@ def test_plateau_scheduler_configures():
     # The opt-in ReduceLROnPlateau path builds a valid optimizer+scheduler dict.
     trainer = _fit(lr_scheduler="plateau")
     assert trainer.lr_scheduler_configs, "plateau scheduler not configured"
+
+
+def test_warmup_scheduler_configures():
+    # warmup_steps>0 builds a step-interval LinearLR (precedence over plateau).
+    trainer = _fit(warmup_steps=5)
+    assert trainer.lr_scheduler_configs, "warmup scheduler not configured"
+    assert trainer.lr_scheduler_configs[0].interval == "step"

--- a/tests/pipelines/chrombpnet_eval/test_onehot.py
+++ b/tests/pipelines/chrombpnet_eval/test_onehot.py
@@ -39,3 +39,16 @@ def test_count_trainable_drops_when_bias_frozen():
     # Frozen-bias params are exactly the difference.
     n_bias = sum(p.numel() for p in model.bias.parameters())
     assert before - after == n_bias
+
+
+def test_bf16_autocast_forward_is_finite():
+    # The bf16-safe forward must not NaN under a bf16 autocast: the exp/log
+    # count-combine is fp32-guarded, so outputs stay finite and upcast to fp32.
+    model = _tiny()
+    x = torch.zeros(2, 4, 2114)
+    x[:, torch.randint(0, 4, (2114,)), torch.arange(2114)] = 1.0
+    with torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+        profile, counts = model(x)
+    assert torch.isfinite(profile).all(), "profile NaN/inf under bf16 autocast"
+    assert torch.isfinite(counts).all(), "counts NaN/inf under bf16 autocast"
+    assert profile.dtype == torch.float32 and counts.dtype == torch.float32

--- a/tests/pipelines/chrombpnet_eval/test_onehot.py
+++ b/tests/pipelines/chrombpnet_eval/test_onehot.py
@@ -1,0 +1,41 @@
+"""One-hot ChromBPNet construction (issue #241)."""
+
+import torch
+
+from marin_dna.pipelines.chrombpnet_eval.onehot import (
+    build_onehot_chrombpnet,
+    count_trainable_params,
+)
+
+
+def _tiny() -> torch.nn.Module:
+    # Small tower so the test is fast; out_dim must stay 1000 (the central
+    # window) for the conv crop math to line up with a 2114 bp input.
+    return build_onehot_chrombpnet(bias_h5=None, n_filters=8, n_layers=2)
+
+
+def test_forward_shapes():
+    model = _tiny()
+    x = torch.zeros(3, 4, 2114)
+    x[:, torch.randint(0, 4, (2114,)), torch.arange(2114)] = 1.0
+    profile, counts = model(x)
+    assert profile.shape == (3, 1000), profile.shape
+    assert counts.numel() == 3, counts.shape  # [B,1] log-count per region
+
+
+def test_no_bias_keeps_fresh_trainable_bias():
+    # Without a bias .h5 the fresh bias is left trainable (smoke-only path).
+    model = _tiny()
+    assert all(p.requires_grad for p in model.bias.parameters())
+
+
+def test_count_trainable_drops_when_bias_frozen():
+    model = _tiny()
+    before = count_trainable_params(model)
+    for p in model.bias.parameters():
+        p.requires_grad = False
+    after = count_trainable_params(model)
+    assert 0 < after < before, (before, after)
+    # Frozen-bias params are exactly the difference.
+    n_bias = sum(p.numel() for p in model.bias.parameters())
+    assert before - after == n_bias

--- a/tests/pipelines/chrombpnet_eval/test_qtl_eval.py
+++ b/tests/pipelines/chrombpnet_eval/test_qtl_eval.py
@@ -88,6 +88,7 @@ class _ToyDS(Dataset):
 
 
 def test_callback_logs_qtl_metrics():
+    L.seed_everything(0)  # deterministic init+training (no flaky model divergence)
     model = build_onehot_chrombpnet(bias_h5=None, n_filters=8, n_layers=2)
     lit = ChromBPNetLit(model, alpha=1.0, beta=1.0, lr=1e-3)
     ref, alt = _ref_alt_onehot(6)

--- a/tests/pipelines/chrombpnet_eval/test_qtl_eval.py
+++ b/tests/pipelines/chrombpnet_eval/test_qtl_eval.py
@@ -1,0 +1,112 @@
+"""Online QTL eval: window extraction, log2FC scoring, and the live callback."""
+
+import lightning as L
+import numpy as np
+import pytest
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from marin_dna.pipelines.chrombpnet_eval.lit import ChromBPNetLit
+from marin_dna.pipelines.chrombpnet_eval.onehot import build_onehot_chrombpnet
+from marin_dna.pipelines.chrombpnet_eval.qtl_eval import (
+    QTLEvalCallback,
+    QTLSpec,
+    extract_ref_alt_onehot,
+    score_log2fc,
+    signed_correlations,
+)
+
+HALF = 2114 // 2  # variant sits at the center index
+
+
+def _genome_all_a(chrom: str, start: int, end: int, strand: str = "+") -> str:
+    # A fake genome that returns all-'A' of the requested length.
+    return "A" * (end - start)
+
+
+def _ref_alt_onehot(n: int) -> tuple[np.ndarray, np.ndarray]:
+    ref = np.zeros((n, 4, 2114), dtype=np.float32)
+    ref[:, 0, :] = 1.0  # all A
+    alt = ref.copy()
+    alt[:, 0, HALF] = 0.0
+    alt[:, 1, HALF] = 1.0  # center -> C
+    return ref, alt
+
+
+def test_extract_ref_alt_onehot_basic():
+    ref_oh, alt_oh = extract_ref_alt_onehot(
+        ["1", "2", "X"],
+        [2000, 3000, 5000],
+        ["A", "A", "A"],
+        ["C", "G", "T"],
+        _genome_all_a,
+    )
+    assert ref_oh.shape == (3, 4, 2114) and alt_oh.shape == (3, 4, 2114)
+    # ref center base is A (channel 0); no other channel set at the center
+    assert ref_oh[:, 0, HALF].all() and ref_oh[:, 1:, HALF].sum() == 0
+    # alt center is the substituted allele (C=1, G=2, T=3)
+    assert (
+        alt_oh[0, 1, HALF] == 1 and alt_oh[1, 2, HALF] == 1 and alt_oh[2, 3, HALF] == 1
+    )
+    # flanks untouched (still A)
+    assert alt_oh[0, 0, 0] == 1 and alt_oh[0, 0, HALF - 1] == 1
+
+
+def test_extract_ref_mismatch_raises():
+    # genome is all-A but we claim ref=C everywhere -> 0% match -> loud failure.
+    with pytest.raises(AssertionError, match="reference-build"):
+        extract_ref_alt_onehot(["1"], [2000], ["C"], ["G"], _genome_all_a)
+
+
+def test_extract_rejects_indel():
+    with pytest.raises(AssertionError, match="SNP-only"):
+        extract_ref_alt_onehot(["1"], [2000], ["A"], ["AC"], _genome_all_a)
+
+
+def test_score_log2fc_shape_and_finite():
+    model = build_onehot_chrombpnet(bias_h5=None, n_filters=8, n_layers=2)
+    ref, alt = _ref_alt_onehot(5)
+    scores = score_log2fc(model, ref, alt, batch_size=2)
+    assert scores.shape == (5,) and np.isfinite(scores).all()
+    # identical ref/alt -> zero effect
+    z = score_log2fc(model, ref, ref, batch_size=2)
+    assert np.allclose(z, 0.0, atol=1e-4)
+
+
+def test_signed_correlations_constant_is_zero():
+    assert signed_correlations(np.ones(5), np.arange(5.0)) == (0.0, 0.0)
+
+
+class _ToyDS(Dataset):
+    def __len__(self) -> int:
+        return 8
+
+    def __getitem__(self, i: int) -> dict:
+        oh = torch.zeros(4, 2114)
+        oh[torch.randint(0, 4, (2114,)), torch.arange(2114)] = 1.0
+        return {"onehot_seq": oh, "profile": torch.randint(0, 5, (1000,)).float()}
+
+
+def test_callback_logs_qtl_metrics():
+    model = build_onehot_chrombpnet(bias_h5=None, n_filters=8, n_layers=2)
+    lit = ChromBPNetLit(model, alpha=1.0, beta=1.0, lr=1e-3)
+    ref, alt = _ref_alt_onehot(6)
+    spec = QTLSpec("caqtl", ref, alt, np.random.default_rng(0).standard_normal(6))
+    trainer = L.Trainer(
+        max_epochs=1,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        accelerator="cpu",
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        num_sanity_val_steps=0,
+        callbacks=[QTLEvalCallback([spec], batch_size=4)],
+    )
+    trainer.fit(
+        lit, DataLoader(_ToyDS(), batch_size=4), DataLoader(_ToyDS(), batch_size=4)
+    )
+    metrics = {**trainer.callback_metrics, **trainer.logged_metrics}
+    assert "qtl_caqtl_pearson" in metrics, sorted(metrics)
+    assert "qtl_caqtl_spearman" in metrics, sorted(metrics)
+    assert torch.isfinite(torch.as_tensor(float(metrics["qtl_caqtl_pearson"])))

--- a/uv.lock
+++ b/uv.lock
@@ -2189,6 +2189,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+chrombpnet = [
+    { name = "h5py", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-9-marin-dna-marin' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'extra-9-marin-dna-tpu' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'group-9-marin-dna-aws-cli' and extra == 'group-9-marin-dna-genome-s3')" },
+    { name = "lightning", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-9-marin-dna-marin' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'extra-9-marin-dna-tpu' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'group-9-marin-dna-aws-cli' and extra == 'group-9-marin-dna-genome-s3')" },
+    { name = "pooch", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-9-marin-dna-marin' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'extra-9-marin-dna-tpu' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'group-9-marin-dna-aws-cli' and extra == 'group-9-marin-dna-genome-s3')" },
+]
 marin = [
     { name = "dupekit", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "lm-eval", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2238,9 +2243,11 @@ requires-dist = [
     { name = "datasets" },
     { name = "dupekit", marker = "extra == 'marin'" },
     { name = "einops" },
+    { name = "h5py", marker = "extra == 'chrombpnet'" },
     { name = "huggingface-hub" },
     { name = "jaxtyping" },
     { name = "liftover" },
+    { name = "lightning", marker = "extra == 'chrombpnet'" },
     { name = "lm-eval", marker = "extra == 'marin'", git = "https://github.com/stanford-crfm/lm-evaluation-harness.git?rev=d5e3391f22cde186c827674d5c3ec7c5f4fe0cab" },
     { name = "marin", marker = "extra == 'marin'" },
     { name = "marin", extras = ["tpu"], marker = "sys_platform == 'linux' and extra == 'tpu'" },
@@ -2254,6 +2261,7 @@ requires-dist = [
     { name = "pandas" },
     { name = "polars" },
     { name = "polars-bio" },
+    { name = "pooch", marker = "extra == 'chrombpnet'" },
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pybigwig" },
     { name = "pyfaidx", specifier = ">=0.8.0" },
@@ -2269,7 +2277,7 @@ requires-dist = [
     { name = "wandb" },
     { name = "zstandard" },
 ]
-provides-extras = ["tpu", "marin"]
+provides-extras = ["tpu", "marin", "chrombpnet"]
 
 [package.metadata.requires-dev]
 alphagenome-eval = [{ name = "alphagenome" }]
@@ -3324,6 +3332,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d7f42a8b3f16fc66002cc0f6516f7dd7653396886ae0ed362ab95c0b3408b59", size = 56250788, upload-time = "2026-04-22T19:14:39.743Z" },
     { url = "https://files.pythonhosted.org/packages/10/0f/e4b3ffc748827a14a474ec9c42e45c066050e440fec57e914091d9adda75/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5f7becc237a7ec9d9a10878dc8e54b73bbf4e2d94a2991c37d7a0b38590d8f9", size = 50432590, upload-time = "2026-04-22T19:14:43.388Z" },
     { url = "https://files.pythonhosted.org/packages/d9/0b/b8d95fbed869fa4caabe9c400e4210374913b376e925e96fdcfa9be6416b/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:992d14cf191dde043d36fbdbc98a65e43fbc7e9a5024cecd45f838ac4988c1ee", size = 54155564, upload-time = "2026-04-22T19:14:47.239Z" },
+]
+
+[[package]]
+name = "pooch"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-9-marin-dna-marin' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'extra-9-marin-dna-tpu' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'group-9-marin-dna-aws-cli' and extra == 'group-9-marin-dna-genome-s3')" },
+    { name = "platformdirs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-9-marin-dna-marin' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'extra-9-marin-dna-tpu' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'group-9-marin-dna-aws-cli' and extra == 'group-9-marin-dna-genome-s3')" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-9-marin-dna-marin' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'extra-9-marin-dna-tpu' and extra == 'group-9-marin-dna-aws-cli') or (extra == 'group-9-marin-dna-aws-cli' and extra == 'group-9-marin-dna-genome-s3')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

**M1b of #236:** train our own **one-hot ChromBPNet** on GM12878 DNase end-to-end — validating the whole training pipeline (data loading, counts+profile loss, early-stopping, W&B instrumentation) before the slow gLM-embedding arm (#243) — and add a light **online caQTL/dsQTL metric** so we watch the eval *target* during training, not just the accessibility proxy.

**Result:** the trained one-hot ChromBPNet reaches `val_count_pearson` ≈ **0.649** (official ChromBPNet's ~0.6–0.7 range) and **reproduces ARSENAL's one-hot caQTL/dsQTL numbers** on our train split — caqtl **0.644** vs ARSENAL 0.665, dsqtl **0.719** vs 0.733 (signed Pearson over positives). Full comparison incl. the ARSENAL *finetuned* ceiling (the #243 target: caqtl 0.685 / dsqtl 0.767) is recorded in https://github.com/Open-Athena/marin-dna/issues/241#issuecomment-4617582317.

## What's here

- **Vendored `arsenal-chrombpnet`** (`src/.../chrombpnet_eval/_vendor/`, pinned `dcfa42b`) — the one-hot `ChromBPNet`, the `BPNet` tower + bias, and the GM12878 `DataModule` (DART-Eval chrom splits). Pinned third-party, **excluded from ruff/mypy**; opt-in `chrombpnet` extra (lightning / h5py / pooch).
- **`onehot.build_onehot_chrombpnet`** — faithful one-hot ChromBPNet (4-ch one-hot, official 512f/8L tower) + a **frozen pretrained Tn5/DNase bias** from `bias_model_scaled.h5`. `OneHotChromBPNet` adds a **bf16-safe forward** (fp32 `exp/log` count-combine) so `--precision bf16-mixed` won't NaN.
- **`lit.ChromBPNetLit`** — the vendored counts+profile objective as our `LightningModule`, instrumented for pipeline validation: per-step losses + **gradient L2 norm** + `lr`; per-validation **`val_count_pearson` + `val_count_spearman`**; Adam + optional LR warmup / plateau. Arm-agnostic (the gLM arm reuses it).
- **`qtl_eval`** — the online metric: at each validation, score the caqtl/dsqtl **train positives** (3,173 / 309) by predicted `log2 FC` of counts and log signed **Pearson/Spearman** vs the observed effect. Positives-only + correlation-only (cheap). dsQTL effect sign-flipped (the known `obs.estimate` vs ChromBPNet-logfc convention).
- **`scripts/chrombpnet_eval/train_onehot.py`** driver + **`sky/run_onehot.yaml`** (A10G, us-east-2) + **`vram_probe.py`** (batch × precision VRAM fit-table) + a README.
- **Stabilization (#247):** full fp32 by default (`--matmul-precision highest`), **LR warmup**, global-norm **grad-clip**, and **`seed_everything`** — fixes an early-step gradient spike that diverged to NaN. bf16-mixed then validated to train clean.

## Test plan

- **28 unit/smoke tests** (`tests/pipelines/chrombpnet_eval/`): the M1a metric/scores harness + one-hot construction/forward, the bf16-no-NaN guard, the train-loop instrumentation (val Pearson/Spearman + grad-norm), the LR-warmup config, and the QTL extraction/scoring/callback on synthetic data. `uv run --extra chrombpnet pytest tests/pipelines/chrombpnet_eval/` — green. ruff + mypy clean (vendor excluded).
- **Real GM12878 on A10G:** fp32 + bf16/128 smokes, then the full early-stopped run (epoch 12, 0 NaN) reproducing ARSENAL one-hot (numbers above).

## Notes

- Closes #241. The stabilization addresses #247 (the loss-range `lgamma` monitoring-cleanup is the only minor remainder there).
- Deferred: the **gLM-embedding arm** (`model.py` / `embedding.py` / `GLMChromBPNet`) is #243; this PR carries the shared training stack + the one-hot arm.
- **VRAM / host-RAM:** batch 256 fits the A10G's VRAM only at the ragged edge and host-OOMs the g5.xlarge's 15 GB RAM; **bf16 + batch 128 is the sweet spot** (see `vram_probe.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
