### PR TITLE
VEP online↔offline BOS root cause (#257) + monkeypatch fix (#263)

### DIFF
--- a/experiments/parity/exp257_ccre_eval_only.py
+++ b/experiments/parity/exp257_ccre_eval_only.py
@@ -201,9 +201,14 @@ def _run_eval_harness_only(_config: _EvalConfig) -> None:
             _local = _osp.dirname(_c[0]) if _c else _local
         ckpt_path = _local
         print(f"[exp257] downloaded HF export -> {ckpt_path}", flush=True)
+    # Compute dtype: bfloat16 (training/default) or float32. The fp32 run tests
+    # whether the torch(0.158)-vs-levanter(0.251) distal/fwd gap is a bf16
+    # numerical sensitivity (fp32 reconciles them) or a real math difference.
+    _compute = os.getenv("COMPUTE_DTYPE", "bfloat16")
     run_name = (
         WANDB_RUN_NAME
         + ("-hfckpt" if ckpt_is_hf else "")
+        + ("-f32" if _compute == "float32" else "")
         + (f"-mps{_mps}" if _mps != 64 else "")
         + (f"-{_tag}" if _tag else "")
     )
@@ -222,7 +227,7 @@ def _run_eval_harness_only(_config: _EvalConfig) -> None:
                 tags=list(WANDB_TAGS),
                 name=run_name,
             ),
-            mp=jmp.get_policy("p=f32,c=bfloat16"),
+            mp=jmp.get_policy(f"p=f32,c={_compute}"),
             per_device_eval_parallelism=64,
         ),
         model=_build_model_config(seq_len),
@@ -238,6 +243,7 @@ def main() -> None:
     mps = os.getenv("MAX_PACKED_SEGMENTS", "64")
     step_tag = os.getenv("STEP_TAG", "")
     ckpt_is_hf = os.getenv("CHECKPOINT_IS_HF", "0")
+    compute = os.getenv("COMPUTE_DTYPE", "bfloat16")
     env_vars: dict[str, str] = {
         "HF_HUB_DOWNLOAD_TIMEOUT": "120",
         "UV_LOCK_TIMEOUT": "7200",
@@ -246,15 +252,17 @@ def main() -> None:
         "DUMP_GCS": os.getenv("DUMP_GCS", ""),
         "CHECKPOINT_PATH": os.getenv("CHECKPOINT_PATH", ""),
         "CHECKPOINT_IS_HF": ckpt_is_hf,
+        "COMPUTE_DTYPE": compute,
     }
     if "WANDB_API_KEY" in os.environ:
         env_vars["WANDB_API_KEY"] = os.environ["WANDB_API_KEY"]
 
-    # Fold checkpoint mode + packing + tag into the step name so the
-    # content-addressed marin executor re-runs (rather than skipping a
+    # Fold checkpoint mode + compute dtype + packing + tag into the step name so
+    # the content-addressed marin executor re-runs (rather than skipping a
     # same-named, already-done step).
     name_suffix = (
         ("-hfckpt" if ckpt_is_hf == "1" else "")
+        + ("-f32" if compute == "float32" else "")
         + ("" if mps == "64" else f"-mps{mps}")
         + (f"-{step_tag}" if step_tag else "")
     )

--- a/experiments/parity/exp257_ccre_eval_only.py
+++ b/experiments/parity/exp257_ccre_eval_only.py
@@ -195,7 +195,9 @@ def _run_eval_harness_only(_config: _EvalConfig) -> None:
         import fsspec
 
         _local = "/tmp/exp257_ckpt_hf"
-        fsspec.filesystem("gcs").get(ckpt_path.rstrip("/") + "/", _local + "/", recursive=True)
+        fsspec.filesystem("gcs").get(
+            ckpt_path.rstrip("/") + "/", _local + "/", recursive=True
+        )
         if not _osp.exists(_osp.join(_local, "config.json")):
             _c = glob.glob(_local + "/**/config.json", recursive=True)
             _local = _osp.dirname(_c[0]) if _c else _local

--- a/experiments/parity/exp257_ccre_eval_only.py
+++ b/experiments/parity/exp257_ccre_eval_only.py
@@ -1,0 +1,251 @@
+# Copyright The Marin Authors / MarinDNA Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Issue #257 — reproduce the ONLINE in-training mendelian eval on the exact
+exp232 ``v4_ccre_non_promoter`` step-4999 model, via the real levanter lm_eval
+path (not a from-scratch approximation).
+
+Context: the in-training online metric logged ``distal/fwd/auprc = 0.2507`` at
+the final step, but the offline ``evals_v2`` pipeline (and three from-scratch
+reproductions) score the exported step-4999 checkpoint at **0.158** on that
+exact cell — while matching online on 28/30 other (subset, strand) cells. So the
+divergence is isolated to ``distal/fwd``. This run answers: does the *actual*
+levanter lm_eval path reproduce 0.251 on this model?
+
+  * Loads the **native levanter checkpoint** (the exact training state the
+    in-training eval ran on — ``checkpoint_is_hf=False``, ``latest_checkpoint_path``
+    resolves ``…/checkpoints`` → ``step-4999``).
+  * Runs ``mendelian_traits_255`` (the same task, FWD/RC/AVG + AUPRC).
+  * Monkeypatches the aggregation to dump every ``distal`` per-(variant, strand)
+    raw LLR to stdout (``DISTAL_ITEM {...}``) so we can diff per-variant against
+    the offline scores parquet and localize *which* distal variants diverge.
+
+Adapted from ``experiments/parity/exp179_eval_only.py`` (geometry 1B→0.25B;
+HF→native checkpoint; + the distal dump). Launch from a CPU box with gcloud
+authed (``--cluster=marin`` auto-tunnels):
+
+    uv run --extra marin iris --cluster=marin job run \\
+        --no-wait --user gonzalo --job-name exp257-ccre-online-repro \\
+        --cpu 1 --memory 2g --extra marin --region us-east5 \\
+        -e WANDB_API_KEY "$(grep -A2 api.wandb.ai ~/.netrc | grep password | awk '{print $2}')" \\
+        -e HF_HUB_DOWNLOAD_TIMEOUT 120 -e UV_LOCK_TIMEOUT 7200 \\
+        -- python experiments/parity/exp257_ccre_eval_only.py
+"""
+
+import dataclasses
+import logging
+import os
+
+import jmp
+import levanter.eval_harness as eval_harness
+from fray.cluster import ResourceConfig
+from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
+from levanter.models.qwen import Qwen3Config
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from marin.evaluation.evaluation_config import convert_to_levanter_task_config
+from marin.execution.executor import ExecutorStep, executor_main
+from marin.execution.remote import remote
+
+from marin_dna.levanter.defaults import dna_effective_seq_len
+from marin_dna.pipelines.evals.lm_eval.task_configs import MENDELIAN_TRAITS_255
+
+logger = logging.getLogger(__name__)
+
+MODEL_NAME = "exp232-v4_ccre_non_promoter-step-4999"
+# Native levanter checkpoint root (the in-training state). load_checkpoint via
+# latest_checkpoint_path(…/checkpoints) resolves to step-4999 (the latest).
+CHECKPOINT_PATH = (
+    "gs://marin-us-east5/checkpoints/"
+    "dna-exp232-zoonomia-v1-0p25b-v4_ccre_non_promoter-v0.1-feca83/checkpoints"
+)
+TOKENIZER = "bolinas-dna/tokenizer-char-bos"
+
+# exp232 Qwen3-0.25B geometry (hidden=1152, layers=12, heads=9, head_dim=128) —
+# verbatim from experiments/exp232_per_region.py::_build_model_config so the
+# native checkpoint's array structure matches exactly.
+DNA_BASE_SEQ_LEN = 255
+HIDDEN_DIM = 1152
+INTERMEDIATE_DIM = HIDDEN_DIM * 4  # 4608
+NUM_HEADS = HIDDEN_DIM // 128  # 9
+NUM_LAYERS = 12
+INITIALIZER_RANGE = 0.02
+
+# v6e-4 (us-east5-b) is data-local to the checkpoint + mendelian data and, per
+# `iris cluster status`, idle (10 ready / 0 demand) vs the heavily-contended
+# v5p-8 us-east5-a pool (20 ready / 42 demand). A 0.25B eval needs nothing
+# bigger; levanter reshards the v5p-8-saved checkpoint onto 4 chips on load.
+# Env-overridable (comma-separated) to re-route without editing.
+TPU_TYPES: tuple[str, ...] = tuple(
+    t.strip() for t in os.getenv("TPU_TYPE", "v6e-4").split(",") if t.strip()
+)
+_EVAL_DEPENDENCY_GROUPS = ["marin", "tpu"]
+
+WANDB_PROJECT = "marin"
+WANDB_RUN_NAME = "dna-exp232-ccre-step4999-online-repro-issue257"
+WANDB_TAGS = ("dna", "exp232", "issue257", "online-repro", "parity")
+
+
+def _build_model_config(seq_len: int) -> Qwen3Config:
+    return Qwen3Config(
+        hidden_dim=HIDDEN_DIM,
+        intermediate_dim=INTERMEDIATE_DIM,
+        num_layers=NUM_LAYERS,
+        num_heads=NUM_HEADS,
+        num_kv_heads=NUM_HEADS,
+        max_seq_len=seq_len,
+        rope=Llama3RotaryEmbeddingsConfig(),
+        initializer_range=INITIALIZER_RANGE,
+    )
+
+
+def _install_llr_dump() -> None:
+    """Wrap the AUPRC aggregation to write every per-(variant, strand) RAW LLR to
+    a GCS JSONL (``DUMP_GCS`` env) — durable, unlike pod stdout which never reaches
+    the launcher's iris logs / wandb console. For per-variant offline diffing."""
+    import json
+    import sys
+
+    from marin_dna.pipelines.evals.lm_eval import dna_vep_llr_eval as dv
+
+    # lm_eval resolves the task's `!function dna_vep_llr_eval.DnaVepLlrEvalTask`
+    # by importing a TOP-LEVEL `dna_vep_llr_eval` module — a *different* object
+    # than this package import, so a naive class patch misses the copy lm_eval
+    # actually uses. Pre-register THIS module under that name so lm_eval reuses
+    # it (and the patch below applies to the aggregation lm_eval calls).
+    sys.modules["dna_vep_llr_eval"] = dv
+
+    orig = dv._AuprcAggregation.__call__
+
+    def patched(self, items):
+        rows = [
+            {
+                "llr": float(llr),
+                "label": int(target),
+                "subset": str(subset),
+                "chrom": str(vid[0]),
+                "pos": int(vid[1]),
+                "ref": str(vid[2]),
+                "alt": str(vid[3]),
+                "match_group": int(mg),
+                "strand": strand,
+            }
+            for llr, target, subset, vid, mg, strand in items
+        ]
+        dump_gcs = os.getenv("DUMP_GCS")
+        if dump_gcs:
+            try:
+                import fsspec
+
+                with fsspec.open(dump_gcs, "w") as f:
+                    f.write("\n".join(json.dumps(r) for r in rows))
+                print(f"[exp257] wrote {len(rows)} LLR rows -> {dump_gcs}", flush=True)
+            except Exception as exc:
+                print(f"[exp257] GCS dump FAILED ({dump_gcs}): {exc}", flush=True)
+        else:
+            print(f"[exp257] DUMP_GCS unset; {len(rows)} rows not written", flush=True)
+        return orig(self, items)
+
+    dv._AuprcAggregation.__call__ = patched
+
+
+@dataclasses.dataclass(frozen=True)
+class _EvalConfig:
+    """ExecutorStep requires a config dataclass; eval is fully parameterized by
+    module-level constants."""
+
+
+def _run_eval_harness_only(_config: _EvalConfig) -> None:
+    # MUST be inside the function body — iris cloudpickles __main__ by-value and
+    # never re-imports the module on the worker, so the lm-eval/levanter
+    # monkeypatches (and our distal dump) only install if triggered here.
+    import marin_dna.pipelines.evals.lm_eval  # noqa: F401
+
+    _install_llr_dump()
+
+    # Issue #257: levanter's lm_eval hardcodes max_packed_segments=64 (sequence
+    # packing w/ block-diagonal segment attention). Set MAX_PACKED_SEGMENTS=1 to
+    # disable packing (each sequence forwarded alone, positions from 0) and test
+    # whether the packed path is what makes distal/fwd score 0.25 vs the offline
+    # kernel's 0.158.
+    _mps = int(os.getenv("MAX_PACKED_SEGMENTS", "64"))
+    if _mps != 64:
+        _orig_worker_init = eval_harness._LmEvalHarnessWorker.__init__
+
+        def _patched_worker_init(self, *a, **kw):
+            kw["max_packed_segments"] = _mps
+            print(f"[exp257] OVERRIDE max_packed_segments -> {_mps}", flush=True)
+            return _orig_worker_init(self, *a, **kw)
+
+        eval_harness._LmEvalHarnessWorker.__init__ = _patched_worker_init
+
+    _tag = os.getenv("STEP_TAG", "")
+    run_name = (
+        WANDB_RUN_NAME
+        + (f"-mps{_mps}" if _mps != 64 else "")
+        + (f"-{_tag}" if _tag else "")
+    )
+    seq_len = dna_effective_seq_len(DNA_BASE_SEQ_LEN, TOKENIZER)
+    eval_config = eval_harness.EvalHarnessMainConfig(
+        eval_harness=eval_harness.LmEvalHarnessConfig(
+            task_spec=convert_to_levanter_task_config([MENDELIAN_TRAITS_255]),
+            log_samples=False,
+        ),
+        tokenizer=TOKENIZER,
+        checkpoint_path=CHECKPOINT_PATH,
+        checkpoint_is_hf=False,  # native levanter checkpoint = exact training state
+        trainer=TrainerConfig(
+            tracker=WandbConfig(
+                project=WANDB_PROJECT,
+                tags=list(WANDB_TAGS),
+                name=run_name,
+            ),
+            mp=jmp.get_policy("p=f32,c=bfloat16"),
+            per_device_eval_parallelism=64,
+        ),
+        model=_build_model_config(seq_len),
+    )
+    eval_harness.run_eval_harness_main(eval_config)
+
+
+def main() -> None:
+    # Propagate the packing knob to the TPU pod (the iris-job `-e` only sets it
+    # on the launcher). Also fold it into the step name so the content-addressed
+    # marin executor doesn't treat a different packing mode as the same
+    # (already-done) step and skip re-execution.
+    mps = os.getenv("MAX_PACKED_SEGMENTS", "64")
+    step_tag = os.getenv("STEP_TAG", "")
+    env_vars: dict[str, str] = {
+        "HF_HUB_DOWNLOAD_TIMEOUT": "120",
+        "UV_LOCK_TIMEOUT": "7200",
+        "MAX_PACKED_SEGMENTS": mps,
+        "STEP_TAG": step_tag,
+        "DUMP_GCS": os.getenv("DUMP_GCS", ""),
+    }
+    if "WANDB_API_KEY" in os.environ:
+        env_vars["WANDB_API_KEY"] = os.environ["WANDB_API_KEY"]
+
+    # Fold packing mode + tag into the step name so the content-addressed marin
+    # executor re-runs (rather than skipping a same-named, already-done step).
+    name_suffix = ("" if mps == "64" else f"-mps{mps}") + (f"-{step_tag}" if step_tag else "")
+    step = ExecutorStep(
+        name=f"evaluation/lm_evaluation_harness_levanter/exp257_{MODEL_NAME}{name_suffix}",
+        fn=remote(
+            _run_eval_harness_only,
+            resources=ResourceConfig.with_tpu(TPU_TYPES),
+            pip_dependency_groups=_EVAL_DEPENDENCY_GROUPS,
+            env_vars=env_vars,
+        ),
+        config=_EvalConfig(),
+    )
+    executor_main(
+        steps=[step],
+        description=(
+            "issue #257 — reproduce online mendelian eval on exp232 ccre "
+            "step-4999 (native ckpt) via levanter lm_eval; dump distal per-variant LLRs."
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/parity/exp257_ccre_eval_only.py
+++ b/experiments/parity/exp257_ccre_eval_only.py
@@ -180,8 +180,30 @@ def _run_eval_harness_only(_config: _EvalConfig) -> None:
         eval_harness._LmEvalHarnessWorker.__init__ = _patched_worker_init
 
     _tag = os.getenv("STEP_TAG", "")
+    # Checkpoint source: native levanter (default) or the HF export. Running the
+    # HF export through levanter splits "HF-conversion fidelity" (A) from
+    # "torch-vs-JAX model impl" (B) for the #257 discrepancy: if the HF export
+    # scores 0.158 in levanter too → (A) the export differs from native; if 0.251
+    # → (B) same weights, divergent impls. levanter's HF loader wants a local dir,
+    # so a gs:// HF export is downloaded first.
+    ckpt_path = os.getenv("CHECKPOINT_PATH", CHECKPOINT_PATH)
+    ckpt_is_hf = os.getenv("CHECKPOINT_IS_HF", "0") == "1"
+    if ckpt_is_hf and ckpt_path.startswith("gs://"):
+        import glob
+        import os.path as _osp
+
+        import fsspec
+
+        _local = "/tmp/exp257_ckpt_hf"
+        fsspec.filesystem("gcs").get(ckpt_path.rstrip("/") + "/", _local + "/", recursive=True)
+        if not _osp.exists(_osp.join(_local, "config.json")):
+            _c = glob.glob(_local + "/**/config.json", recursive=True)
+            _local = _osp.dirname(_c[0]) if _c else _local
+        ckpt_path = _local
+        print(f"[exp257] downloaded HF export -> {ckpt_path}", flush=True)
     run_name = (
         WANDB_RUN_NAME
+        + ("-hfckpt" if ckpt_is_hf else "")
         + (f"-mps{_mps}" if _mps != 64 else "")
         + (f"-{_tag}" if _tag else "")
     )
@@ -192,8 +214,8 @@ def _run_eval_harness_only(_config: _EvalConfig) -> None:
             log_samples=False,
         ),
         tokenizer=TOKENIZER,
-        checkpoint_path=CHECKPOINT_PATH,
-        checkpoint_is_hf=False,  # native levanter checkpoint = exact training state
+        checkpoint_path=ckpt_path,
+        checkpoint_is_hf=ckpt_is_hf,
         trainer=TrainerConfig(
             tracker=WandbConfig(
                 project=WANDB_PROJECT,
@@ -215,19 +237,27 @@ def main() -> None:
     # (already-done) step and skip re-execution.
     mps = os.getenv("MAX_PACKED_SEGMENTS", "64")
     step_tag = os.getenv("STEP_TAG", "")
+    ckpt_is_hf = os.getenv("CHECKPOINT_IS_HF", "0")
     env_vars: dict[str, str] = {
         "HF_HUB_DOWNLOAD_TIMEOUT": "120",
         "UV_LOCK_TIMEOUT": "7200",
         "MAX_PACKED_SEGMENTS": mps,
         "STEP_TAG": step_tag,
         "DUMP_GCS": os.getenv("DUMP_GCS", ""),
+        "CHECKPOINT_PATH": os.getenv("CHECKPOINT_PATH", ""),
+        "CHECKPOINT_IS_HF": ckpt_is_hf,
     }
     if "WANDB_API_KEY" in os.environ:
         env_vars["WANDB_API_KEY"] = os.environ["WANDB_API_KEY"]
 
-    # Fold packing mode + tag into the step name so the content-addressed marin
-    # executor re-runs (rather than skipping a same-named, already-done step).
-    name_suffix = ("" if mps == "64" else f"-mps{mps}") + (f"-{step_tag}" if step_tag else "")
+    # Fold checkpoint mode + packing + tag into the step name so the
+    # content-addressed marin executor re-runs (rather than skipping a
+    # same-named, already-done step).
+    name_suffix = (
+        ("-hfckpt" if ckpt_is_hf == "1" else "")
+        + ("" if mps == "64" else f"-mps{mps}")
+        + (f"-{step_tag}" if step_tag else "")
+    )
     step = ExecutorStep(
         name=f"evaluation/lm_evaluation_harness_levanter/exp257_{MODEL_NAME}{name_suffix}",
         fn=remote(

--- a/scripts/issue257/README.md
+++ b/scripts/issue257/README.md
@@ -5,12 +5,23 @@ the online (in-training `lm_eval`) and offline (`evals_v2`) VEP eval disagree on
 `distal/fwd` AUPRC for `exp232 v4_ccre_non_promoter @ step-4999` (online 0.251 vs
 offline 0.159).
 
-**Conclusion:** none of the eval-convention hypotheses (4-nuc vs full-vocab
-softmax, packing, prefix-sharing, precision) explain it. The gap is a
-**torch-HF-export-Qwen3 vs JAX-native-levanter-Qwen3 model discrepancy** — same
-weights + byte-identical inputs, divergent logits — localized to ~6 OOD distal
-positives (a cluster at `chr7:156791470–480`). See the issue comments for the
-full chain.
+**Conclusion: it's a missing `[BOS]` token.** The online (in-training
+`lm_eval`) harness forwards each variant sequence **without** the leading
+`[BOS]` token that the model was trained with and that offline `evals_v2`
+correctly prepends. The online sequence is 255 tokens (no BOS); the offline one
+is 256 (`[BOS]` + 255 nt). This no-BOS distribution shift changes every variant's
+LLR — e.g. `chr7:156791472 C>A`: **−3.2 with BOS → −8.0 without** — and on the
+`distal/+` subset shifts AUPRC from **0.159** (offline, with-BOS, correct) to
+**0.2501** (online, no-BOS).
+
+The effect is **framework-independent**: torch reproduces −8.06 without BOS and
+−3.16 with BOS, matching the online and offline references respectively; levanter
+agrees (−7.90 / −3.04). Earlier hypotheses are all refuted — softmax space,
+packing, prefix-sharing, precision, RoPE-scaling, and (crucially) the
+"transformers-vs-levanter forward divergence" of #261: the two frameworks agree
+to <0.2 nats once given the **same** BOS condition, and the native checkpoint and
+its HF export are **bit-identical** (135/135 tensors, max|Δ|=0). See the issue
+comments for the full chain.
 
 ## Setup
 
@@ -29,14 +40,26 @@ ephemeral data under `scratch/issue257/`.
 
 ## Scripts → what each shows
 
+**The root-cause scripts (read these first):**
+
+| script | shows |
+| --- | --- |
+| `bos_test.py` | **The smoking gun.** Single most-divergent variant, both stacks, with-BOS vs no-BOS: torch −3.16/−8.06, levanter −3.04/−7.90. no-BOS matches online (−8.05), with-BOS matches offline (−3.21). Gap is entirely the BOS prefix, framework-independent. |
+| `bos_auprc.py` | End-to-end: distal/+ AUPRC over all 580 variants, with-BOS (≈0.159, reproduces offline) vs no-BOS (≈0.2501, reproduces online). |
+| `native_vs_export.py` | Native levanter checkpoint vs its HF export, loaded into the *same* levanter class: **bit-identical** (135/135 tensors, max\|Δ\|=0). Refutes "lossy export". Both give the same LLR (−3.04) under a plain forward. |
+| `compare_stacks.py` | torch vs levanter, single sequence, fp32+bf16, per-layer residual diffs. A plain levanter forward gives the **offline** value (−3.04), not the online (−8.05) → the online value is not a property of the levanter *framework* (it's the harness input). |
+
+**The earlier elimination scripts:**
+
 | script | shows |
 | --- | --- |
 | `verify_softmax_space.py` | Dual kernel: per-variant LLR in **4-nuc** (offline) vs **full-vocab** (online) softmax from *identical logits*. 4-nuc reproduces the offline parquet (corr 0.9997); full-vocab gives the **same** AUPRC (Δ=0.0000) → softmax space is not the cause. |
 | `diag_leakage.py` | Special-token probability mass at scored positions ≈ 1e-5 (max 4e-4) → the "differential leakage" premise is false; 4-nuc ≈ full-vocab. |
-| `compare_inputs.py` | The online harness dataset (`evals_mendelian_traits_harness_255`) vs offline on-the-fly extraction: all 580 distal inputs byte-identical (context/completions/tokenization/labels). |
+| `compare_inputs.py` | The online harness dataset (`evals_mendelian_traits_harness_255`) vs offline on-the-fly extraction: all 580 distal inputs byte-identical *as nucleotide content* (the BOS difference is in tokenization, not the stored strings). |
 | `compare_offline_online.py` | Offline `evals_v2` metrics vs the in-training online metric for the two *clean* finished arms (utr3, bg): agree to ~0.01 across ~50 cells → offline==online is the norm; ccre/distal/fwd is the lone outlier. |
 | `full_forward_test.py` | torch full-forward (no KV-cache) == prefix-share == 0.158 → prefix-sharing/full-forward is not the cause. |
-| `diff_per_variant.py` | Per-variant diff of online (levanter, GCS dump) vs offline (kernel) LLRs. ~6 distal positives at `chr7:156791470–480` drive the gap (neutralizing them → 0.250→0.174). |
+| `diff_per_variant.py` | Per-variant diff of online (levanter, GCS dump) vs offline (kernel) LLRs. ~6 distal positives at `chr7:156791470–480` drive the gap (these are the variants the BOS shift moves most). |
+| `rope_test.py` | torch RoPE-scaling A/B: disabling llama3 `rope_scaling` → 0.1585 ≈ as-is 0.1589 → RoPE config is not the cause. |
 | `wandb_check.py` | Helper: compact status of an `exp257` online-repro wandb run. |
 
 The **online reproduction** (real levanter `lm_eval` on the checkpoint, which

--- a/scripts/issue257/README.md
+++ b/scripts/issue257/README.md
@@ -1,0 +1,47 @@
+# issue #257 — online↔offline VEP AUPRC divergence: reproduction scripts
+
+Investigation of [Open-Athena/marin-dna#257](https://github.com/Open-Athena/marin-dna/issues/257):
+the online (in-training `lm_eval`) and offline (`evals_v2`) VEP eval disagree on
+`distal/fwd` AUPRC for `exp232 v4_ccre_non_promoter @ step-4999` (online 0.251 vs
+offline 0.159).
+
+**Conclusion:** none of the eval-convention hypotheses (4-nuc vs full-vocab
+softmax, packing, prefix-sharing, precision) explain it. The gap is a
+**torch-HF-export-Qwen3 vs JAX-native-levanter-Qwen3 model discrepancy** — same
+weights + byte-identical inputs, divergent logits — localized to ~6 OOD distal
+positives (a cluster at `chr7:156791470–480`). See the issue comments for the
+full chain.
+
+## Setup
+
+```bash
+# checkpoint (the exact one in the issue) -> scratch/ (gitignored data dir)
+mkdir -p scratch/issue257/ckpt-ccre-4999
+gcloud storage cp -r \
+  "gs://marin-us-east5/checkpoints/dna-exp232-zoonomia-v1-0p25b-v4_ccre_non_promoter-v0.1-feca83/hf/step-4999/*" \
+  scratch/issue257/ckpt-ccre-4999/
+export AWS_DEFAULT_REGION=us-east-2   # S3 (scores parquet, genome)
+```
+
+Run from the repo root with `uv run --group genome-s3 python scripts/issue257/<script>.py`
+(the `genome-s3` group lets pyfaidx read GRCh38 from S3). Scripts read/write
+ephemeral data under `scratch/issue257/`.
+
+## Scripts → what each shows
+
+| script | shows |
+| --- | --- |
+| `verify_softmax_space.py` | Dual kernel: per-variant LLR in **4-nuc** (offline) vs **full-vocab** (online) softmax from *identical logits*. 4-nuc reproduces the offline parquet (corr 0.9997); full-vocab gives the **same** AUPRC (Δ=0.0000) → softmax space is not the cause. |
+| `diag_leakage.py` | Special-token probability mass at scored positions ≈ 1e-5 (max 4e-4) → the "differential leakage" premise is false; 4-nuc ≈ full-vocab. |
+| `compare_inputs.py` | The online harness dataset (`evals_mendelian_traits_harness_255`) vs offline on-the-fly extraction: all 580 distal inputs byte-identical (context/completions/tokenization/labels). |
+| `compare_offline_online.py` | Offline `evals_v2` metrics vs the in-training online metric for the two *clean* finished arms (utr3, bg): agree to ~0.01 across ~50 cells → offline==online is the norm; ccre/distal/fwd is the lone outlier. |
+| `full_forward_test.py` | torch full-forward (no KV-cache) == prefix-share == 0.158 → prefix-sharing/full-forward is not the cause. |
+| `diff_per_variant.py` | Per-variant diff of online (levanter, GCS dump) vs offline (kernel) LLRs. ~6 distal positives at `chr7:156791470–480` drive the gap (neutralizing them → 0.250→0.174). |
+| `wandb_check.py` | Helper: compact status of an `exp257` online-repro wandb run. |
+
+The **online reproduction** (real levanter `lm_eval` on the checkpoint, which
+gives 0.2501) is the eval-only harness at
+[`experiments/parity/exp257_ccre_eval_only.py`](../../experiments/parity/exp257_ccre_eval_only.py)
+— launched on iris (`v6e-4`), with `MAX_PACKED_SEGMENTS` / `DUMP_GCS` knobs for
+the packing and per-variant-dump experiments. `diff_per_variant.py` consumes its
+`DUMP_GCS` JSONL.

--- a/scripts/issue257/bos_auprc.py
+++ b/scripts/issue257/bos_auprc.py
@@ -1,0 +1,86 @@
+"""Issue #257: does the BOS-prefix mismatch reproduce the whole distal/fwd
+AUPRC gap (offline 0.159 with-BOS vs online 0.2501 no-BOS), end-to-end?
+
+bos_test.py proved it for the single most-divergent variant. This confirms it
+over the *entire* distal/+ subset (580 variants) under identical weights (the HF
+export, torch + offline kernel): score every variant with-BOS (the offline
+256-token input) and no-BOS (drop the leading [BOS] → 255 tokens, the online
+harness input), and report distal/fwd AUPRC for each.
+
+Expectation: with-BOS ≈ 0.159 (reproduces offline), no-BOS ≈ 0.2501
+(reproduces online) — i.e. the online↔offline gap is entirely the BOS token.
+
+Usage:
+  AWS_DEFAULT_REGION=us-east-2 uv run --group genome-s3 python scripts/issue257/bos_auprc.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import torch
+from sklearn.metrics import average_precision_score
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from marin_dna.data.dna import NUCLEOTIDES
+from marin_dna.data.genome import Genome
+from marin_dna.data.transforms import (
+    _get_nucleotide_token_ids,
+    _get_special_token_counts,
+    in_seq_var_pos,
+    transform_llr_clm,
+)
+from marin_dna.model.scoring import compute_variant_score_bundle
+
+CKPT = "scratch/issue257/ckpt-ccre-4999"
+GENOME = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+SCORES = (
+    "s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+    "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet"
+)
+WINDOW = 255
+
+
+def main() -> None:
+    torch.set_num_threads(4)
+    tok = AutoTokenizer.from_pretrained(CKPT)
+    model = AutoModelForCausalLM.from_pretrained(CKPT, trust_remote_code=True).eval()
+    genome = Genome(GENOME)
+
+    df = pl.read_parquet(SCORES).filter(pl.col("subset") == "distal").to_pandas()
+    lab = df["label"].to_numpy()
+    n_prefix, _ = _get_special_token_counts(tok)
+    assert n_prefix == 1
+    nuc = torch.tensor([_get_nucleotide_token_ids(tok)[n] for n in NUCLEOTIDES])
+    vp_bos = in_seq_var_pos(WINDOW, "+") + n_prefix  # 128
+    vp_nobos = in_seq_var_pos(WINDOW, "+")  # 127
+
+    rows = [transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")]
+    llr_bos = np.zeros(len(rows))
+    llr_nobos = np.zeros(len(rows))
+    with torch.no_grad():
+        for i in range(0, len(rows), 64):
+            ch = rows[i:i + 64]
+            ids = torch.stack([c["input_ids"] for c in ch])  # [B, 256] with BOS
+            alt = torch.tensor([c["alt_token_id"] for c in ch])
+            out_bos = compute_variant_score_bundle(model, ids, alt, var_pos=vp_bos, nuc_token_ids=nuc)
+            out_nobos = compute_variant_score_bundle(
+                model, ids[:, n_prefix:].contiguous(), alt, var_pos=vp_nobos, nuc_token_ids=nuc
+            )
+            llr_bos[i:i + len(ch)] = out_bos[:, 0].numpy()
+            llr_nobos[i:i + len(ch)] = out_nobos[:, 0].numpy()
+
+    ap_bos = average_precision_score(lab, -llr_bos)
+    ap_nobos = average_precision_score(lab, -llr_nobos)
+    print("\n=== distal/fwd AUPRC, n=%d (torch, HF export) ===" % len(rows))
+    print(f"  with-BOS (256-tok, offline input) : {ap_bos:.4f}   (offline reference 0.1589)")
+    print(f"  no-BOS   (255-tok, online input)  : {ap_nobos:.4f}   (online  reference 0.2501)")
+    print(f"\n  mean LLR pos (label=1): BOS {llr_bos[lab==1].mean():+.3f}  noBOS {llr_nobos[lab==1].mean():+.3f}")
+    print(f"  mean LLR neg (label=0): BOS {llr_bos[lab==0].mean():+.3f}  noBOS {llr_nobos[lab==0].mean():+.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue257/bos_auprc.py
+++ b/scripts/issue257/bos_auprc.py
@@ -58,28 +58,44 @@ def main() -> None:
     vp_bos = in_seq_var_pos(WINDOW, "+") + n_prefix  # 128
     vp_nobos = in_seq_var_pos(WINDOW, "+")  # 127
 
-    rows = [transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")]
+    rows = [
+        transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")
+    ]
     llr_bos = np.zeros(len(rows))
     llr_nobos = np.zeros(len(rows))
     with torch.no_grad():
         for i in range(0, len(rows), 64):
-            ch = rows[i:i + 64]
+            ch = rows[i : i + 64]
             ids = torch.stack([c["input_ids"] for c in ch])  # [B, 256] with BOS
             alt = torch.tensor([c["alt_token_id"] for c in ch])
-            out_bos = compute_variant_score_bundle(model, ids, alt, var_pos=vp_bos, nuc_token_ids=nuc)
-            out_nobos = compute_variant_score_bundle(
-                model, ids[:, n_prefix:].contiguous(), alt, var_pos=vp_nobos, nuc_token_ids=nuc
+            out_bos = compute_variant_score_bundle(
+                model, ids, alt, var_pos=vp_bos, nuc_token_ids=nuc
             )
-            llr_bos[i:i + len(ch)] = out_bos[:, 0].numpy()
-            llr_nobos[i:i + len(ch)] = out_nobos[:, 0].numpy()
+            out_nobos = compute_variant_score_bundle(
+                model,
+                ids[:, n_prefix:].contiguous(),
+                alt,
+                var_pos=vp_nobos,
+                nuc_token_ids=nuc,
+            )
+            llr_bos[i : i + len(ch)] = out_bos[:, 0].numpy()
+            llr_nobos[i : i + len(ch)] = out_nobos[:, 0].numpy()
 
     ap_bos = average_precision_score(lab, -llr_bos)
     ap_nobos = average_precision_score(lab, -llr_nobos)
     print("\n=== distal/fwd AUPRC, n=%d (torch, HF export) ===" % len(rows))
-    print(f"  with-BOS (256-tok, offline input) : {ap_bos:.4f}   (offline reference 0.1589)")
-    print(f"  no-BOS   (255-tok, online input)  : {ap_nobos:.4f}   (online  reference 0.2501)")
-    print(f"\n  mean LLR pos (label=1): BOS {llr_bos[lab==1].mean():+.3f}  noBOS {llr_nobos[lab==1].mean():+.3f}")
-    print(f"  mean LLR neg (label=0): BOS {llr_bos[lab==0].mean():+.3f}  noBOS {llr_nobos[lab==0].mean():+.3f}")
+    print(
+        f"  with-BOS (256-tok, offline input) : {ap_bos:.4f}   (offline reference 0.1589)"
+    )
+    print(
+        f"  no-BOS   (255-tok, online input)  : {ap_nobos:.4f}   (online  reference 0.2501)"
+    )
+    print(
+        f"\n  mean LLR pos (label=1): BOS {llr_bos[lab == 1].mean():+.3f}  noBOS {llr_nobos[lab == 1].mean():+.3f}"
+    )
+    print(
+        f"  mean LLR neg (label=0): BOS {llr_bos[lab == 0].mean():+.3f}  noBOS {llr_nobos[lab == 0].mean():+.3f}"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/issue257/bos_test.py
+++ b/scripts/issue257/bos_test.py
@@ -21,7 +21,6 @@ Usage:
 
 from __future__ import annotations
 
-import dataclasses
 
 import jax
 import jmp
@@ -73,19 +72,27 @@ def seq_llr(logits_ref, logits_alt, ref_ids, alt_ids, p, nuc_ids):
 
     tot = 0.0
     for i in range(p - 1, L - 1):
-        tot += lsm(logits_alt[i])[n2i[int(alt_ids[i + 1])]] - lsm(logits_ref[i])[n2i[int(ref_ids[i + 1])]]
+        tot += (
+            lsm(logits_alt[i])[n2i[int(alt_ids[i + 1])]]
+            - lsm(logits_ref[i])[n2i[int(ref_ids[i + 1])]]
+        )
     return float(tot)
 
 
 def build_inputs(tok):
     genome = Genome(GENOME)
-    row = pl.read_parquet(SCORES).filter(
-        (pl.col("subset") == "distal")
-        & (pl.col("chrom").cast(pl.Utf8) == TARGET["chrom"])
-        & (pl.col("pos") == TARGET["pos"])
-        & (pl.col("ref") == TARGET["ref"])
-        & (pl.col("alt") == TARGET["alt"])
-    ).to_pandas().to_dict("records")[0]
+    row = (
+        pl.read_parquet(SCORES)
+        .filter(
+            (pl.col("subset") == "distal")
+            & (pl.col("chrom").cast(pl.Utf8) == TARGET["chrom"])
+            & (pl.col("pos") == TARGET["pos"])
+            & (pl.col("ref") == TARGET["ref"])
+            & (pl.col("alt") == TARGET["alt"])
+        )
+        .to_pandas()
+        .to_dict("records")[0]
+    )
     rec = transform_llr_clm(row, tok, genome, WINDOW, "+")
     n_prefix, _ = _get_special_token_counts(tok)
     var_pos = in_seq_var_pos(WINDOW, "+") + n_prefix  # 128 (= 127 + 1 BOS)
@@ -105,7 +112,9 @@ def build_inputs(tok):
     return dict(
         nuc_ids=nuc_ids,
         bos=dict(ref=ref_bos, alt=alt_bos, p=var_pos, L=len(ref_bos)),
-        nobos=dict(ref=ref_nobos, alt=alt_nobos, p=var_pos - n_prefix, L=len(ref_nobos)),
+        nobos=dict(
+            ref=ref_nobos, alt=alt_nobos, p=var_pos - n_prefix, L=len(ref_nobos)
+        ),
     )
 
 
@@ -129,31 +138,64 @@ def main():
     inp = build_inputs(tok)
     nuc_ids = inp["nuc_ids"]
 
-    print(f"[target] {TARGET['chrom']}:{TARGET['pos']} {TARGET['ref']}>{TARGET['alt']}  "
-          "(offline -3.21 ; online -8.05)")
+    print(
+        f"[target] {TARGET['chrom']}:{TARGET['pos']} {TARGET['ref']}>{TARGET['alt']}  "
+        "(offline -3.21 ; online -8.05)"
+    )
     print(f"  with-BOS: L={inp['bos']['L']} variant@{inp['bos']['p']}")
     print(f"  no-BOS  : L={inp['nobos']['L']} variant@{inp['nobos']['p']}")
 
     # torch
     tmodel = AutoModelForCausalLM.from_pretrained(CKPT, trust_remote_code=True).eval()
-    t_bos = seq_llr(torch_logits(tmodel, inp["bos"]["ref"]), torch_logits(tmodel, inp["bos"]["alt"]),
-                    inp["bos"]["ref"], inp["bos"]["alt"], inp["bos"]["p"], nuc_ids)
-    t_nobos = seq_llr(torch_logits(tmodel, inp["nobos"]["ref"]), torch_logits(tmodel, inp["nobos"]["alt"]),
-                      inp["nobos"]["ref"], inp["nobos"]["alt"], inp["nobos"]["p"], nuc_ids)
+    t_bos = seq_llr(
+        torch_logits(tmodel, inp["bos"]["ref"]),
+        torch_logits(tmodel, inp["bos"]["alt"]),
+        inp["bos"]["ref"],
+        inp["bos"]["alt"],
+        inp["bos"]["p"],
+        nuc_ids,
+    )
+    t_nobos = seq_llr(
+        torch_logits(tmodel, inp["nobos"]["ref"]),
+        torch_logits(tmodel, inp["nobos"]["alt"]),
+        inp["nobos"]["ref"],
+        inp["nobos"]["alt"],
+        inp["nobos"]["p"],
+        nuc_ids,
+    )
     del tmodel
 
     # levanter
-    mesh = Mesh(np.asarray(jax.devices()).reshape(1, 1, 1), ("replica", "data", "model"))
+    mesh = Mesh(
+        np.asarray(jax.devices()).reshape(1, 1, 1), ("replica", "data", "model")
+    )
     with set_mesh(mesh):
         cfg0 = Qwen3Config()
         conv = cfg0.hf_checkpoint_converter(ref_checkpoint=CKPT)
         cfg = conv.config_from_hf_config(conv.hf_config_from_hf_checkpoint(CKPT))
-        lmodel = inference_mode(conv.load_pretrained(Qwen3LMHeadModel, ref=CKPT, config=cfg, dtype=jnp.float32), True)
+        lmodel = inference_mode(
+            conv.load_pretrained(
+                Qwen3LMHeadModel, ref=CKPT, config=cfg, dtype=jnp.float32
+            ),
+            True,
+        )
         lmodel = jmp.get_policy("p=f32,c=bfloat16").cast_to_compute(lmodel)
-        l_bos = seq_llr(lev_logits(lmodel, inp["bos"]["ref"]), lev_logits(lmodel, inp["bos"]["alt"]),
-                        inp["bos"]["ref"], inp["bos"]["alt"], inp["bos"]["p"], nuc_ids)
-        l_nobos = seq_llr(lev_logits(lmodel, inp["nobos"]["ref"]), lev_logits(lmodel, inp["nobos"]["alt"]),
-                          inp["nobos"]["ref"], inp["nobos"]["alt"], inp["nobos"]["p"], nuc_ids)
+        l_bos = seq_llr(
+            lev_logits(lmodel, inp["bos"]["ref"]),
+            lev_logits(lmodel, inp["bos"]["alt"]),
+            inp["bos"]["ref"],
+            inp["bos"]["alt"],
+            inp["bos"]["p"],
+            nuc_ids,
+        )
+        l_nobos = seq_llr(
+            lev_logits(lmodel, inp["nobos"]["ref"]),
+            lev_logits(lmodel, inp["nobos"]["alt"]),
+            inp["nobos"]["ref"],
+            inp["nobos"]["alt"],
+            inp["nobos"]["p"],
+            nuc_ids,
+        )
 
     print("\n=== full-sequence 4-nuc LLR (chr7:156791472 C>A) ===")
     print(f"  {'':10} | {'with-BOS':>10} | {'no-BOS':>10}")

--- a/scripts/issue257/bos_test.py
+++ b/scripts/issue257/bos_test.py
@@ -1,0 +1,166 @@
+"""Issue #257: is the online↔offline LLR gap a BOS-prefix mismatch?
+
+The harness dataset (bolinas-dna/evals_mendelian_traits_harness_255) stores each
+variant as raw nucleotide strings: context (127 nt) + ref/alt_completion (128 nt)
+= 255 nt, NO BOS. The offline evals_v2 kernel builds a 256-token input = [BOS] +
+255 nt (n_prefix=1). If the levanter lm_eval harness tokenizes the raw strings
+*without* prepending BOS, the online model scores a 255-token, no-BOS sequence
+while offline scores a 256-token, BOS sequence — different context for the
+variant ⇒ different LLR.
+
+This tests it directly on the single most-divergent distal variant
+(chr7:156791472 C>A, offline -3.21 / online -8.05) under identical weights:
+compute the full-sequence 4-nuc LLR with-BOS vs no-BOS, in BOTH torch and
+levanter. If with-BOS ≈ -3.2 and no-BOS ≈ -8.0 in *both* stacks, the gap is the
+BOS prefix (a framework-independent input difference), not a forward-pass bug.
+
+Usage:
+  AWS_DEFAULT_REGION=us-east-2 JAX_PLATFORMS=cpu \
+    uv run --group genome-s3 --extra marin python scripts/issue257/bos_test.py
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import jax
+import jmp
+import numpy as np
+import polars as pl
+import torch
+
+jax.config.update("jax_platform_name", "cpu")
+
+import haliax as hax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+from haliax.partitioning import set_mesh  # noqa: E402
+from jax.sharding import Mesh  # noqa: E402
+from levanter.layers.attention import AttentionMask  # noqa: E402
+from levanter.models.qwen import Qwen3Config, Qwen3LMHeadModel  # noqa: E402
+from levanter.utils.tree_utils import inference_mode  # noqa: E402
+from transformers import AutoModelForCausalLM, AutoTokenizer  # noqa: E402
+
+from marin_dna.data.dna import NUCLEOTIDES  # noqa: E402
+from marin_dna.data.genome import Genome  # noqa: E402
+from marin_dna.data.transforms import (  # noqa: E402
+    _get_nucleotide_token_ids,
+    _get_special_token_counts,
+    in_seq_var_pos,
+    transform_llr_clm,
+)
+
+CKPT = "scratch/issue257/ckpt-ccre-4999"
+GENOME = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+SCORES = (
+    "s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+    "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet"
+)
+WINDOW = 255
+TARGET = dict(chrom="7", pos=156791472, ref="C", alt="A")
+
+
+def seq_llr(logits_ref, logits_alt, ref_ids, alt_ids, p, nuc_ids):
+    """Full-sequence 4-nuc LLR over [p-1, L-2] (variant + downstream)."""
+    n2i = {int(t): i for i, t in enumerate(nuc_ids)}
+    L = len(ref_ids)
+
+    def lsm(rowl):
+        z = rowl[nuc_ids].astype(np.float64)
+        return z - (np.log(np.exp(z - z.max()).sum()) + z.max())
+
+    tot = 0.0
+    for i in range(p - 1, L - 1):
+        tot += lsm(logits_alt[i])[n2i[int(alt_ids[i + 1])]] - lsm(logits_ref[i])[n2i[int(ref_ids[i + 1])]]
+    return float(tot)
+
+
+def build_inputs(tok):
+    genome = Genome(GENOME)
+    row = pl.read_parquet(SCORES).filter(
+        (pl.col("subset") == "distal")
+        & (pl.col("chrom").cast(pl.Utf8) == TARGET["chrom"])
+        & (pl.col("pos") == TARGET["pos"])
+        & (pl.col("ref") == TARGET["ref"])
+        & (pl.col("alt") == TARGET["alt"])
+    ).to_pandas().to_dict("records")[0]
+    rec = transform_llr_clm(row, tok, genome, WINDOW, "+")
+    n_prefix, _ = _get_special_token_counts(tok)
+    var_pos = in_seq_var_pos(WINDOW, "+") + n_prefix  # 128 (= 127 + 1 BOS)
+    nuc_map = _get_nucleotide_token_ids(tok)
+    nuc_ids = np.array([nuc_map[n] for n in NUCLEOTIDES])
+
+    # WITH BOS: the offline 256-token input (BOS + 255 nt), variant at index 128.
+    ref_bos = rec["input_ids"].numpy().astype(np.int64)
+    alt_bos = ref_bos.copy()
+    alt_bos[var_pos] = int(rec["alt_token_id"])
+    assert n_prefix == 1, f"expected 1 BOS, got n_prefix={n_prefix}"
+
+    # NO BOS: drop the BOS prefix → 255 nt, variant now at index 127.
+    ref_nobos = ref_bos[n_prefix:].copy()
+    alt_nobos = alt_bos[n_prefix:].copy()
+
+    return dict(
+        nuc_ids=nuc_ids,
+        bos=dict(ref=ref_bos, alt=alt_bos, p=var_pos, L=len(ref_bos)),
+        nobos=dict(ref=ref_nobos, alt=alt_nobos, p=var_pos - n_prefix, L=len(ref_nobos)),
+    )
+
+
+def torch_logits(model, ids_np):
+    with torch.no_grad():
+        out = model(torch.tensor(ids_np)[None, :])
+    return out.logits[0].float().numpy()
+
+
+def lev_logits(model, ids_np):
+    L = len(ids_np)
+    Batch, Pos = hax.Axis("batch", 1), hax.Axis("position", L)
+    ids = hax.named(jnp.asarray(ids_np[None, :], dtype=jnp.int32), (Batch, Pos))
+    lg = model(ids, attn_mask=AttentionMask.causal())
+    return np.asarray(lg.astype(jnp.float32).array)[0]
+
+
+def main():
+    torch.set_num_threads(4)
+    tok = AutoTokenizer.from_pretrained(CKPT)
+    inp = build_inputs(tok)
+    nuc_ids = inp["nuc_ids"]
+
+    print(f"[target] {TARGET['chrom']}:{TARGET['pos']} {TARGET['ref']}>{TARGET['alt']}  "
+          "(offline -3.21 ; online -8.05)")
+    print(f"  with-BOS: L={inp['bos']['L']} variant@{inp['bos']['p']}")
+    print(f"  no-BOS  : L={inp['nobos']['L']} variant@{inp['nobos']['p']}")
+
+    # torch
+    tmodel = AutoModelForCausalLM.from_pretrained(CKPT, trust_remote_code=True).eval()
+    t_bos = seq_llr(torch_logits(tmodel, inp["bos"]["ref"]), torch_logits(tmodel, inp["bos"]["alt"]),
+                    inp["bos"]["ref"], inp["bos"]["alt"], inp["bos"]["p"], nuc_ids)
+    t_nobos = seq_llr(torch_logits(tmodel, inp["nobos"]["ref"]), torch_logits(tmodel, inp["nobos"]["alt"]),
+                      inp["nobos"]["ref"], inp["nobos"]["alt"], inp["nobos"]["p"], nuc_ids)
+    del tmodel
+
+    # levanter
+    mesh = Mesh(np.asarray(jax.devices()).reshape(1, 1, 1), ("replica", "data", "model"))
+    with set_mesh(mesh):
+        cfg0 = Qwen3Config()
+        conv = cfg0.hf_checkpoint_converter(ref_checkpoint=CKPT)
+        cfg = conv.config_from_hf_config(conv.hf_config_from_hf_checkpoint(CKPT))
+        lmodel = inference_mode(conv.load_pretrained(Qwen3LMHeadModel, ref=CKPT, config=cfg, dtype=jnp.float32), True)
+        lmodel = jmp.get_policy("p=f32,c=bfloat16").cast_to_compute(lmodel)
+        l_bos = seq_llr(lev_logits(lmodel, inp["bos"]["ref"]), lev_logits(lmodel, inp["bos"]["alt"]),
+                        inp["bos"]["ref"], inp["bos"]["alt"], inp["bos"]["p"], nuc_ids)
+        l_nobos = seq_llr(lev_logits(lmodel, inp["nobos"]["ref"]), lev_logits(lmodel, inp["nobos"]["alt"]),
+                          inp["nobos"]["ref"], inp["nobos"]["alt"], inp["nobos"]["p"], nuc_ids)
+
+    print("\n=== full-sequence 4-nuc LLR (chr7:156791472 C>A) ===")
+    print(f"  {'':10} | {'with-BOS':>10} | {'no-BOS':>10}")
+    print(f"  {'torch':10} | {t_bos:>10.4f} | {t_nobos:>10.4f}")
+    print(f"  {'levanter':10} | {l_bos:>10.4f} | {l_nobos:>10.4f}")
+    print("\n  offline reference -3.21 ; online reference -8.05")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue257/compare_inputs.py
+++ b/scripts/issue257/compare_inputs.py
@@ -1,0 +1,116 @@
+"""Compare the ONLINE harness dataset vs OFFLINE source for the distal subset:
+variant set, labels, match_groups, AND the materialized (context, completion)
+sequences vs an on-the-fly offline extraction. No model — pure data check.
+
+If the online↔offline AUPRC gap were an input/sequence/tokenization difference,
+it would show up here. If everything matches, the gap is in the scoring path
+(or is an in-training-eval artifact), not the inputs.
+"""
+
+from __future__ import annotations
+
+import datasets
+import pandas as pd
+from transformers import AutoTokenizer
+
+from marin_dna.data.dna import complement_base
+from marin_dna.data.genome import Genome
+from marin_dna.data.transforms import _get_variant_window, in_seq_var_pos
+
+CKPT = "scratch/issue257/ckpt-ccre-4999"
+GENOME = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+OFFLINE = ("bolinas-dna/evals_mendelian_traits", "4aed58e50c5dea0b878a665007af2ef9e5108e9f")
+HARNESS = ("bolinas-dna/evals_mendelian_traits_harness_255", "7b92f047f9a36f90e9ac47886afa2a99264ee35c")
+WINDOW = 255
+
+
+def offline_materialize(rec: dict, genome: Genome, strand: str) -> dict:
+    """Reproduce materialize._add_eval_harness_fields from the offline variant."""
+    window, var_pos = _get_variant_window(rec, genome, WINDOW, strand=strand)
+    alt = str(rec["alt"]).upper()
+    alt_in_strand = alt if strand == "+" else complement_base(alt)
+    right = window[var_pos + 1 :]
+    return {
+        "context": window[:var_pos],
+        "ref_completion": window[var_pos:],
+        "alt_completion": alt_in_strand + right,
+    }
+
+
+def main() -> None:
+    off = datasets.load_dataset(OFFLINE[0], revision=OFFLINE[1], split="train").to_pandas()
+    off = off[off["subset"] == "distal"].reset_index(drop=True)
+    har = datasets.load_dataset(
+        HARNESS[0], name="default", revision=HARNESS[1], split="train"
+    ).to_pandas()
+    har = har[har["subset"] == "distal"].reset_index(drop=True)
+    print(f"offline distal rows: {len(off)} | harness distal rows: {len(har)} "
+          f"(harness = 2 strands/variant → expect 2x)")
+    print("harness columns:", list(har.columns))
+    print("harness strand counts:", har["strand"].value_counts().to_dict() if "strand" in har else "NO strand col")
+
+    har_fwd = har[har["strand"] == "+"].reset_index(drop=True) if "strand" in har else har
+    print(f"\nharness distal '+' rows: {len(har_fwd)}")
+
+    key = ["chrom", "pos", "ref", "alt"]
+    off_k = off.set_index([*key])
+    # target vs label name
+    label_col = "label" if "label" in off.columns else "target"
+    tgt_col = "target" if "target" in har_fwd.columns else "label"
+
+    merged = har_fwd.merge(off, on=key, suffixes=("_har", "_off"), how="outer", indicator=True)
+    print("\nmerge indicator:", merged["_merge"].value_counts().to_dict())
+
+    # label / subset / match_group agreement
+    both = merged[merged["_merge"] == "both"].copy()
+    lab_off = both[f"{label_col}_off"] if f"{label_col}_off" in both else both[label_col]
+    lab_har = both[f"{tgt_col}_har"] if f"{tgt_col}_har" in both else both[tgt_col]
+    print(f"label/target mismatches: {(lab_off.values != lab_har.values).sum()} / {len(both)}")
+    if "match_group_off" in both and "match_group_har" in both:
+        print(f"match_group mismatches: {(both['match_group_off'].values != both['match_group_har'].values).sum()}")
+
+    # ---- sequence comparison: harness vs offline on-the-fly ----
+    genome = Genome(GENOME)
+    tok = AutoTokenizer.from_pretrained(CKPT)
+    n_ctx_mismatch = n_ref_mismatch = n_alt_mismatch = 0
+    n_tok_mismatch = 0
+    examples = []
+    for _, row in har_fwd.iterrows():
+        rec = {"chrom": str(row["chrom"]), "pos": int(row["pos"]),
+               "ref": str(row["ref"]), "alt": str(row["alt"])}
+        mine = offline_materialize(rec, genome, "+")
+        cm = mine["context"] != row["context"]
+        rm = mine["ref_completion"] != row["ref_completion"]
+        am = mine["alt_completion"] != row["alt_completion"]
+        n_ctx_mismatch += cm
+        n_ref_mismatch += rm
+        n_alt_mismatch += am
+        # tokenization: lm_eval-style whole vs offline-style full window
+        whole_off = tok.encode(mine["context"] + mine["ref_completion"])
+        whole_har = tok.encode(str(row["context"]) + str(row["ref_completion"]))
+        if whole_off != whole_har:
+            n_tok_mismatch += 1
+        if (cm or rm or am) and len(examples) < 3:
+            examples.append((rec, mine, dict(row[["context", "ref_completion", "alt_completion"]])))
+
+    n = len(har_fwd)
+    print(f"\n=== sequence mismatches (harness '+' vs offline extraction), n={n} ===")
+    print(f"  context mismatches:        {n_ctx_mismatch}")
+    print(f"  ref_completion mismatches: {n_ref_mismatch}")
+    print(f"  alt_completion mismatches: {n_alt_mismatch}")
+    print(f"  whole-encoding mismatches: {n_tok_mismatch}")
+    for rec, mine, har_row in examples:
+        print("\n  MISMATCH", rec)
+        for fld in ["context", "ref_completion", "alt_completion"]:
+            m = mine[fld]; h = har_row[fld]
+            print(f"    {fld}: offline_len={len(m)} har_len={len(h)} equal={m==h}")
+            if m != h:
+                print(f"      offline: ...{m[-30:]}")
+                print(f"      harness: ...{h[-30:]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue257/compare_inputs.py
+++ b/scripts/issue257/compare_inputs.py
@@ -10,20 +10,25 @@ it would show up here. If everything matches, the gap is in the scoring path
 from __future__ import annotations
 
 import datasets
-import pandas as pd
 from transformers import AutoTokenizer
 
 from marin_dna.data.dna import complement_base
 from marin_dna.data.genome import Genome
-from marin_dna.data.transforms import _get_variant_window, in_seq_var_pos
+from marin_dna.data.transforms import _get_variant_window
 
 CKPT = "scratch/issue257/ckpt-ccre-4999"
 GENOME = (
     "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
     "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
 )
-OFFLINE = ("bolinas-dna/evals_mendelian_traits", "4aed58e50c5dea0b878a665007af2ef9e5108e9f")
-HARNESS = ("bolinas-dna/evals_mendelian_traits_harness_255", "7b92f047f9a36f90e9ac47886afa2a99264ee35c")
+OFFLINE = (
+    "bolinas-dna/evals_mendelian_traits",
+    "4aed58e50c5dea0b878a665007af2ef9e5108e9f",
+)
+HARNESS = (
+    "bolinas-dna/evals_mendelian_traits_harness_255",
+    "7b92f047f9a36f90e9ac47886afa2a99264ee35c",
+)
 WINDOW = 255
 
 
@@ -41,18 +46,27 @@ def offline_materialize(rec: dict, genome: Genome, strand: str) -> dict:
 
 
 def main() -> None:
-    off = datasets.load_dataset(OFFLINE[0], revision=OFFLINE[1], split="train").to_pandas()
+    off = datasets.load_dataset(
+        OFFLINE[0], revision=OFFLINE[1], split="train"
+    ).to_pandas()
     off = off[off["subset"] == "distal"].reset_index(drop=True)
     har = datasets.load_dataset(
         HARNESS[0], name="default", revision=HARNESS[1], split="train"
     ).to_pandas()
     har = har[har["subset"] == "distal"].reset_index(drop=True)
-    print(f"offline distal rows: {len(off)} | harness distal rows: {len(har)} "
-          f"(harness = 2 strands/variant → expect 2x)")
+    print(
+        f"offline distal rows: {len(off)} | harness distal rows: {len(har)} "
+        f"(harness = 2 strands/variant → expect 2x)"
+    )
     print("harness columns:", list(har.columns))
-    print("harness strand counts:", har["strand"].value_counts().to_dict() if "strand" in har else "NO strand col")
+    print(
+        "harness strand counts:",
+        har["strand"].value_counts().to_dict() if "strand" in har else "NO strand col",
+    )
 
-    har_fwd = har[har["strand"] == "+"].reset_index(drop=True) if "strand" in har else har
+    har_fwd = (
+        har[har["strand"] == "+"].reset_index(drop=True) if "strand" in har else har
+    )
     print(f"\nharness distal '+' rows: {len(har_fwd)}")
 
     key = ["chrom", "pos", "ref", "alt"]
@@ -61,16 +75,24 @@ def main() -> None:
     label_col = "label" if "label" in off.columns else "target"
     tgt_col = "target" if "target" in har_fwd.columns else "label"
 
-    merged = har_fwd.merge(off, on=key, suffixes=("_har", "_off"), how="outer", indicator=True)
+    merged = har_fwd.merge(
+        off, on=key, suffixes=("_har", "_off"), how="outer", indicator=True
+    )
     print("\nmerge indicator:", merged["_merge"].value_counts().to_dict())
 
     # label / subset / match_group agreement
     both = merged[merged["_merge"] == "both"].copy()
-    lab_off = both[f"{label_col}_off"] if f"{label_col}_off" in both else both[label_col]
+    lab_off = (
+        both[f"{label_col}_off"] if f"{label_col}_off" in both else both[label_col]
+    )
     lab_har = both[f"{tgt_col}_har"] if f"{tgt_col}_har" in both else both[tgt_col]
-    print(f"label/target mismatches: {(lab_off.values != lab_har.values).sum()} / {len(both)}")
+    print(
+        f"label/target mismatches: {(lab_off.values != lab_har.values).sum()} / {len(both)}"
+    )
     if "match_group_off" in both and "match_group_har" in both:
-        print(f"match_group mismatches: {(both['match_group_off'].values != both['match_group_har'].values).sum()}")
+        print(
+            f"match_group mismatches: {(both['match_group_off'].values != both['match_group_har'].values).sum()}"
+        )
 
     # ---- sequence comparison: harness vs offline on-the-fly ----
     genome = Genome(GENOME)
@@ -79,8 +101,12 @@ def main() -> None:
     n_tok_mismatch = 0
     examples = []
     for _, row in har_fwd.iterrows():
-        rec = {"chrom": str(row["chrom"]), "pos": int(row["pos"]),
-               "ref": str(row["ref"]), "alt": str(row["alt"])}
+        rec = {
+            "chrom": str(row["chrom"]),
+            "pos": int(row["pos"]),
+            "ref": str(row["ref"]),
+            "alt": str(row["alt"]),
+        }
         mine = offline_materialize(rec, genome, "+")
         cm = mine["context"] != row["context"]
         rm = mine["ref_completion"] != row["ref_completion"]
@@ -94,7 +120,9 @@ def main() -> None:
         if whole_off != whole_har:
             n_tok_mismatch += 1
         if (cm or rm or am) and len(examples) < 3:
-            examples.append((rec, mine, dict(row[["context", "ref_completion", "alt_completion"]])))
+            examples.append(
+                (rec, mine, dict(row[["context", "ref_completion", "alt_completion"]]))
+            )
 
     n = len(har_fwd)
     print(f"\n=== sequence mismatches (harness '+' vs offline extraction), n={n} ===")
@@ -105,8 +133,9 @@ def main() -> None:
     for rec, mine, har_row in examples:
         print("\n  MISMATCH", rec)
         for fld in ["context", "ref_completion", "alt_completion"]:
-            m = mine[fld]; h = har_row[fld]
-            print(f"    {fld}: offline_len={len(m)} har_len={len(h)} equal={m==h}")
+            m = mine[fld]
+            h = har_row[fld]
+            print(f"    {fld}: offline_len={len(m)} har_len={len(h)} equal={m == h}")
             if m != h:
                 print(f"      offline: ...{m[-30:]}")
                 print(f"      harness: ...{h[-30:]}")

--- a/scripts/issue257/compare_offline_online.py
+++ b/scripts/issue257/compare_offline_online.py
@@ -1,0 +1,58 @@
+"""Cross-check: offline evals_v2 metrics (just computed) vs the online
+in-training wandb metric, for the two finished exp232 arms with CLEAN final
+steps (utr3, bg). If offline ~ online here, it confirms the two paths agree at
+the final step when there's no glitch — isolating ccre/distal/FWD as the anomaly.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import wandb
+
+ARMS = ["v4_utr3", "v4_bg"]
+METRICS = "s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics/exp232-{arm}-step-4999/mendelian_traits.parquet"
+api = wandb.Api(timeout=40)
+proj = "gonzalobenegas/marin"
+
+
+def online_vals(arm: str) -> dict:
+    rs = list(api.runs(proj, filters={"display_name": {"$regex": f"exp232.*{arm}-v0.1$"}}, per_page=5))
+    r = rs[0]
+    out = {}
+    for k, v in r.summary.items():
+        # lm_eval/mendelian_traits_255/<subset>/<strand>/auprc
+        parts = k.split("/")
+        # lm_eval / mendelian_traits_255 / <subset> / <strand> / auprc  (5 parts)
+        if len(parts) == 5 and parts[0] == "lm_eval" and parts[1] == "mendelian_traits_255" and parts[4] == "auprc":
+            subset, strand = parts[2], parts[3]
+            out[(subset, strand)] = float(v)
+    return out
+
+
+for arm in ARMS:
+    off = pl.read_parquet(METRICS.format(arm=arm))
+    on = online_vals(arm)
+    # offline minus_llr_{fwd,rc,avg} → map to online fwd/rc/avg
+    off = off.filter(pl.col("score_type").str.starts_with("minus_llr_"))
+    off = off.with_columns(
+        pl.col("score_type").str.replace("minus_llr_", "").alias("strand")
+    )
+    print(f"\n{'='*78}\n### {arm}-step-4999   offline minus_llr  vs  online (in-training final)\n{'='*78}")
+    print(f"{'subset':<34}{'strand':<6}{'offline':>9}{'online':>9}{'Δ(off-on)':>11}")
+    rows = off.select(["subset", "strand", "value", "n_rows"]).sort(["subset", "strand"]).to_dicts()
+    big = []
+    for row in rows:
+        sub, strand, val = row["subset"], row["strand"], row["value"]
+        onv = on.get((sub, strand))
+        if onv is None:
+            print(f"{sub:<34}{strand:<6}{val:>9.4f}{'—':>9}{'(no online)':>11}")
+            continue
+        d = val - onv
+        flag = "  <<" if abs(d) > 0.05 else ""
+        print(f"{sub:<34}{strand:<6}{val:>9.4f}{onv:>9.4f}{d:>+11.4f}{flag}")
+        if abs(d) > 0.05:
+            big.append((sub, strand, val, onv, d))
+    if big:
+        print("  >>> |Δ|>0.05:", [(s, st, f"off={o:.3f}", f"on={n:.3f}") for s, st, o, n, _ in big])
+    else:
+        print("  >>> all |Δ| <= 0.05 — offline reproduces online (no glitch at this final step)")

--- a/scripts/issue257/compare_offline_online.py
+++ b/scripts/issue257/compare_offline_online.py
@@ -16,14 +16,25 @@ proj = "gonzalobenegas/marin"
 
 
 def online_vals(arm: str) -> dict:
-    rs = list(api.runs(proj, filters={"display_name": {"$regex": f"exp232.*{arm}-v0.1$"}}, per_page=5))
+    rs = list(
+        api.runs(
+            proj,
+            filters={"display_name": {"$regex": f"exp232.*{arm}-v0.1$"}},
+            per_page=5,
+        )
+    )
     r = rs[0]
     out = {}
     for k, v in r.summary.items():
         # lm_eval/mendelian_traits_255/<subset>/<strand>/auprc
         parts = k.split("/")
         # lm_eval / mendelian_traits_255 / <subset> / <strand> / auprc  (5 parts)
-        if len(parts) == 5 and parts[0] == "lm_eval" and parts[1] == "mendelian_traits_255" and parts[4] == "auprc":
+        if (
+            len(parts) == 5
+            and parts[0] == "lm_eval"
+            and parts[1] == "mendelian_traits_255"
+            and parts[4] == "auprc"
+        ):
             subset, strand = parts[2], parts[3]
             out[(subset, strand)] = float(v)
     return out
@@ -37,9 +48,15 @@ for arm in ARMS:
     off = off.with_columns(
         pl.col("score_type").str.replace("minus_llr_", "").alias("strand")
     )
-    print(f"\n{'='*78}\n### {arm}-step-4999   offline minus_llr  vs  online (in-training final)\n{'='*78}")
+    print(
+        f"\n{'=' * 78}\n### {arm}-step-4999   offline minus_llr  vs  online (in-training final)\n{'=' * 78}"
+    )
     print(f"{'subset':<34}{'strand':<6}{'offline':>9}{'online':>9}{'Δ(off-on)':>11}")
-    rows = off.select(["subset", "strand", "value", "n_rows"]).sort(["subset", "strand"]).to_dicts()
+    rows = (
+        off.select(["subset", "strand", "value", "n_rows"])
+        .sort(["subset", "strand"])
+        .to_dicts()
+    )
     big = []
     for row in rows:
         sub, strand, val = row["subset"], row["strand"], row["value"]
@@ -53,6 +70,11 @@ for arm in ARMS:
         if abs(d) > 0.05:
             big.append((sub, strand, val, onv, d))
     if big:
-        print("  >>> |Δ|>0.05:", [(s, st, f"off={o:.3f}", f"on={n:.3f}") for s, st, o, n, _ in big])
+        print(
+            "  >>> |Δ|>0.05:",
+            [(s, st, f"off={o:.3f}", f"on={n:.3f}") for s, st, o, n, _ in big],
+        )
     else:
-        print("  >>> all |Δ| <= 0.05 — offline reproduces online (no glitch at this final step)")
+        print(
+            "  >>> all |Δ| <= 0.05 — offline reproduces online (no glitch at this final step)"
+        )

--- a/scripts/issue257/compare_stacks.py
+++ b/scripts/issue257/compare_stacks.py
@@ -1,0 +1,259 @@
+"""Issue #257: localize the torch-HF (0.158) vs JAX-levanter (0.251) distal/fwd
+divergence on a SINGLE sequence, entirely on CPU — no iris/TPU needed.
+
+Background. The online (levanter) and offline (transformers) VEP evals run the
+*same* weights on *byte-identical* inputs, yet the distal/FWD AUPRC differs
+(0.159 offline vs 0.251 online). We already ruled out softmax-space, packing,
+prefix-sharing, the checkpoint, HF-conversion and RoPE-scaling. What's left is
+the forward pass itself: transformers (torch) vs levanter (JAX) Qwen3.
+
+This script runs ONE forward of ONE sequence (the single most-divergent distal
+variant, chr7:156791472 C>A — online -8.05 vs offline -3.21) through BOTH stacks
+at fp32 and bf16, and reports:
+
+  (1) the per-variant 4-nucleotide LLR in every config, and
+  (2) per-layer residual-stream max-abs-diff, to localize the first op that
+      diverges.
+
+The fork it settles:
+  * levanter-fp32 LLR ~= torch (-3.21)  -> the divergence is bf16 *precision*,
+    not math; per-layer bf16 diffs localize the unstable op.
+  * levanter-fp32 LLR ~= online (-8.05) -> a genuine *math* difference; per-layer
+    fp32 diffs localize the diverging op.
+
+Leading hypothesis going in: levanter attention runs scores+softmax in the
+compute dtype (bf16) because AttentionConfig.upcast_attn defaults to False
+(layers/attention.py:1749), whereas transformers Qwen3 upcasts the softmax to
+fp32. The `--upcast` A/B below tests exactly that: loading levanter with
+upcast_attn=True should recover torch's value if attention precision is the cause.
+
+Usage:
+  uv run --group genome-s3 --extra marin python scripts/issue257/compare_stacks.py
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import jax
+import jmp
+import numpy as np
+import polars as pl
+import torch
+
+jax.config.update("jax_platform_name", "cpu")
+
+import haliax as hax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+from haliax.partitioning import set_mesh  # noqa: E402
+from jax.sharding import Mesh  # noqa: E402
+from levanter.layers.attention import AttentionMask  # noqa: E402
+from levanter.models.qwen import Qwen3Config, Qwen3LMHeadModel  # noqa: E402
+from levanter.utils.tree_utils import inference_mode  # noqa: E402
+from transformers import AutoModelForCausalLM, AutoTokenizer  # noqa: E402
+
+from marin_dna.data.dna import NUCLEOTIDES  # noqa: E402
+from marin_dna.data.genome import Genome  # noqa: E402
+from marin_dna.data.transforms import (  # noqa: E402
+    _get_nucleotide_token_ids,
+    _get_special_token_counts,
+    in_seq_var_pos,
+    transform_llr_clm,
+)
+
+CKPT = "scratch/issue257/ckpt-ccre-4999"
+GENOME = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+SCORES = (
+    "s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+    "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet"
+)
+WINDOW = 255
+# The single most-divergent distal/+ positive (online -8.05, offline -3.21).
+TARGET = dict(chrom="7", pos=156791472, ref="C", alt="A")
+
+
+def _logsoftmax_nuc(logits_row: np.ndarray, nuc_ids: np.ndarray) -> np.ndarray:
+    """4-nucleotide log-softmax of a single logits row, in fp64."""
+    z = logits_row[nuc_ids].astype(np.float64)
+    return z - (np.log(np.exp(z - z.max()).sum()) + z.max())
+
+
+def _seq_llr(
+    logits_ref: np.ndarray,
+    logits_alt: np.ndarray,
+    ref_ids: np.ndarray,
+    alt_ids: np.ndarray,
+    p: int,
+    nuc_ids: np.ndarray,
+) -> float:
+    """Full-sequence 4-nuc LLR = logP(alt_seq) - logP(ref_seq), matching the
+    offline kernel: variant-position term (logits[p-1]) + downstream
+    autoregressive terms (logits[p..L-2]); the swapped token at p changes the
+    context for every later prediction, so ref/alt suffixes diverge."""
+    nuc_to_idx = {int(t): i for i, t in enumerate(nuc_ids)}
+    L = len(ref_ids)
+    total = 0.0
+    for i in range(p - 1, L - 1):  # logits index i predicts token i+1
+        za = _logsoftmax_nuc(logits_alt[i], nuc_ids)
+        zr = _logsoftmax_nuc(logits_ref[i], nuc_ids)
+        total += za[nuc_to_idx[int(alt_ids[i + 1])]] - zr[nuc_to_idx[int(ref_ids[i + 1])]]
+    return float(total)
+
+
+def build_input(tok) -> dict:
+    genome = Genome(GENOME)
+    df = pl.read_parquet(SCORES).filter(
+        (pl.col("subset") == "distal")
+        & (pl.col("chrom").cast(pl.Utf8) == TARGET["chrom"])
+        & (pl.col("pos") == TARGET["pos"])
+        & (pl.col("ref") == TARGET["ref"])
+        & (pl.col("alt") == TARGET["alt"])
+    )
+    assert df.height == 1, f"expected 1 target row, got {df.height}"
+    row = df.to_pandas().to_dict("records")[0]
+    print(f"[target] {row['chrom']}:{row['pos']} {row['ref']}>{row['alt']} "
+          f"label={row['label']}  offline llr_fwd={row['llr_fwd']:.4f}")
+    rec = transform_llr_clm(row, tok, genome, WINDOW, "+")
+    n_prefix, _ = _get_special_token_counts(tok)
+    var_pos = in_seq_var_pos(WINDOW, "+") + n_prefix
+    nuc_map = _get_nucleotide_token_ids(tok)
+    nuc_ids = np.array([nuc_map[n] for n in NUCLEOTIDES])
+    alt_id = int(rec["alt_token_id"])
+    ref_ids = rec["input_ids"].numpy().astype(np.int64)
+    ref_id = int(ref_ids[var_pos])  # ref token at var_pos by construction
+    assert ref_id == nuc_map[TARGET["ref"]], (
+        f"ref token {ref_id} != nuc id for {TARGET['ref']} ({nuc_map[TARGET['ref']]})"
+    )
+    assert alt_id == nuc_map[TARGET["alt"]], (
+        f"alt token {alt_id} != nuc id for {TARGET['alt']} ({nuc_map[TARGET['alt']]})"
+    )
+    alt_ids = ref_ids.copy()
+    alt_ids[var_pos] = alt_id
+    assert 0 < var_pos < len(ref_ids) - 1
+    return dict(
+        ref_ids=ref_ids, alt_ids=alt_ids, var_pos=var_pos, nuc_ids=nuc_ids,
+        ref_id=ref_id, alt_id=alt_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# torch / transformers
+# ---------------------------------------------------------------------------
+def run_torch(inp: dict, dtype: torch.dtype) -> dict:
+    model = AutoModelForCausalLM.from_pretrained(
+        CKPT, trust_remote_code=True, torch_dtype=dtype
+    ).eval()
+
+    def fwd(ids_np):
+        ids = torch.tensor(ids_np)[None, :]
+        with torch.no_grad():
+            out = model(ids, output_hidden_states=True)
+        logits = out.logits[0].float().numpy()
+        hs = [h[0].float().numpy() for h in out.hidden_states]
+        return logits, hs
+
+    logits_ref, hs = fwd(inp["ref_ids"])
+    logits_alt, _ = fwd(inp["alt_ids"])
+    llr = _seq_llr(logits_ref, logits_alt, inp["ref_ids"], inp["alt_ids"],
+                   inp["var_pos"], inp["nuc_ids"])
+    del model
+    return dict(llr=llr, logits=logits_ref, hiddens=hs)
+
+
+# ---------------------------------------------------------------------------
+# levanter / JAX
+# ---------------------------------------------------------------------------
+def _load_levanter(upcast_attn: bool) -> Qwen3LMHeadModel:
+    cfg0 = Qwen3Config()  # only used to get a converter bound to the right HF class
+    conv = cfg0.hf_checkpoint_converter(ref_checkpoint=CKPT)
+    hf_cfg = conv.hf_config_from_hf_checkpoint(CKPT)
+    cfg = conv.config_from_hf_config(hf_cfg)
+    cfg = dataclasses.replace(cfg, upcast_attn=upcast_attn)
+    model = conv.load_pretrained(Qwen3LMHeadModel, ref=CKPT, config=cfg, dtype=jnp.float32)
+    return inference_mode(model, True)
+
+
+def run_levanter(inp: dict, model: Qwen3LMHeadModel, compute_dtype: jnp.dtype) -> dict:
+    mp = jmp.get_policy(f"p=f32,c={'bfloat16' if compute_dtype == jnp.bfloat16 else 'float32'}")
+    model = mp.cast_to_compute(model)
+
+    seq_len = inp["ref_ids"].shape[0]
+    Batch = hax.Axis("batch", 1)
+    Pos = hax.Axis("position", seq_len)
+    mask = AttentionMask.causal()
+
+    def fwd(ids_np):
+        ids = hax.named(jnp.asarray(ids_np[None, :], dtype=jnp.int32), (Batch, Pos))
+        x = model.embeddings.embed(ids)
+        hs = [np.asarray(x.astype(jnp.float32).array)[0]]  # [seq, hidden]
+        for layer in model.transformer.layers.unstacked():
+            x = layer(x, mask, key=None, pos_ids=None)
+            hs.append(np.asarray(x.astype(jnp.float32).array)[0])
+        x_normed = model.transformer.norm(x)
+        # Online upcasts activations + lm_head to fp32 before the final projection.
+        logits = model.embeddings.unembed(x_normed.astype(jnp.float32))
+        return np.asarray(logits.astype(jnp.float32).array)[0], hs
+
+    logits_ref, hs = fwd(inp["ref_ids"])
+    logits_alt, _ = fwd(inp["alt_ids"])
+    llr = _seq_llr(logits_ref, logits_alt, inp["ref_ids"], inp["alt_ids"],
+                   inp["var_pos"], inp["nuc_ids"])
+    return dict(llr=llr, logits=logits_ref, hiddens=hs)
+
+
+def _maxdiff(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.abs(a.astype(np.float64) - b.astype(np.float64)).max())
+
+
+def main() -> None:
+    torch.set_num_threads(4)
+    tok = AutoTokenizer.from_pretrained(CKPT)
+    inp = build_input(tok)
+
+    print("\n=== loading + forward (CPU) ===")
+    t_f32 = run_torch(inp, torch.float32)
+    t_bf16 = run_torch(inp, torch.bfloat16)
+
+    # Single-device mesh with a `data` axis — mirrors the harness's
+    # `with config.trainer.use_device_mesh()` so the HF loader's best-effort
+    # sharding finds a `data` axis (size 1 ⇒ no real sharding).
+    mesh = Mesh(np.asarray(jax.devices()).reshape(1, 1, 1), ("replica", "data", "model"))
+    with set_mesh(mesh):
+        lev = _load_levanter(upcast_attn=False)
+        lev_up = _load_levanter(upcast_attn=True)
+        l_f32 = run_levanter(inp, lev, jnp.float32)
+        l_bf16 = run_levanter(inp, lev, jnp.bfloat16)
+        l_bf16_up = run_levanter(inp, lev_up, jnp.bfloat16)
+
+    print("\n=== per-variant 4-nuc LLR (target chr7:156791472 C>A) ===")
+    print(f"  offline reference (parquet llr_fwd)         : -3.2072")
+    print(f"  online  reference (levanter in-training)    : -8.0487")
+    print("  ---")
+    print(f"  torch    fp32                               : {t_f32['llr']:+.4f}")
+    print(f"  torch    bf16                               : {t_bf16['llr']:+.4f}")
+    print(f"  levanter fp32  (upcast_attn=F)              : {l_f32['llr']:+.4f}")
+    print(f"  levanter bf16  (upcast_attn=F, == online)   : {l_bf16['llr']:+.4f}")
+    print(f"  levanter bf16  (upcast_attn=T)              : {l_bf16_up['llr']:+.4f}")
+
+    print("\n=== final-logit max-abs-diff (torch vs levanter) ===")
+    print(f"  fp32:  {_maxdiff(t_f32['logits'], l_f32['logits']):.4e}")
+    print(f"  bf16:  {_maxdiff(t_bf16['logits'], l_bf16['logits']):.4e}")
+    print(f"  bf16 (levanter upcast_attn=T): {_maxdiff(t_bf16['logits'], l_bf16_up['logits']):.4e}")
+
+    print("\n=== per-layer residual-stream max-abs-diff (torch hidden_states[i] vs levanter) ===")
+    n = min(len(t_f32["hiddens"]), len(l_f32["hiddens"]))
+    print(f"  (torch has {len(t_f32['hiddens'])} hidden_states, levanter captured {len(l_f32['hiddens'])})")
+    print(f"  {'idx':>3} | {'fp32 diff':>12} | {'bf16 diff':>12} | {'bf16 upcast':>12}")
+    for i in range(n):
+        d_f32 = _maxdiff(t_f32["hiddens"][i], l_f32["hiddens"][i])
+        d_bf16 = _maxdiff(t_bf16["hiddens"][i], l_bf16["hiddens"][i])
+        d_up = _maxdiff(t_bf16["hiddens"][i], l_bf16_up["hiddens"][i])
+        tag = "  <- embed" if i == 0 else ""
+        print(f"  {i:>3} | {d_f32:>12.4e} | {d_bf16:>12.4e} | {d_up:>12.4e}{tag}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue257/compare_stacks.py
+++ b/scripts/issue257/compare_stacks.py
@@ -99,7 +99,9 @@ def _seq_llr(
     for i in range(p - 1, L - 1):  # logits index i predicts token i+1
         za = _logsoftmax_nuc(logits_alt[i], nuc_ids)
         zr = _logsoftmax_nuc(logits_ref[i], nuc_ids)
-        total += za[nuc_to_idx[int(alt_ids[i + 1])]] - zr[nuc_to_idx[int(ref_ids[i + 1])]]
+        total += (
+            za[nuc_to_idx[int(alt_ids[i + 1])]] - zr[nuc_to_idx[int(ref_ids[i + 1])]]
+        )
     return float(total)
 
 
@@ -114,8 +116,10 @@ def build_input(tok) -> dict:
     )
     assert df.height == 1, f"expected 1 target row, got {df.height}"
     row = df.to_pandas().to_dict("records")[0]
-    print(f"[target] {row['chrom']}:{row['pos']} {row['ref']}>{row['alt']} "
-          f"label={row['label']}  offline llr_fwd={row['llr_fwd']:.4f}")
+    print(
+        f"[target] {row['chrom']}:{row['pos']} {row['ref']}>{row['alt']} "
+        f"label={row['label']}  offline llr_fwd={row['llr_fwd']:.4f}"
+    )
     rec = transform_llr_clm(row, tok, genome, WINDOW, "+")
     n_prefix, _ = _get_special_token_counts(tok)
     var_pos = in_seq_var_pos(WINDOW, "+") + n_prefix
@@ -134,8 +138,12 @@ def build_input(tok) -> dict:
     alt_ids[var_pos] = alt_id
     assert 0 < var_pos < len(ref_ids) - 1
     return dict(
-        ref_ids=ref_ids, alt_ids=alt_ids, var_pos=var_pos, nuc_ids=nuc_ids,
-        ref_id=ref_id, alt_id=alt_id,
+        ref_ids=ref_ids,
+        alt_ids=alt_ids,
+        var_pos=var_pos,
+        nuc_ids=nuc_ids,
+        ref_id=ref_id,
+        alt_id=alt_id,
     )
 
 
@@ -157,8 +165,14 @@ def run_torch(inp: dict, dtype: torch.dtype) -> dict:
 
     logits_ref, hs = fwd(inp["ref_ids"])
     logits_alt, _ = fwd(inp["alt_ids"])
-    llr = _seq_llr(logits_ref, logits_alt, inp["ref_ids"], inp["alt_ids"],
-                   inp["var_pos"], inp["nuc_ids"])
+    llr = _seq_llr(
+        logits_ref,
+        logits_alt,
+        inp["ref_ids"],
+        inp["alt_ids"],
+        inp["var_pos"],
+        inp["nuc_ids"],
+    )
     del model
     return dict(llr=llr, logits=logits_ref, hiddens=hs)
 
@@ -172,12 +186,16 @@ def _load_levanter(upcast_attn: bool) -> Qwen3LMHeadModel:
     hf_cfg = conv.hf_config_from_hf_checkpoint(CKPT)
     cfg = conv.config_from_hf_config(hf_cfg)
     cfg = dataclasses.replace(cfg, upcast_attn=upcast_attn)
-    model = conv.load_pretrained(Qwen3LMHeadModel, ref=CKPT, config=cfg, dtype=jnp.float32)
+    model = conv.load_pretrained(
+        Qwen3LMHeadModel, ref=CKPT, config=cfg, dtype=jnp.float32
+    )
     return inference_mode(model, True)
 
 
 def run_levanter(inp: dict, model: Qwen3LMHeadModel, compute_dtype: jnp.dtype) -> dict:
-    mp = jmp.get_policy(f"p=f32,c={'bfloat16' if compute_dtype == jnp.bfloat16 else 'float32'}")
+    mp = jmp.get_policy(
+        f"p=f32,c={'bfloat16' if compute_dtype == jnp.bfloat16 else 'float32'}"
+    )
     model = mp.cast_to_compute(model)
 
     seq_len = inp["ref_ids"].shape[0]
@@ -199,8 +217,14 @@ def run_levanter(inp: dict, model: Qwen3LMHeadModel, compute_dtype: jnp.dtype) -
 
     logits_ref, hs = fwd(inp["ref_ids"])
     logits_alt, _ = fwd(inp["alt_ids"])
-    llr = _seq_llr(logits_ref, logits_alt, inp["ref_ids"], inp["alt_ids"],
-                   inp["var_pos"], inp["nuc_ids"])
+    llr = _seq_llr(
+        logits_ref,
+        logits_alt,
+        inp["ref_ids"],
+        inp["alt_ids"],
+        inp["var_pos"],
+        inp["nuc_ids"],
+    )
     return dict(llr=llr, logits=logits_ref, hiddens=hs)
 
 
@@ -220,7 +244,9 @@ def main() -> None:
     # Single-device mesh with a `data` axis — mirrors the harness's
     # `with config.trainer.use_device_mesh()` so the HF loader's best-effort
     # sharding finds a `data` axis (size 1 ⇒ no real sharding).
-    mesh = Mesh(np.asarray(jax.devices()).reshape(1, 1, 1), ("replica", "data", "model"))
+    mesh = Mesh(
+        np.asarray(jax.devices()).reshape(1, 1, 1), ("replica", "data", "model")
+    )
     with set_mesh(mesh):
         lev = _load_levanter(upcast_attn=False)
         lev_up = _load_levanter(upcast_attn=True)
@@ -229,8 +255,8 @@ def main() -> None:
         l_bf16_up = run_levanter(inp, lev_up, jnp.bfloat16)
 
     print("\n=== per-variant 4-nuc LLR (target chr7:156791472 C>A) ===")
-    print(f"  offline reference (parquet llr_fwd)         : -3.2072")
-    print(f"  online  reference (levanter in-training)    : -8.0487")
+    print("  offline reference (parquet llr_fwd)         : -3.2072")
+    print("  online  reference (levanter in-training)    : -8.0487")
     print("  ---")
     print(f"  torch    fp32                               : {t_f32['llr']:+.4f}")
     print(f"  torch    bf16                               : {t_bf16['llr']:+.4f}")
@@ -241,11 +267,17 @@ def main() -> None:
     print("\n=== final-logit max-abs-diff (torch vs levanter) ===")
     print(f"  fp32:  {_maxdiff(t_f32['logits'], l_f32['logits']):.4e}")
     print(f"  bf16:  {_maxdiff(t_bf16['logits'], l_bf16['logits']):.4e}")
-    print(f"  bf16 (levanter upcast_attn=T): {_maxdiff(t_bf16['logits'], l_bf16_up['logits']):.4e}")
+    print(
+        f"  bf16 (levanter upcast_attn=T): {_maxdiff(t_bf16['logits'], l_bf16_up['logits']):.4e}"
+    )
 
-    print("\n=== per-layer residual-stream max-abs-diff (torch hidden_states[i] vs levanter) ===")
+    print(
+        "\n=== per-layer residual-stream max-abs-diff (torch hidden_states[i] vs levanter) ==="
+    )
     n = min(len(t_f32["hiddens"]), len(l_f32["hiddens"]))
-    print(f"  (torch has {len(t_f32['hiddens'])} hidden_states, levanter captured {len(l_f32['hiddens'])})")
+    print(
+        f"  (torch has {len(t_f32['hiddens'])} hidden_states, levanter captured {len(l_f32['hiddens'])})"
+    )
     print(f"  {'idx':>3} | {'fp32 diff':>12} | {'bf16 diff':>12} | {'bf16 upcast':>12}")
     for i in range(n):
         d_f32 = _maxdiff(t_f32["hiddens"][i], l_f32["hiddens"][i])

--- a/scripts/issue257/diag_leakage.py
+++ b/scripts/issue257/diag_leakage.py
@@ -10,7 +10,6 @@ diff ~ 0, then full-vocab == 4-nuc is correct → softmax space can't explain th
 
 from __future__ import annotations
 
-import numpy as np
 import polars as pl
 import torch
 import torch.nn.functional as F
@@ -44,7 +43,9 @@ def main() -> None:
     tok = AutoTokenizer.from_pretrained(CKPT)
     model = AutoModelForCausalLM.from_pretrained(CKPT, trust_remote_code=True).eval()
     genome = Genome(GENOME)
-    df = pl.read_parquet(SCORES).filter(pl.col("subset") == "distal").head(N).to_pandas()
+    df = (
+        pl.read_parquet(SCORES).filter(pl.col("subset") == "distal").head(N).to_pandas()
+    )
 
     n_prefix, _ = _get_special_token_counts(tok)
     nuc_ids = torch.tensor(
@@ -52,7 +53,9 @@ def main() -> None:
     )
     var_pos = in_seq_var_pos(WINDOW, "+") + n_prefix
 
-    rows = [transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")]
+    rows = [
+        transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")
+    ]
     input_ids = torch.stack([r["input_ids"] for r in rows])  # [N, L]
     alt_tok = torch.tensor([r["alt_token_id"] for r in rows], dtype=torch.long)
 

--- a/scripts/issue257/diag_leakage.py
+++ b/scripts/issue257/diag_leakage.py
@@ -1,0 +1,90 @@
+"""Sanity-check the refutation: is the 4-nuc vs full-vocab equivalence real
+(model puts ~all mass on ACGT) or a bug in my full-vocab branch?
+
+Measures, on the actual distal sequences, the special-token probability mass
+P([PAD],[UNK],[BOS]) = 1 - sum(P_ACGT) at every scored (downstream) position,
+and the per-variant |llr_4nuc - llr_fullvocab|. If leakage ~ 0 and the LLR
+diff ~ 0, then full-vocab == 4-nuc is correct → softmax space can't explain the
+0.158 -> 0.251 gap.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import torch
+import torch.nn.functional as F
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from marin_dna.data.dna import NUCLEOTIDES
+from marin_dna.data.genome import Genome
+from marin_dna.data.transforms import (
+    _get_nucleotide_token_ids,
+    _get_special_token_counts,
+    in_seq_var_pos,
+    transform_llr_clm,
+)
+
+CKPT = "scratch/issue257/ckpt-ccre-4999"
+GENOME = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+SCORES = (
+    "s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+    "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet"
+)
+WINDOW = 255
+N = 64
+
+
+@torch.no_grad()
+def main() -> None:
+    torch.set_num_threads(4)
+    tok = AutoTokenizer.from_pretrained(CKPT)
+    model = AutoModelForCausalLM.from_pretrained(CKPT, trust_remote_code=True).eval()
+    genome = Genome(GENOME)
+    df = pl.read_parquet(SCORES).filter(pl.col("subset") == "distal").head(N).to_pandas()
+
+    n_prefix, _ = _get_special_token_counts(tok)
+    nuc_ids = torch.tensor(
+        [_get_nucleotide_token_ids(tok)[n] for n in NUCLEOTIDES], dtype=torch.long
+    )
+    var_pos = in_seq_var_pos(WINDOW, "+") + n_prefix
+
+    rows = [transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")]
+    input_ids = torch.stack([r["input_ids"] for r in rows])  # [N, L]
+    alt_tok = torch.tensor([r["alt_token_id"] for r in rows], dtype=torch.long)
+
+    # Forward the full (ref) sequences; look at downstream scored positions.
+    logits = model(input_ids).logits.float()  # [N, L, 7]
+    # scored next-token positions for the suffix: predict tokens var_pos..L-1,
+    # i.e. logits at positions var_pos-1 .. L-2.
+    L = input_ids.shape[1]
+    pos = slice(var_pos - 1, L - 1)
+    lp = F.log_softmax(logits[:, pos], dim=-1)  # [N, n_scored, 7]
+    p_acgt = lp[..., nuc_ids].exp().sum(-1)  # [N, n_scored] — prob mass on ACGT
+    leak = 1.0 - p_acgt  # special-token mass
+    logZ = torch.log(p_acgt.clamp_min(1e-30))  # the term that differs 4nuc vs full
+
+    print(f"n_seq={N}  scored_positions/seq={lp.shape[1]}  vocab={logits.shape[-1]}")
+    print("\n=== special-token probability mass (leakage) at scored positions ===")
+    print(f"  mean leakage      : {leak.mean().item():.3e}")
+    print(f"  median leakage    : {leak.median().item():.3e}")
+    print(f"  max leakage       : {leak.max().item():.3e}")
+    print(f"  99th pct leakage  : {torch.quantile(leak.flatten(), 0.99).item():.3e}")
+    print(f"  frac positions >1e-3 leakage: {(leak > 1e-3).float().mean().item():.3e}")
+    print("\n=== logZ = log(sum P_ACGT) — the per-position 4nuc-vs-full correction ===")
+    print(f"  mean |logZ| : {logZ.abs().mean().item():.3e}")
+    print(f"  max  |logZ| : {logZ.abs().max().item():.3e}")
+    print(
+        "\nInterpretation: llr_full - llr_4nuc = sum over scored positions of "
+        "[logZ(ctx_alt) - logZ(ctx_ref)].\n"
+        "If |logZ| ~ 0 everywhere, the two softmax spaces give the same LLR "
+        "(confirmed: full-vocab AUPRC == 4-nuc AUPRC), so the softmax convention "
+        "cannot be the source of the online 0.251."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue257/diff_per_variant.py
+++ b/scripts/issue257/diff_per_variant.py
@@ -17,46 +17,87 @@ from sklearn.metrics import average_precision_score
 
 GCS = "gs://marin-us-east5/tmp/issue257/online_llrs_dump2.jsonl"
 LOCAL = "scratch/issue257/online_llrs_dump2.jsonl"
-OFF = ("s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
-       "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet")
+OFF = (
+    "s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+    "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet"
+)
 
 subprocess.run(["gcloud", "storage", "cp", GCS, LOCAL], check=True)
 on = pl.DataFrame([json.loads(line) for line in open(LOCAL) if line.strip()])
-print(f"online rows: {on.shape}  strands={on['strand'].unique().to_list()}  "
-      f"subsets={on['subset'].n_unique()}")
+print(
+    f"online rows: {on.shape}  strands={on['strand'].unique().to_list()}  "
+    f"subsets={on['subset'].n_unique()}"
+)
 
 off = pl.read_parquet(OFF)
 # offline long form: one (chrom,pos,ref,alt,strand,off_llr) per strand
-off_long = pl.concat([
-    off.select(["chrom", "pos", "ref", "alt", "subset", "label",
-                pl.col("llr_fwd").alias("off_llr"), pl.lit("+").alias("strand")]),
-    off.select(["chrom", "pos", "ref", "alt", "subset", "label",
-                pl.col("llr_rc").alias("off_llr"), pl.lit("-").alias("strand")]),
-])
+off_long = pl.concat(
+    [
+        off.select(
+            [
+                "chrom",
+                "pos",
+                "ref",
+                "alt",
+                "subset",
+                "label",
+                pl.col("llr_fwd").alias("off_llr"),
+                pl.lit("+").alias("strand"),
+            ]
+        ),
+        off.select(
+            [
+                "chrom",
+                "pos",
+                "ref",
+                "alt",
+                "subset",
+                "label",
+                pl.col("llr_rc").alias("off_llr"),
+                pl.lit("-").alias("strand"),
+            ]
+        ),
+    ]
+)
 on = on.with_columns(pl.col("pos").cast(pl.Int64))
-m = on.join(off_long.select(["chrom", "pos", "ref", "alt", "strand", "off_llr"]),
-            on=["chrom", "pos", "ref", "alt", "strand"], how="inner")
+m = on.join(
+    off_long.select(["chrom", "pos", "ref", "alt", "strand", "off_llr"]),
+    on=["chrom", "pos", "ref", "alt", "strand"],
+    how="inner",
+)
 m = m.with_columns((pl.col("llr") - pl.col("off_llr")).alias("d"))
 print(f"merged rows: {m.shape[0]} (expect ~{on.shape[0]})")
 
 print("\n=== per (subset,strand): corr + mean|online-offline| LLR ===")
 print(f"{'subset':<30}{'strand':<5}{'n':>5}{'corr':>8}{'mean|d|':>9}{'max|d|':>8}")
-for (sub, st), g in sorted(m.group_by(["subset", "strand"]), key=lambda x: (x[0][0], x[0][1])):
+for (sub, st), g in sorted(
+    m.group_by(["subset", "strand"]), key=lambda x: (x[0][0], x[0][1])
+):
     a, b = g["llr"].to_numpy(), g["off_llr"].to_numpy()
     c = np.corrcoef(a, b)[0, 1] if len(a) > 2 else float("nan")
-    print(f"{sub:<30}{st:<5}{len(a):>5}{c:>8.4f}{np.abs(a-b).mean():>9.4f}{np.abs(a-b).max():>8.3f}")
+    print(
+        f"{sub:<30}{st:<5}{len(a):>5}{c:>8.4f}{np.abs(a - b).mean():>9.4f}{np.abs(a - b).max():>8.3f}"
+    )
 
 # --- distal/fwd focus ---
-d = m.filter((pl.col("subset") == "distal") & (pl.col("strand") == "+")).sort("d", descending=True)
+d = m.filter((pl.col("subset") == "distal") & (pl.col("strand") == "+")).sort(
+    "d", descending=True
+)
 lab = d["label"].to_numpy()
 print(f"\n=== distal/fwd: n={len(d)} pos={int(lab.sum())} ===")
-print(f"AUPRC online(-llr)={average_precision_score(lab, -d['llr'].to_numpy()):.4f}  "
-      f"offline(-off_llr)={average_precision_score(lab, -d['off_llr'].to_numpy()):.4f}")
-print(f"mean d (online-offline) over distal/fwd: {d['d'].mean():.4f} ; "
-      f"pos-only mean d: {d.filter(pl.col('label')==1)['d'].mean():.4f} ; "
-      f"neg-only mean d: {d.filter(pl.col('label')==0)['d'].mean():.4f}")
+print(
+    f"AUPRC online(-llr)={average_precision_score(lab, -d['llr'].to_numpy()):.4f}  "
+    f"offline(-off_llr)={average_precision_score(lab, -d['off_llr'].to_numpy()):.4f}"
+)
+print(
+    f"mean d (online-offline) over distal/fwd: {d['d'].mean():.4f} ; "
+    f"pos-only mean d: {d.filter(pl.col('label') == 1)['d'].mean():.4f} ; "
+    f"neg-only mean d: {d.filter(pl.col('label') == 0)['d'].mean():.4f}"
+)
 print("\ntop 12 |online-offline| distal/fwd variants:")
 top = d.with_columns(pl.col("d").abs().alias("ad")).sort("ad", descending=True).head(12)
 for r in top.iter_rows(named=True):
-    print(f"  {r['chrom']}:{r['pos']} {r['ref']}>{r['alt']} label={r['label']} "
-          f"online={r['llr']:+.3f} offline={r['off_llr']:+.3f} d={r['d']:+.3f}")
+    print(
+        f"  {r['chrom']}:{r['pos']} {r['ref']}>{r['alt']} label={r['label']} "
+        f"online={r['llr']:+.3f} offline={r['off_llr']:+.3f} d={r['d']:+.3f}"
+    )

--- a/scripts/issue257/diff_per_variant.py
+++ b/scripts/issue257/diff_per_variant.py
@@ -1,0 +1,62 @@
+"""Diff per-variant raw LLRs: online (levanter, GCS dump) vs offline (kernel,
+S3 scores parquet). Localizes WHICH variants diverge (esp. distal/fwd) and
+whether it's a few outliers or a systematic shift.
+
+online dump rows: {llr, label, subset, chrom, pos, ref, alt, match_group, strand}
+  strand '+' -> compare to offline llr_fwd ; '-' -> offline llr_rc
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import numpy as np
+import polars as pl
+from sklearn.metrics import average_precision_score
+
+GCS = "gs://marin-us-east5/tmp/issue257/online_llrs_dump2.jsonl"
+LOCAL = "scratch/issue257/online_llrs_dump2.jsonl"
+OFF = ("s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+       "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet")
+
+subprocess.run(["gcloud", "storage", "cp", GCS, LOCAL], check=True)
+on = pl.DataFrame([json.loads(line) for line in open(LOCAL) if line.strip()])
+print(f"online rows: {on.shape}  strands={on['strand'].unique().to_list()}  "
+      f"subsets={on['subset'].n_unique()}")
+
+off = pl.read_parquet(OFF)
+# offline long form: one (chrom,pos,ref,alt,strand,off_llr) per strand
+off_long = pl.concat([
+    off.select(["chrom", "pos", "ref", "alt", "subset", "label",
+                pl.col("llr_fwd").alias("off_llr"), pl.lit("+").alias("strand")]),
+    off.select(["chrom", "pos", "ref", "alt", "subset", "label",
+                pl.col("llr_rc").alias("off_llr"), pl.lit("-").alias("strand")]),
+])
+on = on.with_columns(pl.col("pos").cast(pl.Int64))
+m = on.join(off_long.select(["chrom", "pos", "ref", "alt", "strand", "off_llr"]),
+            on=["chrom", "pos", "ref", "alt", "strand"], how="inner")
+m = m.with_columns((pl.col("llr") - pl.col("off_llr")).alias("d"))
+print(f"merged rows: {m.shape[0]} (expect ~{on.shape[0]})")
+
+print("\n=== per (subset,strand): corr + mean|online-offline| LLR ===")
+print(f"{'subset':<30}{'strand':<5}{'n':>5}{'corr':>8}{'mean|d|':>9}{'max|d|':>8}")
+for (sub, st), g in sorted(m.group_by(["subset", "strand"]), key=lambda x: (x[0][0], x[0][1])):
+    a, b = g["llr"].to_numpy(), g["off_llr"].to_numpy()
+    c = np.corrcoef(a, b)[0, 1] if len(a) > 2 else float("nan")
+    print(f"{sub:<30}{st:<5}{len(a):>5}{c:>8.4f}{np.abs(a-b).mean():>9.4f}{np.abs(a-b).max():>8.3f}")
+
+# --- distal/fwd focus ---
+d = m.filter((pl.col("subset") == "distal") & (pl.col("strand") == "+")).sort("d", descending=True)
+lab = d["label"].to_numpy()
+print(f"\n=== distal/fwd: n={len(d)} pos={int(lab.sum())} ===")
+print(f"AUPRC online(-llr)={average_precision_score(lab, -d['llr'].to_numpy()):.4f}  "
+      f"offline(-off_llr)={average_precision_score(lab, -d['off_llr'].to_numpy()):.4f}")
+print(f"mean d (online-offline) over distal/fwd: {d['d'].mean():.4f} ; "
+      f"pos-only mean d: {d.filter(pl.col('label')==1)['d'].mean():.4f} ; "
+      f"neg-only mean d: {d.filter(pl.col('label')==0)['d'].mean():.4f}")
+print("\ntop 12 |online-offline| distal/fwd variants:")
+top = d.with_columns(pl.col("d").abs().alias("ad")).sort("ad", descending=True).head(12)
+for r in top.iter_rows(named=True):
+    print(f"  {r['chrom']}:{r['pos']} {r['ref']}>{r['alt']} label={r['label']} "
+          f"online={r['llr']:+.3f} offline={r['off_llr']:+.3f} d={r['d']:+.3f}")

--- a/scripts/issue257/full_forward_test.py
+++ b/scripts/issue257/full_forward_test.py
@@ -17,7 +17,6 @@ import torch.nn.functional as F
 from sklearn.metrics import average_precision_score
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from marin_dna.data.dna import NUCLEOTIDES
 from marin_dna.data.genome import Genome
 from marin_dna.data.transforms import (
     _get_nucleotide_token_ids,
@@ -28,10 +27,14 @@ from marin_dna.data.transforms import (
 from marin_dna.model.scoring import _repeat_interleave_kv_cache
 
 CKPT = "scratch/issue257/ckpt-ccre-4999"
-GENOME = ("s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
-          "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz")
-SCORES = ("s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
-          "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet")
+GENOME = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+SCORES = (
+    "s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+    "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet"
+)
 WINDOW = 255
 
 
@@ -47,9 +50,11 @@ def full_forward_llr(model, input_ids, alt_tok, var_pos, dtype):
     logits = m(both).logits.float()  # [2B, L, V]
     lp = F.log_softmax(logits, dim=-1)
     # predict token t (t in [var_pos, L-1]) from position t-1
-    idx = both[:, var_pos:].unsqueeze(-1)                 # [2B, L-var_pos, 1] targets
-    pred = lp[:, var_pos - 1 : L - 1]                      # [2B, L-var_pos, V]
-    tok_lp = pred.gather(-1, idx).squeeze(-1).sum(-1)     # [2B] seq logprob over completion
+    idx = both[:, var_pos:].unsqueeze(-1)  # [2B, L-var_pos, 1] targets
+    pred = lp[:, var_pos - 1 : L - 1]  # [2B, L-var_pos, V]
+    tok_lp = (
+        pred.gather(-1, idx).squeeze(-1).sum(-1)
+    )  # [2B] seq logprob over completion
     ref_lp, alt_lp = tok_lp[:B], tok_lp[B:]
     if dtype != torch.float32:
         model.to(torch.float32)
@@ -60,6 +65,7 @@ def full_forward_llr(model, input_ids, alt_tok, var_pos, dtype):
 def prefix_share_full_llr(model, input_ids, alt_tok, var_pos):
     """Prefix-shared full-vocab LLR (offline kernel structure), fp32."""
     from einops import rearrange
+
     B, L = input_ids.shape
     p = var_pos
     prefix = input_ids[:, :p].contiguous()
@@ -74,8 +80,10 @@ def prefix_share_full_llr(model, input_ids, alt_tok, var_pos):
     lp = rearrange(lp, "(B V) L W -> B V L W", B=B)
     lpr, lpa = lp[:, 0, :-1], lp[:, 1, :-1]
     plp = F.log_softmax(plast.float(), -1)
-    at_var = plp.gather(-1, alt_tok[:, None]).squeeze(-1) - plp.gather(-1, input_ids[:, p][:, None]).squeeze(-1)
-    tgt = input_ids[:, p + 1:].unsqueeze(-1)
+    at_var = plp.gather(-1, alt_tok[:, None]).squeeze(-1) - plp.gather(
+        -1, input_ids[:, p][:, None]
+    ).squeeze(-1)
+    tgt = input_ids[:, p + 1 :].unsqueeze(-1)
     down = (lpa.gather(-1, tgt).squeeze(-1) - lpr.gather(-1, tgt).squeeze(-1)).sum(-1)
     return (at_var + down).numpy()
 
@@ -90,26 +98,42 @@ def main():
     n_prefix, _ = _get_special_token_counts(tok)
     nuc = _get_nucleotide_token_ids(tok)
     var_pos = in_seq_var_pos(WINDOW, "+") + n_prefix
-    rows = [transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")]
+    rows = [
+        transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")
+    ]
     input_ids = torch.stack([r["input_ids"] for r in rows])
     alt_tok = torch.tensor([r["alt_token_id"] for r in rows])
 
     res = {}
     for name, fn in [
         ("ps_full_fp32", lambda b, a: prefix_share_full_llr(model, b, a, var_pos)),
-        ("ff_full_fp32", lambda b, a: full_forward_llr(model, b, a, var_pos, torch.float32)),
-        ("ff_full_bf16", lambda b, a: full_forward_llr(model, b, a, var_pos, torch.bfloat16)),
+        (
+            "ff_full_fp32",
+            lambda b, a: full_forward_llr(model, b, a, var_pos, torch.float32),
+        ),
+        (
+            "ff_full_bf16",
+            lambda b, a: full_forward_llr(model, b, a, var_pos, torch.bfloat16),
+        ),
     ]:
         out = np.zeros(len(rows))
         for i in range(0, len(rows), 64):
-            out[i:i + 64] = fn(input_ids[i:i + 64], alt_tok[i:i + 64])
+            out[i : i + 64] = fn(input_ids[i : i + 64], alt_tok[i : i + 64])
         res[name] = out
         print(f"{name:<16} distal/fwd AUPRC = {average_precision_score(lab, -out):.4f}")
 
-    print("\noffline parquet (bf16 prefix-share) = 0.1589 ; online (levanter bf16) = 0.2507")
-    print(f"corr(ps_full_fp32, ff_full_fp32) = {np.corrcoef(res['ps_full_fp32'], res['ff_full_fp32'])[0,1]:.6f}")
-    print(f"max|ps_fp32 - ff_fp32| = {np.abs(res['ps_full_fp32']-res['ff_full_fp32']).max():.2e}")
-    print(f"max|ff_fp32 - ff_bf16| = {np.abs(res['ff_full_fp32']-res['ff_full_bf16']).max():.3f}")
+    print(
+        "\noffline parquet (bf16 prefix-share) = 0.1589 ; online (levanter bf16) = 0.2507"
+    )
+    print(
+        f"corr(ps_full_fp32, ff_full_fp32) = {np.corrcoef(res['ps_full_fp32'], res['ff_full_fp32'])[0, 1]:.6f}"
+    )
+    print(
+        f"max|ps_fp32 - ff_fp32| = {np.abs(res['ps_full_fp32'] - res['ff_full_fp32']).max():.2e}"
+    )
+    print(
+        f"max|ff_fp32 - ff_bf16| = {np.abs(res['ff_full_fp32'] - res['ff_full_bf16']).max():.3f}"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/issue257/full_forward_test.py
+++ b/scripts/issue257/full_forward_test.py
@@ -1,0 +1,116 @@
+"""Does the offline kernel's prefix-sharing (KV-cache) vs a plain full forward
+(what lm_eval does) explain the distal/fwd gap (offline 0.158 vs online 0.251)?
+
+Computes distal/FWD LLR three ways on the same checkpoint+inputs:
+  ps_full   = prefix-shared full-vocab (the offline kernel path)         -> expect 0.158
+  ff_full   = full-forward full-vocab, fp32 (lm_eval math, no KV-cache)
+  ff_full16 = full-forward full-vocab, bf16 (closest to the online run)
+All score the same 128 completion positions with the same full-vocab softmax.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import torch
+import torch.nn.functional as F
+from sklearn.metrics import average_precision_score
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from marin_dna.data.dna import NUCLEOTIDES
+from marin_dna.data.genome import Genome
+from marin_dna.data.transforms import (
+    _get_nucleotide_token_ids,
+    _get_special_token_counts,
+    in_seq_var_pos,
+    transform_llr_clm,
+)
+from marin_dna.model.scoring import _repeat_interleave_kv_cache
+
+CKPT = "scratch/issue257/ckpt-ccre-4999"
+GENOME = ("s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+          "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz")
+SCORES = ("s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+          "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet")
+WINDOW = 255
+
+
+@torch.no_grad()
+def full_forward_llr(model, input_ids, alt_tok, var_pos, dtype):
+    """lm_eval-style: forward whole ref & alt seqs, sum full-vocab logprob over
+    completion positions [var_pos:L], LLR = alt - ref. No KV-cache."""
+    B, L = input_ids.shape
+    alt_ids = input_ids.clone()
+    alt_ids[:, var_pos] = alt_tok
+    both = torch.cat([input_ids, alt_ids], 0)  # [2B, L]
+    m = model.to(dtype) if dtype != torch.float32 else model
+    logits = m(both).logits.float()  # [2B, L, V]
+    lp = F.log_softmax(logits, dim=-1)
+    # predict token t (t in [var_pos, L-1]) from position t-1
+    idx = both[:, var_pos:].unsqueeze(-1)                 # [2B, L-var_pos, 1] targets
+    pred = lp[:, var_pos - 1 : L - 1]                      # [2B, L-var_pos, V]
+    tok_lp = pred.gather(-1, idx).squeeze(-1).sum(-1)     # [2B] seq logprob over completion
+    ref_lp, alt_lp = tok_lp[:B], tok_lp[B:]
+    if dtype != torch.float32:
+        model.to(torch.float32)
+    return (alt_lp - ref_lp).numpy()
+
+
+@torch.no_grad()
+def prefix_share_full_llr(model, input_ids, alt_tok, var_pos):
+    """Prefix-shared full-vocab LLR (offline kernel structure), fp32."""
+    from einops import rearrange
+    B, L = input_ids.shape
+    p = var_pos
+    prefix = input_ids[:, :p].contiguous()
+    ref_suf = input_ids[:, p:].contiguous()
+    alt_suf = torch.cat([alt_tok.unsqueeze(-1), ref_suf[:, 1:]], -1)
+    suf = rearrange(torch.stack([ref_suf, alt_suf], 1), "B V L -> (B V) L").contiguous()
+    out = model(prefix, use_cache=True, logits_to_keep=1)
+    plast = out.logits[:, -1]
+    past = _repeat_interleave_kv_cache(out.past_key_values, 2)
+    slog = model(suf, past_key_values=past, use_cache=False).logits
+    lp = F.log_softmax(slog.float(), -1)
+    lp = rearrange(lp, "(B V) L W -> B V L W", B=B)
+    lpr, lpa = lp[:, 0, :-1], lp[:, 1, :-1]
+    plp = F.log_softmax(plast.float(), -1)
+    at_var = plp.gather(-1, alt_tok[:, None]).squeeze(-1) - plp.gather(-1, input_ids[:, p][:, None]).squeeze(-1)
+    tgt = input_ids[:, p + 1:].unsqueeze(-1)
+    down = (lpa.gather(-1, tgt).squeeze(-1) - lpr.gather(-1, tgt).squeeze(-1)).sum(-1)
+    return (at_var + down).numpy()
+
+
+def main():
+    torch.set_num_threads(4)
+    tok = AutoTokenizer.from_pretrained(CKPT)
+    model = AutoModelForCausalLM.from_pretrained(CKPT, trust_remote_code=True).eval()
+    genome = Genome(GENOME)
+    df = pl.read_parquet(SCORES).filter(pl.col("subset") == "distal").to_pandas()
+    lab = df["label"].to_numpy()
+    n_prefix, _ = _get_special_token_counts(tok)
+    nuc = _get_nucleotide_token_ids(tok)
+    var_pos = in_seq_var_pos(WINDOW, "+") + n_prefix
+    rows = [transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")]
+    input_ids = torch.stack([r["input_ids"] for r in rows])
+    alt_tok = torch.tensor([r["alt_token_id"] for r in rows])
+
+    res = {}
+    for name, fn in [
+        ("ps_full_fp32", lambda b, a: prefix_share_full_llr(model, b, a, var_pos)),
+        ("ff_full_fp32", lambda b, a: full_forward_llr(model, b, a, var_pos, torch.float32)),
+        ("ff_full_bf16", lambda b, a: full_forward_llr(model, b, a, var_pos, torch.bfloat16)),
+    ]:
+        out = np.zeros(len(rows))
+        for i in range(0, len(rows), 64):
+            out[i:i + 64] = fn(input_ids[i:i + 64], alt_tok[i:i + 64])
+        res[name] = out
+        print(f"{name:<16} distal/fwd AUPRC = {average_precision_score(lab, -out):.4f}")
+
+    print("\noffline parquet (bf16 prefix-share) = 0.1589 ; online (levanter bf16) = 0.2507")
+    print(f"corr(ps_full_fp32, ff_full_fp32) = {np.corrcoef(res['ps_full_fp32'], res['ff_full_fp32'])[0,1]:.6f}")
+    print(f"max|ps_fp32 - ff_fp32| = {np.abs(res['ps_full_fp32']-res['ff_full_fp32']).max():.2e}")
+    print(f"max|ff_fp32 - ff_bf16| = {np.abs(res['ff_full_fp32']-res['ff_full_bf16']).max():.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue257/native_vs_export.py
+++ b/scripts/issue257/native_vs_export.py
@@ -30,7 +30,6 @@ Usage (CPU box with gcloud creds for the gs:// native checkpoint):
 
 from __future__ import annotations
 
-import dataclasses
 
 import equinox as eqx
 import jax
@@ -104,7 +103,9 @@ def load_native() -> Qwen3LMHeadModel:
         try:
             with use_cpu_device():
                 Vocab = hax.Axis("vocab", vsize)
-                template = eqx.filter_eval_shape(cfg.build, Vocab, key=jax.random.PRNGKey(0))
+                template = eqx.filter_eval_shape(
+                    cfg.build, Vocab, key=jax.random.PRNGKey(0)
+                )
                 model = load_checkpoint(template, cp, subpath="model", axis_mapping={})
             print(f"[native] loaded with Vocab={vsize}")
             return inference_mode(model, True)
@@ -117,7 +118,9 @@ def load_export() -> Qwen3LMHeadModel:
     cfg0 = Qwen3Config()
     conv = cfg0.hf_checkpoint_converter(ref_checkpoint=EXPORT)
     cfg = conv.config_from_hf_config(conv.hf_config_from_hf_checkpoint(EXPORT))
-    model = conv.load_pretrained(Qwen3LMHeadModel, ref=EXPORT, config=cfg, dtype=jnp.float32)
+    model = conv.load_pretrained(
+        Qwen3LMHeadModel, ref=EXPORT, config=cfg, dtype=jnp.float32
+    )
     return inference_mode(model, True)
 
 
@@ -173,19 +176,27 @@ def variant_llr(model: Qwen3LMHeadModel, inp: dict) -> float:
     p, L = inp["var_pos"], SEQ_LEN
     tot = 0.0
     for i in range(p - 1, L - 1):
-        tot += lsm(la[i])[n2i[int(inp["alt_ids"][i + 1])]] - lsm(lr[i])[n2i[int(inp["ref_ids"][i + 1])]]
+        tot += (
+            lsm(la[i])[n2i[int(inp["alt_ids"][i + 1])]]
+            - lsm(lr[i])[n2i[int(inp["ref_ids"][i + 1])]]
+        )
     return float(tot)
 
 
 def build_input(tok) -> dict:
     genome = Genome(GENOME)
-    row = pl.read_parquet(SCORES).filter(
-        (pl.col("subset") == "distal")
-        & (pl.col("chrom").cast(pl.Utf8) == TARGET["chrom"])
-        & (pl.col("pos") == TARGET["pos"])
-        & (pl.col("ref") == TARGET["ref"])
-        & (pl.col("alt") == TARGET["alt"])
-    ).to_pandas().to_dict("records")[0]
+    row = (
+        pl.read_parquet(SCORES)
+        .filter(
+            (pl.col("subset") == "distal")
+            & (pl.col("chrom").cast(pl.Utf8) == TARGET["chrom"])
+            & (pl.col("pos") == TARGET["pos"])
+            & (pl.col("ref") == TARGET["ref"])
+            & (pl.col("alt") == TARGET["alt"])
+        )
+        .to_pandas()
+        .to_dict("records")[0]
+    )
     rec = transform_llr_clm(row, tok, genome, WINDOW, "+")
     var_pos = in_seq_var_pos(WINDOW, "+") + _get_special_token_counts(tok)[0]
     nuc_map = _get_nucleotide_token_ids(tok)
@@ -199,10 +210,14 @@ def build_input(tok) -> dict:
 def main() -> None:
     tok = AutoTokenizer.from_pretrained(EXPORT)
     inp = build_input(tok)
-    print(f"[target] {TARGET['chrom']}:{TARGET['pos']} {TARGET['ref']}>{TARGET['alt']}  "
-          "(offline/torch -3.21 ; online/levanter -8.05)")
+    print(
+        f"[target] {TARGET['chrom']}:{TARGET['pos']} {TARGET['ref']}>{TARGET['alt']}  "
+        "(offline/torch -3.21 ; online/levanter -8.05)"
+    )
 
-    mesh = Mesh(np.asarray(jax.devices()).reshape(1, 1, 1), ("replica", "data", "model"))
+    mesh = Mesh(
+        np.asarray(jax.devices()).reshape(1, 1, 1), ("replica", "data", "model")
+    )
     with set_mesh(mesh):
         native = load_native()
         export = load_export()

--- a/scripts/issue257/native_vs_export.py
+++ b/scripts/issue257/native_vs_export.py
@@ -1,0 +1,219 @@
+"""Issue #257: does the levanter native checkpoint differ from its HF export?
+
+The reframing. Earlier work assumed offline (transformers) and online (levanter)
+evaluate the *same* weights and chased a forward-pass discrepancy. They do not.
+
+  * Offline evals_v2 loads the **HF export** (transformers). AUPRC 0.159.
+  * A levanter eval of that **same HF export** also scores ~0.150
+    (iris run exp257-…-hfckpt: macro_avg_auprc 0.1499).
+  * The in-training / online eval loads the **native levanter checkpoint**
+    (Orbax). AUPRC 0.250.
+
+So both frameworks agree the HF export is a 0.15 model, while the native
+checkpoint is a 0.25 model. The discrepancy is not softmax-space, precision,
+packing, prefix-sharing or RoPE — offline and online simply evaluate
+**different weights**, because the levanter→HF export does not round-trip.
+
+This script proves that locally on CPU, two ways:
+  (1) Per-parameter max-abs-diff between the native checkpoint and the HF export,
+      both loaded into the *same* levanter model class (so any diff is a real
+      weight difference, not a framework artifact). Localizes WHICH tensors the
+      export changed.
+  (2) The single most-divergent distal variant's 4-nuc LLR under each set of
+      weights (plain causal bf16 forward): native should reproduce the online
+      -8.05, the export the offline -3.04.
+
+Usage (CPU box with gcloud creds for the gs:// native checkpoint):
+  AWS_DEFAULT_REGION=us-east-2 JAX_PLATFORMS=cpu \
+    uv run --group genome-s3 --extra marin python scripts/issue257/native_vs_export.py
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import equinox as eqx
+import jax
+import jmp
+import numpy as np
+import polars as pl
+
+jax.config.update("jax_platform_name", "cpu")
+
+import haliax as hax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+from haliax.partitioning import set_mesh  # noqa: E402
+from haliax.state_dict import to_torch_compatible_state_dict  # noqa: E402
+from jax.sharding import Mesh  # noqa: E402
+from levanter.checkpoint import latest_checkpoint_path, load_checkpoint  # noqa: E402
+from levanter.layers.attention import AttentionMask  # noqa: E402
+from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig  # noqa: E402
+from levanter.models.qwen import Qwen3Config, Qwen3LMHeadModel  # noqa: E402
+from levanter.utils.jax_utils import use_cpu_device  # noqa: E402
+from levanter.utils.tree_utils import inference_mode  # noqa: E402
+from transformers import AutoTokenizer  # noqa: E402
+
+from marin_dna.data.dna import NUCLEOTIDES  # noqa: E402
+from marin_dna.data.genome import Genome  # noqa: E402
+from marin_dna.data.transforms import (  # noqa: E402
+    _get_nucleotide_token_ids,
+    _get_special_token_counts,
+    in_seq_var_pos,
+    transform_llr_clm,
+)
+
+NATIVE = (
+    "gs://marin-us-east5/checkpoints/"
+    "dna-exp232-zoonomia-v1-0p25b-v4_ccre_non_promoter-v0.1-feca83/checkpoints"
+)
+EXPORT = "scratch/issue257/ckpt-ccre-4999"
+GENOME = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+SCORES = (
+    "s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+    "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet"
+)
+WINDOW = 255
+SEQ_LEN = 256
+TARGET = dict(chrom="7", pos=156791472, ref="C", alt="A")
+
+
+def _native_config() -> Qwen3Config:
+    # Exactly experiments/parity/exp257_ccre_eval_only.py:_build_model_config.
+    return Qwen3Config(
+        hidden_dim=1152,
+        intermediate_dim=4608,
+        num_layers=12,
+        num_heads=9,
+        num_kv_heads=9,
+        max_seq_len=SEQ_LEN,
+        rope=Llama3RotaryEmbeddingsConfig(),
+        initializer_range=0.02,
+    )
+
+
+def load_native() -> Qwen3LMHeadModel:
+    cfg = _native_config()
+    cp = latest_checkpoint_path(NATIVE)
+    print(f"[native] latest checkpoint: {cp}")
+    # The checkpoint was saved on TPU with the vocab padded for partitioning;
+    # try the plausible padded sizes until the Orbax shapes line up.
+    for vsize in (8, 7, 16, 64, 128, 256):
+        try:
+            with use_cpu_device():
+                Vocab = hax.Axis("vocab", vsize)
+                template = eqx.filter_eval_shape(cfg.build, Vocab, key=jax.random.PRNGKey(0))
+                model = load_checkpoint(template, cp, subpath="model", axis_mapping={})
+            print(f"[native] loaded with Vocab={vsize}")
+            return inference_mode(model, True)
+        except Exception as e:  # noqa: BLE001
+            print(f"[native] Vocab={vsize} failed: {type(e).__name__}: {str(e)[:120]}")
+    raise RuntimeError("could not load native checkpoint at any candidate vocab size")
+
+
+def load_export() -> Qwen3LMHeadModel:
+    cfg0 = Qwen3Config()
+    conv = cfg0.hf_checkpoint_converter(ref_checkpoint=EXPORT)
+    cfg = conv.config_from_hf_config(conv.hf_config_from_hf_checkpoint(EXPORT))
+    model = conv.load_pretrained(Qwen3LMHeadModel, ref=EXPORT, config=cfg, dtype=jnp.float32)
+    return inference_mode(model, True)
+
+
+def diff_weights(native: Qwen3LMHeadModel, export: Qwen3LMHeadModel) -> None:
+    sd_n = to_torch_compatible_state_dict(native)
+    sd_e = to_torch_compatible_state_dict(export)
+    keys = sorted(set(sd_n) | set(sd_e))
+    print(f"\n=== per-parameter native-vs-export diff ({len(keys)} tensors) ===")
+    rows = []
+    for k in keys:
+        if k not in sd_n or k not in sd_e:
+            print(f"  {k:60s} MISSING in {'native' if k not in sd_n else 'export'}")
+            continue
+        a = np.asarray(sd_n[k]).astype(np.float64)
+        b = np.asarray(sd_e[k]).astype(np.float64)
+        if a.shape != b.shape:  # embed/lm_head: native padded vocab vs export trimmed
+            m = min(a.shape[0], b.shape[0])
+            note = f"  [shape {a.shape} vs {b.shape}; compare [:{m}]]"
+            a, b = a[:m], b[:m]
+        else:
+            note = ""
+        md = float(np.abs(a - b).max())
+        rel = md / (float(np.abs(a).max()) + 1e-9)
+        rows.append((md, rel, k, note))
+    rows.sort(reverse=True)
+    print(f"  {'max|Δ|':>11} | {'rel':>9} | tensor")
+    for md, rel, k, note in rows:
+        print(f"  {md:>11.4e} | {rel:>9.2e} | {k}{note}")
+    allbig = [k for md, rel, k, _ in rows if md > 1e-3]
+    print(f"\n  tensors with max|Δ| > 1e-3: {len(allbig)} / {len(rows)}")
+
+
+def variant_llr(model: Qwen3LMHeadModel, inp: dict) -> float:
+    mp = jmp.get_policy("p=f32,c=bfloat16")
+    model = mp.cast_to_compute(model)
+    Batch = hax.Axis("batch", 1)
+    Pos = hax.Axis("position", SEQ_LEN)
+    mask = AttentionMask.causal()
+
+    def logits(ids_np):
+        ids = hax.named(jnp.asarray(ids_np[None, :], dtype=jnp.int32), (Batch, Pos))
+        lg = model(ids, attn_mask=mask)
+        return np.asarray(lg.astype(jnp.float32).array)[0]
+
+    nuc_ids = inp["nuc_ids"]
+    n2i = {int(t): i for i, t in enumerate(nuc_ids)}
+
+    def lsm(rowl):
+        z = rowl[nuc_ids].astype(np.float64)
+        return z - (np.log(np.exp(z - z.max()).sum()) + z.max())
+
+    lr, la = logits(inp["ref_ids"]), logits(inp["alt_ids"])
+    p, L = inp["var_pos"], SEQ_LEN
+    tot = 0.0
+    for i in range(p - 1, L - 1):
+        tot += lsm(la[i])[n2i[int(inp["alt_ids"][i + 1])]] - lsm(lr[i])[n2i[int(inp["ref_ids"][i + 1])]]
+    return float(tot)
+
+
+def build_input(tok) -> dict:
+    genome = Genome(GENOME)
+    row = pl.read_parquet(SCORES).filter(
+        (pl.col("subset") == "distal")
+        & (pl.col("chrom").cast(pl.Utf8) == TARGET["chrom"])
+        & (pl.col("pos") == TARGET["pos"])
+        & (pl.col("ref") == TARGET["ref"])
+        & (pl.col("alt") == TARGET["alt"])
+    ).to_pandas().to_dict("records")[0]
+    rec = transform_llr_clm(row, tok, genome, WINDOW, "+")
+    var_pos = in_seq_var_pos(WINDOW, "+") + _get_special_token_counts(tok)[0]
+    nuc_map = _get_nucleotide_token_ids(tok)
+    nuc_ids = np.array([nuc_map[n] for n in NUCLEOTIDES])
+    ref_ids = rec["input_ids"].numpy().astype(np.int64)
+    alt_ids = ref_ids.copy()
+    alt_ids[var_pos] = int(rec["alt_token_id"])
+    return dict(ref_ids=ref_ids, alt_ids=alt_ids, var_pos=var_pos, nuc_ids=nuc_ids)
+
+
+def main() -> None:
+    tok = AutoTokenizer.from_pretrained(EXPORT)
+    inp = build_input(tok)
+    print(f"[target] {TARGET['chrom']}:{TARGET['pos']} {TARGET['ref']}>{TARGET['alt']}  "
+          "(offline/torch -3.21 ; online/levanter -8.05)")
+
+    mesh = Mesh(np.asarray(jax.devices()).reshape(1, 1, 1), ("replica", "data", "model"))
+    with set_mesh(mesh):
+        native = load_native()
+        export = load_export()
+        diff_weights(native, export)
+        llr_native = variant_llr(native, inp)
+        llr_export = variant_llr(export, inp)
+
+    print("\n=== this variant's 4-nuc LLR (plain causal bf16 forward) ===")
+    print(f"  native checkpoint : {llr_native:+.4f}   (online reference -8.05)")
+    print(f"  HF export         : {llr_export:+.4f}   (offline reference -3.21)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue257/rope_test.py
+++ b/scripts/issue257/rope_test.py
@@ -1,0 +1,82 @@
+"""Issue #257: is transformers' llama3 `rope_scaling` the source of the
+torch-HF (0.158) vs JAX-levanter (0.251) distal/fwd discrepancy?
+
+The HF config has rope_scaling={rope_type:llama3, factor:8, original_max:8192}
+with max_position_embeddings=256 (transformers warns the config is inverted).
+Score distal/fwd in torch with the rope config swapped, to see which one
+matches levanter's 0.251:
+
+  asis    -> the exported config (llama3, original_max 8192)   [expect 0.158]
+  none    -> rope_scaling disabled (standard RoPE, theta only)
+  fixed   -> llama3 but original_max=256 (matches the real context)
+
+Usage: uv run --group genome-s3 python scripts/issue257/rope_test.py <asis|none|fixed>
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import polars as pl
+import torch
+from sklearn.metrics import average_precision_score
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+
+from marin_dna.data.dna import NUCLEOTIDES
+from marin_dna.data.genome import Genome
+from marin_dna.data.transforms import (
+    _get_nucleotide_token_ids,
+    _get_special_token_counts,
+    in_seq_var_pos,
+    transform_llr_clm,
+)
+from marin_dna.model.scoring import compute_variant_score_bundle
+
+CKPT = "scratch/issue257/ckpt-ccre-4999"
+GENOME = ("s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+          "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz")
+SCORES = ("s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+          "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet")
+WINDOW = 255
+
+
+def main() -> None:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "none"
+    torch.set_num_threads(4)
+    cfg = AutoConfig.from_pretrained(CKPT)
+    print(f"[rope] original rope_scaling = {cfg.rope_scaling}")
+    if mode == "none":
+        cfg.rope_scaling = None
+    elif mode == "fixed":
+        cfg.rope_scaling = dict(cfg.rope_scaling)
+        cfg.rope_scaling["original_max_position_embeddings"] = WINDOW + 1
+    print(f"[rope] mode={mode} -> rope_scaling = {cfg.rope_scaling}")
+
+    tok = AutoTokenizer.from_pretrained(CKPT)
+    model = AutoModelForCausalLM.from_pretrained(
+        CKPT, config=cfg, trust_remote_code=True
+    ).eval()
+    genome = Genome(GENOME)
+    df = pl.read_parquet(SCORES).filter(pl.col("subset") == "distal").to_pandas()
+    lab = df["label"].to_numpy()
+
+    n_prefix, _ = _get_special_token_counts(tok)
+    nuc = torch.tensor([_get_nucleotide_token_ids(tok)[n] for n in NUCLEOTIDES])
+    var_pos = in_seq_var_pos(WINDOW, "+") + n_prefix
+    rows = [transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")]
+    llr = np.zeros(len(rows))
+    with torch.no_grad():
+        for i in range(0, len(rows), 64):
+            ch = rows[i:i + 64]
+            ids = torch.stack([c["input_ids"] for c in ch])
+            alt = torch.tensor([c["alt_token_id"] for c in ch])
+            out = compute_variant_score_bundle(model, ids, alt, var_pos=var_pos, nuc_token_ids=nuc)
+            llr[i:i + len(ch)] = out[:, 0].numpy()
+    ap = average_precision_score(lab, -llr)
+    print(f"\n[rope] mode={mode}  distal/fwd 4-nuc AUPRC = {ap:.4f}")
+    print("  reference: transformers as-is (offline) 0.1589 ; levanter (JAX) 0.2501")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue257/rope_test.py
+++ b/scripts/issue257/rope_test.py
@@ -34,10 +34,14 @@ from marin_dna.data.transforms import (
 from marin_dna.model.scoring import compute_variant_score_bundle
 
 CKPT = "scratch/issue257/ckpt-ccre-4999"
-GENOME = ("s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
-          "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz")
-SCORES = ("s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
-          "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet")
+GENOME = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+SCORES = (
+    "s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+    "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet"
+)
 WINDOW = 255
 
 
@@ -64,15 +68,19 @@ def main() -> None:
     n_prefix, _ = _get_special_token_counts(tok)
     nuc = torch.tensor([_get_nucleotide_token_ids(tok)[n] for n in NUCLEOTIDES])
     var_pos = in_seq_var_pos(WINDOW, "+") + n_prefix
-    rows = [transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")]
+    rows = [
+        transform_llr_clm(r, tok, genome, WINDOW, "+") for r in df.to_dict("records")
+    ]
     llr = np.zeros(len(rows))
     with torch.no_grad():
         for i in range(0, len(rows), 64):
-            ch = rows[i:i + 64]
+            ch = rows[i : i + 64]
             ids = torch.stack([c["input_ids"] for c in ch])
             alt = torch.tensor([c["alt_token_id"] for c in ch])
-            out = compute_variant_score_bundle(model, ids, alt, var_pos=var_pos, nuc_token_ids=nuc)
-            llr[i:i + len(ch)] = out[:, 0].numpy()
+            out = compute_variant_score_bundle(
+                model, ids, alt, var_pos=var_pos, nuc_token_ids=nuc
+            )
+            llr[i : i + len(ch)] = out[:, 0].numpy()
     ap = average_precision_score(lab, -llr)
     print(f"\n[rope] mode={mode}  distal/fwd 4-nuc AUPRC = {ap:.4f}")
     print("  reference: transformers as-is (offline) 0.1589 ; levanter (JAX) 0.2501")

--- a/scripts/issue257/verify_bos_fix.py
+++ b/scripts/issue257/verify_bos_fix.py
@@ -22,40 +22,80 @@ import marin_dna.pipelines.evals.lm_eval  # noqa: F401  installs the BOS monkeyp
 from levanter import eval_harness
 
 CKPT = "scratch/issue257/ckpt-ccre-4999"
-HARNESS = ("bolinas-dna/evals_mendelian_traits_harness_255", "7b92f047f9a36f90e9ac47886afa2a99264ee35c")
+HARNESS = (
+    "bolinas-dna/evals_mendelian_traits_harness_255",
+    "7b92f047f9a36f90e9ac47886afa2a99264ee35c",
+)
 
 
 def main() -> None:
-    assert getattr(eval_harness, "_marin_dna_bos_patched", False), "BOS patch not installed"
+    assert getattr(eval_harness, "_marin_dna_bos_patched", False), (
+        "BOS patch not installed"
+    )
     tok = AutoTokenizer.from_pretrained(CKPT)
     bos = tok.bos_token_id
     assert bos is not None
 
-    df = datasets.load_dataset(HARNESS[0], name="default", revision=HARNESS[1], split="train").to_pandas()
+    df = datasets.load_dataset(
+        HARNESS[0], name="default", revision=HARNESS[1], split="train"
+    ).to_pandas()
     for c in ("chrom", "pos", "ref", "alt", "strand"):
         df[c] = df[c].astype(str)
-    row = df[(df.chrom == "7") & (df.pos == "156791472") & (df.ref == "C")
-             & (df.alt == "A") & (df.strand == "+")].iloc[0]
+    row = df[
+        (df.chrom == "7")
+        & (df.pos == "156791472")
+        & (df.ref == "C")
+        & (df.alt == "A")
+        & (df.strand == "+")
+    ].iloc[0]
     ctx, refc, altc = row["context"], row["ref_completion"], row["alt_completion"]
-    print(f"[data] len(context)={len(ctx)} len(ref_completion)={len(refc)} (raw strings, no BOS)")
+    print(
+        f"[data] len(context)={len(ctx)} len(ref_completion)={len(refc)} (raw strings, no BOS)"
+    )
 
     reqs = [
-        Instance(request_type="loglikelihood", doc={}, arguments=(ctx, refc), idx=0, metadata=(None, None, None)),
-        Instance(request_type="loglikelihood", doc={}, arguments=(ctx, altc), idx=1, metadata=(None, None, None)),
+        Instance(
+            request_type="loglikelihood",
+            doc={},
+            arguments=(ctx, refc),
+            idx=0,
+            metadata=(None, None, None),
+        ),
+        Instance(
+            request_type="loglikelihood",
+            doc={},
+            arguments=(ctx, altc),
+            idx=1,
+            metadata=(None, None, None),
+        ),
     ]
-    pcs = list(eval_harness._iterate_tokenized_requests(reqs, tok, max_length=4096, batch_size=8))
+    pcs = list(
+        eval_harness._iterate_tokenized_requests(
+            reqs, tok, max_length=4096, batch_size=8
+        )
+    )
     assert len(pcs) == 2
     for pc, name in zip(pcs, ("ref", "alt")):
         ids = list(pc.ids)
-        print(f"[{name}] len={len(ids)} ids[0]={ids[0]} prompt_length={pc.prompt_length} "
-              f"first_scored_token_idx={pc.prompt_length}")
-        assert ids[0] == bos, f"{name}: first token {ids[0]} != BOS {bos} — patch did not apply"
-        assert len(ids) == 1 + len(ctx) + len(refc), f"{name}: unexpected length {len(ids)}"
+        print(
+            f"[{name}] len={len(ids)} ids[0]={ids[0]} prompt_length={pc.prompt_length} "
+            f"first_scored_token_idx={pc.prompt_length}"
+        )
+        assert ids[0] == bos, (
+            f"{name}: first token {ids[0]} != BOS {bos} — patch did not apply"
+        )
+        assert len(ids) == 1 + len(ctx) + len(refc), (
+            f"{name}: unexpected length {len(ids)}"
+        )
         # boundary = 1 BOS + 127 context tokens (1 token/nt for this tokenizer)
-        assert pc.prompt_length == 1 + len(ctx), f"{name}: boundary {pc.prompt_length} != {1 + len(ctx)}"
+        assert pc.prompt_length == 1 + len(ctx), (
+            f"{name}: boundary {pc.prompt_length} != {1 + len(ctx)}"
+        )
 
-    print("\n[OK] real harness tokenization now forwards [BOS] + 255 nt (256 tokens), "
-          "completion boundary at 128 — matches the offline with-BOS input.")
+    print(
+        "\n[OK] real harness tokenization now forwards [BOS] + 255 nt (256 tokens), "
+        "completion boundary at 128 — matches the offline with-BOS input."
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/issue257/verify_bos_fix.py
+++ b/scripts/issue257/verify_bos_fix.py
@@ -1,0 +1,62 @@
+"""Issue #263: verify the BOS monkeypatch fixes the *real* harness tokenization.
+
+Imports `marin_dna.pipelines.evals.lm_eval` (which installs `_install_bos_fix`),
+then runs levanter's actual loglikelihood tokenizer
+(`eval_harness._iterate_tokenized_requests`) on the real checkpoint tokenizer and
+the real dataset row for chr7:156791472 C>A — the variant whose missing-BOS LLR
+drove #257. Asserts the forwarded sequence now starts with `[BOS]`, is 256 tokens
+(`[BOS]` + 127 context + 128 completion), and that the prompt/completion boundary
+lands at 128 (so the scored completion tokens are unchanged — only BOS is added).
+
+Usage:
+  uv run --extra marin python scripts/issue257/verify_bos_fix.py
+"""
+
+from __future__ import annotations
+
+import datasets
+from lm_eval.api.instance import Instance
+from transformers import AutoTokenizer
+
+import marin_dna.pipelines.evals.lm_eval  # noqa: F401  installs the BOS monkeypatch
+from levanter import eval_harness
+
+CKPT = "scratch/issue257/ckpt-ccre-4999"
+HARNESS = ("bolinas-dna/evals_mendelian_traits_harness_255", "7b92f047f9a36f90e9ac47886afa2a99264ee35c")
+
+
+def main() -> None:
+    assert getattr(eval_harness, "_marin_dna_bos_patched", False), "BOS patch not installed"
+    tok = AutoTokenizer.from_pretrained(CKPT)
+    bos = tok.bos_token_id
+    assert bos is not None
+
+    df = datasets.load_dataset(HARNESS[0], name="default", revision=HARNESS[1], split="train").to_pandas()
+    for c in ("chrom", "pos", "ref", "alt", "strand"):
+        df[c] = df[c].astype(str)
+    row = df[(df.chrom == "7") & (df.pos == "156791472") & (df.ref == "C")
+             & (df.alt == "A") & (df.strand == "+")].iloc[0]
+    ctx, refc, altc = row["context"], row["ref_completion"], row["alt_completion"]
+    print(f"[data] len(context)={len(ctx)} len(ref_completion)={len(refc)} (raw strings, no BOS)")
+
+    reqs = [
+        Instance(request_type="loglikelihood", doc={}, arguments=(ctx, refc), idx=0, metadata=(None, None, None)),
+        Instance(request_type="loglikelihood", doc={}, arguments=(ctx, altc), idx=1, metadata=(None, None, None)),
+    ]
+    pcs = list(eval_harness._iterate_tokenized_requests(reqs, tok, max_length=4096, batch_size=8))
+    assert len(pcs) == 2
+    for pc, name in zip(pcs, ("ref", "alt")):
+        ids = list(pc.ids)
+        print(f"[{name}] len={len(ids)} ids[0]={ids[0]} prompt_length={pc.prompt_length} "
+              f"first_scored_token_idx={pc.prompt_length}")
+        assert ids[0] == bos, f"{name}: first token {ids[0]} != BOS {bos} — patch did not apply"
+        assert len(ids) == 1 + len(ctx) + len(refc), f"{name}: unexpected length {len(ids)}"
+        # boundary = 1 BOS + 127 context tokens (1 token/nt for this tokenizer)
+        assert pc.prompt_length == 1 + len(ctx), f"{name}: boundary {pc.prompt_length} != {1 + len(ctx)}"
+
+    print("\n[OK] real harness tokenization now forwards [BOS] + 255 nt (256 tokens), "
+          "completion boundary at 128 — matches the offline with-BOS input.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue257/verify_softmax_space.py
+++ b/scripts/issue257/verify_softmax_space.py
@@ -102,7 +102,8 @@ def compute_llr_dual(
     ) - prefix_log_p4.gather(-1, ref_var_idx.unsqueeze(-1)).squeeze(-1)
     tgt4 = _token_id_to_nuc_idx(suffix_targets, nuc_ids).unsqueeze(-1)
     llr_down4 = (
-        log_p_alt4.gather(-1, tgt4).squeeze(-1) - log_p_ref4.gather(-1, tgt4).squeeze(-1)
+        log_p_alt4.gather(-1, tgt4).squeeze(-1)
+        - log_p_ref4.gather(-1, tgt4).squeeze(-1)
     ).sum(dim=-1)
     llr_4nuc = llr_at_var4 + llr_down4
 
@@ -119,7 +120,8 @@ def compute_llr_dual(
     ) - prefix_log_pf.gather(-1, ref_var_tok).squeeze(-1)
     tgtf = suffix_targets.unsqueeze(-1)  # actual token ids
     llr_downf = (
-        log_p_altf.gather(-1, tgtf).squeeze(-1) - log_p_reff.gather(-1, tgtf).squeeze(-1)
+        log_p_altf.gather(-1, tgtf).squeeze(-1)
+        - log_p_reff.gather(-1, tgtf).squeeze(-1)
     ).sum(dim=-1)
     llr_full = llr_at_varf + llr_downf
 
@@ -153,7 +155,9 @@ def main() -> None:
 
     n_prefix, _ = _get_special_token_counts(tok)
     nuc_ids_dict = _get_nucleotide_token_ids(tok)
-    nuc_token_ids = torch.tensor([nuc_ids_dict[n] for n in NUCLEOTIDES], dtype=torch.long)
+    nuc_token_ids = torch.tensor(
+        [nuc_ids_dict[n] for n in NUCLEOTIDES], dtype=torch.long
+    )
     print(f"[tok] n_prefix(BOS)={n_prefix} nuc_token_ids={nuc_ids_dict}")
 
     strands = [s for s in args.strands.split(",") if s]

--- a/scripts/issue257/verify_softmax_space.py
+++ b/scripts/issue257/verify_softmax_space.py
@@ -1,0 +1,220 @@
+"""Issue #257 verification — is the online↔offline distal-FWD AUPRC gap caused
+*solely* by the softmax-normalization space?
+
+Offline `compute_variant_score_bundle` renormalizes next-token log-probs over
+the 4 nucleotides {A,C,G,T}; online lm_eval `loglikelihood` uses the full
+7-token vocab ([PAD],[UNK],[BOS],a,c,g,t). This runs the exp232
+v4_ccre_non_promoter step-4999 checkpoint ONCE on the mendelian `distal`
+variants and computes the per-variant LLR BOTH ways *from the same logits*, so
+the only thing that varies is the normalizer.
+
+Expected if the proposed root cause is right (offline numbers from the S3
+scores parquet; online from the in-training wandb metric reported in #257):
+
+    4-nuc      FWD 0.159, RC 0.112   (reproduces the offline parquet)
+    full-vocab FWD ~0.251 (jumps to the online value), RC ~0.112 (control: stays)
+
+The RC strand is a built-in negative control: online and offline already agree
+there (~0.112), so flipping the normalizer should NOT move RC.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+import polars as pl
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+from sklearn.metrics import average_precision_score
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from marin_dna.data.dna import NUCLEOTIDES
+from marin_dna.data.genome import Genome
+from marin_dna.data.transforms import (
+    _get_nucleotide_token_ids,
+    _get_special_token_counts,
+    in_seq_var_pos,
+    transform_llr_clm,
+)
+from marin_dna.model.scoring import _repeat_interleave_kv_cache, _token_id_to_nuc_idx
+
+CKPT = "scratch/issue257/ckpt-ccre-4999"
+GENOME = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+SCORES = (
+    "s3://oa-bolinas/snakemake/analysis/evals_v2/results/scores/"
+    "exp232-v4_ccre_non_promoter-step-4999/mendelian_traits.parquet"
+)
+WINDOW = 255  # 255 bp DNA + BOS = 256 tokens
+
+
+@torch.no_grad()
+def compute_llr_dual(
+    model,
+    input_ids: torch.Tensor,
+    alt_token_id: torch.Tensor,
+    *,
+    var_pos: int,
+    nuc_token_ids: torch.Tensor,
+) -> torch.Tensor:
+    """[B, 2] = (llr_4nuc, llr_fullvocab) from a single shared forward.
+
+    The 4-nuc branch is a verbatim copy of `compute_variant_score_bundle`'s LLR
+    (minus the JSD); the full-vocab branch reuses the *same* `prefix_last_logits`
+    / `suffix_logits`, only swapping the slice-then-log_softmax for a
+    log_softmax over the whole vocab and gathering at the actual token ids.
+    """
+    B, L = input_ids.shape
+    p = var_pos
+    assert 0 < p < L - 1
+
+    prefix = input_ids[:, :p].contiguous()
+    ref_suffix = input_ids[:, p:].contiguous()
+    alt_suffix = torch.cat([alt_token_id.unsqueeze(-1), ref_suffix[:, 1:]], dim=-1)
+    suffixes = torch.stack([ref_suffix, alt_suffix], dim=1)  # [B, 2, L-p]
+    suffixes_flat = rearrange(suffixes, "B V L -> (B V) L").contiguous()
+
+    prefix_out = model(prefix, use_cache=True, logits_to_keep=1)
+    prefix_last_logits = prefix_out.logits[:, -1]  # [B, V]
+    past_kv = _repeat_interleave_kv_cache(prefix_out.past_key_values, 2)
+    suffix_logits = model(
+        suffixes_flat, past_key_values=past_kv, use_cache=False
+    ).logits  # [B*2, L-p, V]
+
+    nuc_ids = nuc_token_ids.to(suffix_logits.device)
+    suffix_targets = input_ids[:, p + 1 :]  # [B, L-p-1] — shared ref/alt downstream
+
+    # ---------- 4-nuc (offline) ----------
+    log_p_nuc = F.log_softmax(suffix_logits[..., nuc_ids].float(), dim=-1)
+    log_p_nuc = rearrange(log_p_nuc, "(B V) L C -> B V L C", B=B)
+    log_p_ref4 = log_p_nuc[:, 0, :-1]
+    log_p_alt4 = log_p_nuc[:, 1, :-1]
+    prefix_log_p4 = F.log_softmax(prefix_last_logits[..., nuc_ids].float(), dim=-1)
+    ref_var_idx = _token_id_to_nuc_idx(input_ids[:, p], nuc_ids)
+    alt_var_idx = _token_id_to_nuc_idx(alt_token_id, nuc_ids)
+    llr_at_var4 = prefix_log_p4.gather(-1, alt_var_idx.unsqueeze(-1)).squeeze(
+        -1
+    ) - prefix_log_p4.gather(-1, ref_var_idx.unsqueeze(-1)).squeeze(-1)
+    tgt4 = _token_id_to_nuc_idx(suffix_targets, nuc_ids).unsqueeze(-1)
+    llr_down4 = (
+        log_p_alt4.gather(-1, tgt4).squeeze(-1) - log_p_ref4.gather(-1, tgt4).squeeze(-1)
+    ).sum(dim=-1)
+    llr_4nuc = llr_at_var4 + llr_down4
+
+    # ---------- full-vocab (online lm_eval loglikelihood) ----------
+    log_p_full = F.log_softmax(suffix_logits.float(), dim=-1)
+    log_p_full = rearrange(log_p_full, "(B V) L W -> B V L W", B=B)
+    log_p_reff = log_p_full[:, 0, :-1]
+    log_p_altf = log_p_full[:, 1, :-1]
+    prefix_log_pf = F.log_softmax(prefix_last_logits.float(), dim=-1)  # [B, V]
+    ref_var_tok = input_ids[:, p].unsqueeze(-1)
+    alt_var_tok = alt_token_id.unsqueeze(-1)
+    llr_at_varf = prefix_log_pf.gather(-1, alt_var_tok).squeeze(
+        -1
+    ) - prefix_log_pf.gather(-1, ref_var_tok).squeeze(-1)
+    tgtf = suffix_targets.unsqueeze(-1)  # actual token ids
+    llr_downf = (
+        log_p_altf.gather(-1, tgtf).squeeze(-1) - log_p_reff.gather(-1, tgtf).squeeze(-1)
+    ).sum(dim=-1)
+    llr_full = llr_at_varf + llr_downf
+
+    return torch.stack([llr_4nuc, llr_full], dim=1)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--subset", default="distal")
+    ap.add_argument("--strands", default="+,-")
+    ap.add_argument("--limit", type=int, default=0, help="0 = all (probe with small N)")
+    ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument("--threads", type=int, default=4)
+    args = ap.parse_args()
+    torch.set_num_threads(args.threads)
+
+    print(f"[load] tokenizer + model from {CKPT}")
+    tok = AutoTokenizer.from_pretrained(CKPT)
+    model = AutoModelForCausalLM.from_pretrained(CKPT, trust_remote_code=True).eval()
+    genome = Genome(GENOME)
+
+    df = pl.read_parquet(SCORES).filter(pl.col("subset") == args.subset)
+    if args.limit:
+        df = df.head(args.limit)
+    pdf = df.to_pandas()
+    label = pdf["label"].to_numpy()
+    print(
+        f"[data] subset={args.subset} n={len(pdf)} positives={int(label.sum())} "
+        f"(offline llr_fwd/llr_rc carried for cross-check)"
+    )
+
+    n_prefix, _ = _get_special_token_counts(tok)
+    nuc_ids_dict = _get_nucleotide_token_ids(tok)
+    nuc_token_ids = torch.tensor([nuc_ids_dict[n] for n in NUCLEOTIDES], dtype=torch.long)
+    print(f"[tok] n_prefix(BOS)={n_prefix} nuc_token_ids={nuc_ids_dict}")
+
+    strands = [s for s in args.strands.split(",") if s]
+    out: dict[str, np.ndarray] = {}
+    for strand in strands:
+        var_pos = in_seq_var_pos(WINDOW, strand) + n_prefix
+        rows = [
+            transform_llr_clm(rec, tok, genome, WINDOW, strand)
+            for rec in pdf.to_dict("records")
+        ]
+        llrs = np.zeros((len(rows), 2), dtype=np.float64)
+        t0 = time.time()
+        for i in range(0, len(rows), args.batch_size):
+            chunk = rows[i : i + args.batch_size]
+            input_ids = torch.stack([c["input_ids"] for c in chunk])
+            alt_tok = torch.tensor([c["alt_token_id"] for c in chunk], dtype=torch.long)
+            o = compute_llr_dual(
+                model, input_ids, alt_tok, var_pos=var_pos, nuc_token_ids=nuc_token_ids
+            )
+            llrs[i : i + len(chunk)] = o.numpy()
+        dt = time.time() - t0
+        out[strand] = llrs
+        print(
+            f"[run] strand={strand} var_pos={var_pos} n={len(rows)} "
+            f"wall={dt:.1f}s ({dt / max(len(rows), 1) * 1000:.0f} ms/variant)"
+        )
+
+    if args.limit:
+        print("\n[probe] timing only; AUPRC on a truncated set is not meaningful.")
+        return
+
+    # ---- cross-check + AUPRC (minus_llr protocol: score = -llr) ----
+    strand_key = {"+": "fwd", "-": "rc"}
+    print("\n=== per-variant cross-check: my 4-nuc llr vs offline parquet ===")
+    for s in strands:
+        col = f"llr_{strand_key[s]}"
+        mine = out[s][:, 0]
+        offline = pdf[col].to_numpy()
+        mad = np.mean(np.abs(mine - offline))
+        r = np.corrcoef(mine, offline)[0, 1]
+        print(f"  strand={s}: MAD(mine_4nuc, {col})={mad:.4f}  corr={r:.5f}")
+
+    print("\n=== AUPRC(label, -llr) ===")
+    print(f"{'strand':<8}{'4-nuc (offline)':<20}{'full-vocab (online)':<22}{'Δ':<8}")
+    for s in strands:
+        ap4 = average_precision_score(label, -out[s][:, 0])
+        apf = average_precision_score(label, -out[s][:, 1])
+        print(f"{s:<8}{ap4:<20.4f}{apf:<22.4f}{apf - ap4:+.4f}")
+    # AVG = mean raw llr across strands, then negate
+    if set(strands) == {"+", "-"}:
+        llr4_avg = (out["+"][:, 0] + out["-"][:, 0]) / 2
+        llrf_avg = (out["+"][:, 1] + out["-"][:, 1]) / 2
+        ap4 = average_precision_score(label, -llr4_avg)
+        apf = average_precision_score(label, -llrf_avg)
+        print(f"{'avg':<8}{ap4:<20.4f}{apf:<22.4f}{apf - ap4:+.4f}")
+
+    print(
+        "\nReference: offline parquet distal FWD 0.1589 / RC 0.1118 ; "
+        "online (wandb, #257) distal FWD 0.251."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue257/wandb_check.py
+++ b/scripts/issue257/wandb_check.py
@@ -3,11 +3,14 @@
 Optional argv[1] = display-name regex (default the base repro run; pass
 'issue257-mps1$' for the no-packing run).
 """
+
 import sys
 
 import wandb
 
-pat = sys.argv[1] if len(sys.argv) > 1 else "exp232-ccre-step4999-online-repro-issue257$"
+pat = (
+    sys.argv[1] if len(sys.argv) > 1 else "exp232-ccre-step4999-online-repro-issue257$"
+)
 api = wandb.Api(timeout=20)
 rs = list(
     api.runs(

--- a/scripts/issue257/wandb_check.py
+++ b/scripts/issue257/wandb_check.py
@@ -1,0 +1,26 @@
+"""Compact status of the exp257 online-repro wandb run (for the babysit poller).
+
+Optional argv[1] = display-name regex (default the base repro run; pass
+'issue257-mps1$' for the no-packing run).
+"""
+import sys
+
+import wandb
+
+pat = sys.argv[1] if len(sys.argv) > 1 else "exp232-ccre-step4999-online-repro-issue257$"
+api = wandb.Api(timeout=20)
+rs = list(
+    api.runs(
+        "gonzalobenegas/marin",
+        filters={"display_name": {"$regex": pat}},
+        per_page=3,
+    )
+)
+if not rs:
+    print("norun")
+else:
+    r = rs[0]
+    d = r.summary.get("lm_eval/mendelian_traits_255/distal/fwd/auprc", "-")
+    g = r.summary.get("lm_eval/mendelian_traits_255/_global_/avg/auprc", "-")
+    rt = r.summary.get("_runtime", "-")
+    print(f"{r.state} distal_fwd={d} global_avg={g} rt={rt}s")

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -264,6 +264,21 @@ models:
     window_size: 255
     datasets: [mendelian_traits]
 
+  # exp232 — per-region Qwen3-0.25B sweep on the v4 partitions (issue #232).
+  # Added for the issue #257 cross-check: independently re-score finished-run
+  # final checkpoints through the offline pipeline to compare against the
+  # in-training online metric (the ccre-step-4999 parquet was produced ad-hoc
+  # during that sanity-check; these are the other two finished arms).
+  # 255 bp + BOS, same convention as exp187.
+  - name: exp232-v4_utr3-step-4999
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp232-zoonomia-v1-0p25b-v4_utr3-v0.1-5a3011/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits]
+  - name: exp232-v4_bg-step-4999
+    gcs_path: gs://marin-us-east5/checkpoints/dna-exp232-zoonomia-v1-0p25b-v4_bg-v0.1-4ec1c6/hf/step-4999
+    window_size: 255
+    datasets: [mendelian_traits]
+
   # Eric's mix-v0.9 1B runs (Slack #marin_dna, 2026-05-18). Qwen3-1B,
   # 255 bp + BOS context. The i0-uniform run is the headline uniform-
   # mixture baseline; the i16 run continues training from i0's final

--- a/src/marin_dna/pipelines/evals/lm_eval/__init__.py
+++ b/src/marin_dna/pipelines/evals/lm_eval/__init__.py
@@ -98,9 +98,7 @@ def _install_levanter_rename_patch() -> None:
     LmEvalHarnessConfig._marin_dna_rename_patched = True
 
 
-def _prepend_bos(
-    ids: list[list[int]], bos_token_id: int | None
-) -> list[list[int]]:
+def _prepend_bos(ids: list[list[int]], bos_token_id: int | None) -> list[list[int]]:
     """Prepend ``bos_token_id`` to each token sequence (idempotent).
 
     No-op when ``bos_token_id is None`` (a tokenizer without a BOS), so the
@@ -109,9 +107,7 @@ def _prepend_bos(
     """
     if bos_token_id is None:
         return ids
-    return [
-        seq if seq[:1] == [bos_token_id] else [bos_token_id, *seq] for seq in ids
-    ]
+    return [seq if seq[:1] == [bos_token_id] else [bos_token_id, *seq] for seq in ids]
 
 
 def _install_bos_fix() -> None:

--- a/src/marin_dna/pipelines/evals/lm_eval/__init__.py
+++ b/src/marin_dna/pipelines/evals/lm_eval/__init__.py
@@ -1,6 +1,6 @@
 """Custom lm-eval-harness tasks for DNA experiments.
 
-Importing this module installs two idempotent monkeypatches:
+Importing this module installs three idempotent monkeypatches:
 
 1. ``lm_eval.tasks.TaskManager.__init__`` — appends this package's directory
    to ``include_path`` so the YAML task definitions here are discoverable.
@@ -13,6 +13,16 @@ Importing this module installs two idempotent monkeypatches:
    ``ValueError`` otherwise. ``DnaVepLlrEvalTask`` extends ``Task`` directly
    because ``ConfigurableTask.__init__`` eagerly walks fewshot docs and hangs
    on large datasets.
+
+3. ``levanter.eval_harness._encode_batch`` — prepends the tokenizer's ``[BOS]``
+   id to loglikelihood token sequences. Upstream hardcodes
+   ``add_special_tokens=False``, so the online VEP eval forwards each variant
+   sequence WITHOUT the ``[BOS]`` our DNA gLMs train with (offline ``evals_v2``
+   prepends it). That dropped BOS was the root cause of the online↔offline AUPRC
+   divergence in #257 (``ccre distal/fwd`` 0.158 with-BOS vs 0.250 no-BOS,
+   reproduced framework-independently). This is a **stopgap** monkeypatch (#263);
+   the durable per-task ``add_special_tokens`` flag threaded through levanter is
+   tracked in #264.
 """
 
 import logging
@@ -88,5 +98,50 @@ def _install_levanter_rename_patch() -> None:
     LmEvalHarnessConfig._marin_dna_rename_patched = True
 
 
+def _prepend_bos(
+    ids: list[list[int]], bos_token_id: int | None
+) -> list[list[int]]:
+    """Prepend ``bos_token_id`` to each token sequence (idempotent).
+
+    No-op when ``bos_token_id is None`` (a tokenizer without a BOS), so the
+    raw-nucleotide eval datasets stay tokenizer-agnostic; skips sequences that
+    already start with BOS.
+    """
+    if bos_token_id is None:
+        return ids
+    return [
+        seq if seq[:1] == [bos_token_id] else [bos_token_id, *seq] for seq in ids
+    ]
+
+
+def _install_bos_fix() -> None:
+    """Wrap ``levanter.eval_harness._encode_batch`` to prepend the tokenizer's BOS.
+
+    Upstream hardcodes ``add_special_tokens=False`` at this single loglikelihood
+    tokenization chokepoint, dropping the ``[BOS]`` our DNA gLMs train with — the
+    root cause of #257. Applied to both the combined and the context encodings,
+    so the ``prompt_length`` boundary stays consistent and only the prepended BOS
+    changes. Stopgap for #263; the durable per-task-flag fix is #264.
+    """
+    try:
+        from levanter import eval_harness
+    except ImportError:
+        return
+
+    if getattr(eval_harness, "_marin_dna_bos_patched", False):
+        return
+
+    original_encode_batch = eval_harness._encode_batch
+
+    @wraps(original_encode_batch)
+    def patched_encode_batch(tokenizer, texts):
+        ids = original_encode_batch(tokenizer, texts)
+        return _prepend_bos(ids, getattr(tokenizer, "bos_token_id", None))
+
+    eval_harness._encode_batch = patched_encode_batch
+    eval_harness._marin_dna_bos_patched = True
+
+
 _install_task_manager_patch()
 _install_levanter_rename_patch()
+_install_bos_fix()

--- a/tests/pipelines/evals/test_lm_eval_patch.py
+++ b/tests/pipelines/evals/test_lm_eval_patch.py
@@ -97,6 +97,63 @@ def test_levanter_rename_patch_marker_set():
     assert getattr(LmEvalHarnessConfig, "_marin_dna_rename_patched", False) is True
 
 
+# --- [BOS] fix (#257 root cause; stopgap #263; durable fix #264) -------------
+
+
+@pytest.mark.parametrize(
+    "ids, bos, expected",
+    [
+        ([[10, 11], [12]], 2, [[2, 10, 11], [2, 12]]),  # prepend
+        ([[2, 10], [2, 12]], 2, [[2, 10], [2, 12]]),  # idempotent (already BOS)
+        ([[2, 10], [12]], 2, [[2, 10], [2, 12]]),  # mixed: only the BOS-less one
+        ([[10], [11]], None, [[10], [11]]),  # no-BOS tokenizer → no-op
+        ([[]], 2, [[2]]),  # empty completion still gets BOS
+    ],
+)
+def test_prepend_bos(ids, bos, expected):
+    from marin_dna.pipelines.evals.lm_eval import _prepend_bos
+
+    assert _prepend_bos(ids, bos) == expected
+
+
+def test_bos_patch_marker_set():
+    import marin_dna.pipelines.evals.lm_eval  # noqa: F401
+    from levanter import eval_harness
+
+    assert getattr(eval_harness, "_marin_dna_bos_patched", False) is True
+
+
+def test_bos_patch_is_idempotent():
+    """Re-running the installer must not double-wrap ``_encode_batch``."""
+    import marin_dna.pipelines.evals.lm_eval as pkg
+    from levanter import eval_harness
+
+    before = eval_harness._encode_batch
+    pkg._install_bos_fix()
+    pkg._install_bos_fix()
+    assert eval_harness._encode_batch is before
+
+
+def test_bos_patch_prepends_through_encode_batch():
+    """The patched ``_encode_batch`` prepends the tokenizer's BOS id; a tokenizer
+    without a BOS is left untouched (datasets stay tokenizer-agnostic)."""
+    import marin_dna.pipelines.evals.lm_eval  # noqa: F401  triggers the patch
+    from levanter import eval_harness
+
+    class _FakeTok:
+        def __init__(self, bos):
+            self.bos_token_id = bos
+
+        def encode_batch(self, texts):  # MarinTokenizer-style: list[list[int]]
+            return [[10, 11, 12] for _ in texts]
+
+    assert eval_harness._encode_batch(_FakeTok(bos=2), ["A", "C"]) == [
+        [2, 10, 11, 12],
+        [2, 10, 11, 12],
+    ]
+    assert eval_harness._encode_batch(_FakeTok(bos=None), ["A"]) == [[10, 11, 12]]
+
+
 def test_levanter_rename_patch_is_idempotent():
     import marin_dna.pipelines.evals.lm_eval  # noqa: F401
     from marin_dna.pipelines.evals.lm_eval import _install_levanter_rename_patch


### PR DESCRIPTION
## What

Fixes the root cause of #257: the online (in-training levanter `lm_eval`) VEP eval forwarded each variant sequence **without** the leading `[BOS]` the DNA gLMs train with (offline `evals_v2` prepends it), because levanter's `eval_harness._encode_batch` hardcodes `add_special_tokens=False`. On `exp232 ccre v4 distal/fwd` that dropped BOS shifted AUPRC from **0.158** (faithful) to **0.250** (OOD artifact) — proven framework-independent and end-to-end in #257.

## Change

`_install_bos_fix()` in the lm_eval package `__init__` (beside the existing TaskManager / rename monkeypatches) wraps `_encode_batch` to prepend the tokenizer's BOS id (`_prepend_bos`):
- **idempotent** and a **no-op for a BOS-less tokenizer** → the raw-nucleotide `*_harness_255` datasets stay tokenizer-agnostic;
- applied to **both** the combined and context encodings → the prompt/completion boundary is unchanged, only the BOS is added.

This is a **stopgap** (it patches a pinned dependency at runtime). The durable per-task `add_special_tokens` flag threaded through levanter is **#264**.

## Validation

- 33 eval tests pass; new tests cover `_prepend_bos`, the patch marker, idempotency, and prepend-through-`_encode_batch`.
- `scripts/issue257/verify_bos_fix.py`: the real harness path + real tokenizer on `chr7:156791472` now yields `[BOS]` + 255 nt (256 tokens), boundary at 128.
- with-BOS reproduces offline 0.158 end-to-end over all 580 distal variants (`scripts/issue257/bos_auprc.py`).

This branch also carries the #257 investigation scripts (the evidence chain) + README.

## Not in this PR

- ⚠️ **Re-eval**: every existing online VEP leaderboard value is no-BOS and needs re-running once this lands (tracked in #263).
- Durable upstream fix: #264.

Root cause: #257. Stopgap tracker: #263. Durable fix: #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
