### PR TITLE
scoring: 4-allele marginal atom + entropy (cLLR 2/4)

### DIFF
--- a/scripts/issue269_sky.yaml
+++ b/scripts/issue269_sky.yaml
@@ -1,0 +1,46 @@
+# SkyPilot task: validate the #269 marginal-LLR path on a GPU, in bf16 — the
+# same precision the evals_v2 scores parquets were computed in — so the
+# comparison is directly against the canonical S3 numbers.
+#
+# Reads the cached checkpoint + GRCh38 reference from s3://oa-bolinas via the
+# instance role (no GCS/gcloud needed), runs scripts/issue269_validate_marginal_llr.py,
+# and uploads the summary/plot back to s3://oa-bolinas/scratch/issue269_validation.
+#
+# Launch (auto-down after):
+#   sky launch -c issue269-validate --down scripts/issue269_sky.yaml
+
+name: issue269-validate
+
+resources:
+    infra: aws/us-east-2
+    accelerators: A10G:1        # 24 GB Ampere, bf16-capable — matches the evals_v2 eval node.
+    disk_size: 100
+    labels:
+        project: dna
+
+workdir: .
+
+envs:
+    MODEL: exp136-proj_v30-step-9999
+    WINDOW_SIZE: "255"
+    DATASET: mendelian_traits
+    N: "2000"                    # variant subset (0 = all 16,140)
+    BATCH_SIZE: "64"
+
+setup: |
+    set -euxo pipefail
+    if ! command -v uv >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    fi
+    export PATH="$HOME/.local/bin:$PATH"
+    uv sync --frozen --group genome-s3
+
+run: |
+    set -euxo pipefail
+    export PATH="$HOME/.local/bin:$PATH"
+    export WANDB_DISABLED=true   # no API key on a fresh node; this is inference-only.
+
+    uv run --group genome-s3 python scripts/issue269_validate_marginal_llr.py \
+        --model "$MODEL" --window-size "$WINDOW_SIZE" --dataset "$DATASET" \
+        --n "$N" --batch-size "$BATCH_SIZE" --device cuda --bf16 \
+        --upload-prefix s3://oa-bolinas/scratch/issue269_validation

--- a/scripts/issue269_validate_marginal_llr.py
+++ b/scripts/issue269_validate_marginal_llr.py
@@ -118,8 +118,10 @@ def main() -> None:
     ap.add_argument(
         "--num-workers",
         type=int,
-        default=4,
-        help="dataloader workers (parallelize S3 genome reads)",
+        default=0,
+        help="dataloader workers. Keep 0: workers fork() and the S3 genome's "
+        "s3fs/boto handle is not fork-safe (deadlocks). For small n the serial "
+        "in-process reads are plenty fast.",
     )
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--device", default="cpu", choices=["cpu", "cuda"])

--- a/scripts/issue269_validate_marginal_llr.py
+++ b/scripts/issue269_validate_marginal_llr.py
@@ -115,6 +115,12 @@ def main() -> None:
     ap.add_argument("--dataset", default="mendelian_traits")
     ap.add_argument("--n", type=int, default=64, help="variant subset size (0 = all)")
     ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument(
+        "--num-workers",
+        type=int,
+        default=4,
+        help="dataloader workers (parallelize S3 genome reads)",
+    )
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--device", default="cpu", choices=["cpu", "cuda"])
     ap.add_argument("--bf16", action="store_true", help="bf16_full_eval (GPU only)")
@@ -162,7 +168,7 @@ def main() -> None:
     )
     inference_kwargs = dict(
         per_device_eval_batch_size=args.batch_size,
-        dataloader_num_workers=0,
+        dataloader_num_workers=args.num_workers,
         remove_unused_columns=False,
         report_to="none",
         bf16_full_eval=args.bf16,

--- a/scripts/issue269_validate_marginal_llr.py
+++ b/scripts/issue269_validate_marginal_llr.py
@@ -56,7 +56,9 @@ GENOME_PATH = (
 )
 # RC marginal column i is the forward allele complement(NUCLEOTIDES[i]); realign
 # to forward ACGT order before reading per-strand RC LLRs (cf. rc_average_marginal).
-_RC_PERM = [NUCLEOTIDES.index({"A": "T", "C": "G", "G": "C", "T": "A"}[n]) for n in NUCLEOTIDES]
+_RC_PERM = [
+    NUCLEOTIDES.index({"A": "T", "C": "G", "G": "C", "T": "A"}[n]) for n in NUCLEOTIDES
+]
 
 
 def _nuc_idx(bases: list[str]) -> np.ndarray:
@@ -116,9 +118,16 @@ def main() -> None:
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--device", default="cpu", choices=["cpu", "cuda"])
     ap.add_argument("--bf16", action="store_true", help="bf16_full_eval (GPU only)")
-    ap.add_argument("--threads", type=int, default=2, help="torch CPU threads (shared box etiquette)")
+    ap.add_argument(
+        "--threads",
+        type=int,
+        default=2,
+        help="torch CPU threads (shared box etiquette)",
+    )
     ap.add_argument("--outdir", default="scratch/issue269_validation")
-    ap.add_argument("--upload-prefix", default="", help="optional s3:// prefix to upload outputs")
+    ap.add_argument(
+        "--upload-prefix", default="", help="optional s3:// prefix to upload outputs"
+    )
     args = ap.parse_args()
 
     torch.set_num_threads(args.threads)
@@ -163,8 +172,14 @@ def main() -> None:
     # 4. Marginal path → per-strand LLRs + FWD+RC-averaged LLR.
     print("running run_variant_marginal (rc=True) ...")
     marg = run_variant_marginal(
-        model, tokenizer, ds, genome, args.window_size, rc=True,
-        data_transform_on_the_fly=True, inference_kwargs=inference_kwargs,
+        model,
+        tokenizer,
+        ds,
+        genome,
+        args.window_size,
+        rc=True,
+        data_transform_on_the_fly=True,
+        inference_kwargs=inference_kwargs,
     )
     avg = rc_average_marginal(marg["fwd"], marg["rc"])  # [N, 4], forward ACGT order
     rc_aligned = marg["rc"][:, _RC_PERM]
@@ -179,8 +194,14 @@ def main() -> None:
     # 5. Recompute the bundle locally (same precision) → clean apples-to-apples.
     print("running run_variant_score_bundle (rc=True) ...")
     bundle = run_variant_score_bundle(
-        model, tokenizer, ds, genome, args.window_size, rc=True,
-        data_transform_on_the_fly=True, inference_kwargs=inference_kwargs,
+        model,
+        tokenizer,
+        ds,
+        genome,
+        args.window_size,
+        rc=True,
+        data_transform_on_the_fly=True,
+        inference_kwargs=inference_kwargs,
     )
     b_local = {
         "fwd": bundle["fwd"][:, 0],
@@ -195,19 +216,27 @@ def main() -> None:
     }
 
     # 6. Compare.
-    print(f"\n=== marginal LLR vs locally-recomputed bundle ({args.device} fp{'16' if args.bf16 else '32'}, apples-to-apples) ===")
+    print(
+        f"\n=== marginal LLR vs locally-recomputed bundle ({args.device} fp{'16' if args.bf16 else '32'}, apples-to-apples) ==="
+    )
     summary = [_summarize(f"{s}", m_llr[s], b_local[s]) for s in ("fwd", "rc", "avg")]
     print("\n=== marginal LLR vs S3 bundle LLR (bf16 GPU-eval baseline) ===")
-    summary += [_summarize(f"{s}_vs_s3", m_llr[s], b_s3[s]) for s in ("fwd", "rc", "avg")]
+    summary += [
+        _summarize(f"{s}_vs_s3", m_llr[s], b_s3[s]) for s in ("fwd", "rc", "avg")
+    ]
 
     # 7. Persist comparison table + per-variant LLRs + a scatter plot.
-    pl.DataFrame(summary).write_parquet(outdir / f"summary_{args.model}_{args.dataset}.parquet")
+    pl.DataFrame(summary).write_parquet(
+        outdir / f"summary_{args.model}_{args.dataset}.parquet"
+    )
     per_variant = df.select(["chrom", "pos", "ref", "alt"]).with_columns(
         marginal_llr_avg=pl.Series(m_llr["avg"]),
         bundle_local_llr_avg=pl.Series(b_local["avg"]),
         bundle_s3_llr_avg=pl.Series(b_s3["avg"]),
     )
-    per_variant.write_parquet(outdir / f"per_variant_{args.model}_{args.dataset}.parquet")
+    per_variant.write_parquet(
+        outdir / f"per_variant_{args.model}_{args.dataset}.parquet"
+    )
 
     try:
         import matplotlib

--- a/scripts/issue269_validate_marginal_llr.py
+++ b/scripts/issue269_validate_marginal_llr.py
@@ -1,0 +1,247 @@
+"""Validate the #269 marginal-LLR path against the evals_v2 bundle LLR.
+
+`compute_marginal_clm` returns the 4-allele marginal `log p(x)`; the LLR read
+off it as `marginal[alt] - marginal[ref]` (FWD+RC-averaged via
+`rc_average_marginal`) is — by construction — the same quantity
+`compute_variant_score_bundle` already emits as `llr_fwd`/`llr_rc` in the
+evals_v2 scores parquets. The unit/end-to-end tests prove that algebra on a tiny
+random model; this script checks the *real-checkpoint plumbing* (tokenizer/BOS,
+`window_size`, the 4-vs-2 suffix batching) against a known-good baseline.
+
+Two comparisons, on the same variant subset + checkpoint:
+
+  1. **marginal vs locally-recomputed bundle**, both fp32 on this box — the clean
+     apples-to-apples check. Expect agreement at fp32 noise (~1e-5).
+  2. **marginal (fp32) vs the S3 parquet's bundle LLR** (computed in bf16 on the
+     GPU eval). Expect ~1% / r≈0.999+ — the residual is the fp32-vs-bf16 gap, not
+     a marginal-vs-bundle discrepancy. (1) confirms the local run is faithful;
+     (2) ties it to the canonical numbers.
+
+Run (needs `--group genome-s3` so pyfaidx can read the reference from S3):
+
+    uv run --group genome-s3 python scripts/issue269_validate_marginal_llr.py \
+        --model exp136-proj_v30-step-9999 --window-size 255 \
+        --dataset mendelian_traits --n 64
+
+`--window-size` must match the model's evals_v2 config entry (255 = BOS runs,
+256 = no-BOS, 512 = older 512-context). On a GPU box pass `--device cuda
+--bf16` to reproduce the eval precision exactly (then comparison (2) collapses to
+bf16 noise too).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+os.environ.setdefault("AWS_REGION", "us-east-2")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-2")
+
+import numpy as np
+import polars as pl
+import torch
+from datasets import Dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from marin_dna.data.dna import NUCLEOTIDES
+from marin_dna.data.genome import Genome
+from marin_dna.model.runner import run_variant_marginal, run_variant_score_bundle
+from marin_dna.model.scoring import rc_average_marginal
+
+S3_BASE = "s3://oa-bolinas/snakemake/analysis/evals_v2/results"
+GENOME_PATH = (
+    "s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/"
+    "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+)
+# RC marginal column i is the forward allele complement(NUCLEOTIDES[i]); realign
+# to forward ACGT order before reading per-strand RC LLRs (cf. rc_average_marginal).
+_RC_PERM = [NUCLEOTIDES.index({"A": "T", "C": "G", "G": "C", "T": "A"}[n]) for n in NUCLEOTIDES]
+
+
+def _nuc_idx(bases: list[str]) -> np.ndarray:
+    return np.array([NUCLEOTIDES.index(b) for b in bases])
+
+
+def _download_s3_dir(s3_uri: str, local: Path) -> None:
+    """Recursively download an S3 prefix to ``local`` via fsspec/s3fs.
+
+    Avoids a hard dependency on the ``aws`` CLI (absent on a fresh sky node);
+    s3fs is already pulled in by the ``genome-s3`` group.
+    """
+    import fsspec
+
+    fs = fsspec.filesystem("s3")
+    base = s3_uri.replace("s3://", "").rstrip("/")
+    for key in fs.find(base):
+        dest = local / key[len(base) + 1 :]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        fs.get_file(key, str(dest))
+
+
+def _upload_dir(local: Path, s3_prefix: str, pattern: str) -> None:
+    """Upload ``local``'s files matching ``pattern`` under an S3 prefix via fsspec."""
+    import fsspec
+
+    fs = fsspec.filesystem("s3")
+    base = s3_prefix.replace("s3://", "").rstrip("/")
+    for f in sorted(local.glob(pattern)):
+        fs.put_file(str(f), f"{base}/{f.name}")
+    print(f"uploaded {pattern} → s3://{base}/")
+
+
+def _summarize(name: str, marginal: np.ndarray, baseline: np.ndarray) -> dict:
+    d = marginal - baseline
+    r = float(np.corrcoef(marginal, baseline)[0, 1])
+    row = {
+        "comparison": name,
+        "max_abs_diff": float(np.abs(d).max()),
+        "mean_abs_diff": float(np.abs(d).mean()),
+        "pearson_r": r,
+    }
+    print(
+        f"  {name:24s}  max|Δ|={row['max_abs_diff']:.2e}  "
+        f"mean|Δ|={row['mean_abs_diff']:.2e}  r={r:.7f}"
+    )
+    return row
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", default="exp136-proj_v30-step-9999")
+    ap.add_argument("--window-size", type=int, default=255)
+    ap.add_argument("--dataset", default="mendelian_traits")
+    ap.add_argument("--n", type=int, default=64, help="variant subset size (0 = all)")
+    ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--device", default="cpu", choices=["cpu", "cuda"])
+    ap.add_argument("--bf16", action="store_true", help="bf16_full_eval (GPU only)")
+    ap.add_argument("--threads", type=int, default=2, help="torch CPU threads (shared box etiquette)")
+    ap.add_argument("--outdir", default="scratch/issue269_validation")
+    ap.add_argument("--upload-prefix", default="", help="optional s3:// prefix to upload outputs")
+    args = ap.parse_args()
+
+    torch.set_num_threads(args.threads)
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    # 1. Bundle-LLR baseline from S3 + variant subset.
+    scores_uri = f"{S3_BASE}/scores/{args.model}/{args.dataset}.parquet"
+    df = pl.read_parquet(scores_uri).select(
+        ["chrom", "pos", "ref", "alt", "llr_fwd", "llr_rc"]
+    )
+    if args.n and args.n < df.height:
+        df = df.sample(n=args.n, seed=args.seed)
+    print(f"{df.height} variants from {scores_uri}")
+
+    # 2. Pull the cached HF checkpoint locally (idempotent).
+    ckpt_local = outdir / "ckpt" / args.model
+    if not (ckpt_local / "config.json").exists():
+        print(f"downloading checkpoint → {ckpt_local}")
+        _download_s3_dir(f"{S3_BASE}/checkpoints/{args.model}/", ckpt_local)
+
+    # 3. Model / tokenizer / genome.
+    tokenizer = AutoTokenizer.from_pretrained(ckpt_local)
+    model = (
+        AutoModelForCausalLM.from_pretrained(ckpt_local, trust_remote_code=True)
+        .to(args.device)
+        .eval()
+    )
+    genome = Genome(GENOME_PATH)
+    ds = Dataset.from_pandas(
+        df.select(["chrom", "pos", "ref", "alt"]).to_pandas(), preserve_index=False
+    )
+    inference_kwargs = dict(
+        per_device_eval_batch_size=args.batch_size,
+        dataloader_num_workers=0,
+        remove_unused_columns=False,
+        report_to="none",
+        bf16_full_eval=args.bf16,
+        use_cpu=(args.device == "cpu"),
+    )
+
+    # 4. Marginal path → per-strand LLRs + FWD+RC-averaged LLR.
+    print("running run_variant_marginal (rc=True) ...")
+    marg = run_variant_marginal(
+        model, tokenizer, ds, genome, args.window_size, rc=True,
+        data_transform_on_the_fly=True, inference_kwargs=inference_kwargs,
+    )
+    avg = rc_average_marginal(marg["fwd"], marg["rc"])  # [N, 4], forward ACGT order
+    rc_aligned = marg["rc"][:, _RC_PERM]
+    ref_idx, alt_idx = _nuc_idx(df["ref"].to_list()), _nuc_idx(df["alt"].to_list())
+    rows = np.arange(df.height)
+    m_llr = {
+        "fwd": marg["fwd"][rows, alt_idx] - marg["fwd"][rows, ref_idx],
+        "rc": rc_aligned[rows, alt_idx] - rc_aligned[rows, ref_idx],
+        "avg": avg[rows, alt_idx] - avg[rows, ref_idx],
+    }
+
+    # 5. Recompute the bundle locally (same precision) → clean apples-to-apples.
+    print("running run_variant_score_bundle (rc=True) ...")
+    bundle = run_variant_score_bundle(
+        model, tokenizer, ds, genome, args.window_size, rc=True,
+        data_transform_on_the_fly=True, inference_kwargs=inference_kwargs,
+    )
+    b_local = {
+        "fwd": bundle["fwd"][:, 0],
+        "rc": bundle["rc"][:, 0],
+        "avg": 0.5 * (bundle["fwd"][:, 0] + bundle["rc"][:, 0]),
+    }
+    # S3 bf16 baseline.
+    b_s3 = {
+        "fwd": df["llr_fwd"].to_numpy(),
+        "rc": df["llr_rc"].to_numpy(),
+        "avg": 0.5 * (df["llr_fwd"].to_numpy() + df["llr_rc"].to_numpy()),
+    }
+
+    # 6. Compare.
+    print(f"\n=== marginal LLR vs locally-recomputed bundle ({args.device} fp{'16' if args.bf16 else '32'}, apples-to-apples) ===")
+    summary = [_summarize(f"{s}", m_llr[s], b_local[s]) for s in ("fwd", "rc", "avg")]
+    print("\n=== marginal LLR vs S3 bundle LLR (bf16 GPU-eval baseline) ===")
+    summary += [_summarize(f"{s}_vs_s3", m_llr[s], b_s3[s]) for s in ("fwd", "rc", "avg")]
+
+    # 7. Persist comparison table + per-variant LLRs + a scatter plot.
+    pl.DataFrame(summary).write_parquet(outdir / f"summary_{args.model}_{args.dataset}.parquet")
+    per_variant = df.select(["chrom", "pos", "ref", "alt"]).with_columns(
+        marginal_llr_avg=pl.Series(m_llr["avg"]),
+        bundle_local_llr_avg=pl.Series(b_local["avg"]),
+        bundle_s3_llr_avg=pl.Series(b_s3["avg"]),
+    )
+    per_variant.write_parquet(outdir / f"per_variant_{args.model}_{args.dataset}.parquet")
+
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, axes = plt.subplots(1, 2, figsize=(10, 5))
+        for ax, b, title in (
+            (axes[0], b_local["avg"], "vs local bundle (fp32)"),
+            (axes[1], b_s3["avg"], "vs S3 bundle (bf16)"),
+        ):
+            lo = min(m_llr["avg"].min(), b.min())
+            hi = max(m_llr["avg"].max(), b.max())
+            ax.plot([lo, hi], [lo, hi], "k--", lw=0.8, alpha=0.6)
+            ax.scatter(b, m_llr["avg"], s=10, alpha=0.6)
+            ax.set_xlabel(f"bundle LLR_avg ({title})")
+            ax.set_ylabel("marginal LLR_avg")
+            ax.set_title(title)
+        fig.suptitle(f"{args.model} · {args.dataset} · n={df.height}")
+        fig.tight_layout()
+        png = outdir / f"scatter_{args.model}_{args.dataset}.png"
+        fig.savefig(png, dpi=130)
+        print(f"\nwrote {png}")
+    except ImportError:
+        print("\n(matplotlib unavailable — skipping scatter)")
+
+    if args.upload_prefix:
+        _upload_dir(
+            outdir,
+            f"{args.upload_prefix.rstrip('/')}/{args.model}_{args.dataset}",
+            f"*_{args.model}_{args.dataset}.*",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue269_validate_marginal_llr.py
+++ b/scripts/issue269_validate_marginal_llr.py
@@ -47,7 +47,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from marin_dna.data.dna import NUCLEOTIDES
 from marin_dna.data.genome import Genome
 from marin_dna.model.runner import run_variant_marginal, run_variant_score_bundle
-from marin_dna.model.scoring import rc_average_marginal
+from marin_dna.model.scoring import _RC_ALLELE_PERM, rc_average_marginal
 
 S3_BASE = "s3://oa-bolinas/snakemake/analysis/evals_v2/results"
 GENOME_PATH = (
@@ -55,10 +55,8 @@ GENOME_PATH = (
     "Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
 )
 # RC marginal column i is the forward allele complement(NUCLEOTIDES[i]); realign
-# to forward ACGT order before reading per-strand RC LLRs (cf. rc_average_marginal).
-_RC_PERM = [
-    NUCLEOTIDES.index({"A": "T", "C": "G", "G": "C", "T": "A"}[n]) for n in NUCLEOTIDES
-]
+# to forward ACGT order before reading per-strand RC LLRs. Reuse scoring's
+# permutation (the same one rc_average_marginal applies) so they can't diverge.
 
 
 def _nuc_idx(bases: list[str]) -> np.ndarray:
@@ -190,7 +188,7 @@ def main() -> None:
         inference_kwargs=inference_kwargs,
     )
     avg = rc_average_marginal(marg["fwd"], marg["rc"])  # [N, 4], forward ACGT order
-    rc_aligned = marg["rc"][:, _RC_PERM]
+    rc_aligned = marg["rc"][:, _RC_ALLELE_PERM]
     ref_idx, alt_idx = _nuc_idx(df["ref"].to_list()), _nuc_idx(df["alt"].to_list())
     rows = np.arange(df.height)
     m_llr = {
@@ -225,7 +223,7 @@ def main() -> None:
 
     # 6. Compare.
     print(
-        f"\n=== marginal LLR vs locally-recomputed bundle ({args.device} fp{'16' if args.bf16 else '32'}, apples-to-apples) ==="
+        f"\n=== marginal LLR vs locally-recomputed bundle ({args.device} {'bf16' if args.bf16 else 'fp32'}, apples-to-apples) ==="
     )
     summary = [_summarize(f"{s}", m_llr[s], b_local[s]) for s in ("fwd", "rc", "avg")]
     print("\n=== marginal LLR vs S3 bundle LLR (bf16 GPU-eval baseline) ===")

--- a/src/marin_dna/data/transforms.py
+++ b/src/marin_dna/data/transforms.py
@@ -210,6 +210,33 @@ def transform_reflogprob_clm(
     return dict(input_ids=new_input_ids, ref=ref)
 
 
+def transform_variant_marginal_clm(
+    example: dict[str, Any],
+    tokenizer: Any,
+    genome: Any,
+    window_size: int,
+    strand: Literal["+", "-"] = "+",
+) -> dict[str, Any]:
+    """Variant-window transform for ``compute_marginal_clm`` — just the ``[L]`` window.
+
+    Extracts the strand-aware window around the variant via ``_get_variant_window``
+    (which N-pads at chromosome edges and asserts the genome base equals
+    ``example["ref"]`` on the forward strand, or its complement on RC) and
+    tokenizes it. Returns ``{"input_ids": [L]}``.
+
+    Unlike ``transform_reflogprob_clm`` / ``transform_llr_clm`` it does **not**
+    materialize the alleles: ``compute_marginal_clm`` builds the four allele
+    suffixes itself via prefix-sharing, so the dataset only carries the ``[L]``
+    reference window. The token-level variant position is derived by the runner
+    from ``window_size`` / strand / ``n_prefix`` and bound into the kernel
+    (mirroring ``run_variant_score_bundle``), so it is not returned here — only
+    ``chrom``, ``pos`` and ``ref`` are read from ``example`` (no ``alt``: the
+    kernel scores all four alleles).
+    """
+    seq, _pos = _get_variant_window(example, genome, window_size, strand=strand)
+    return dict(input_ids=torch.tensor(tokenizer.encode(seq)))
+
+
 def transform_ll_clm(
     example: dict[str, Any],
     tokenizer: Any,

--- a/src/marin_dna/model/runner.py
+++ b/src/marin_dna/model/runner.py
@@ -41,10 +41,12 @@ from marin_dna.data.transforms import (
     in_seq_var_pos,
     transform_ll_clm,
     transform_llr_clm,
+    transform_variant_marginal_clm,
     transform_window_embedding,
 )
 from marin_dna.model.scoring import (
     compute_ll_clm,
+    compute_marginal_clm,
     compute_variant_score_bundle,
     compute_window_embedding,
 )
@@ -186,6 +188,85 @@ def run_variant_score_bundle(
             ),
             data_transform_fn=partial(
                 transform_llr_clm, genome=genome, window_size=window_size, strand=strand
+            ),
+            **kwargs,
+        )
+
+    out: dict[str, np.ndarray] = {"fwd": np.asarray(_one("+"))}
+    if rc:
+        out["rc"] = np.asarray(_one("-"))
+    return out
+
+
+def run_variant_marginal(
+    model: nn.Module,
+    tokenizer: Any,
+    dataset: datasets.Dataset,
+    genome: Genome,
+    window_size: int,
+    rc: bool = False,
+    **kwargs: Any,
+) -> dict[str, np.ndarray]:
+    """Per-site 4-allele marginal ``log p(x)`` per strand → ``{"fwd": [N, 4], ...}``.
+
+    The opt-in entropy/calibration route (issue #269), parallel to and
+    independent of the default LLR+JSD bundle (``run_variant_score_bundle``),
+    which is left untouched. Each row's marginal over ``{A,C,G,T}`` at the
+    variant position is produced by ``compute_marginal_clm`` (1 prefix + 4
+    cached-suffix forwards — the bundle's prefix-sharing generalized to all four
+    alleles). Entropy (``entropy_from_marginal``), ref log-prob
+    (``marginal[:, ref]``) and the three LLRs (``marginal[:, alt] −
+    marginal[:, ref]``) are CPU reductions on the returned ``[N, 4]``; FWD+RC
+    averaging is applied downstream on those derived scores (entropy is
+    permutation-invariant, so the two per-strand entropies simply average).
+
+    Mirrors ``run_variant_score_bundle``: ``var_pos`` is computed per strand and
+    bound into the compute_fn as a Python int (constant within the call → no
+    torch.compile graph break), and FWD/RC are separate ``Trainer.predict``
+    passes (``var_pos`` differs across strands for even ``window_size``).
+
+    Args:
+        model: HF-shaped causal LM (see module docstring for the interface).
+        tokenizer: Tokenizer for the model.
+        dataset: Dataset with site information (chrom, pos, ref); ``alt`` is not
+            required — the kernel scores all four alleles.
+        genome: Genome object for sequence extraction.
+        window_size: Window size for sequence context.
+        rc: If True, also score the reverse-complemented window per site and
+            return its marginal. Doubles inference cost.
+        **kwargs: Additional arguments passed to ``run_inference``.
+
+    Returns:
+        ``{"fwd": [N, 4]}`` when ``rc=False``, else
+        ``{"fwd": [N, 4], "rc": [N, 4]}``. Columns are ``log p(A), log p(C),
+        log p(G), log p(T)`` in ``NUCLEOTIDES`` order on the requested strand
+        (the RC marginal is over RC-strand alleles, i.e. column ``i`` is the
+        forward-strand complement of ``NUCLEOTIDES[i]`` — irrelevant for the
+        permutation-invariant entropy, but the ref/LLR gather must account for
+        it on RC).
+    """
+    n_prefix, _ = _get_special_token_counts(tokenizer)
+    nuc_ids_dict = _get_nucleotide_token_ids(tokenizer)
+    nuc_token_ids = torch.tensor(
+        [nuc_ids_dict[nuc] for nuc in NUCLEOTIDES], dtype=torch.long
+    )
+
+    def _one(strand: Literal["+", "-"]) -> Any:
+        var_pos = in_seq_var_pos(window_size, strand) + n_prefix
+        return run_inference(
+            model,
+            tokenizer,
+            dataset,
+            compute_fn=partial(
+                compute_marginal_clm,
+                var_pos=var_pos,
+                nuc_token_ids=nuc_token_ids,
+            ),
+            data_transform_fn=partial(
+                transform_variant_marginal_clm,
+                genome=genome,
+                window_size=window_size,
+                strand=strand,
             ),
             **kwargs,
         )

--- a/src/marin_dna/model/runner.py
+++ b/src/marin_dna/model/runner.py
@@ -216,9 +216,11 @@ def run_variant_marginal(
     cached-suffix forwards — the bundle's prefix-sharing generalized to all four
     alleles). Entropy (``entropy_from_marginal``), ref log-prob
     (``marginal[:, ref]``) and the three LLRs (``marginal[:, alt] −
-    marginal[:, ref]``) are CPU reductions on the returned ``[N, 4]``; FWD+RC
-    averaging is applied downstream on those derived scores (entropy is
-    permutation-invariant, so the two per-strand entropies simply average).
+    marginal[:, ref]``) are CPU reductions on the returned ``[N, 4]``. For FWD+RC,
+    average the two per-strand log-marginals first with ``rc_average_marginal``
+    (a plain mean after the complement realignment) and apply the reduction to
+    that — so the calibrated entropy is ``H`` of the FWD+RC-averaged marginal and
+    each LLR is the mean of the two per-strand LLRs.
 
     Mirrors ``run_variant_score_bundle``: ``var_pos`` is computed per strand and
     bound into the compute_fn as a Python int (constant within the call → no
@@ -241,9 +243,9 @@ def run_variant_marginal(
         ``{"fwd": [N, 4], "rc": [N, 4]}``. Columns are ``log p(A), log p(C),
         log p(G), log p(T)`` in ``NUCLEOTIDES`` order on the requested strand
         (the RC marginal is over RC-strand alleles, i.e. column ``i`` is the
-        forward-strand complement of ``NUCLEOTIDES[i]`` — irrelevant for the
-        permutation-invariant entropy, but the ref/LLR gather must account for
-        it on RC).
+        forward-strand complement of ``NUCLEOTIDES[i]``; ``rc_average_marginal``
+        realigns this before averaging, and a per-strand ref/LLR gather must
+        account for it on RC).
     """
     n_prefix, _ = _get_special_token_counts(tokenizer)
     nuc_ids_dict = _get_nucleotide_token_ids(tokenizer)

--- a/src/marin_dna/model/scoring.py
+++ b/src/marin_dna/model/scoring.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import math
 from typing import Any
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 from einops import rearrange, reduce
@@ -274,6 +275,135 @@ def compute_variant_score_bundle(
     llr = llr_at_var + llr_downstream
 
     return torch.stack([llr, next_token_jsd_mean], dim=1)
+
+
+def compute_marginal_clm(
+    model: Any,
+    input_ids: Int[Tensor, "B L"],
+    *,
+    var_pos: int,
+    nuc_token_ids: Int[Tensor, " 4"],
+) -> Float[Tensor, "B 4"]:
+    """Per-site 4-allele marginal ``log p(x)`` over ``{A,C,G,T}`` via prefix-sharing.
+
+    The opt-in entropy/calibration atom (issue #269). Generalizes
+    ``compute_variant_score_bundle``'s prefix-sharing kernel from 2 alleles
+    (ref/alt) to all 4: the four alleles share the prefix ``input_ids[:var_pos]``
+    and the downstream tail ``input_ids[var_pos+1:]``, differing only at the
+    variant token, so the shared prefix is forwarded once (KV-cached) and the
+    four divergent suffixes (length ``L - var_pos``) are forwarded against it —
+    1 prefix + 4 suffix forwards, vs the 4 full-length forwards of the legacy
+    ``compute_reflogprob_clm``.
+
+    Works in the same **4-nucleotide softmax** space as the bundle. For allele
+    ``x`` the full-sequence score, up to the shared-prefix log-prob (constant
+    across alleles → cancels in the final softmax), is
+
+        ``L(x) = log p(x | prefix) + Σ_t log p(tail_t | prefix, x, tail_<t)``
+
+    and the marginal is ``log_softmax_x L(x)``. By construction
+    ``marginal[:, alt] − marginal[:, ref]`` is *identically* the bundle's LLR
+    (the softmax normalizer cancels in the difference), so calibration LLRs
+    derived here match the eval LLRs exactly.
+
+    Downstream CPU reductions on the returned ``[B, 4]`` give the per-site
+    Shannon entropy (``entropy_from_marginal``), the ref log-prob
+    (``marginal[:, ref]``), and all three LLRs (``marginal[:, alt] −
+    marginal[:, ref]``) with no further forward passes.
+
+    Args:
+        model: HF-shaped causal LM (see ``compute_variant_score_bundle`` for the
+            duck-typed cache / ``logits_to_keep`` contract).
+        input_ids: Reference window token IDs, shape ``[B, L]``. Only the prefix
+            ``[:var_pos]`` and tail ``[var_pos+1:]`` are read; the token at
+            ``var_pos`` is overwritten by each allele.
+        var_pos: Token-level variant position (Python int, constant within the
+            batch — derived in the runner from ``window_size`` / strand /
+            ``n_prefix`` and bound via ``partial`` so it never graph-breaks
+            torch.compile).
+        nuc_token_ids: Length-4 tensor of token IDs for A/C/G/T in
+            ``NUCLEOTIDES`` order. The returned columns follow this order.
+
+    Returns:
+        ``[B, 4]`` marginal log-probabilities ``log p(x)`` over the four
+        nucleotides at ``var_pos`` (each row ``logsumexp``-es to 0).
+    """
+    B, L = input_ids.shape
+    p = var_pos
+    assert 0 < p < L, (
+        f"variant at token position {p} of length-{L} sequence has no shared "
+        f"prefix; expected 0 < var_pos < L"
+    )
+
+    nuc = nuc_token_ids.to(input_ids.device)  # [4]
+    n_alleles = nuc.shape[0]
+
+    # The 4 alleles differ only at var_pos; build each allele's suffix as
+    # [allele_x] + shared_tail (tail = input_ids[:, p+1:], identical across
+    # alleles). [B, V, L-p] flattened "(B V)" matches _repeat_interleave_kv_cache's
+    # repeat_interleave ordering — exactly how compute_variant_score_bundle lays
+    # out its 2 alleles, generalized to 4.
+    tail = input_ids[:, p + 1 :]  # [B, L-p-1] (empty iff p == L-1)
+    allele_tokens = nuc.view(1, n_alleles, 1).expand(B, n_alleles, 1)  # [B, 4, 1]
+    tail_rep = tail.unsqueeze(1).expand(B, n_alleles, tail.shape[1])  # [B, 4, L-p-1]
+    suffixes = torch.cat([allele_tokens, tail_rep], dim=-1)  # [B, 4, L-p]
+    suffixes_flat = rearrange(suffixes, "B V L -> (B V) L").contiguous()  # [B*4, L-p]
+
+    # 1. Prefix forward — only the last position (predicts the variant token).
+    prefix = input_ids[:, :p].contiguous()
+    prefix_out = model(prefix, use_cache=True, logits_to_keep=1)
+    prefix_last_logits = prefix_out.logits[:, -1]  # [B, V]
+    past_kv = _repeat_interleave_kv_cache(prefix_out.past_key_values, n_alleles)
+
+    # 2. Suffix forward with the cached prefix.
+    suffix_logits = model(
+        suffixes_flat, past_key_values=past_kv, use_cache=False
+    ).logits  # [B*4, L-p, V]
+
+    # 3. 4-nuc log-softmax (fp32 — inherits the biofoundation#21 stability fix).
+    nuc_ids = nuc.to(suffix_logits.device)
+    log_p_nuc = F.log_softmax(
+        suffix_logits[..., nuc_ids].float(), dim=-1
+    )  # [B*4, L-p, 4]
+    log_p_nuc = rearrange(log_p_nuc, "(B V) L C -> B V L C", B=B)  # [B, 4, L-p, 4]
+
+    # 4. Variant-position term: log p(allele | prefix), [B, 4].
+    prefix_log_p = F.log_softmax(
+        prefix_last_logits[..., nuc_ids].float(), dim=-1
+    )  # [B, 4]
+
+    # 5. Downstream term: Σ_t log p(tail_t | prefix, allele, tail_<t), per allele.
+    #    Drop the last suffix position (predicts off-the-end); the remaining
+    #    L-p-1 positions predict the shared tail (same targets for every allele).
+    log_p_down = log_p_nuc[:, :, :-1, :]  # [B, 4, L-p-1, 4]
+    target_idx = _token_id_to_nuc_idx(tail, nuc_ids)  # [B, L-p-1]
+    target_idx = target_idx.view(B, 1, -1, 1).expand(B, n_alleles, -1, 1)
+    down_term = log_p_down.gather(-1, target_idx).squeeze(-1).sum(dim=-1)  # [B, 4]
+
+    # 6. Marginal: the shared-prefix log-prob is constant across alleles and
+    #    cancels in the softmax, so log_softmax(var-term + downstream-term) is
+    #    the full-sequence 4-allele marginal.
+    marginal_log_prob = F.log_softmax(prefix_log_p + down_term, dim=-1)  # [B, 4]
+    return marginal_log_prob
+
+
+def entropy_from_marginal(marginal_log_prob: np.ndarray) -> np.ndarray:
+    """Shannon entropy ``H = −Σ_x exp(mlp)·mlp`` of a 4-allele marginal.
+
+    Pure-CPU reduction over the last axis of a ``[..., 4]`` marginal
+    log-probability array — the output of ``compute_marginal_clm`` /
+    ``marin_dna.model.runner.run_variant_marginal``. Returns ``[...]`` entropy in
+    nats, in ``[0, log 4]`` (``log 4`` at the uniform marginal, ``→ 0`` at a
+    degenerate one).
+
+    Entropy is permutation-invariant, so the FWD and RC marginals — whose four
+    columns are labelled by complementary alleles — give the same value;
+    averaging the two per-strand entropies for the FWD+RC mean is therefore
+    unambiguous. Accepts NumPy arrays, the dtype the HF Trainer harness returns
+    from ``run_variant_marginal``.
+    """
+    mlp = np.asarray(marginal_log_prob, dtype=np.float64)
+    return -(np.exp(mlp) * mlp).sum(axis=-1)
 
 
 def _token_id_to_nuc_idx(

--- a/src/marin_dna/model/scoring.py
+++ b/src/marin_dna/model/scoring.py
@@ -26,6 +26,8 @@ from jaxtyping import Bool, Float, Int
 from torch import Tensor
 from transformers.cache_utils import DynamicCache
 
+from marin_dna.data.dna import COMPLEMENT, NUCLEOTIDES
+
 
 # https://github.com/ArcInstitute/evo2/blob/4c3c8522dc99d2dc14b5b5a07cd65f2b67e6f457/evo2/scoring.py#L37
 def _logits_to_logprobs(
@@ -388,22 +390,54 @@ def compute_marginal_clm(
 
 
 def entropy_from_marginal(marginal_log_prob: np.ndarray) -> np.ndarray:
-    """Shannon entropy ``H = −Σ_x exp(mlp)·mlp`` of a 4-allele marginal.
+    """Shannon entropy ``H = −Σ_x p(x)·log p(x)`` of a 4-allele marginal.
 
-    Pure-CPU reduction over the last axis of a ``[..., 4]`` marginal
-    log-probability array — the output of ``compute_marginal_clm`` /
-    ``marin_dna.model.runner.run_variant_marginal``. Returns ``[...]`` entropy in
-    nats, in ``[0, log 4]`` (``log 4`` at the uniform marginal, ``→ 0`` at a
-    degenerate one).
+    Pure-CPU reduction over the last axis of a ``[..., 4]`` array — the
+    per-strand output of ``compute_marginal_clm`` /
+    ``marin_dna.model.runner.run_variant_marginal``, or an ``rc_average_marginal``
+    of the two strands. Returns ``[...]`` entropy in nats, in ``[0, log 4]``
+    (``log 4`` at the uniform marginal, ``→ 0`` at a degenerate one).
 
-    Entropy is permutation-invariant, so the FWD and RC marginals — whose four
-    columns are labelled by complementary alleles — give the same value;
-    averaging the two per-strand entropies for the FWD+RC mean is therefore
-    unambiguous. Accepts NumPy arrays, the dtype the HF Trainer harness returns
-    from ``run_variant_marginal``.
+    **Normalizes its input internally** (``log_softmax`` over the 4 alleles), so
+    it accepts either a normalized log-marginal or an unnormalized one — logits
+    up to a per-row additive constant. That is what lets the FWD+RC combination
+    be a plain mean of log-probs with no separate renormalization step
+    (``rc_average_marginal``): the normalization is deferred to here. Idempotent
+    on an already-normalized marginal. Accepts NumPy arrays, the dtype the HF
+    Trainer harness returns.
     """
-    mlp = np.asarray(marginal_log_prob, dtype=np.float64)
-    return -(np.exp(mlp) * mlp).sum(axis=-1)
+    logp = np.asarray(marginal_log_prob, dtype=np.float64)
+    logp = logp - np.logaddexp.reduce(logp, axis=-1, keepdims=True)  # log_softmax
+    return -(np.exp(logp) * logp).sum(axis=-1)
+
+
+# RC marginal columns are the complement alleles: column i of the RC-strand
+# marginal is the forward-strand allele complement(NUCLEOTIDES[i]). Realigning to
+# forward-strand ACGT order before averaging is the A↔T / C↔G reversal [3,2,1,0].
+_RC_ALLELE_PERM = [NUCLEOTIDES.index(COMPLEMENT[n]) for n in NUCLEOTIDES]
+
+
+def rc_average_marginal(fwd: np.ndarray, rc: np.ndarray) -> np.ndarray:
+    """FWD+RC mean of two per-strand 4-allele log-marginals, in forward ACGT order.
+
+    The forward and reverse-complement passes of ``run_variant_marginal`` estimate
+    the same site distribution from opposite strands. This averages their
+    log-probabilities (the geometric mean of the two strand distributions) after
+    realigning the RC columns to forward-strand allele order — the RC marginal's
+    column ``i`` is the forward allele ``complement(NUCLEOTIDES[i])``, so the
+    realignment is the ``A↔T / C↔G`` reversal ``[3, 2, 1, 0]``. A naive
+    ``(fwd + rc) / 2`` would average mismatched alleles: a silent strand bug.
+
+    Returns the averaged log-marginal ``[..., 4]`` (forward ACGT order), left
+    **unnormalized** — feed it to ``entropy_from_marginal`` (which normalizes
+    internally) or take allele differences for the LLR (normalization-invariant).
+    The average is linear in the log-marginal, so ``avg[alt] − avg[ref]`` equals
+    the mean of the two per-strand LLRs — matching how the eval bundle FWD+RC
+    -averages.
+    """
+    fwd = np.asarray(fwd, dtype=np.float64)
+    rc = np.asarray(rc, dtype=np.float64)
+    return 0.5 * (fwd + rc[..., _RC_ALLELE_PERM])
 
 
 def _token_id_to_nuc_idx(

--- a/tests/data/test_transforms.py
+++ b/tests/data/test_transforms.py
@@ -21,6 +21,7 @@ from marin_dna.data.transforms import (
     transform_ll_clm,
     transform_llr_clm,
     transform_reflogprob_clm,
+    transform_variant_marginal_clm,
 )
 
 
@@ -506,6 +507,77 @@ def test_transform_reflogprob_clm_different_positions():
         # The nucleotide at pos should match what's in the sequence
         nucleotides = ["A", "C", "G", "T"]
         assert nucleotides[result["ref"]] == seq[pos]
+
+
+# --- transform_variant_marginal_clm tests ----------------------------------
+
+
+def test_transform_variant_marginal_clm_basic(tmp_path):
+    """Returns just ``{input_ids: [L]}`` — the window, no allele materialization."""
+    tokenizer = AutoTokenizer.from_pretrained("songlab/tokenizer-dna-mlm")
+    genome = Genome(_write_long_test_fasta(tmp_path))
+    window_size = 16
+    example = {"chrom": "chr1", "pos": 200, "ref": "T"}
+
+    result = transform_variant_marginal_clm(example, tokenizer, genome, window_size)
+
+    assert set(result.keys()) == {"input_ids"}
+    assert isinstance(result["input_ids"], torch.Tensor)
+    assert result["input_ids"].shape == (window_size,)
+    # Variant base sits at window_size // 2 on the forward strand (no BOS).
+    assert result["input_ids"][window_size // 2].item() == tokenizer.encode("T")[0]
+
+
+@pytest.mark.parametrize("window_size", [15, 16])
+def test_transform_variant_marginal_clm_strand_rc(tmp_path, window_size):
+    """RC window is the reverse complement; the variant base is complemented."""
+    tokenizer = AutoTokenizer.from_pretrained("songlab/tokenizer-dna-mlm")
+    genome = Genome(_write_long_test_fasta(tmp_path))
+    example = {"chrom": "chr1", "pos": 200, "ref": "T"}
+
+    fwd = transform_variant_marginal_clm(
+        example, tokenizer, genome, window_size, strand="+"
+    )
+    rc = transform_variant_marginal_clm(
+        example, tokenizer, genome, window_size, strand="-"
+    )
+
+    nuc_ids = {n: tokenizer.encode(n)[0] for n in "ACGT"}
+    fwd_var_pos = window_size // 2
+    rc_var_pos = window_size - 1 - window_size // 2
+    assert fwd["input_ids"][fwd_var_pos].item() == nuc_ids["T"]
+    assert rc["input_ids"][rc_var_pos].item() == nuc_ids["A"]  # complement(T)
+    # The whole window reverse-complements between strands.
+    id_to_nuc = {v: k for k, v in nuc_ids.items()}
+    fwd_dna = "".join(id_to_nuc[t.item()] for t in fwd["input_ids"])
+    rc_dna = "".join(id_to_nuc[t.item()] for t in rc["input_ids"])
+    assert str(Seq(fwd_dna).reverse_complement()) == rc_dna
+
+
+def test_transform_variant_marginal_clm_asserts_ref_matches_genome(tmp_path):
+    """A ref disagreeing with the genome base trips _get_variant_window's assertion."""
+    tokenizer = AutoTokenizer.from_pretrained("songlab/tokenizer-dna-mlm")
+    genome = Genome(_write_long_test_fasta(tmp_path))
+    example = {"chrom": "chr1", "pos": 200, "ref": "A"}  # genome base at pos 200 is T
+
+    with pytest.raises(AssertionError):
+        transform_variant_marginal_clm(example, tokenizer, genome, 16)
+
+
+def test_transform_variant_marginal_clm_n_padding(tmp_path):
+    """A window near the chromosome start N-pads to full width."""
+    tokenizer = AutoTokenizer.from_pretrained("songlab/tokenizer-dna-mlm")
+    genome = Genome(_write_test_fasta(tmp_path))  # 10-bp chrom: ACGTACGTAC
+    window_size = 8
+    example = {"chrom": "chr1", "pos": 2, "ref": "C"}  # pos 2 (1-based) → "C"
+
+    result = transform_variant_marginal_clm(example, tokenizer, genome, window_size)
+
+    assert result["input_ids"].shape == (window_size,)
+    nuc_ids = {n: tokenizer.encode(n)[0] for n in "ACGTN"}
+    id_to_nuc = {v: k for k, v in nuc_ids.items()}
+    dna = "".join(id_to_nuc.get(t.item(), "?") for t in result["input_ids"])
+    assert "N" in dna  # left flank padded past the chrom start
 
 
 # --- transform_ll_clm tests -------------------------------------------------

--- a/tests/model/test_scoring.py
+++ b/tests/model/test_scoring.py
@@ -35,13 +35,17 @@ from marin_dna.data.transforms import (
 from marin_dna.model.runner import (
     run_inference,
     run_ll_clm,
+    run_variant_marginal,
     run_variant_score_bundle,
 )
 from marin_dna.model.scoring import (
     _logits_to_logprobs,
+    _token_id_to_nuc_idx,
     compute_ll_clm,
+    compute_marginal_clm,
     compute_reflogprob_clm,
     compute_variant_score_bundle,
+    entropy_from_marginal,
 )
 
 
@@ -806,3 +810,237 @@ def test_compute_variant_score_bundle_jsd_analytic():
     # 2 downstream positions, JSD nonzero only at the first.
     expected_mean = jsd_at_var / 2
     np.testing.assert_allclose(out[0, 1].item(), expected_mean, rtol=1e-5)
+
+
+# --- compute_marginal_clm / entropy_from_marginal --------------------------
+
+_SONGLAB_NUC_TOKEN_IDS = torch.tensor([3, 4, 5, 6], dtype=torch.long)  # A C G T
+
+
+def test_compute_marginal_clm_is_log_prob_distribution():
+    """Each row of the [B, 4] marginal is a normalized log-prob (logsumexp == 0)."""
+    torch.manual_seed(0)
+    model = _DeterministicCausalLM(vocab_size=8)
+    model.eval()
+    B, L, var_pos = 3, 12, 5
+    # Nucleotide-only token ids (songlab ACGT live at 3-6).
+    input_ids = torch.randint(3, 7, (B, L))
+    out = compute_marginal_clm(
+        model, input_ids, var_pos=var_pos, nuc_token_ids=_SONGLAB_NUC_TOKEN_IDS
+    )
+    assert out.shape == (B, 4)
+    np.testing.assert_allclose(
+        torch.logsumexp(out, dim=-1).detach().numpy(), 0.0, atol=1e-5
+    )
+    # log of a probability ⇒ every entry ≤ 0.
+    assert (out <= 1e-6).all()
+
+
+def test_compute_marginal_clm_matches_bundle_llr():
+    """``marginal[:, alt] − marginal[:, ref]`` is identically
+    ``compute_variant_score_bundle``'s LLR.
+
+    Both kernels build the same ref/alt suffixes against the same shared prefix
+    and reduce in the same 4-nuc-softmax space, so the allele difference of the
+    marginal equals the bundle's LLR column to fp precision for *every* alt.
+    This is the consistency contract that lets calibration LLRs reuse the eval
+    LLR definition for free."""
+    torch.manual_seed(0)
+    model = _DeterministicCausalLM(vocab_size=8)
+    model.eval()
+    B, L, var_pos = 5, 14, 6
+    input_ids = torch.randint(3, 7, (B, L))
+
+    marginal = compute_marginal_clm(
+        model, input_ids, var_pos=var_pos, nuc_token_ids=_SONGLAB_NUC_TOKEN_IDS
+    )  # [B, 4]
+    ref_idx = _token_id_to_nuc_idx(input_ids[:, var_pos], _SONGLAB_NUC_TOKEN_IDS)
+    rows = torch.arange(B)
+    for alt_nuc_idx in range(4):
+        alt_token_id = _SONGLAB_NUC_TOKEN_IDS[alt_nuc_idx].repeat(B)
+        bundle = compute_variant_score_bundle(
+            model,
+            input_ids,
+            alt_token_id,
+            var_pos=var_pos,
+            nuc_token_ids=_SONGLAB_NUC_TOKEN_IDS,
+        )
+        marginal_llr = marginal[rows, alt_nuc_idx] - marginal[rows, ref_idx]
+        np.testing.assert_allclose(
+            marginal_llr.detach().numpy(),
+            bundle[:, 0].detach().numpy(),
+            rtol=1e-4,
+            atol=1e-5,
+        )
+
+
+def test_entropy_from_marginal_range_and_endpoints():
+    """Entropy ∈ [0, log 4]; log 4 at uniform, → 0 at a near-degenerate marginal."""
+    uniform = np.log(np.full((3, 4), 0.25))
+    np.testing.assert_allclose(entropy_from_marginal(uniform), math.log(4), atol=1e-6)
+    degen = np.log(np.array([[0.9997, 0.0001, 0.0001, 0.0001]]))
+    ent_degen = entropy_from_marginal(degen)
+    assert 0.0 <= ent_degen[0] < 0.01
+    # Random valid marginals stay in range.
+    rng = np.random.default_rng(0)
+    logits = rng.standard_normal((20, 4))
+    marg = logits - np.log(np.exp(logits).sum(-1, keepdims=True))  # log_softmax
+    ent = entropy_from_marginal(marg)
+    assert (ent >= -1e-9).all() and (ent <= math.log(4) + 1e-9).all()
+
+
+def test_entropy_from_marginal_matches_reduction_on_compute_marginal():
+    """``entropy_from_marginal`` equals ``−(m.exp()·m).sum()`` of
+    ``compute_marginal_clm``'s output."""
+    torch.manual_seed(0)
+    model = _DeterministicCausalLM(vocab_size=8)
+    model.eval()
+    input_ids = torch.randint(3, 7, (4, 12))
+    m = compute_marginal_clm(
+        model, input_ids, var_pos=5, nuc_token_ids=_SONGLAB_NUC_TOKEN_IDS
+    )
+    expected = -(m.exp() * m).sum(dim=-1)
+    np.testing.assert_allclose(
+        entropy_from_marginal(m.detach().numpy()),
+        expected.detach().numpy(),
+        atol=1e-5,
+    )
+
+
+def test_entropy_from_marginal_permutation_invariant():
+    """Permuting the 4 allele columns (the A↔T / C↔G complement relabel between
+    FWD and RC) leaves entropy unchanged."""
+    rng = np.random.default_rng(1)
+    logits = rng.standard_normal((10, 4))
+    marg = logits - np.log(np.exp(logits).sum(-1, keepdims=True))
+    comp = marg[:, [3, 2, 1, 0]]  # A↔T (0↔3), C↔G (1↔2)
+    np.testing.assert_allclose(
+        entropy_from_marginal(marg), entropy_from_marginal(comp), atol=1e-12
+    )
+
+
+def test_run_variant_marginal_rc_returns_both_strands(tmp_path):
+    """``run_variant_marginal(rc=True)`` returns ``{"fwd": [N,4], "rc": [N,4]}``
+    with distinct, normalized per-strand marginals; ``rc=False`` returns only
+    ``fwd`` and agrees with the rc=True fwd.
+
+    Uses the real tiny CLM rather than the content-independent mock: the mock's
+    per-position logits depend only on that position's token, so the variant-site
+    marginal collapses to a constant and FWD/RC would be indistinguishable. The
+    real model's context dependence makes the two strands genuinely differ."""
+    torch.manual_seed(0)
+    tokenizer = AutoTokenizer.from_pretrained("songlab/tokenizer-dna-mlm")
+    model = AutoModelForCausalLM.from_pretrained(TINY_CLM)
+    model.eval()
+    genome = Genome(_write_long_fasta(tmp_path))
+    dataset = _make_variant_dataset()
+    window_size = 16
+
+    both = run_variant_marginal(
+        model,
+        tokenizer,
+        dataset,
+        genome,
+        window_size,
+        rc=True,
+        data_transform_on_the_fly=True,
+        inference_kwargs=_INFERENCE_KWARGS,
+    )
+    fwd_only = run_variant_marginal(
+        model,
+        tokenizer,
+        dataset,
+        genome,
+        window_size,
+        rc=False,
+        data_transform_on_the_fly=True,
+        inference_kwargs=_INFERENCE_KWARGS,
+    )
+    assert set(fwd_only.keys()) == {"fwd"}
+    assert set(both.keys()) == {"fwd", "rc"}
+    assert both["fwd"].shape == (4, 4)
+    assert both["rc"].shape == (4, 4)
+    np.testing.assert_allclose(both["fwd"], fwd_only["fwd"], rtol=1e-5, atol=1e-6)
+    # Each row is a normalized log-prob marginal.
+    np.testing.assert_allclose(
+        np.logaddexp.reduce(both["fwd"], axis=-1), 0.0, atol=1e-5
+    )
+    assert not np.allclose(both["fwd"], both["rc"], atol=1e-6)
+
+
+def test_run_variant_marginal_reproducible(tmp_path):
+    """Two identical runs produce bit-identical marginals (snakemake `params:`
+    rerun-trigger contract — see the bundle's reproducibility test)."""
+    torch.manual_seed(0)
+    tokenizer = AutoTokenizer.from_pretrained("songlab/tokenizer-dna-mlm")
+    model = _DeterministicCausalLM(vocab_size=8)
+    model.eval()
+    genome = Genome(_write_long_fasta(tmp_path))
+    dataset = _make_variant_dataset()
+
+    a = run_variant_marginal(
+        model,
+        tokenizer,
+        dataset,
+        genome,
+        16,
+        rc=True,
+        data_transform_on_the_fly=True,
+        inference_kwargs=_INFERENCE_KWARGS,
+    )
+    b = run_variant_marginal(
+        model,
+        tokenizer,
+        dataset,
+        genome,
+        16,
+        rc=True,
+        data_transform_on_the_fly=True,
+        inference_kwargs=_INFERENCE_KWARGS,
+    )
+    np.testing.assert_array_equal(a["fwd"], b["fwd"])
+    np.testing.assert_array_equal(a["rc"], b["rc"])
+
+
+def test_run_variant_marginal_matches_bundle_llr_end_to_end(tmp_path):
+    """End-to-end: ``marginal[:, alt] − marginal[:, ref]`` (FWD) matches
+    ``run_variant_score_bundle``'s FWD LLR on the same variants — the transform
+    + kernel + runner wiring agrees with the production LLR path.
+
+    On the real tiny CLM (genuine context dependence) both prefix-shared kernels
+    see the same cached prefix and the same ref/alt suffixes, so their LLRs agree
+    to fp precision."""
+    torch.manual_seed(0)
+    tokenizer = AutoTokenizer.from_pretrained("songlab/tokenizer-dna-mlm")
+    model = AutoModelForCausalLM.from_pretrained(TINY_CLM)
+    model.eval()
+    genome = Genome(_write_long_fasta(tmp_path))
+    dataset = _make_variant_dataset()
+    window_size = 16
+
+    marg = run_variant_marginal(
+        model,
+        tokenizer,
+        dataset,
+        genome,
+        window_size,
+        rc=False,
+        data_transform_on_the_fly=True,
+        inference_kwargs=_INFERENCE_KWARGS,
+    )
+    bundle = run_variant_score_bundle(
+        model,
+        tokenizer,
+        dataset,
+        genome,
+        window_size,
+        rc=False,
+        data_transform_on_the_fly=True,
+        inference_kwargs=_INFERENCE_KWARGS,
+    )
+    # FWD strand: marginal column index == NUCLEOTIDES.index(letter).
+    ref_idx = np.array([NUCLEOTIDES.index(r) for r in dataset["ref"]])
+    alt_idx = np.array([NUCLEOTIDES.index(a) for a in dataset["alt"]])
+    rows = np.arange(len(dataset))
+    marg_llr = marg["fwd"][rows, alt_idx] - marg["fwd"][rows, ref_idx]
+    np.testing.assert_allclose(marg_llr, bundle["fwd"][:, 0], rtol=1e-4, atol=1e-4)

--- a/tests/model/test_scoring.py
+++ b/tests/model/test_scoring.py
@@ -46,6 +46,7 @@ from marin_dna.model.scoring import (
     compute_reflogprob_clm,
     compute_variant_score_bundle,
     entropy_from_marginal,
+    rc_average_marginal,
 )
 
 
@@ -917,6 +918,78 @@ def test_entropy_from_marginal_permutation_invariant():
     np.testing.assert_allclose(
         entropy_from_marginal(marg), entropy_from_marginal(comp), atol=1e-12
     )
+
+
+def test_entropy_from_marginal_normalizes_internally():
+    """``entropy_from_marginal`` accepts unnormalized logits (it normalizes
+    internally) — so a plain-mean FWD+RC average of log-probs needs no separate
+    renormalization. Per-row additive shifts leave the entropy unchanged."""
+    rng = np.random.default_rng(3)
+    logits = rng.standard_normal((8, 4)) * 3.0  # arbitrary, unnormalized
+    norm = logits - np.log(np.exp(logits).sum(-1, keepdims=True))  # log_softmax
+    expected = -(np.exp(norm) * norm).sum(-1)
+    np.testing.assert_allclose(entropy_from_marginal(logits), expected, atol=1e-10)
+    # softmax is shift-invariant → entropy of (logits + per-row const) is unchanged.
+    shifted = logits + rng.standard_normal((8, 1)) * 10.0
+    np.testing.assert_allclose(
+        entropy_from_marginal(logits), entropy_from_marginal(shifted), atol=1e-10
+    )
+
+
+def test_rc_average_marginal_realigns_complement_columns():
+    """``rc_average_marginal`` realigns the RC complement columns before averaging.
+
+    If the RC marginal labels the *same* distribution as FWD but by complement
+    (columns permuted ``[3,2,1,0]``), the aligned average recovers FWD exactly;
+    a naive ``(fwd + rc)/2`` would not."""
+    rng = np.random.default_rng(4)
+    fwd = rng.standard_normal((5, 4))
+    rc_same_dist = fwd[:, [3, 2, 1, 0]]  # RC names the same distribution by complement
+    np.testing.assert_allclose(rc_average_marginal(fwd, rc_same_dist), fwd, atol=1e-12)
+    assert not np.allclose(0.5 * (fwd + rc_same_dist), fwd, atol=1e-3)
+
+
+def test_rc_average_marginal_llr_matches_bundle_rc_average(tmp_path):
+    """End-to-end: the LLR read off ``rc_average_marginal`` equals the eval
+    bundle's FWD+RC-averaged LLR — validating both the complement realignment and
+    the average-then-derive ≡ derive-then-average linearity."""
+    torch.manual_seed(0)
+    tokenizer = AutoTokenizer.from_pretrained("songlab/tokenizer-dna-mlm")
+    model = AutoModelForCausalLM.from_pretrained(TINY_CLM)
+    model.eval()
+    genome = Genome(_write_long_fasta(tmp_path))
+    dataset = _make_variant_dataset()
+    window_size = 16
+
+    marg = run_variant_marginal(
+        model,
+        tokenizer,
+        dataset,
+        genome,
+        window_size,
+        rc=True,
+        data_transform_on_the_fly=True,
+        inference_kwargs=_INFERENCE_KWARGS,
+    )
+    avg = rc_average_marginal(marg["fwd"], marg["rc"])  # [N, 4], forward ACGT order
+
+    bundle = run_variant_score_bundle(
+        model,
+        tokenizer,
+        dataset,
+        genome,
+        window_size,
+        rc=True,
+        data_transform_on_the_fly=True,
+        inference_kwargs=_INFERENCE_KWARGS,
+    )
+    bundle_llr_avg = 0.5 * (bundle["fwd"][:, 0] + bundle["rc"][:, 0])
+
+    ref_idx = np.array([NUCLEOTIDES.index(r) for r in dataset["ref"]])
+    alt_idx = np.array([NUCLEOTIDES.index(a) for a in dataset["alt"]])
+    rows = np.arange(len(dataset))
+    marg_avg_llr = avg[rows, alt_idx] - avg[rows, ref_idx]
+    np.testing.assert_allclose(marg_avg_llr, bundle_llr_avg, rtol=1e-4, atol=1e-4)
 
 
 def test_run_variant_marginal_rc_returns_both_strands(tmp_path):


### PR DESCRIPTION
🤖 Implements #269 (stage 2/4 of the cLLR work, #267) — the opt-in **4-allele marginal scoring atom** from which entropy, ref-log-prob, and all three LLRs fall out as cheap CPU reductions.

## What

- **[`compute_marginal_clm(model, input_ids[B,L], *, var_pos, nuc_token_ids) → [B,4]`](https://github.com/Open-Athena/marin-dna/blob/70f62c3eceeb8ed445fbcf11afe382b35afb498d/src/marin_dna/model/scoring.py#L282)** — per-site normalized log-marginal `log p(x)` over `{A,C,G,T}`. Generalizes [`compute_variant_score_bundle`](https://github.com/Open-Athena/marin-dna/blob/70f62c3eceeb8ed445fbcf11afe382b35afb498d/src/marin_dna/model/scoring.py#L151)'s prefix-sharing kernel from 2 alleles to 4: **1 prefix forward + 4 cached-suffix forwards** (vs the legacy `compute_reflogprob_clm`'s 4 full-length forwards). Same 4-nuc-softmax space as the bundle, so **`marginal[alt] − marginal[ref]` is identically the bundle's LLR** — calibration LLRs match eval LLRs exactly.
- **[`entropy_from_marginal(marginal[...,4]) → [...]`](https://github.com/Open-Athena/marin-dna/blob/70f62c3eceeb8ed445fbcf11afe382b35afb498d/src/marin_dna/model/scoring.py#L392)** — CPU Shannon entropy (∈ `[0, log 4]`). **Normalizes internally**, so it accepts a normalized log-marginal *or* an unnormalized one (logits up to a per-row constant) — which is what lets the FWD+RC average be a plain mean with no renormalization step.
- **[`rc_average_marginal(fwd, rc) → [N,4]`](https://github.com/Open-Athena/marin-dna/blob/70f62c3eceeb8ed445fbcf11afe382b35afb498d/src/marin_dna/model/scoring.py#L420)** — plain mean of the two per-strand log-marginals after the `[3,2,1,0]` complement realignment (RC column `i` is the forward allele `complement(ACGT[i])`; a naive `(fwd+rc)/2` averages mismatched alleles). `avg[alt] − avg[ref]` equals the mean of the per-strand LLRs.
- **[`transform_variant_marginal_clm(...) → {input_ids:[L]}`](https://github.com/Open-Athena/marin-dna/blob/70f62c3eceeb8ed445fbcf11afe382b35afb498d/src/marin_dna/data/transforms.py#L213)** — strand-aware window only; the kernel builds the alleles, so no `[4,L]` materialization.
- **[`run_variant_marginal(...) → {"fwd":[N,4], "rc":[N,4]}`](https://github.com/Open-Athena/marin-dna/blob/70f62c3eceeb8ed445fbcf11afe382b35afb498d/src/marin_dna/model/runner.py#L201)** — per-strand runner mirroring [`run_variant_score_bundle`](https://github.com/Open-Athena/marin-dna/blob/70f62c3eceeb8ed445fbcf11afe382b35afb498d/src/marin_dna/model/runner.py#L123).

## Design (per the discussion on #269)

- **Parallel, opt-in route.** The default LLR+JSD bundle ([`compute_variant_score_bundle`](https://github.com/Open-Athena/marin-dna/blob/70f62c3eceeb8ed445fbcf11afe382b35afb498d/src/marin_dna/model/scoring.py#L151)) stays the cheap 2-forward default for every checkpoint and is untouched; the marginal route runs only where we want entropy/calibration.
- **One GPU atom, CPU reductions.** The GPU produces only the `[N,4]` marginal; entropy, ref-log-prob (`marginal[ref]`), and all three LLRs (`marginal[alt] − marginal[ref]`) are CPU post-hoc — so one neutral-site pass feeds stage 3 both `entropy_neutral_mean` and `llr_neutral_mean`.
- **FWD+RC averaging = average the log-marginals, normalize on top.** `rc_average_marginal` is a plain mean of the per-strand log-probs (after complement realignment); normalization is deferred to whatever you apply next — entropy normalizes internally, LLR is a difference (normalization-invariant). No renormalize-after-average step. The resulting entropy is `H(softmax(½(log p_fwd + log p_rc)))` and the LLR is the mean of the per-strand LLRs (consistent with the eval bundle's RC average).
- **Legacy untouched.** `compute_reflogprob_clm` / `transform_reflogprob_clm` (4 full forwards, full-vocab, currently test-only) left as-is; deleting them is a flagged follow-up.

## Tests (15 new)

- `compute_marginal_clm`: normalized rows (`logsumexp == 0`); **`marginal[:,alt] − marginal[:,ref]` matches `compute_variant_score_bundle`'s LLR** for all 4 alts (unit) and end-to-end through the runners on the real tiny CLM.
- `entropy_from_marginal`: range, endpoints (uniform → `log 4`), matches `−(p·log p).sum()`, permutation-invariant; **normalizes internally** (accepts unnormalized logits, shift-invariant per row).
- `rc_average_marginal`: complement realignment (RC = complement-permuted FWD ⇒ average recovers FWD; naive mean does not); end-to-end **LLR off the average matches the bundle's FWD+RC-averaged LLR**.
- `transform_variant_marginal_clm`: `[L]` shape, strand RC, ref/genome assertion, N-padding.
- `run_variant_marginal`: `{fwd, rc}` shape, FWD ≠ RC, bitwise-reproducible.

Full suite: **1030+ passed, 0 failures** (the 31 collection errors are pre-existing optional-dep gaps — `lightning`, `alphagenome_pytorch`, 2bit — unrelated to this change). `ruff` and whole-tree `mypy` clean.

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
