### PR TITLE
neutral_sites: GPN-Star neutral-site dataset pipeline

### DIFF
--- a/snakemake/neutral_sites/README.md
+++ b/snakemake/neutral_sites/README.md
@@ -53,8 +53,11 @@ Pin destination (uploaded at the end of a run; consumed by `evals_v2`):
 
 CPU-only but **heavy I/O**: it downloads ~15 GB of bigWigs plus rmsk/chain and
 scans the bigWigs genome-wide (single-threaded). Budget the disk and ~tens of
-minutes. Fine on a CPU box; not worth a GPU. The bigWigs/rmsk/chain are kept
-**local** (no S3 storage churn) — only the small final parquet is pinned.
+minutes. Not worth a GPU. The bigWigs/rmsk/chain are kept **local** (no S3
+storage churn) — only the small final parquet is pinned. The enumerate step is
+RAM-bound (it materializes every neutral base), so run it on a memory-optimized
+node. [`sky/run.yaml`](sky/run.yaml) provisions one (`r6id.2xlarge`, 64 GB) and
+pins the parquet to S3.
 
 ## Setup
 
@@ -78,6 +81,15 @@ uv run --group genome-s3 snakemake
 # Pin the artifact for evals_v2 to consume.
 aws s3 cp results/neutral_sites.parquet \
   s3://oa-bolinas/snakemake/neutral_sites/results/neutral_sites.parquet
+```
+
+### On SkyPilot (the intended path)
+
+```bash
+# Provisions a memory-optimized CPU node, runs the pipeline, sanity-checks,
+# and pins the parquet to s3://oa-bolinas/snakemake/neutral_sites/...
+sky launch snakemake/neutral_sites/sky/run.yaml -c neutral-sites
+sky down neutral-sites   # when done
 ```
 
 ## Library

--- a/snakemake/neutral_sites/README.md
+++ b/snakemake/neutral_sites/README.md
@@ -1,0 +1,92 @@
+# neutral_sites — GPN-Star neutral-site set for mutation-rate calibration (#267)
+
+Builds a reusable, **model-independent** parquet of high-confidence neutral
+`(chrom, pos, ref)` sites on GRCh38, replicating the GPN-Star neutral
+definition. The per-model calibration step in
+[`snakemake/analysis/evals_v2`](../analysis/evals_v2/) consumes this artifact to
+build per-checkpoint `llr_neutral_mean` / `entropy_neutral_mean` tables for
+calibrated LLR / entropy (cLLR) scoring. See
+[issue #267](https://github.com/Open-Athena/marin-dna/issues/267).
+
+Kept as its own pipeline (not folded into `evals_v2`) because it's run-once,
+model-independent, and needs a genome-data toolchain (bedtools + UCSC liftOver,
+via conda) alien to evals_v2's GPU-inference env — the same separation as
+`snakemake/evals` (builds the eval datasets) vs `evals_v2` (consumes them).
+
+## What it does
+
+Replicates GPN-Star's hg38 calibration inputs exactly
+([songlab-cal/gpn `calibration.smk`](https://github.com/songlab-cal/gpn/blob/20abe5df998872a47ec08d40c11ab472012ccca5/analysis/gpn-star/train_and_eval/workflow/rules/calibration.smk)):
+
+1. **Ancestral repeats** — download UCSC RepeatMasker for hg38 (target) and mm39
+   (outgroup) + the `mm39.hg38.rbest` chain; `liftOver` the mm39 repeats into
+   hg38; keep hg38 repeats overlapping a lifted mm39 repeat (`bedtools
+   intersect -u`). `Simple_repeat` / `Low_complexity` are excluded in
+   `parse_rmsk`.
+2. **Low-constraint sites** — scan the vertebrate 100-way `phyloP` + `phastCons`
+   bigWigs; keep bases with `|phyloP| < 0.1 AND phastCons == 0` (NaN excluded).
+3. **Neutral set** — `bedtools intersect` (1) ∩ (2), then enumerate every base
+   to `(chrom, pos, ref)`, keeping `ACGT` refs only.
+
+### Two deliberate choices vs the reference (flagged in #267)
+
+- **`Simple_repeat` / `Low_complexity` are actually excluded.** GPN's awk emits
+  `swScore` in the column it then filters against the class strings, so its
+  exclusion is a silent no-op; `parse_rmsk` filters `repClass` correctly (these
+  are poor neutral proxies). One-line revert if exact bug-for-bug parity is
+  wanted.
+- **Coordinates.** Everything through the liftOver/bedtools steps stays in
+  BED-land (UCSC `chr`-prefixed, 0-based half-open). `enumerate_positions` is
+  the single boundary back: it strips `chr` (our Ensembl reference uses bare
+  names) and emits **1-based** `pos`, matching the HF eval datasets so the same
+  scoring path consumes neutral sites and eval variants alike.
+
+## Output
+
+`results/neutral_sites.parquet` — columns `[chrom, pos, ref]` (bare chrom,
+1-based pos, `ref` ∈ {A,C,G,T}), autosomes + X + Y.
+
+Pin destination (uploaded at the end of a run; consumed by `evals_v2`):
+`s3://oa-bolinas/snakemake/neutral_sites/results/neutral_sites.parquet`.
+
+## Where to run
+
+CPU-only but **heavy I/O**: it downloads ~15 GB of bigWigs plus rmsk/chain and
+scans the bigWigs genome-wide (single-threaded). Budget the disk and ~tens of
+minutes. Fine on a CPU box; not worth a GPU. The bigWigs/rmsk/chain are kept
+**local** (no S3 storage churn) — only the small final parquet is pinned.
+
+## Setup
+
+```bash
+# bedtools + liftOver come from the conda env (use-conda in the default profile).
+# The reference is read from S3 by pyfaidx, so install the genome-s3 group:
+uv sync --frozen --group genome-s3
+```
+
+## Usage
+
+```bash
+cd snakemake/neutral_sites
+
+# Inspect the DAG.
+uv run --group genome-s3 snakemake -n
+
+# Run (conda envs are built on first use).
+uv run --group genome-s3 snakemake
+
+# Pin the artifact for evals_v2 to consume.
+aws s3 cp results/neutral_sites.parquet \
+  s3://oa-bolinas/snakemake/neutral_sites/results/neutral_sites.parquet
+```
+
+## Library
+
+Rules are thin glue around `marin_dna.pipelines.neutral_sites.sites`:
+
+- `parse_rmsk` — UCSC `rmsk.txt.gz` → repeat-interval BED frame.
+- `contiguous_runs` / `neutral_mask` / `scan_neutral_intervals` —
+  low-constraint sites from phyloP + phastCons.
+- `enumerate_positions` — neutral intervals → per-base `(chrom, pos, ref)`.
+
+Tests: [`tests/pipelines/neutral_sites/test_sites.py`](../../tests/pipelines/neutral_sites/test_sites.py).

--- a/snakemake/neutral_sites/config/config.yaml
+++ b/snakemake/neutral_sites/config/config.yaml
@@ -1,0 +1,32 @@
+# neutral_sites — GPN-Star neutral-site set on GRCh38 for mutation-rate
+# calibration (issue #267). Replicates GPN-Star's hg38 calibration inputs.
+
+# Reference genome (Ensembl GRCh38, soft-masked) for the ref base at each
+# neutral position. Same canonical reference as snakemake/analysis/evals_v2.
+# The S3 path requires `--group genome-s3` at install (pyfaidx + s3fs).
+genome_path: s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz
+
+# Source files — exactly what GPN-Star used for the hg38 calibration
+# (songlab-cal/gpn analysis/gpn-star/.../Snakefile_hg38 CALIBRATION_CONFIGS),
+# via UCSC https mirrors of GPN's ftp URLs (byte-identical files).
+rmsk_target_url: https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/rmsk.txt.gz
+rmsk_outgroup_url: https://hgdownload.soe.ucsc.edu/goldenPath/mm39/database/rmsk.txt.gz
+chain_url: https://hgdownload.soe.ucsc.edu/goldenPath/mm39/vsHg38/reciprocalBest/mm39.hg38.rbest.chain.gz
+
+# Conservation tracks that define the low-constraint sites. Keys index
+# marin_dna.pipelines.evals.conservation.CONSERVATION_TRACKS (single source of
+# truth for the URLs) — phyloP_100v / phastCons_100v are the vertebrate 100-way
+# tracks GPN-Star used.
+phylop_track: phyloP_100v
+phastcons_track: phastCons_100v
+
+# Neutral = |phyloP| < threshold AND phastCons == 0. GPN uses 0.1 in the
+# ancestral-repeat setting (0.05 without repeats).
+phylop_threshold: 0.1
+
+# Chromosomes to enumerate (autosomes + X + Y — GPN's CHROMS). The calibration
+# table is a genome-wide background model, so there is no train/test split here.
+chroms: ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","X","Y"]
+
+# bigWig scan granularity (bases per pyBigWig read).
+window_size: 1000000

--- a/snakemake/neutral_sites/sky/run.yaml
+++ b/snakemake/neutral_sites/sky/run.yaml
@@ -63,23 +63,8 @@ run: |
         --rerun-incomplete \
         $SNAKEMAKE_ARGS
 
-    # Sanity-check the artifact, then pin it to S3 (instance role creds).
-    uv run --project ../.. --group genome-s3 python - "$OUTPUT_S3" <<'PY'
-    import sys
-    import polars as pl
-    import s3fs
-
-    local = "results/neutral_sites.parquet"
-    dst = sys.argv[1]
-    df = pl.read_parquet(local)
-    print(f"[neutral_sites] rows={df.height:,}  chroms={sorted(df['chrom'].unique().to_list())}")
-    print(df.head(5))
-    assert df.height > 0, "empty neutral set"
-    assert set(df["ref"].unique().to_list()) <= set("ACGT"), "non-ACGT ref"
-    assert df["pos"].min() >= 1, "pos must be 1-based"
-    assert df.select(pl.struct(["chrom", "pos"]).n_unique()).item() == df.height, "duplicate (chrom,pos)"
-
-    bucket_key = dst.removeprefix("s3://")
-    s3fs.S3FileSystem().put(local, bucket_key)
-    print(f"[neutral_sites] pinned -> {dst}")
-PY
+    # Sanity (the neutral_sites_parquet rule already asserts ACGT / pos>=1 /
+    # no dups) + pin to S3 via s3fs (the genome-s3 group; awscli would conflict
+    # on the s3fs pin). Single-line python -c on purpose — a heredoc would break
+    # the YAML `run: |` block scalar.
+    uv run --project ../.. --group genome-s3 python -c "import sys, polars as pl, s3fs; df = pl.read_parquet('results/neutral_sites.parquet'); print('[neutral_sites] rows', df.height, 'chroms', sorted(df['chrom'].unique().to_list())); assert df.height > 0 and set(df['ref'].unique().to_list()) <= set('ACGT') and df['pos'].min() >= 1; s3fs.S3FileSystem().put('results/neutral_sites.parquet', sys.argv[1].removeprefix('s3://')); print('[neutral_sites] pinned', sys.argv[1])" "$OUTPUT_S3"

--- a/snakemake/neutral_sites/sky/run.yaml
+++ b/snakemake/neutral_sites/sky/run.yaml
@@ -1,0 +1,85 @@
+name: neutral-sites
+
+# Build the GPN-Star neutral-site parquet on a CPU node (#268). Downloads
+# ~15 GB of bigWigs + rmsk/chain, liftOver + bedtools intersect, scans the
+# bigWigs genome-wide, enumerates the neutral positions, and pins the parquet
+# to S3. CPU-only, ~30-60 min wall. The reference is read from S3 by pyfaidx
+# (byte-range), and the result is uploaded via the instance role.
+#
+# Memory-optimized instance: the enumerate step materializes every neutral
+# base (tens of millions of rows) before writing, so RAM, not CPU, is the
+# binding constraint.
+#
+# Launch:
+#   sky launch snakemake/neutral_sites/sky/run.yaml -c neutral-sites
+
+resources:
+    infra: aws/us-east-2
+    instance_type: r6id.2xlarge      # 8 vCPU, 64 GB RAM, 474 GB local NVMe
+    disk_size: 120
+    labels:
+        project: dna
+
+workdir: .
+
+envs:
+    SNAKEMAKE_ARGS: ""
+    # Canonical pin destination for the parquet (consumed by evals_v2 stage 3).
+    OUTPUT_S3: s3://oa-bolinas/snakemake/neutral_sites/results/neutral_sites.parquet
+
+setup: |
+    set -euxo pipefail
+
+    if [ ! -d "$HOME/miniforge3" ]; then
+        curl -fsSL -o /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+        bash /tmp/miniforge.sh -b -p "$HOME/miniforge3"
+        rm /tmp/miniforge.sh
+    fi
+
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+
+    grep -q 'miniforge3/bin' "$HOME/.bashrc" || \
+        echo 'export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+
+    export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+    # genome-s3 → s3fs, so pyfaidx reads the GRCh38 reference from S3.
+    uv sync --frozen --group genome-s3
+
+run: |
+    set -euxo pipefail
+
+    source "$HOME/miniforge3/etc/profile.d/conda.sh"
+    export PATH="$HOME/miniforge3/bin:$HOME/.local/bin:$PATH"
+    export CONDA_EXE="$HOME/miniforge3/bin/conda"
+
+    cd snakemake/neutral_sites
+
+    uv run --project ../.. --group genome-s3 snakemake \
+        --profile workflow/profiles/default \
+        --use-conda \
+        --printshellcmds \
+        --rerun-incomplete \
+        $SNAKEMAKE_ARGS
+
+    # Sanity-check the artifact, then pin it to S3 (instance role creds).
+    uv run --project ../.. --group genome-s3 python - "$OUTPUT_S3" <<'PY'
+    import sys
+    import polars as pl
+    import s3fs
+
+    local = "results/neutral_sites.parquet"
+    dst = sys.argv[1]
+    df = pl.read_parquet(local)
+    print(f"[neutral_sites] rows={df.height:,}  chroms={sorted(df['chrom'].unique().to_list())}")
+    print(df.head(5))
+    assert df.height > 0, "empty neutral set"
+    assert set(df["ref"].unique().to_list()) <= set("ACGT"), "non-ACGT ref"
+    assert df["pos"].min() >= 1, "pos must be 1-based"
+    assert df.select(pl.struct(["chrom", "pos"]).n_unique()).item() == df.height, "duplicate (chrom,pos)"
+
+    bucket_key = dst.removeprefix("s3://")
+    s3fs.S3FileSystem().put(local, bucket_key)
+    print(f"[neutral_sites] pinned -> {dst}")
+PY

--- a/snakemake/neutral_sites/workflow/Snakefile
+++ b/snakemake/neutral_sites/workflow/Snakefile
@@ -1,0 +1,13 @@
+configfile: "config/config.yaml"
+
+
+include: "rules/common.smk"
+include: "rules/download.smk"
+include: "rules/ancestral_repeats.smk"
+include: "rules/conserved.smk"
+include: "rules/neutral.smk"
+
+
+rule all:
+    input:
+        "results/neutral_sites.parquet",

--- a/snakemake/neutral_sites/workflow/envs/bioinformatics.yaml
+++ b/snakemake/neutral_sites/workflow/envs/bioinformatics.yaml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bedtools
+  - ucsc-liftover

--- a/snakemake/neutral_sites/workflow/profiles/default/config.yaml
+++ b/snakemake/neutral_sites/workflow/profiles/default/config.yaml
@@ -1,0 +1,6 @@
+# Local-first: this pipeline pulls ~15 GB of bigWigs + rmsk/chain as scratch
+# and emits a single small parquet. We keep everything local (no
+# default-storage-provider) and upload only the final neutral_sites.parquet to
+# S3 at pin time — see README. `use-conda` provides bedtools + liftOver.
+cores: all
+use-conda: true

--- a/snakemake/neutral_sites/workflow/rules/ancestral_repeats.smk
+++ b/snakemake/neutral_sites/workflow/rules/ancestral_repeats.smk
@@ -1,0 +1,51 @@
+"""Ancestral repeats = hg38 repeats overlapping mm39 repeats lifted to hg38.
+
+Mirrors GPN-Star's ``get_ancestral_repeats`` (Simple_repeat / Low_complexity
+excluded inside ``parse_rmsk`` — see its docstring for why that differs from
+the reference's no-op awk filter).
+"""
+
+
+rule rmsk_target_bed:
+    input:
+        "results/downloads/rmsk_target.txt.gz",
+    output:
+        "results/ancestral/target.rmsk.bed",
+    run:
+        parse_rmsk(input[0]).to_csv(output[0], sep="\t", header=False, index=False)
+
+
+rule rmsk_outgroup_bed:
+    input:
+        "results/downloads/rmsk_outgroup.txt.gz",
+    output:
+        "results/ancestral/outgroup.rmsk.bed",
+    run:
+        parse_rmsk(input[0]).to_csv(output[0], sep="\t", header=False, index=False)
+
+
+rule liftover_outgroup:
+    """Lift mm39 repeats into hg38 coordinates via the reciprocal-best chain."""
+    input:
+        bed="results/ancestral/outgroup.rmsk.bed",
+        chain="results/downloads/mm39.hg38.rbest.chain",
+    output:
+        mapped="results/ancestral/outgroup_in_target.bed",
+        unmapped="results/ancestral/outgroup_unmapped.bed",
+    conda:
+        "../envs/bioinformatics.yaml"
+    shell:
+        "liftOver {input.bed} {input.chain} {output.mapped} {output.unmapped}"
+
+
+rule ancestral_repeats:
+    """hg38 repeats overlapping any lifted mm39 repeat (`-u` = whole A feature)."""
+    input:
+        target="results/ancestral/target.rmsk.bed",
+        lifted="results/ancestral/outgroup_in_target.bed",
+    output:
+        "results/ancestral/ancestral_repeats.bed",
+    conda:
+        "../envs/bioinformatics.yaml"
+    shell:
+        "bedtools intersect -u -a {input.target} -b {input.lifted} > {output}"

--- a/snakemake/neutral_sites/workflow/rules/common.smk
+++ b/snakemake/neutral_sites/workflow/rules/common.smk
@@ -1,0 +1,20 @@
+import pandas as pd
+
+from marin_dna.data.genome import Genome
+from marin_dna.pipelines.evals.conservation import CONSERVATION_TRACKS
+from marin_dna.pipelines.neutral_sites.sites import (
+    enumerate_positions,
+    parse_rmsk,
+    scan_neutral_intervals,
+)
+
+CHROMS = [str(c) for c in config["chroms"]]
+
+# Resolve the conservation-track URLs from the single source of truth. Fail
+# fast at parse time on an unknown track key (typo in config).
+for _key in (config["phylop_track"], config["phastcons_track"]):
+    assert (
+        _key in CONSERVATION_TRACKS
+    ), f"unknown conservation track {_key!r}; known: {sorted(CONSERVATION_TRACKS)}"
+PHYLOP_URL = CONSERVATION_TRACKS[config["phylop_track"]]
+PHASTCONS_URL = CONSERVATION_TRACKS[config["phastcons_track"]]

--- a/snakemake/neutral_sites/workflow/rules/conserved.smk
+++ b/snakemake/neutral_sites/workflow/rules/conserved.smk
@@ -1,0 +1,24 @@
+"""Low-constraint sites: |phyloP| < threshold AND phastCons == 0.
+
+Heavy I/O — scans the two ~5-9 GB bigWigs window-by-window. Single-threaded
+(pyBigWig); no conda (uses the pipeline's own python env).
+"""
+
+
+rule conserved_sites:
+    input:
+        phylop="results/downloads/phylop.bw",
+        phastcons="results/downloads/phastcons.bw",
+    output:
+        "results/conserved/conserved_sites.bed",
+    run:
+        df = scan_neutral_intervals(
+            input.phylop,
+            input.phastcons,
+            CHROMS,
+            config["phylop_threshold"],
+            window_size=config["window_size"],
+        )
+        assert len(df) > 0, "no low-constraint sites found — check tracks/threshold"
+        df.to_csv(output[0], sep="\t", header=False, index=False)
+        print(f"[neutral_sites] {len(df):,} low-constraint intervals")

--- a/snakemake/neutral_sites/workflow/rules/download.smk
+++ b/snakemake/neutral_sites/workflow/rules/download.smk
@@ -1,0 +1,47 @@
+"""Fetch the GPN-Star calibration inputs (UCSC). Plain ``wget``, no conda."""
+
+
+rule download_rmsk_target:
+    output:
+        "results/downloads/rmsk_target.txt.gz",
+    params:
+        url=config["rmsk_target_url"],
+    shell:
+        "wget -q -O {output} {params.url}"
+
+
+rule download_rmsk_outgroup:
+    output:
+        "results/downloads/rmsk_outgroup.txt.gz",
+    params:
+        url=config["rmsk_outgroup_url"],
+    shell:
+        "wget -q -O {output} {params.url}"
+
+
+rule download_chain:
+    """mm39->hg38 reciprocal-best chain, gunzipped (liftOver needs it plain)."""
+    output:
+        "results/downloads/mm39.hg38.rbest.chain",
+    params:
+        url=config["chain_url"],
+    shell:
+        "wget -q -O {output}.gz {params.url} && gunzip -f {output}.gz"
+
+
+rule download_phylop:
+    output:
+        "results/downloads/phylop.bw",
+    params:
+        url=PHYLOP_URL,
+    shell:
+        "wget -q -O {output} {params.url}"
+
+
+rule download_phastcons:
+    output:
+        "results/downloads/phastcons.bw",
+    params:
+        url=PHASTCONS_URL,
+    shell:
+        "wget -q -O {output} {params.url}"

--- a/snakemake/neutral_sites/workflow/rules/neutral.smk
+++ b/snakemake/neutral_sites/workflow/rules/neutral.smk
@@ -30,20 +30,12 @@ rule neutral_sites_parquet:
             names=["chrom", "start", "end"],
             dtype={"chrom": str},
         )
-        genome = Genome(config["genome_path"])
-        df = enumerate_positions(intervals, genome, set(CHROMS))
-        # rmsk/conserved intervals are non-overlapping so this is normally a
-        # no-op, but a duplicate (chrom,pos) would double-weight a calibration
-        # bin — drop loudly if it ever happens.
-        before = len(df)
-        df = df.drop_duplicates(["chrom", "pos"]).reset_index(drop=True)
-        if len(df) < before:
-            print(
-                f"[neutral_sites] dropped {before - len(df):,} duplicate positions"
-            )
+        # enumerate_positions handles the chr→bare boundary, 1-based pos, ACGT
+        # filtering, and (chrom,pos) dedup — all unit-tested in the library.
+        df = enumerate_positions(
+            intervals, Genome(config["genome_path"]), set(CHROMS)
+        )
         assert len(df) > 0, "empty neutral set"
-        assert df["ref"].isin(set("ACGT")).all()
-        assert (df["pos"] >= 1).all()
         df.to_parquet(output[0], index=False)
         print(
             f"[neutral_sites] {len(df):,} neutral sites across "

--- a/snakemake/neutral_sites/workflow/rules/neutral.smk
+++ b/snakemake/neutral_sites/workflow/rules/neutral.smk
@@ -1,0 +1,51 @@
+"""Neutral set = ancestral repeats ∩ low-constraint sites → per-base parquet."""
+
+
+rule neutral_intervals:
+    """Clip ancestral repeats to the low-constraint runs. Both inputs are sets
+of non-overlapping intervals, so the intersection is non-overlapping too."""
+    input:
+        ancestral="results/ancestral/ancestral_repeats.bed",
+        conserved="results/conserved/conserved_sites.bed",
+    output:
+        "results/neutral/neutral_intervals.bed",
+    conda:
+        "../envs/bioinformatics.yaml"
+    shell:
+        "bedtools intersect -a {input.ancestral} -b {input.conserved} "
+        "| cut -f1-3 | bedtools sort -i - > {output}"
+
+
+rule neutral_sites_parquet:
+    """Enumerate every base in the neutral intervals → (chrom, pos, ref)."""
+    input:
+        "results/neutral/neutral_intervals.bed",
+    output:
+        "results/neutral_sites.parquet",
+    run:
+        intervals = pd.read_csv(
+            input[0],
+            sep="\t",
+            header=None,
+            names=["chrom", "start", "end"],
+            dtype={"chrom": str},
+        )
+        genome = Genome(config["genome_path"])
+        df = enumerate_positions(intervals, genome, set(CHROMS))
+        # rmsk/conserved intervals are non-overlapping so this is normally a
+        # no-op, but a duplicate (chrom,pos) would double-weight a calibration
+        # bin — drop loudly if it ever happens.
+        before = len(df)
+        df = df.drop_duplicates(["chrom", "pos"]).reset_index(drop=True)
+        if len(df) < before:
+            print(
+                f"[neutral_sites] dropped {before - len(df):,} duplicate positions"
+            )
+        assert len(df) > 0, "empty neutral set"
+        assert df["ref"].isin(set("ACGT")).all()
+        assert (df["pos"] >= 1).all()
+        df.to_parquet(output[0], index=False)
+        print(
+            f"[neutral_sites] {len(df):,} neutral sites across "
+            f"{df['chrom'].nunique()} chromosomes -> {output[0]}"
+        )

--- a/src/marin_dna/pipelines/neutral_sites/__init__.py
+++ b/src/marin_dna/pipelines/neutral_sites/__init__.py
@@ -1,0 +1,7 @@
+"""Build the GPN-Star neutral-site set on GRCh38 for mutation-rate calibration.
+
+Model-independent genome engineering: it produces a reusable parquet of
+high-confidence neutral ``(chrom, pos, ref)`` sites that the calibration step in
+``snakemake/analysis/evals_v2`` then scores per checkpoint. See
+``snakemake/neutral_sites/README.md`` and issue #267.
+"""

--- a/src/marin_dna/pipelines/neutral_sites/sites.py
+++ b/src/marin_dna/pipelines/neutral_sites/sites.py
@@ -94,6 +94,14 @@ def parse_rmsk(
     df = df[~df["repClass"].isin(exclude_classes)].copy()
     assert (df["end"] > df["start"]).all(), "rmsk has empty/inverted intervals"
     out = df[["chrom", "start", "end", "repName"]].rename(columns={"repName": "name"})
+    # Fail fast on a shifted-column mis-parse (e.g. a dump served without the
+    # leading ``bin`` column would slide every index by one): UCSC ``genoName``
+    # is always ``chr``-prefixed, so a non-``chr`` value means we parsed the
+    # wrong columns.
+    assert out["chrom"].str.startswith("chr").all(), (
+        f"rmsk genoName values are not chr-prefixed in {path} — wrong column "
+        "layout? expected the UCSC bin-column rmsk.txt.gz schema"
+    )
     return out.reset_index(drop=True)
 
 
@@ -167,7 +175,12 @@ def scan_neutral_intervals(
         phylo_chroms = phylo.chroms()
         phast_chroms = phast.chroms()
         for chrom in chroms:
-            bw_chrom = f"{chrom_prefix}{chrom}" if chrom_prefix else chrom
+            # Idempotent prefixing — if a caller ever passes already-``chr``ed
+            # names, don't produce ``chrchr1`` (which would silently skip the
+            # whole contig below).
+            bw_chrom = (
+                chrom if chrom.startswith(chrom_prefix) else f"{chrom_prefix}{chrom}"
+            )
             if bw_chrom not in phylo_chroms or bw_chrom not in phast_chroms:
                 # A track may legitimately lack a contig; skip rather than guess.
                 continue
@@ -200,8 +213,16 @@ def enumerate_positions(
     """Expand neutral intervals to per-base ``(chrom, pos, ref)`` rows.
 
     The boundary back into our conventions: strip the UCSC ``chr`` prefix to
-    address the (Ensembl-named) reference, emit **1-based** ``pos``, and keep
-    only ``A/C/G/T`` reference bases (drops ``N`` and soft-masked-to-N).
+    address the (Ensembl-named) reference, emit **1-based** ``pos``, keep only
+    ``A/C/G/T`` reference bases (drops ``N`` / soft-masked-to-N), and
+    de-duplicate ``(chrom, pos)`` — slightly-overlapping RepeatMasker features
+    can cover a base twice, and a duplicate would double-weight a calibration
+    bin downstream.
+
+    The reference is read **once per chromosome** (over the span of that
+    chromosome's intervals) rather than once per interval: a fragmented neutral
+    set is millions of short intervals, and one byte-range read per interval
+    against an ``s3://`` genome would be millions of round-trips.
 
     Args:
         intervals: ``[chrom, start, end]`` 0-based half-open, ``chr``-prefixed
@@ -214,37 +235,50 @@ def enumerate_positions(
 
     Returns:
         DataFrame ``[chrom, pos, ref]`` — bare ``chrom``, 1-based ``pos``,
-        ``ref`` ∈ {A,C,G,T}.
+        ``ref`` ∈ {A,C,G,T}, unique ``(chrom, pos)``.
     """
     for col in ("chrom", "start", "end"):
         assert col in intervals.columns, f"intervals missing column {col!r}"
 
-    valid = set("ACGT")
-    chrom_out: list[str] = []
-    pos_out: list[int] = []
-    ref_out: list[str] = []
+    # Group the requested intervals by (chr-stripped) chromosome so each
+    # chromosome's reference is read exactly once.
+    by_chrom: dict[str, list[tuple[int, int]]] = {}
     for chrom_raw, start, end in zip(
         intervals["chrom"], intervals["start"], intervals["end"]
     ):
         chrom = str(chrom_raw)
-        if chrom.startswith("chr"):
+        if chrom[:3].lower() == "chr":  # case-insensitive UCSC strip
             chrom = chrom[3:]
         if chrom not in chroms:
             continue
         start, end = int(start), int(end)
         assert end > start, f"empty/inverted interval {chrom}:{start}-{end}"
-        seq = get_seq(chrom, start, end).upper()
-        assert len(seq) == end - start, (
-            f"reference returned {len(seq)} bp for {chrom}:{start}-{end} "
-            f"(expected {end - start})"
+        by_chrom.setdefault(chrom, []).append((start, end))
+
+    valid = set("ACGT")
+    chrom_out: list[str] = []
+    pos_out: list[int] = []
+    ref_out: list[str] = []
+    for chrom, ivs in by_chrom.items():
+        lo = min(s for s, _ in ivs)
+        hi = max(e for _, e in ivs)
+        span = get_seq(chrom, lo, hi).upper()
+        assert len(span) == hi - lo, (
+            f"reference returned {len(span)} bp for {chrom}:{lo}-{hi} "
+            f"(expected {hi - lo})"
         )
-        for i, ref in enumerate(seq):
-            if ref in valid:
-                chrom_out.append(chrom)
-                pos_out.append(start + i + 1)  # 0-based index -> 1-based pos
-                ref_out.append(ref)
+        for start, end in ivs:
+            for i in range(start, end):
+                ref = span[i - lo]
+                if ref in valid:
+                    chrom_out.append(chrom)
+                    pos_out.append(i + 1)  # 0-based index -> 1-based pos
+                    ref_out.append(ref)
 
     out = pd.DataFrame({"chrom": chrom_out, "pos": pos_out, "ref": ref_out})
+    # Collapse positions covered by more than one source interval so no
+    # calibration bin is double-weighted.
+    out = out.drop_duplicates(["chrom", "pos"]).reset_index(drop=True)
     # Defensive: the whole point is a clean neutral set — no surprises downstream.
     assert out["ref"].isin(valid).all(), "non-ACGT ref leaked into neutral set"
     return out

--- a/src/marin_dna/pipelines/neutral_sites/sites.py
+++ b/src/marin_dna/pipelines/neutral_sites/sites.py
@@ -1,0 +1,250 @@
+"""GPN-Star neutral-site construction: ancestral repeats ∩ low conservation.
+
+Replicates the GPN-Star neutral definition used for mutation-rate calibration
+(GPN-Star Methods, "Mutation Rate Calibration"; reference implementation
+``analysis/gpn-star/train_and_eval/workflow/rules/calibration.smk`` in
+songlab-cal/gpn). The library pieces, each a thin testable unit the snakemake
+rules call into:
+
+- :func:`parse_rmsk` — RepeatMasker ``.txt.gz`` → repeat-interval BED frame
+  (excluding ``Simple_repeat`` / ``Low_complexity``).
+- :func:`contiguous_runs` / :func:`neutral_mask` / :func:`scan_neutral_intervals`
+  — low-conservation sites from phyloP + phastCons bigWigs
+  (``|phyloP| < threshold ∧ phastCons == 0``).
+- :func:`enumerate_positions` — neutral intervals → per-base ``(chrom, pos, ref)``.
+
+Coordinate / chromosome-name conventions
+----------------------------------------
+Everything in "BED land" (rmsk, liftOver, bedtools, the UCSC bigWigs) is
+0-based half-open with UCSC ``chr``-prefixed chromosome names. We keep that
+convention *unchanged* through the intersect/liftOver steps — it is the native
+format of all those tools, and converting earlier would just invite mistakes.
+
+:func:`enumerate_positions` is the single boundary back into our world: it
+strips the ``chr`` prefix (our GRCh38 reference is Ensembl, which uses bare
+``1``/``2``/``X`` names) and emits **1-based** ``pos`` — matching the HF eval
+datasets so the exact same scoring path consumes neutral sites and eval
+variants alike. (Per CLAUDE.md, 1-based lives only at this tool boundary; the
+rest of the codebase is 0-based half-open.)
+
+Deviation from the reference flagged for review (issue #267): GPN's awk emits
+``swScore`` where it then tries to filter ``Simple_repeat`` / ``Low_complexity``,
+so that exclusion is a silent no-op there. We filter ``repClass`` correctly —
+ancestral *simple* repeats are poor neutral proxies — which is the reference's
+evident intent, not its behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pandas as pd
+import pyBigWig
+
+# UCSC RepeatMasker classes that are not suitable neutral references: simple
+# tandem repeats and low-complexity regions evolve under non-neutral,
+# length-changing processes and align poorly.
+RMSK_EXCLUDE_CLASSES: frozenset[str] = frozenset({"Simple_repeat", "Low_complexity"})
+
+# Column layout of the UCSC ``rmsk`` table dump (``hg38/database/rmsk.txt.gz``),
+# which carries a leading ``bin`` column. 0-indexed positions we need.
+_RMSK_COLS: dict[str, int] = {
+    "chrom": 5,  # genoName  (e.g. "chr1")
+    "start": 6,  # genoStart (0-based)
+    "end": 7,  # genoEnd   (0-based, exclusive)
+    "repName": 10,
+    "repClass": 11,
+}
+
+
+def parse_rmsk(
+    path: str,
+    exclude_classes: frozenset[str] = RMSK_EXCLUDE_CLASSES,
+) -> pd.DataFrame:
+    """Parse a UCSC ``rmsk.txt.gz`` dump into a repeat-interval BED frame.
+
+    Args:
+        path: Path to ``rmsk.txt.gz`` (gzipped, tab-separated, ``bin``-column
+            layout — the standard ``goldenPath/<db>/database/rmsk.txt.gz``).
+        exclude_classes: ``repClass`` values to drop (default
+            :data:`RMSK_EXCLUDE_CLASSES`).
+
+    Returns:
+        DataFrame ``[chrom, start, end, name]``, 0-based half-open, UCSC
+        ``chr``-prefixed ``chrom`` (BED-land convention — fed to liftOver /
+        bedtools). ``name`` is the ``repName`` (kept only so the BED has a
+        4th column for liftOver; not unique).
+    """
+    # Read by positional index then rename — combining ``names`` with a
+    # positional ``usecols`` is ambiguous across pandas versions, so we select
+    # by integer position (columns come back labelled by their original index)
+    # and rename explicitly.
+    df = pd.read_csv(
+        path,
+        sep="\t",
+        header=None,
+        compression="gzip",
+        usecols=sorted(_RMSK_COLS.values()),
+        dtype=str,
+    )
+    df = df.rename(columns={idx: name for name, idx in _RMSK_COLS.items()})
+    df["start"] = df["start"].astype(int)
+    df["end"] = df["end"].astype(int)
+    df = df[~df["repClass"].isin(exclude_classes)].copy()
+    assert (df["end"] > df["start"]).all(), "rmsk has empty/inverted intervals"
+    out = df[["chrom", "start", "end", "repName"]].rename(columns={"repName": "name"})
+    return out.reset_index(drop=True)
+
+
+def contiguous_runs(mask: np.ndarray) -> list[tuple[int, int]]:
+    """Yield ``(start, end)`` 0-based half-open spans of each ``True`` run.
+
+    Ported from the reference ``contiguous_runs``. ``start``/``end`` are
+    indices *into* ``mask`` (the caller adds any window offset).
+    """
+    assert mask.ndim == 1, "mask must be 1-D"
+    if not mask.any():
+        return []
+    diff = np.diff(mask.astype(np.int8))
+    starts = (np.where(diff == 1)[0] + 1).tolist()
+    ends = (np.where(diff == -1)[0] + 1).tolist()
+    if mask[0]:  # run starts at index 0
+        starts = [0] + starts
+    if mask[-1]:  # run extends to the array end
+        ends = ends + [int(mask.size)]
+    assert len(starts) == len(ends)
+    return list(zip(starts, ends))
+
+
+def neutral_mask(
+    phylop: np.ndarray,
+    phastcons: np.ndarray,
+    phylop_threshold: float,
+) -> np.ndarray:
+    """Boolean per-base neutrality mask: ``|phyloP| < t ∧ phastCons == 0``.
+
+    NaN (bigWig "no data") fails both predicates, so unaligned/uncovered bases
+    are correctly excluded — ``abs(nan) < t`` and ``nan == 0`` are both False.
+    """
+    assert phylop.shape == phastcons.shape, "phyloP/phastCons length mismatch"
+    with np.errstate(invalid="ignore"):
+        return (np.abs(phylop) < phylop_threshold) & (phastcons == 0)
+
+
+def scan_neutral_intervals(
+    phylop_bw_path: str,
+    phastcons_bw_path: str,
+    chroms: list[str],
+    phylop_threshold: float,
+    *,
+    window_size: int = 1_000_000,
+    chrom_prefix: str = "chr",
+) -> pd.DataFrame:
+    """Scan phyloP+phastCons bigWigs → low-conservation interval BED frame.
+
+    Iterates each chromosome in fixed windows, reads both tracks, and emits the
+    contiguous runs passing :func:`neutral_mask`. Bare ``chroms`` (e.g.
+    ``"1"``) are ``chrom_prefix``-prefixed for the bigWig lookup; output
+    ``chrom`` keeps the ``chr`` prefix (BED-land, for the downstream bedtools
+    intersect with the ancestral-repeat BED).
+
+    Args:
+        phylop_bw_path, phastcons_bw_path: local bigWig paths.
+        chroms: bare chromosome names to scan.
+        phylop_threshold: ``|phyloP|`` cutoff (GPN uses 0.1 with ancestral
+            repeats, 0.05 without).
+        window_size: scan granularity (rows read per bigWig call).
+        chrom_prefix: prefix added to bare names for the bigWig lookup.
+
+    Returns:
+        DataFrame ``[chrom, start, end]`` (0-based half-open, ``chr``-prefixed).
+    """
+    phylo = pyBigWig.open(phylop_bw_path)
+    phast = pyBigWig.open(phastcons_bw_path)
+    rows: list[tuple[str, int, int]] = []
+    try:
+        phylo_chroms = phylo.chroms()
+        phast_chroms = phast.chroms()
+        for chrom in chroms:
+            bw_chrom = f"{chrom_prefix}{chrom}" if chrom_prefix else chrom
+            if bw_chrom not in phylo_chroms or bw_chrom not in phast_chroms:
+                # A track may legitimately lack a contig; skip rather than guess.
+                continue
+            # Use the overlapping length when the two tracks disagree (rare).
+            length = min(int(phylo_chroms[bw_chrom]), int(phast_chroms[bw_chrom]))
+            for win_start in range(0, length, window_size):
+                win_end = min(win_start + window_size, length)
+                pp = np.asarray(
+                    phylo.values(bw_chrom, win_start, win_end, numpy=True),
+                    dtype=np.float64,
+                )
+                pc = np.asarray(
+                    phast.values(bw_chrom, win_start, win_end, numpy=True),
+                    dtype=np.float64,
+                )
+                mask = neutral_mask(pp, pc, phylop_threshold)
+                for s, e in contiguous_runs(mask):
+                    rows.append((bw_chrom, win_start + s, win_start + e))
+    finally:
+        phylo.close()
+        phast.close()
+    return pd.DataFrame(rows, columns=["chrom", "start", "end"])
+
+
+def enumerate_positions(
+    intervals: pd.DataFrame,
+    get_seq: Callable[[str, int, int], str],
+    chroms: set[str],
+) -> pd.DataFrame:
+    """Expand neutral intervals to per-base ``(chrom, pos, ref)`` rows.
+
+    The boundary back into our conventions: strip the UCSC ``chr`` prefix to
+    address the (Ensembl-named) reference, emit **1-based** ``pos``, and keep
+    only ``A/C/G/T`` reference bases (drops ``N`` and soft-masked-to-N).
+
+    Args:
+        intervals: ``[chrom, start, end]`` 0-based half-open, ``chr``-prefixed
+            (as produced by :func:`scan_neutral_intervals` / bedtools).
+        get_seq: ``(chrom, start, end) -> str`` over the reference (e.g. a
+            :class:`marin_dna.data.genome.Genome`); called with bare chrom
+            names and 0-based half-open coords. The returned sequence is
+            upper-cased here, so soft-masking is fine.
+        chroms: bare chromosome names to keep (others skipped).
+
+    Returns:
+        DataFrame ``[chrom, pos, ref]`` — bare ``chrom``, 1-based ``pos``,
+        ``ref`` ∈ {A,C,G,T}.
+    """
+    for col in ("chrom", "start", "end"):
+        assert col in intervals.columns, f"intervals missing column {col!r}"
+
+    valid = set("ACGT")
+    chrom_out: list[str] = []
+    pos_out: list[int] = []
+    ref_out: list[str] = []
+    for chrom_raw, start, end in zip(
+        intervals["chrom"], intervals["start"], intervals["end"]
+    ):
+        chrom = str(chrom_raw)
+        if chrom.startswith("chr"):
+            chrom = chrom[3:]
+        if chrom not in chroms:
+            continue
+        start, end = int(start), int(end)
+        assert end > start, f"empty/inverted interval {chrom}:{start}-{end}"
+        seq = get_seq(chrom, start, end).upper()
+        assert len(seq) == end - start, (
+            f"reference returned {len(seq)} bp for {chrom}:{start}-{end} "
+            f"(expected {end - start})"
+        )
+        for i, ref in enumerate(seq):
+            if ref in valid:
+                chrom_out.append(chrom)
+                pos_out.append(start + i + 1)  # 0-based index -> 1-based pos
+                ref_out.append(ref)
+
+    out = pd.DataFrame({"chrom": chrom_out, "pos": pos_out, "ref": ref_out})
+    # Defensive: the whole point is a clean neutral set — no surprises downstream.
+    assert out["ref"].isin(valid).all(), "non-ACGT ref leaked into neutral set"
+    return out

--- a/tests/pipelines/neutral_sites/test_sites.py
+++ b/tests/pipelines/neutral_sites/test_sites.py
@@ -6,6 +6,7 @@ import gzip
 
 import numpy as np
 import pandas as pd
+import pyBigWig
 import pytest
 
 from marin_dna.pipelines.neutral_sites.sites import (
@@ -13,6 +14,7 @@ from marin_dna.pipelines.neutral_sites.sites import (
     enumerate_positions,
     neutral_mask,
     parse_rmsk,
+    scan_neutral_intervals,
 )
 
 
@@ -163,9 +165,64 @@ class TestEnumeratePositions:
         assert set(out["chrom"]) == {"1"}
         assert list(out["pos"]) == [1, 2, 3, 4]
 
+    def test_dedups_overlapping_intervals(self):
+        # Two chr1 intervals overlapping at 0-based 2-3; shared positions appear
+        # once. g["1"]="ACGTNNACGT": [0,4)->pos 1-4 (ACGT), [2,6)->pos 3-4 (GT;
+        # the N's at 4-5 drop). Union, deduped = pos 1-4.
+        intervals = pd.DataFrame(
+            {"chrom": ["chr1", "chr1"], "start": [0, 2], "end": [4, 6]}
+        )
+        out = enumerate_positions(intervals, self._get_seq(), {"1"})
+        assert list(out["pos"]) == [1, 2, 3, 4]
+        assert list(out["ref"]) == ["A", "C", "G", "T"]
+        assert out.duplicated(["chrom", "pos"]).sum() == 0
+
     def test_length_mismatch_asserts(self):
         # A get_seq that under-returns must trip the defensive length assert.
         bad = lambda chrom, start, end: "AC"  # noqa: E731
         intervals = pd.DataFrame({"chrom": ["chr1"], "start": [0], "end": [5]})
         with pytest.raises(AssertionError, match="expected"):
             enumerate_positions(intervals, bad, {"1"})
+
+
+def _write_bw(path, chrom: str, length: int, values: list[float]) -> None:
+    """Write a tiny per-base bigWig: ``values[i]`` at 0-based position ``i``."""
+    bw = pyBigWig.open(str(path), "w")
+    bw.addHeader([(chrom, length)])
+    bw.addEntries(chrom, 0, values=[float(v) for v in values], span=1, step=1)
+    bw.close()
+
+
+class TestScanNeutralIntervals:
+    def test_stitches_run_across_window_boundary(self, tmp_path):
+        # chr1 (len 10): neutral (phyloP 0.0, phastCons 0) at 1..6, non-neutral
+        # (phyloP 2.0) at 0,7,8,9. With window_size=5 the run [1,7) splits at the
+        # 5-boundary into two ADJACENT intervals — exercises the per-window
+        # `win_start + s` offset and that no base is lost/duplicated at the seam.
+        pp, pc = tmp_path / "phylop.bw", tmp_path / "phast.bw"
+        _write_bw(pp, "chr1", 10, [2, 0, 0, 0, 0, 0, 0, 2, 2, 2])
+        _write_bw(pc, "chr1", 10, [0] * 10)
+        df = scan_neutral_intervals(str(pp), str(pc), ["1"], 0.1, window_size=5)
+        assert list(zip(df["chrom"], df["start"], df["end"])) == [
+            ("chr1", 1, 5),
+            ("chr1", 5, 7),
+        ]
+
+    def test_phastcons_nonzero_breaks_the_run(self, tmp_path):
+        # A phastCons!=0 base in the middle of a low-phyloP stretch splits it.
+        pp, pc = tmp_path / "phylop.bw", tmp_path / "phast.bw"
+        _write_bw(pp, "chr1", 6, [0, 0, 0, 0, 0, 0])
+        _write_bw(pc, "chr1", 6, [0, 0, 1, 0, 0, 0])  # conserved at idx 2
+        df = scan_neutral_intervals(str(pp), str(pc), ["1"], 0.1, window_size=10)
+        assert list(zip(df["chrom"], df["start"], df["end"])) == [
+            ("chr1", 0, 2),
+            ("chr1", 3, 6),
+        ]
+
+    def test_skips_contig_absent_from_a_track(self, tmp_path):
+        # A requested chrom missing from the bigWigs is skipped, not crashed.
+        pp, pc = tmp_path / "phylop.bw", tmp_path / "phast.bw"
+        _write_bw(pp, "chr1", 4, [0, 0, 0, 0])
+        _write_bw(pc, "chr1", 4, [0, 0, 0, 0])
+        df = scan_neutral_intervals(str(pp), str(pc), ["1", "2"], 0.1, window_size=5)
+        assert list(zip(df["chrom"], df["start"], df["end"])) == [("chr1", 0, 4)]

--- a/tests/pipelines/neutral_sites/test_sites.py
+++ b/tests/pipelines/neutral_sites/test_sites.py
@@ -1,0 +1,171 @@
+"""Tests for the GPN-Star neutral-site construction library."""
+
+from __future__ import annotations
+
+import gzip
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from marin_dna.pipelines.neutral_sites.sites import (
+    contiguous_runs,
+    enumerate_positions,
+    neutral_mask,
+    parse_rmsk,
+)
+
+
+class TestContiguousRuns:
+    def test_empty_and_all_false(self):
+        assert contiguous_runs(np.array([], dtype=bool)) == []
+        assert contiguous_runs(np.zeros(5, dtype=bool)) == []
+
+    def test_all_true(self):
+        assert contiguous_runs(np.ones(4, dtype=bool)) == [(0, 4)]
+
+    def test_internal_run(self):
+        # F T T F F  -> [1, 3)
+        assert contiguous_runs(np.array([0, 1, 1, 0, 0], dtype=bool)) == [(1, 3)]
+
+    def test_runs_at_both_edges(self):
+        # T F T  -> [0,1) and [2,3)
+        assert contiguous_runs(np.array([1, 0, 1], dtype=bool)) == [(0, 1), (2, 3)]
+
+    def test_multiple_runs(self):
+        mask = np.array([1, 1, 0, 1, 0, 0, 1, 1, 1], dtype=bool)
+        assert contiguous_runs(mask) == [(0, 2), (3, 4), (6, 9)]
+
+    def test_runs_partition_the_true_bases(self):
+        rng = np.random.default_rng(0)
+        mask = rng.random(1000) < 0.3
+        runs = contiguous_runs(mask)
+        recovered = np.zeros_like(mask)
+        for s, e in runs:
+            assert not recovered[s:e].any(), "runs overlap"
+            recovered[s:e] = True
+        assert np.array_equal(recovered, mask)
+
+
+class TestNeutralMask:
+    def test_threshold_and_phastcons(self):
+        phylop = np.array([0.0, 0.05, 0.2, -0.05, -0.2])
+        phastcons = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
+        # |phylop| < 0.1 AND phastcons == 0
+        assert neutral_mask(phylop, phastcons, 0.1).tolist() == [
+            True,
+            True,
+            False,
+            True,
+            False,
+        ]
+
+    def test_phastcons_nonzero_excluded(self):
+        phylop = np.zeros(3)
+        phastcons = np.array([0.0, 0.01, 1.0])
+        assert neutral_mask(phylop, phastcons, 0.1).tolist() == [True, False, False]
+
+    def test_nan_excluded(self):
+        # NaN in either track (bigWig "no data") must fail the mask.
+        phylop = np.array([0.0, np.nan, 0.0])
+        phastcons = np.array([0.0, 0.0, np.nan])
+        assert neutral_mask(phylop, phastcons, 0.1).tolist() == [True, False, False]
+
+
+def _write_rmsk(path, rows: list[tuple[str, int, int, str, str]]) -> None:
+    """Write a minimal gzipped UCSC rmsk.txt with the bin-column layout.
+
+    ``rows`` are ``(genoName, genoStart, genoEnd, repName, repClass)``; all the
+    other UCSC columns are filled with dummies at the right positions.
+    """
+    lines = []
+    for genoName, start, end, repName, repClass in rows:
+        cols = ["0"] * 17
+        cols[0] = "585"  # bin
+        cols[1] = "1000"  # swScore
+        cols[5] = genoName
+        cols[6] = str(start)
+        cols[7] = str(end)
+        cols[9] = "+"  # strand
+        cols[10] = repName
+        cols[11] = repClass
+        cols[12] = "fam"  # repFamily
+        lines.append("\t".join(cols))
+    with gzip.open(path, "wt") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+class TestParseRmsk:
+    def test_excludes_simple_and_low_complexity(self, tmp_path):
+        p = tmp_path / "rmsk.txt.gz"
+        _write_rmsk(
+            p,
+            [
+                ("chr1", 100, 200, "AluY", "SINE"),
+                ("chr1", 300, 350, "(TA)n", "Simple_repeat"),
+                ("chr2", 50, 80, "L2", "LINE"),
+                ("chrX", 10, 20, "A-rich", "Low_complexity"),
+            ],
+        )
+        df = parse_rmsk(str(p))
+        # Simple_repeat and Low_complexity dropped; SINE/LINE kept.
+        assert list(df["chrom"]) == ["chr1", "chr2"]
+        assert list(df["start"]) == [100, 50]
+        assert list(df["end"]) == [200, 80]
+        assert list(df["name"]) == ["AluY", "L2"]
+        # chr prefix retained (BED-land); coords are the raw 0-based half-open.
+        assert df.columns.tolist() == ["chrom", "start", "end", "name"]
+
+    def test_custom_exclude_set(self, tmp_path):
+        p = tmp_path / "rmsk.txt.gz"
+        _write_rmsk(
+            p,
+            [
+                ("chr1", 100, 200, "AluY", "SINE"),
+                ("chr1", 300, 350, "L1", "LINE"),
+            ],
+        )
+        df = parse_rmsk(str(p), exclude_classes=frozenset({"SINE"}))
+        assert list(df["name"]) == ["L1"]
+
+
+class TestEnumeratePositions:
+    def _genome(self) -> dict[str, str]:
+        # 0-based:        0123456789
+        return {"1": "ACGTNNACGT", "2": "acgtac"}
+
+    def _get_seq(self):
+        g = self._genome()
+        return lambda chrom, start, end: g[chrom][start:end]
+
+    def test_basic_1based_and_acgt_filter(self):
+        # chr1[2,7) -> bases at 0-based 2..6 = G T N N A; N dropped.
+        intervals = pd.DataFrame({"chrom": ["chr1"], "start": [2], "end": [7]})
+        out = enumerate_positions(intervals, self._get_seq(), {"1", "2"})
+        assert list(out["chrom"]) == ["1", "1", "1"]
+        # 1-based pos: index 2->3 (G), 3->4 (T), 6->7 (A). 4,5 are N -> dropped.
+        assert list(out["pos"]) == [3, 4, 7]
+        assert list(out["ref"]) == ["G", "T", "A"]
+
+    def test_uppercases_softmasked(self):
+        intervals = pd.DataFrame({"chrom": ["chr2"], "start": [0], "end": [6]})
+        out = enumerate_positions(intervals, self._get_seq(), {"1", "2"})
+        assert list(out["ref"]) == ["A", "C", "G", "T", "A", "C"]
+        assert list(out["pos"]) == [1, 2, 3, 4, 5, 6]
+
+    def test_chrom_filter_skips_unlisted(self):
+        intervals = pd.DataFrame(
+            {"chrom": ["chr1", "chrM"], "start": [0, 0], "end": [4, 4]}
+        )
+        # genome has no "M"; if it weren't filtered the get_seq lookup would
+        # KeyError. chroms={"1"} must skip chrM.
+        out = enumerate_positions(intervals, self._get_seq(), {"1"})
+        assert set(out["chrom"]) == {"1"}
+        assert list(out["pos"]) == [1, 2, 3, 4]
+
+    def test_length_mismatch_asserts(self):
+        # A get_seq that under-returns must trip the defensive length assert.
+        bad = lambda chrom, start, end: "AC"  # noqa: E731
+        intervals = pd.DataFrame({"chrom": ["chr1"], "start": [0], "end": [5]})
+        with pytest.raises(AssertionError, match="expected"):
+            enumerate_positions(intervals, bad, {"1"})


### PR DESCRIPTION
Implements the **#268** neutral-site dataset pipeline — stage 1 of the cLLR calibration work (#267). A standalone, model-independent `snakemake/neutral_sites` pipeline that builds the GPN-Star "ancestral repeats ∩ low conservation" neutral set on GRCh38, the reusable input the per-model calibration (stages 3–4) scores.

## What's here

- **Library** `src/marin_dna/pipelines/neutral_sites/sites.py` — `parse_rmsk`, `contiguous_runs` / `neutral_mask` / `scan_neutral_intervals`, `enumerate_positions`. 15 unit tests.
- **Pipeline** `snakemake/neutral_sites/` — download (rmsk hg38 + mm39, `mm39.hg38.rbest` chain, phyloP/phastCons 100-way) → `liftOver` → `bedtools intersect` (ancestral repeats) → bigWig scan (`|phyloP|<0.1 ∧ phastCons==0`) → intersect → enumerate → `results/neutral_sites.parquet`. Conda env (bedtools, ucsc-liftover). Dry-run clean (13 jobs).

Replicates GPN-Star's hg38 calibration inputs exactly. Output schema: `[chrom, pos, ref]` — bare chrom, **1-based** pos (matches the HF eval datasets), `ref ∈ {A,C,G,T}`, autosomes + X + Y.

## Two deliberate deviations (flagged in #267)

- **repClass filter fix** — GPN's awk filters `swScore` against the class strings (a silent no-op); `parse_rmsk` filters `repClass` correctly, excluding `Simple_repeat` / `Low_complexity` (poor neutral proxies). One-line revert for exact parity.
- **Coordinates** — everything through liftOver/bedtools stays BED-land (UCSC `chr`, 0-based half-open); `enumerate_positions` is the single boundary → bare chrom + 1-based pos.

## Not in this PR

The actual **run + S3 pin** of the parquet (heavy I/O: ~15 GB bigWigs + genome scan) — will run on a SkyPilot EC2 CPU instance, then pin to `s3://oa-bolinas/snakemake/neutral_sites/results/neutral_sites.parquet`. Tracked in #268.

Closes #268. Part of #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

