### PR TITLE
evals/lm_eval: prepend [BOS] in levanter loglikelihood tokenization (#263)

### DIFF
--- a/experiments/parity/issue263_bos_fix_parity.py
+++ b/experiments/parity/issue263_bos_fix_parity.py
@@ -1,0 +1,246 @@
+# Copyright The Marin Authors / MarinDNA Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Online↔offline parity check for the #263 [BOS] fix (validates #266).
+
+The online (in-training levanter ``lm_eval``) VEP eval used to forward each
+variant sequence WITHOUT the leading ``[BOS]`` the DNA gLMs train with, because
+levanter's ``eval_harness._encode_batch`` hardcodes ``add_special_tokens=False``.
+That dropped BOS was the root cause of #257: on exp232 ``v4_ccre_non_promoter``
+step-4999, ``mendelian distal/fwd`` AUPRC read **0.250** online (no-BOS, OOD
+artifact) vs **0.158** offline (with-BOS, faithful). PR #266 adds
+``_install_bos_fix()`` to the lm_eval package ``__init__`` (prepends the
+tokenizer's BOS id at ``_encode_batch``).
+
+This runs the *real* levanter ``lm_eval`` path on that exact native checkpoint,
+**with the fix active and packing disabled**, and asserts the online
+``distal/fwd`` AUPRC now lands in the with-BOS regime (≈0.158), refuting the
+no-BOS 0.250. It is the end-to-end, on-iris counterpart to the unit tests in
+``tests/pipelines/evals/test_lm_eval_patch.py`` and the local
+``scripts/issue257/bos_auprc.py``.
+
+Two guards run on the TPU pod (fail-fast, visible in the iris logs):
+  1. ``eval_harness._marin_dna_bos_patched`` — confirms the shipped ``marin_dna``
+     actually carries the fix (catches a stale-workspace deploy).
+  2. ``distal/fwd`` AUPRC ∈ [0.13, 0.19] — the with-BOS regime, excluding 0.250.
+
+Packing is disabled (``max_packed_segments=1``): each sequence is forwarded alone
+with a plain causal mask. No env knobs — this check is deliberately fixed.
+
+Launch from a CPU box (this fix-branch worktree) with an iris tunnel open
+(``--cluster=marin`` auto-tunnels); ``create_environment`` ships the local
+workspace, so the pod installs *this* branch's fixed ``marin_dna``:
+
+    uv run --extra marin iris --cluster=marin job run \\
+        --no-wait --user gonzalo --job-name issue263-bos-fix-parity \\
+        --cpu 1 --memory 2g --extra marin --region us-east5 \\
+        -e WANDB_API_KEY "$(grep -A2 api.wandb.ai ~/.netrc | grep password | awk '{print $2}')" \\
+        -e HF_HUB_DOWNLOAD_TIMEOUT 120 -e UV_LOCK_TIMEOUT 7200 \\
+        -- python experiments/parity/issue263_bos_fix_parity.py
+"""
+
+import dataclasses
+import logging
+import os
+
+import jmp
+import levanter.eval_harness as eval_harness
+from fray.cluster import ResourceConfig
+from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
+from levanter.models.qwen import Qwen3Config
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from marin.evaluation.evaluation_config import convert_to_levanter_task_config
+from marin.execution.executor import ExecutorStep, executor_main
+from marin.execution.remote import remote
+
+from marin_dna.levanter.defaults import dna_effective_seq_len
+from marin_dna.pipelines.evals.lm_eval.task_configs import MENDELIAN_TRAITS_255
+
+logger = logging.getLogger(__name__)
+
+MODEL_NAME = "exp232-v4_ccre_non_promoter-step-4999"
+# Native levanter checkpoint root (the exact in-training state #257 ran on).
+# load_checkpoint via latest_checkpoint_path(…/checkpoints) → step-4999.
+CHECKPOINT_PATH = (
+    "gs://marin-us-east5/checkpoints/"
+    "dna-exp232-zoonomia-v1-0p25b-v4_ccre_non_promoter-v0.1-feca83/checkpoints"
+)
+TOKENIZER = "bolinas-dna/tokenizer-char-bos"
+
+# exp232 Qwen3-0.25B geometry — verbatim from exp232_per_region so the native
+# checkpoint's array structure matches exactly.
+DNA_BASE_SEQ_LEN = 255
+HIDDEN_DIM = 1152
+INTERMEDIATE_DIM = HIDDEN_DIM * 4  # 4608
+NUM_HEADS = HIDDEN_DIM // 128  # 9
+NUM_LAYERS = 12
+INITIALIZER_RANGE = 0.02
+
+# v6e-4 (us-east5-b) is data-local to the checkpoint + mendelian data; a 0.25B
+# eval needs nothing bigger. Env-overridable to re-route if contended (check
+# `iris cluster status` first).
+TPU_TYPES: tuple[str, ...] = tuple(
+    t.strip() for t in os.getenv("TPU_TYPE", "v6e-4").split(",") if t.strip()
+)
+_EVAL_DEPENDENCY_GROUPS = ["marin", "tpu"]
+
+# Parity band: offline (with-BOS) distal/fwd = 0.1589; the pre-fix online no-BOS
+# value was 0.2501. A pass means we're clearly in the with-BOS regime.
+WITH_BOS_REFERENCE = 0.1589
+NO_BOS_REFERENCE = 0.2501
+PARITY_LOW, PARITY_HIGH = 0.13, 0.19
+
+WANDB_PROJECT = "marin"
+WANDB_RUN_NAME = "dna-exp232-ccre-step4999-bos-fix-parity-issue263"
+WANDB_TAGS = ("dna", "exp232", "issue263", "bos-fix", "parity")
+
+# Captured on the pod inside the aggregation wrapper (module global so the
+# post-run assertion can read it).
+_CAPTURED: dict[str, float] = {}
+
+
+def _build_model_config(seq_len: int) -> Qwen3Config:
+    return Qwen3Config(
+        hidden_dim=HIDDEN_DIM,
+        intermediate_dim=INTERMEDIATE_DIM,
+        num_layers=NUM_LAYERS,
+        num_heads=NUM_HEADS,
+        num_kv_heads=NUM_HEADS,
+        max_seq_len=seq_len,
+        rope=Llama3RotaryEmbeddingsConfig(),
+        initializer_range=INITIALIZER_RANGE,
+    )
+
+
+def _install_distal_fwd_capture() -> None:
+    """Capture the ``distal/fwd/auprc`` cell from the AUPRC aggregation so the
+    post-run parity assertion can read it. lm_eval imports the task as a
+    TOP-LEVEL ``dna_vep_llr_eval`` module, so pre-register this package's copy
+    under that name (mirrors exp257) before wrapping its aggregator."""
+    import sys
+
+    from marin_dna.pipelines.evals.lm_eval import dna_vep_llr_eval as dv
+
+    sys.modules["dna_vep_llr_eval"] = dv
+    orig = dv._AuprcAggregation.__call__
+
+    def patched(self, items):
+        out = orig(self, items)
+        val = self.results_store.get("distal/fwd/auprc")
+        if val is not None:
+            _CAPTURED["distal_fwd_auprc"] = float(val)
+            print(f"[parity] captured distal/fwd/auprc = {val:.4f}", flush=True)
+        return out
+
+    dv._AuprcAggregation.__call__ = patched
+
+
+def _force_no_packing() -> None:
+    """Disable sequence packing (``max_packed_segments=1``): each sequence is
+    forwarded alone with a plain causal mask."""
+    orig_init = eval_harness._LmEvalHarnessWorker.__init__
+
+    def patched_init(self, *a, **kw):
+        kw["max_packed_segments"] = 1
+        print("[parity] max_packed_segments -> 1 (packing disabled)", flush=True)
+        return orig_init(self, *a, **kw)
+
+    eval_harness._LmEvalHarnessWorker.__init__ = patched_init
+
+
+@dataclasses.dataclass(frozen=True)
+class _EvalConfig:
+    """ExecutorStep requires a config dataclass; eval is fully parameterized by
+    module-level constants."""
+
+
+def _run_eval_harness_only(_config: _EvalConfig) -> None:
+    # MUST be inside the function body — iris cloudpickles __main__ by-value and
+    # never re-imports this module on the worker, so the package import (which
+    # installs the BOS fix) and our patches only fire if triggered here.
+    import marin_dna.pipelines.evals.lm_eval  # noqa: F401  installs _install_bos_fix
+
+    # Guard 1: the shipped marin_dna must actually carry the fix (catches a
+    # stale-workspace deploy where the pod got pre-fix code).
+    assert getattr(eval_harness, "_marin_dna_bos_patched", False), (
+        "BOS fix (#263) not installed on the pod — the deployed marin_dna predates "
+        "the fix. Launch from the fix-branch worktree so create_environment ships it."
+    )
+    print("[parity] BOS fix present (eval_harness._marin_dna_bos_patched=True)", flush=True)
+
+    _force_no_packing()
+    _install_distal_fwd_capture()
+
+    seq_len = dna_effective_seq_len(DNA_BASE_SEQ_LEN, TOKENIZER)
+    eval_config = eval_harness.EvalHarnessMainConfig(
+        eval_harness=eval_harness.LmEvalHarnessConfig(
+            task_spec=convert_to_levanter_task_config([MENDELIAN_TRAITS_255]),
+            log_samples=False,
+        ),
+        tokenizer=TOKENIZER,
+        checkpoint_path=CHECKPOINT_PATH,
+        checkpoint_is_hf=False,
+        trainer=TrainerConfig(
+            tracker=WandbConfig(
+                project=WANDB_PROJECT,
+                tags=list(WANDB_TAGS),
+                name=WANDB_RUN_NAME,
+            ),
+            mp=jmp.get_policy("p=f32,c=bfloat16"),
+            per_device_eval_parallelism=64,
+        ),
+        model=_build_model_config(seq_len),
+    )
+    eval_harness.run_eval_harness_main(eval_config)
+
+    # Guard 2: parity. distal/fwd must be in the with-BOS regime, not 0.250.
+    auprc = _CAPTURED.get("distal_fwd_auprc")
+    assert auprc is not None, (
+        "distal/fwd/auprc was not captured — the aggregation key may have changed."
+    )
+    status = "PASS" if PARITY_LOW <= auprc <= PARITY_HIGH else "FAIL"
+    print(
+        f"\n[parity] ===== BOS-fix parity {status} =====\n"
+        f"[parity] distal/fwd AUPRC = {auprc:.4f}\n"
+        f"[parity]   with-BOS (offline, faithful): {WITH_BOS_REFERENCE}\n"
+        f"[parity]   no-BOS   (pre-fix online):    {NO_BOS_REFERENCE}\n"
+        f"[parity]   pass band: [{PARITY_LOW}, {PARITY_HIGH}]",
+        flush=True,
+    )
+    assert PARITY_LOW <= auprc <= PARITY_HIGH, (
+        f"BOS-fix parity FAILED: distal/fwd AUPRC {auprc:.4f} is outside the "
+        f"with-BOS band [{PARITY_LOW}, {PARITY_HIGH}] (no-BOS artifact was {NO_BOS_REFERENCE})."
+    )
+
+
+def main() -> None:
+    env_vars: dict[str, str] = {
+        "HF_HUB_DOWNLOAD_TIMEOUT": "120",
+        "UV_LOCK_TIMEOUT": "7200",
+    }
+    if "WANDB_API_KEY" in os.environ:
+        env_vars["WANDB_API_KEY"] = os.environ["WANDB_API_KEY"]
+
+    step = ExecutorStep(
+        name=f"evaluation/lm_evaluation_harness_levanter/issue263_bos_fix_parity_{MODEL_NAME}",
+        fn=remote(
+            _run_eval_harness_only,
+            resources=ResourceConfig.with_tpu(TPU_TYPES),
+            pip_dependency_groups=_EVAL_DEPENDENCY_GROUPS,
+            env_vars=env_vars,
+        ),
+        config=_EvalConfig(),
+    )
+    executor_main(
+        steps=[step],
+        description=(
+            "issue #263 — online↔offline BOS-fix parity: run levanter lm_eval on "
+            "exp232 ccre step-4999 (native ckpt) with the fix + no packing; assert "
+            "distal/fwd AUPRC ≈ 0.158 (with-BOS), not 0.250 (no-BOS)."
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/parity/issue263_bos_fix_parity.py
+++ b/experiments/parity/issue263_bos_fix_parity.py
@@ -167,7 +167,10 @@ def _run_eval_harness_only(_config: _EvalConfig) -> None:
         "BOS fix (#263) not installed on the pod — the deployed marin_dna predates "
         "the fix. Launch from the fix-branch worktree so create_environment ships it."
     )
-    print("[parity] BOS fix present (eval_harness._marin_dna_bos_patched=True)", flush=True)
+    print(
+        "[parity] BOS fix present (eval_harness._marin_dna_bos_patched=True)",
+        flush=True,
+    )
 
     _force_no_packing()
     _install_distal_fwd_capture()

--- a/experiments/parity/issue263_bos_fix_parity.py
+++ b/experiments/parity/issue263_bos_fix_parity.py
@@ -114,26 +114,27 @@ def _build_model_config(seq_len: int) -> Qwen3Config:
 
 
 def _install_distal_fwd_capture() -> None:
-    """Capture the ``distal/fwd/auprc`` cell from the AUPRC aggregation so the
-    post-run parity assertion can read it. lm_eval imports the task as a
-    TOP-LEVEL ``dna_vep_llr_eval`` module, so pre-register this package's copy
-    under that name (mirrors exp257) before wrapping its aggregator."""
-    import sys
+    """Capture the ``distal/fwd`` AUPRC cell by intercepting the levanter tracker
+    log payload. The aggregator pushes per-subset cells via
+    ``levanter.tracker.log({f"{prefix}/distal/fwd/auprc": value, ...})``; patching
+    that (resolved at call time) is robust to the ``dna_vep_llr_eval``
+    module-identity issue a direct aggregator patch hits under lm_eval's
+    top-level ``!function`` import."""
+    import levanter.tracker as lt
 
-    from marin_dna.pipelines.evals.lm_eval import dna_vep_llr_eval as dv
+    orig_log = lt.log
 
-    sys.modules["dna_vep_llr_eval"] = dv
-    orig = dv._AuprcAggregation.__call__
+    def patched_log(metrics, *args, **kwargs):
+        try:
+            for k, v in dict(metrics).items():
+                if k.endswith("distal/fwd/auprc"):
+                    _CAPTURED["distal_fwd_auprc"] = float(v)
+                    print(f"[parity] captured {k} = {float(v):.4f}", flush=True)
+        except Exception:  # never let capture break the real logging
+            pass
+        return orig_log(metrics, *args, **kwargs)
 
-    def patched(self, items):
-        out = orig(self, items)
-        val = self.results_store.get("distal/fwd/auprc")
-        if val is not None:
-            _CAPTURED["distal_fwd_auprc"] = float(val)
-            print(f"[parity] captured distal/fwd/auprc = {val:.4f}", flush=True)
-        return out
-
-    dv._AuprcAggregation.__call__ = patched
+    lt.log = patched_log
 
 
 def _force_no_packing() -> None:

--- a/experiments/parity/issue263_bos_fix_parity.py
+++ b/experiments/parity/issue263_bos_fix_parity.py
@@ -40,7 +40,6 @@ workspace, so the pod installs *this* branch's fixed ``marin_dna``:
 """
 
 import dataclasses
-import logging
 import os
 
 import jmp
@@ -56,8 +55,6 @@ from marin.execution.remote import remote
 
 from marin_dna.levanter.defaults import dna_effective_seq_len
 from marin_dna.pipelines.evals.lm_eval.task_configs import MENDELIAN_TRAITS_255
-
-logger = logging.getLogger(__name__)
 
 MODEL_NAME = "exp232-v4_ccre_non_promoter-step-4999"
 # Native levanter checkpoint root (the exact in-training state #257 ran on).
@@ -77,8 +74,9 @@ NUM_HEADS = HIDDEN_DIM // 128  # 9
 NUM_LAYERS = 12
 INITIALIZER_RANGE = 0.02
 
-# v6e-4 (us-east5-b) is data-local to the checkpoint + mendelian data; a 0.25B
-# eval needs nothing bigger. Env-overridable to re-route if contended (check
+# v6e-4 is small enough for a 0.25B eval; iris schedules it wherever the pool has
+# capacity (e.g. us-east1-d — a cross-region read of the us-east5 checkpoint,
+# fine for a one-off). Env-overridable to re-route if contended (check
 # `iris cluster status` first).
 TPU_TYPES: tuple[str, ...] = tuple(
     t.strip() for t in os.getenv("TPU_TYPE", "v6e-4").split(",") if t.strip()
@@ -95,8 +93,8 @@ WANDB_PROJECT = "marin"
 WANDB_RUN_NAME = "dna-exp232-ccre-step4999-bos-fix-parity-issue263"
 WANDB_TAGS = ("dna", "exp232", "issue263", "bos-fix", "parity")
 
-# Captured on the pod inside the aggregation wrapper (module global so the
-# post-run assertion can read it).
+# Captured on the pod by the tracker-log intercept (module global so the
+# post-run parity assertion can read it).
 _CAPTURED: dict[str, float] = {}
 
 
@@ -201,7 +199,7 @@ def _run_eval_harness_only(_config: _EvalConfig) -> None:
     # Guard 2: parity. distal/fwd must be in the with-BOS regime, not 0.250.
     auprc = _CAPTURED.get("distal_fwd_auprc")
     assert auprc is not None, (
-        "distal/fwd/auprc was not captured — the aggregation key may have changed."
+        "distal/fwd/auprc was not captured — the tracker-log payload key may have changed."
     )
     status = "PASS" if PARITY_LOW <= auprc <= PARITY_HIGH else "FAIL"
     print(

--- a/src/marin_dna/pipelines/evals/lm_eval/__init__.py
+++ b/src/marin_dna/pipelines/evals/lm_eval/__init__.py
@@ -98,9 +98,7 @@ def _install_levanter_rename_patch() -> None:
     LmEvalHarnessConfig._marin_dna_rename_patched = True
 
 
-def _prepend_bos(
-    ids: list[list[int]], bos_token_id: int | None
-) -> list[list[int]]:
+def _prepend_bos(ids: list[list[int]], bos_token_id: int | None) -> list[list[int]]:
     """Prepend ``bos_token_id`` to each token sequence (idempotent).
 
     No-op when ``bos_token_id is None`` (a tokenizer without a BOS), so the
@@ -109,9 +107,7 @@ def _prepend_bos(
     """
     if bos_token_id is None:
         return ids
-    return [
-        seq if seq[:1] == [bos_token_id] else [bos_token_id, *seq] for seq in ids
-    ]
+    return [seq if seq[:1] == [bos_token_id] else [bos_token_id, *seq] for seq in ids]
 
 
 def _install_bos_fix() -> None:

--- a/src/marin_dna/pipelines/evals/lm_eval/__init__.py
+++ b/src/marin_dna/pipelines/evals/lm_eval/__init__.py
@@ -1,6 +1,6 @@
 """Custom lm-eval-harness tasks for DNA experiments.
 
-Importing this module installs two idempotent monkeypatches:
+Importing this module installs three idempotent monkeypatches:
 
 1. ``lm_eval.tasks.TaskManager.__init__`` — appends this package's directory
    to ``include_path`` so the YAML task definitions here are discoverable.
@@ -13,6 +13,16 @@ Importing this module installs two idempotent monkeypatches:
    ``ValueError`` otherwise. ``DnaVepLlrEvalTask`` extends ``Task`` directly
    because ``ConfigurableTask.__init__`` eagerly walks fewshot docs and hangs
    on large datasets.
+
+3. ``levanter.eval_harness._encode_batch`` — prepends the tokenizer's ``[BOS]``
+   id to loglikelihood token sequences. Upstream hardcodes
+   ``add_special_tokens=False``, so the online VEP eval forwards each variant
+   sequence WITHOUT the ``[BOS]`` our DNA gLMs train with (offline ``evals_v2``
+   prepends it). That dropped BOS was the root cause of the online↔offline AUPRC
+   divergence in #257 (``ccre distal/fwd`` 0.158 with-BOS vs 0.250 no-BOS,
+   reproduced framework-independently). This is a **stopgap** monkeypatch (#263);
+   the durable per-task ``add_special_tokens`` flag threaded through levanter is
+   tracked in #264.
 """
 
 import logging
@@ -88,5 +98,50 @@ def _install_levanter_rename_patch() -> None:
     LmEvalHarnessConfig._marin_dna_rename_patched = True
 
 
+def _prepend_bos(
+    ids: list[list[int]], bos_token_id: int | None
+) -> list[list[int]]:
+    """Prepend ``bos_token_id`` to each token sequence (idempotent).
+
+    No-op when ``bos_token_id is None`` (a tokenizer without a BOS), so the
+    raw-nucleotide eval datasets stay tokenizer-agnostic; skips sequences that
+    already start with BOS.
+    """
+    if bos_token_id is None:
+        return ids
+    return [
+        seq if seq[:1] == [bos_token_id] else [bos_token_id, *seq] for seq in ids
+    ]
+
+
+def _install_bos_fix() -> None:
+    """Wrap ``levanter.eval_harness._encode_batch`` to prepend the tokenizer's BOS.
+
+    Upstream hardcodes ``add_special_tokens=False`` at this single loglikelihood
+    tokenization chokepoint, dropping the ``[BOS]`` our DNA gLMs train with — the
+    root cause of #257. Applied to both the combined and the context encodings,
+    so the ``prompt_length`` boundary stays consistent and only the prepended BOS
+    changes. Stopgap for #263; the durable per-task-flag fix is #264.
+    """
+    try:
+        from levanter import eval_harness
+    except ImportError:
+        return
+
+    if getattr(eval_harness, "_marin_dna_bos_patched", False):
+        return
+
+    original_encode_batch = eval_harness._encode_batch
+
+    @wraps(original_encode_batch)
+    def patched_encode_batch(tokenizer, texts):
+        ids = original_encode_batch(tokenizer, texts)
+        return _prepend_bos(ids, getattr(tokenizer, "bos_token_id", None))
+
+    eval_harness._encode_batch = patched_encode_batch
+    eval_harness._marin_dna_bos_patched = True
+
+
 _install_task_manager_patch()
 _install_levanter_rename_patch()
+_install_bos_fix()

--- a/tests/pipelines/evals/test_lm_eval_patch.py
+++ b/tests/pipelines/evals/test_lm_eval_patch.py
@@ -97,6 +97,63 @@ def test_levanter_rename_patch_marker_set():
     assert getattr(LmEvalHarnessConfig, "_marin_dna_rename_patched", False) is True
 
 
+# --- [BOS] fix (#257 root cause; stopgap #263; durable fix #264) -------------
+
+
+@pytest.mark.parametrize(
+    "ids, bos, expected",
+    [
+        ([[10, 11], [12]], 2, [[2, 10, 11], [2, 12]]),  # prepend
+        ([[2, 10], [2, 12]], 2, [[2, 10], [2, 12]]),  # idempotent (already BOS)
+        ([[2, 10], [12]], 2, [[2, 10], [2, 12]]),  # mixed: only the BOS-less one
+        ([[10], [11]], None, [[10], [11]]),  # no-BOS tokenizer → no-op
+        ([[]], 2, [[2]]),  # empty completion still gets BOS
+    ],
+)
+def test_prepend_bos(ids, bos, expected):
+    from marin_dna.pipelines.evals.lm_eval import _prepend_bos
+
+    assert _prepend_bos(ids, bos) == expected
+
+
+def test_bos_patch_marker_set():
+    import marin_dna.pipelines.evals.lm_eval  # noqa: F401
+    from levanter import eval_harness
+
+    assert getattr(eval_harness, "_marin_dna_bos_patched", False) is True
+
+
+def test_bos_patch_is_idempotent():
+    """Re-running the installer must not double-wrap ``_encode_batch``."""
+    import marin_dna.pipelines.evals.lm_eval as pkg
+    from levanter import eval_harness
+
+    before = eval_harness._encode_batch
+    pkg._install_bos_fix()
+    pkg._install_bos_fix()
+    assert eval_harness._encode_batch is before
+
+
+def test_bos_patch_prepends_through_encode_batch():
+    """The patched ``_encode_batch`` prepends the tokenizer's BOS id; a tokenizer
+    without a BOS is left untouched (datasets stay tokenizer-agnostic)."""
+    import marin_dna.pipelines.evals.lm_eval  # noqa: F401  triggers the patch
+    from levanter import eval_harness
+
+    class _FakeTok:
+        def __init__(self, bos):
+            self.bos_token_id = bos
+
+        def encode_batch(self, texts):  # MarinTokenizer-style: list[list[int]]
+            return [[10, 11, 12] for _ in texts]
+
+    assert eval_harness._encode_batch(_FakeTok(bos=2), ["A", "C"]) == [
+        [2, 10, 11, 12],
+        [2, 10, 11, 12],
+    ]
+    assert eval_harness._encode_batch(_FakeTok(bos=None), ["A"]) == [[10, 11, 12]]
+
+
 def test_levanter_rename_patch_is_idempotent():
     import marin_dna.pipelines.evals.lm_eval  # noqa: F401
     from marin_dna.pipelines.evals.lm_eval import _install_levanter_rename_patch


### PR DESCRIPTION
## What

Fixes the root cause of #257: the online (in-training levanter `lm_eval`) VEP eval forwarded each variant sequence **without** the leading `[BOS]` the DNA gLMs train with (offline `evals_v2` prepends it), because levanter's `eval_harness._encode_batch` hardcodes `add_special_tokens=False`. On `exp232 ccre v4 distal/fwd` that dropped BOS shifted AUPRC from **0.158** (faithful) to **0.250** (OOD artifact) — proven framework-independent and end-to-end in #257.

## Change

`_install_bos_fix()` joins the existing TaskManager / rename monkeypatches in the lm_eval package `__init__`, wrapping `_encode_batch` to prepend the tokenizer's BOS id (`_prepend_bos`):

- **idempotent** and a **no-op for a BOS-less tokenizer** → the raw-nucleotide `*_harness_255` datasets stay tokenizer-agnostic;
- applied to **both** the combined and context encodings → the prompt/completion boundary is unchanged, only the BOS is added.

This is a **stopgap** (it patches a pinned dependency at runtime). The durable per-task `add_special_tokens` flag threaded through levanter is **#264**.

## Validation

- New tests in `test_lm_eval_patch.py`: `_prepend_bos` cases, the patch marker, idempotency, and prepend-through-`_encode_batch` (16 patch tests pass; 33 with the task tests).
- (Out-of-PR, on the investigation branch) the real harness path on `chr7:156791472` now forwards `[BOS]` + 255 nt (256 tokens), boundary at 128; with-BOS reproduces offline 0.158 end-to-end over all 580 distal variants.

## Scope

Fix-only — the #257 investigation/repro scripts are deliberately **not** included here. The online-leaderboard re-eval (every existing value is no-BOS) is a separate follow-up, not part of this PR.

Closes #263. Root cause: #257. Durable upstream change tracked in #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


