### PR TITLE
zoonomia_projection_dataset: add v4_ccre_non_promoter-order species-subset dataset

### DIFF
--- a/snakemake/zoonomia_projection_dataset/config/config.yaml
+++ b/snakemake/zoonomia_projection_dataset/config/config.yaml
@@ -86,10 +86,12 @@ hf_owner: "bolinas-dna"
 species_subsets:
   order: "config/species_zoonomia_447_order_dedup.tsv"
 # (intervals_version, species cohort) datasets to build — each reuses the
-# existing intervals subset Parquet, filtered to the cohort. One for now:
-# zoonomia-v1-v4_cds-order (the v4 cds region partition on the 19-order set).
+# existing intervals subset Parquet, filtered to the cohort:
+#   zoonomia-v1-v4_cds-order              (the v4 cds region partition, 19-order set)
+#   zoonomia-v1-v4_ccre_non_promoter-order (the v4 non-promoter cCRE partition, 19-order set)
 species_subset_datasets:
   - { intervals: "v4_cds", species: "order" }
+  - { intervals: "v4_ccre_non_promoter", species: "order" }
 
 # v2 subset: ± bp band around each mRNA TSS (Ensembl protein_coding biotype).
 # 256 bp matches the BOS+255 model context window.


### PR DESCRIPTION
## What

Adds the second **species-cohort** dataset on the axis introduced in #235: [`bolinas-dna/zoonomia-v1-v4_ccre_non_promoter-order`](https://huggingface.co/datasets/bolinas-dna/zoonomia-v1-v4_ccre_non_promoter-order) — the v4 non-promoter cCRE region partition restricted to the 19 one-per-order species. The `ccre_non_promoter` counterpart of [`zoonomia-v1-v4_cds-order`](https://huggingface.co/datasets/bolinas-dna/zoonomia-v1-v4_cds-order).

This is a **one-line config change** — exactly the extension #235 anticipated ("Other intervals × order … each is one `species_subset_datasets` line"). The cohort machinery (card generator, slug parsing, `subset_species` → shard → upload chain) generalizes with no code change.

## Change

```yaml
species_subset_datasets:
  - { intervals: "v4_cds", species: "order" }
  - { intervals: "v4_ccre_non_promoter", species: "order" }   # ← new
```

## Build record

Built + uploaded by running the existing `sky/upload.yaml --env UPLOAD_MODE=species_subset` on `r6i.8xlarge` (us-east-2), **reusing the v1 cross-mammal projection** — the cohort is a strict subset of the 108-family species set, so no re-`halLiftover`. `subset_species` filtered the existing `subsets/v4_ccre_non_promoter.parquet` (4.38 GB, already in S3) to the 19 order species.

- **15,419,526** post-RC training samples (7,709,763 cohort rows × 2), 64 JSONL.zst shards, 1.9 GB.
- Hand-verified: line count across all 64 shards `== 15,419,526` exactly; 19 distinct species; card renders with correct base-dataset links + commit-pinned permalink (`74209664`).
- Snakemake ran exactly the dataset tail — `68 of 68 steps` (1 `subset_species` + 1 `prepare_training_shards` + 64 `compress_shard` + 1 card + 1 `hf_upload`); no projection walk-back, `cds-order` untouched.

## Verification

- `uv run pytest tests/pipelines/projection/ tests/pipelines/zoonomia_projection_dataset/` → **159 passed** (no code change → no new tests; the existing cohort tests from #235 cover this path).
- Dry-run confirms the new `subset_species` job wires up (`intervals=v4_ccre_non_promoter, cohort=order`).

Context: #233 / #235 — this is the anticipated per-dataset config line, not a new feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
