### PR TITLE
neutral_sites: pentanucleotide annotation + per-5-mer subsampling rules

### DIFF
--- a/snakemake/neutral_sites/README.md
+++ b/snakemake/neutral_sites/README.md
@@ -49,6 +49,33 @@ Replicates GPN-Star's hg38 calibration inputs exactly
 Pin destination (uploaded at the end of a run; consumed by `evals_v2`):
 `s3://oa-bolinas/snakemake/neutral_sites/results/neutral_sites.parquet`.
 
+## Calibration subsampling (#267 / #270)
+
+For mutation-rate calibration every neutral site is scored against its 3 non-ref
+alts and binned by pentanucleotide. Two **additive** rules (downstream of the
+pinned `neutral_sites.parquet`, which is left untouched) prepare a reduced set so
+the per-checkpoint scoring in `evals_v2` need not cover all 5.94M × 3 ≈ 18M
+variants:
+
+- `annotate_pentanuc` → `results/neutral_sites_pentanuc.parquet`
+  `[chrom, pos, ref, pentanuc]` — the central 5-mer (window `[pos-2, pos+2]`,
+  variant-centered) read from the genome; model-independent.
+- `subsample_neutral` → `results/subsampled/neutral_sites_n{n}.parquet` — at most
+  `n` sites **per 5-mer**, seeded by `subsample_seed`. `n` is a path wildcard so
+  several caps coexist and `evals_v2` pins one by revision.
+
+**The subsample unit is sites per 5-mer, not per `(5-mer, alt)` bin.** A site's
+three alt-bins share its sites, so `n` sites/5-mer yield `n` observations in
+*each* of its 3 bins, at `3n` variant-scorings per 5-mer → ≈ `3072·n`
+variants/checkpoint (minus depletion: 208/1024 five-mers have < 1000 sites). The
+convergence pilot (issue #270) found `n ≈ 1000` gives a per-bin mean-LLR
+SE ≈ 0.03; `n = 100` is the cheap floor (SE ≈ 0.10). The set is kept site-level /
+alt-agnostic so the LLR path (3 alts) and the entropy atom (#269, 4-allele
+marginal) consume one artifact.
+
+Pin destination (consumed by `evals_v2`):
+`s3://oa-bolinas/snakemake/neutral_sites/results/subsampled/neutral_sites_n{n}.parquet`.
+
 ## Where to run
 
 CPU-only but **heavy I/O**: it downloads ~15 GB of bigWigs plus rmsk/chain and
@@ -81,6 +108,11 @@ uv run --group genome-s3 snakemake
 # Pin the artifact for evals_v2 to consume.
 aws s3 cp results/neutral_sites.parquet \
   s3://oa-bolinas/snakemake/neutral_sites/results/neutral_sites.parquet
+
+# Build + pin a subsampled set (cap = n sites per 5-mer; n is a path wildcard).
+uv run --group genome-s3 snakemake results/subsampled/neutral_sites_n100.parquet
+aws s3 cp results/subsampled/neutral_sites_n100.parquet \
+  s3://oa-bolinas/snakemake/neutral_sites/results/subsampled/neutral_sites_n100.parquet
 ```
 
 ### On SkyPilot (the intended path)
@@ -100,5 +132,8 @@ Rules are thin glue around `marin_dna.pipelines.neutral_sites.sites`:
 - `contiguous_runs` / `neutral_mask` / `scan_neutral_intervals` —
   low-constraint sites from phyloP + phastCons.
 - `enumerate_positions` — neutral intervals → per-base `(chrom, pos, ref)`.
+- `annotate_pentanucleotide` — neutral sites → `+ pentanuc` (central 5-mer; one
+  read per chromosome, asserts 5-mer center == `ref`).
+- `subsample_per_context` — keep at most `n` sites per 5-mer, seeded + deterministic.
 
 Tests: [`tests/pipelines/neutral_sites/test_sites.py`](../../tests/pipelines/neutral_sites/test_sites.py).

--- a/snakemake/neutral_sites/config/config.yaml
+++ b/snakemake/neutral_sites/config/config.yaml
@@ -30,3 +30,9 @@ chroms: ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16",
 
 # bigWig scan granularity (bases per pyBigWig read).
 window_size: 1000000
+
+# Seed for the per-5-mer subsampling (rules/subsample.smk). The sampled cap `n`
+# is a path wildcard (`neutral_sites_n{n}.parquet`); this seed fixes which sites
+# are drawn so the subsampled set is reproducible across runs and shared by every
+# checkpoint's calibration.
+subsample_seed: 270

--- a/snakemake/neutral_sites/workflow/Snakefile
+++ b/snakemake/neutral_sites/workflow/Snakefile
@@ -6,8 +6,13 @@ include: "rules/download.smk"
 include: "rules/ancestral_repeats.smk"
 include: "rules/conserved.smk"
 include: "rules/neutral.smk"
+include: "rules/subsample.smk"
 
 
+# Default target is the full neutral set. The pentanucleotide-annotated and
+# per-5-mer-subsampled artifacts (rules/subsample.smk) are requested explicitly
+# by path, e.g. `snakemake results/subsampled/neutral_sites_n100.parquet`, since
+# the cap `n` is a deliberate choice (see README) — not built by `all`.
 rule all:
     input:
         "results/neutral_sites.parquet",

--- a/snakemake/neutral_sites/workflow/rules/common.smk
+++ b/snakemake/neutral_sites/workflow/rules/common.smk
@@ -3,9 +3,11 @@ import pandas as pd
 from marin_dna.data.genome import Genome
 from marin_dna.pipelines.evals.conservation import CONSERVATION_TRACKS
 from marin_dna.pipelines.neutral_sites.sites import (
+    annotate_pentanucleotide,
     enumerate_positions,
     parse_rmsk,
     scan_neutral_intervals,
+    subsample_per_context,
 )
 
 CHROMS = [str(c) for c in config["chroms"]]

--- a/snakemake/neutral_sites/workflow/rules/subsample.smk
+++ b/snakemake/neutral_sites/workflow/rules/subsample.smk
@@ -43,13 +43,14 @@ pins one by revision — see README."""
         n=r"\d+",
     run:
         sites = pd.read_parquet(input[0])
-        out = subsample_per_context(
-            sites, int(wildcards.n), config["subsample_seed"]
-        )
+        n_cap = int(wildcards.n)
+        out = subsample_per_context(sites, n_cap, config["subsample_seed"])
         per = out.groupby("pentanuc").size()
+        n_depleted = int((per < n_cap).sum())  # 5-mers with fewer than n sites
         out.to_parquet(output[0], index=False)
         print(
-            f"[subsample_neutral] n={wildcards.n} seed={config['subsample_seed']}: "
+            f"[subsample_neutral] n={n_cap} seed={config['subsample_seed']}: "
             f"{len(out):,} sites across {len(per)} 5-mers "
-            f"(<= {per.max()} per 5-mer) -> {output[0]}"
+            f"(<= {per.max()} per 5-mer; {n_depleted} 5-mers below the cap, "
+            f"min {per.min()}) -> {output[0]}"
         )

--- a/snakemake/neutral_sites/workflow/rules/subsample.smk
+++ b/snakemake/neutral_sites/workflow/rules/subsample.smk
@@ -1,0 +1,55 @@
+"""Pentanucleotide annotation + per-5-mer subsampling for cLLR calibration (#267/#270).
+
+Both steps are model-independent (pure functions of genome + position + seed), so
+they live here rather than in the GPU eval pipeline. The subsampled artifact is
+pinned + seeded → every checkpoint calibrates on the same neutral sites, and it is
+kept site-level / alt-agnostic so the LLR path (3 alts) and the entropy atom
+(#269, 4-allele marginal) consume one set.
+"""
+
+
+rule annotate_pentanuc:
+    """Attach each neutral site's central pentanucleotide (5-mer) from the genome.
+
+Additive (consumes the pinned neutral set, leaves it untouched); the genome is
+already wired into this pipeline, so context extraction belongs here."""
+    input:
+        "results/neutral_sites.parquet",
+    output:
+        "results/neutral_sites_pentanuc.parquet",
+    run:
+        sites = pd.read_parquet(input[0])
+        # Genome is the get_seq callable (same as enumerate_positions); reads
+        # once per chromosome and asserts the 5-mer center == ref.
+        out = annotate_pentanucleotide(sites, Genome(config["genome_path"]))
+        assert len(out) > 0, "empty pentanuc-annotated neutral set"
+        out.to_parquet(output[0], index=False)
+        print(
+            f"[annotate_pentanuc] {len(out):,} sites, "
+            f"{out['pentanuc'].nunique()} distinct 5-mers -> {output[0]}"
+        )
+
+
+rule subsample_neutral:
+    """Subsample to at most {n} neutral sites per 5-mer (seeded, deterministic).
+
+`n` is a path wildcard so several caps coexist (e.g. n100, n1000) and evals_v2
+pins one by revision — see README."""
+    input:
+        "results/neutral_sites_pentanuc.parquet",
+    output:
+        "results/subsampled/neutral_sites_n{n}.parquet",
+    wildcard_constraints:
+        n=r"\d+",
+    run:
+        sites = pd.read_parquet(input[0])
+        out = subsample_per_context(
+            sites, int(wildcards.n), config["subsample_seed"]
+        )
+        per = out.groupby("pentanuc").size()
+        out.to_parquet(output[0], index=False)
+        print(
+            f"[subsample_neutral] n={wildcards.n} seed={config['subsample_seed']}: "
+            f"{len(out):,} sites across {len(per)} 5-mers "
+            f"(<= {per.max()} per 5-mer) -> {output[0]}"
+        )

--- a/src/marin_dna/pipelines/neutral_sites/sites.py
+++ b/src/marin_dna/pipelines/neutral_sites/sites.py
@@ -282,3 +282,117 @@ def enumerate_positions(
     # Defensive: the whole point is a clean neutral set — no surprises downstream.
     assert out["ref"].isin(valid).all(), "non-ACGT ref leaked into neutral set"
     return out
+
+
+def annotate_pentanucleotide(
+    sites: pd.DataFrame,
+    get_seq: Callable[[str, int, int], str],
+) -> pd.DataFrame:
+    """Attach each neutral site's central pentanucleotide (5-mer) context.
+
+    The 5-mer is the window ``[pos-2, pos+2]`` (1-based, variant-centered) — in
+    0-based half-open terms the central base is ``pos - 1`` and the 5-mer spans
+    ``[pos-3, pos+2)`` — matching ``_get_variant_window`` in
+    ``marin_dna.data.transforms`` and GPN-Star's ``pentanuc``. The mutation-rate
+    calibration (issue #267) bins by this 5-mer (and, for LLR, ``5mer + "_" +
+    alt``), so it must be computed once, model-independently, here.
+
+    The reference is read **once per chromosome** (over the span covering every
+    site's 5-mer), same as :func:`enumerate_positions` — a per-site byte-range
+    read against an ``s3://`` genome would be millions of round-trips.
+
+    Args:
+        sites: ``[chrom, pos, ref]`` — bare ``chrom``, **1-based** ``pos``,
+            ``ref`` ∈ {A,C,G,T} (as produced by :func:`enumerate_positions`).
+        get_seq: ``(chrom, start, end) -> str`` over the reference (0-based
+            half-open, bare chrom names); the sequence is upper-cased here.
+
+    Returns:
+        ``sites`` plus a ``pentanuc`` column (uppercase 5-mer). Sites whose 5-mer
+        has a non-ACGT flank (``N`` near assembly gaps) are dropped — they can't
+        index a calibration bin; the center is ACGT by construction (it is the
+        ref). The center base of every returned 5-mer equals ``ref`` (asserted).
+    """
+    for col in ("chrom", "pos", "ref"):
+        assert col in sites.columns, f"sites missing column {col!r}"
+
+    sites = sites.reset_index(drop=True)
+    pentanuc = np.empty(len(sites), dtype=object)
+    for chrom, sub in sites.groupby("chrom", sort=False):
+        pos = sub["pos"].to_numpy()
+        # One read spanning every site's 5-mer: leftmost 5-mer starts at
+        # (min_pos - 1) - 2 = min_pos - 3; rightmost ends at (max_pos - 1) + 3.
+        lo = int(pos.min()) - 3
+        hi = int(pos.max()) + 2
+        span = get_seq(str(chrom), lo, hi).upper()
+        assert len(span) == hi - lo, (
+            f"reference returned {len(span)} bp for {chrom}:{lo}-{hi} "
+            f"(expected {hi - lo})"
+        )
+        for i, p in zip(sub.index.to_numpy(), pos):
+            start = int(p) - 3 - lo  # offset of this site's 5-mer within span
+            pentanuc[i] = span[start : start + 5]
+
+    out = sites.copy()
+    out["pentanuc"] = pentanuc
+    # Centering check: the middle base of every 5-mer must equal the stored ref
+    # (validates the 1-based-pos <-> 0-based-reference convention end-to-end).
+    center = out["pentanuc"].str[2]
+    assert (center == out["ref"]).all(), (
+        f"pentanucleotide center != ref for "
+        f"{int((center != out['ref']).sum())} site(s) — centering/coordinate bug"
+    )
+    valid = out["pentanuc"].str.fullmatch("[ACGT]{5}")
+    n_drop = int((~valid).sum())
+    if n_drop:
+        print(
+            f"[annotate_pentanucleotide] dropped {n_drop} site(s) "
+            f"with non-ACGT 5-mer flanks"
+        )
+    return out.loc[valid].reset_index(drop=True)
+
+
+def subsample_per_context(sites: pd.DataFrame, n: int, seed: int) -> pd.DataFrame:
+    """Subsample to at most ``n`` neutral sites per pentanucleotide (5-mer).
+
+    The calibration subsampling unit is the **5-mer** (``pentanuc``), *not* the
+    per-alt bin (``5mer + "_" + alt``): each site is scored against all 3 non-ref
+    alts, so the three bins of a 5-mer share its sites. Keeping ``n`` sites per
+    5-mer therefore yields ``n`` observations in *each* of its 3 calibration
+    bins, at ``3n`` variant-scorings per 5-mer. Site-level + alt-agnostic so the
+    LLR path (3 alts) and the entropy atom (#269, 4-allele marginal) consume one
+    set.
+
+    Deterministic given ``(site set, n, seed)``: sites are canonically sorted
+    first (so the result is independent of input row order), then a single
+    seeded RNG draws ``min(n, count)`` per 5-mer in sorted-5-mer order.
+
+    Args:
+        sites: ``[chrom, pos, ref, pentanuc, ...]`` (e.g. from
+            :func:`annotate_pentanucleotide`).
+        n: max sites to keep per 5-mer. 5-mers with ``count <= n`` are kept whole.
+        seed: RNG seed.
+
+    Returns:
+        The kept sites (all input columns), canonically sorted by
+        ``(chrom, pos)``. Every 5-mer appears at most ``n`` times.
+    """
+    assert n > 0, f"n must be positive, got {n}"
+    for col in ("chrom", "pos", "pentanuc"):
+        assert col in sites.columns, f"sites missing column {col!r}"
+
+    sites = sites.sort_values(["chrom", "pos"]).reset_index(drop=True)
+    rng = np.random.default_rng(seed)
+    keep: list[np.ndarray] = []
+    for _, group in sites.groupby("pentanuc", sort=True):
+        idx = group.index.to_numpy()
+        if len(idx) <= n:
+            keep.append(idx)
+        else:
+            sel = np.sort(rng.choice(len(idx), size=n, replace=False))
+            keep.append(idx[sel])
+
+    out = sites.loc[np.concatenate(keep)].sort_values(["chrom", "pos"])
+    out = out.reset_index(drop=True)
+    assert out.groupby("pentanuc").size().max() <= n, "a 5-mer exceeded the cap"
+    return out

--- a/src/marin_dna/pipelines/neutral_sites/sites.py
+++ b/src/marin_dna/pipelines/neutral_sites/sites.py
@@ -380,7 +380,17 @@ def subsample_per_context(sites: pd.DataFrame, n: int, seed: int) -> pd.DataFram
     assert n > 0, f"n must be positive, got {n}"
     for col in ("chrom", "pos", "pentanuc"):
         assert col in sites.columns, f"sites missing column {col!r}"
+    if len(sites) == 0:
+        return sites.reset_index(drop=True)
+    # Unique (chrom, pos) is the contract (enumerate_positions dedups). Enforce it:
+    # a duplicate would double-weight a calibration bin and make the seeded draw
+    # depend on input row order.
+    assert not sites.duplicated(["chrom", "pos"]).any(), (
+        "duplicate (chrom, pos) sites — would double-weight a calibration bin"
+    )
 
+    # Canonical sort first so the draw depends only on the site set + seed, not on
+    # input row order; the reset index is then in (chrom, pos) order (unique keys).
     sites = sites.sort_values(["chrom", "pos"]).reset_index(drop=True)
     rng = np.random.default_rng(seed)
     keep: list[np.ndarray] = []
@@ -389,10 +399,10 @@ def subsample_per_context(sites: pd.DataFrame, n: int, seed: int) -> pd.DataFram
         if len(idx) <= n:
             keep.append(idx)
         else:
-            sel = np.sort(rng.choice(len(idx), size=n, replace=False))
-            keep.append(idx[sel])
+            keep.append(idx[rng.choice(len(idx), size=n, replace=False)])
 
-    out = sites.loc[np.concatenate(keep)].sort_values(["chrom", "pos"])
-    out = out.reset_index(drop=True)
+    # Sorting the kept positional indices restores (chrom, pos) order in one pass
+    # (the index is already (chrom, pos)-sorted) — no second DataFrame sort.
+    out = sites.loc[np.sort(np.concatenate(keep))].reset_index(drop=True)
     assert out.groupby("pentanuc").size().max() <= n, "a 5-mer exceeded the cap"
     return out

--- a/tests/pipelines/neutral_sites/test_sites.py
+++ b/tests/pipelines/neutral_sites/test_sites.py
@@ -272,6 +272,24 @@ class TestAnnotatePentanucleotide:
         out = annotate_pentanucleotide(sites, self._get_seq(g))
         assert list(out["pentanuc"]) == ["GTACG", "ACGTA"]
 
+    def test_chromosome_boundary_n_padding(self):
+        # A near-the-start site whose 5-mer flank runs off the chromosome must be
+        # dropped. Emulate the real Genome, which N-pads out-of-range reads so the
+        # returned length is always end-start (exercises the lo < 0 path).
+        seq = "ACGTACGT"  # 0-based 0..7
+
+        def padded(chrom, start, end):
+            return "".join(
+                seq[i] if 0 <= i < len(seq) else "N" for i in range(start, end)
+            )
+
+        # pos 1 -> 5-mer 0-based [-2, 3) = "NNACG" (left N-pad) -> dropped;
+        # pos 4 -> 5-mer [1, 6) = "CGTAC" -> kept. (single read lo=-2, hi=6)
+        sites = pd.DataFrame({"chrom": ["1", "1"], "pos": [1, 4], "ref": ["A", "T"]})
+        out = annotate_pentanucleotide(sites, padded)
+        assert list(out["pos"]) == [4]
+        assert list(out["pentanuc"]) == ["CGTAC"]
+
 
 class TestSubsamplePerContext:
     def _sites(self) -> pd.DataFrame:

--- a/tests/pipelines/neutral_sites/test_sites.py
+++ b/tests/pipelines/neutral_sites/test_sites.py
@@ -10,11 +10,13 @@ import pyBigWig
 import pytest
 
 from marin_dna.pipelines.neutral_sites.sites import (
+    annotate_pentanucleotide,
     contiguous_runs,
     enumerate_positions,
     neutral_mask,
     parse_rmsk,
     scan_neutral_intervals,
+    subsample_per_context,
 )
 
 
@@ -226,3 +228,92 @@ class TestScanNeutralIntervals:
         _write_bw(pc, "chr1", 4, [0, 0, 0, 0])
         df = scan_neutral_intervals(str(pp), str(pc), ["1", "2"], 0.1, window_size=5)
         assert list(zip(df["chrom"], df["start"], df["end"])) == [("chr1", 0, 4)]
+
+
+class TestAnnotatePentanucleotide:
+    def _get_seq(self, genome: dict[str, str]):
+        return lambda chrom, start, end: genome[chrom][start:end]
+
+    def test_basic_5mer_and_centering(self):
+        # "1": A C G T A C G T A C G T  (0-based 0..11)
+        g = {"1": "ACGTACGTACGT"}
+        sites = pd.DataFrame({"chrom": ["1", "1"], "pos": [5, 8], "ref": ["A", "T"]})
+        out = annotate_pentanucleotide(sites, self._get_seq(g))
+        # pos 5 -> center0 4 (A); 5-mer 0-based [2,7) = GTACG
+        # pos 8 -> center0 7 (T); 5-mer [5,10) = CGTAC
+        assert list(out["pentanuc"]) == ["GTACG", "CGTAC"]
+        assert (out["pentanuc"].str[2] == out["ref"]).all()
+
+    def test_uppercases_softmasked(self):
+        g = {"1": "acgtacgtacgt"}
+        sites = pd.DataFrame({"chrom": ["1"], "pos": [5], "ref": ["A"]})
+        out = annotate_pentanucleotide(sites, self._get_seq(g))
+        assert list(out["pentanuc"]) == ["GTACG"]
+
+    def test_drops_non_acgt_flank(self):
+        # "2": A C G N T A C G T A C G  — N at 0-based idx 3.
+        g = {"2": "ACGNTACGTACG"}
+        sites = pd.DataFrame({"chrom": ["2", "2"], "pos": [6, 9], "ref": ["A", "T"]})
+        # pos 6 -> 5-mer [3,8) = NTACG (N flank) -> dropped; pos 9 -> CGTAC -> kept.
+        out = annotate_pentanucleotide(sites, self._get_seq(g))
+        assert list(out["pos"]) == [9]
+        assert list(out["pentanuc"]) == ["CGTAC"]
+
+    def test_center_ref_mismatch_asserts(self):
+        g = {"1": "ACGTACGTACGT"}  # center of pos 5 is A, not C
+        sites = pd.DataFrame({"chrom": ["1"], "pos": [5], "ref": ["C"]})
+        with pytest.raises(AssertionError, match="center != ref"):
+            annotate_pentanucleotide(sites, self._get_seq(g))
+
+    def test_one_read_spans_distant_sites(self):
+        # Two far-apart sites on one chrom: a single [min-3, max+2) read covers both.
+        g = {"1": "ACGT" * 10}  # 40 bp; base at idx i is "ACGT"[i % 4]
+        sites = pd.DataFrame({"chrom": ["1", "1"], "pos": [5, 35], "ref": ["A", "G"]})
+        out = annotate_pentanucleotide(sites, self._get_seq(g))
+        assert list(out["pentanuc"]) == ["GTACG", "ACGTA"]
+
+
+class TestSubsamplePerContext:
+    def _sites(self) -> pd.DataFrame:
+        # 5x AAAAA, 2x CCCCC, 1x GGGGG.
+        return pd.DataFrame(
+            {
+                "chrom": ["1"] * 7 + ["2"],
+                "pos": [10, 20, 30, 40, 50, 60, 70, 5],
+                "ref": ["A"] * 5 + ["C"] * 2 + ["G"],
+                "pentanuc": ["AAAAA"] * 5 + ["CCCCC"] * 2 + ["GGGGG"],
+            }
+        )
+
+    def test_caps_and_keeps_small_groups_whole(self):
+        out = subsample_per_context(self._sites(), n=3, seed=0)
+        counts = out.groupby("pentanuc").size().to_dict()
+        assert counts == {"AAAAA": 3, "CCCCC": 2, "GGGGG": 1}  # capped / kept whole
+        # untouched groups keep all their original positions
+        assert set(out.loc[out["pentanuc"] == "CCCCC", "pos"]) == {60, 70}
+
+    def test_deterministic_same_seed(self):
+        a = subsample_per_context(self._sites(), n=3, seed=7)
+        b = subsample_per_context(self._sites(), n=3, seed=7)
+        pd.testing.assert_frame_equal(a, b)
+
+    def test_independent_of_input_row_order(self):
+        ordered = subsample_per_context(self._sites(), n=3, seed=7)
+        shuffled = subsample_per_context(
+            self._sites().sample(frac=1, random_state=1).reset_index(drop=True),
+            n=3,
+            seed=7,
+        )
+        pd.testing.assert_frame_equal(ordered, shuffled)
+
+    def test_preserves_columns_and_is_subset(self):
+        src = self._sites()
+        out = subsample_per_context(src, n=2, seed=0)
+        assert list(out.columns) == list(src.columns)
+        merged = out.merge(src, on=list(src.columns), how="left", indicator=True)
+        assert (merged["_merge"] == "both").all()  # every kept row came from src
+
+    def test_n_larger_than_all_groups_returns_all(self):
+        src = self._sites()
+        out = subsample_per_context(src, n=100, seed=0)
+        assert len(out) == len(src)


### PR DESCRIPTION
## Summary

Adds the neutral-set prep for cLLR mutation-rate calibration (part of #267; consumed by #270's per-checkpoint scoring) so calibration need not score all 5.94M × 3 ≈ 18M neutral variants. Two **additive** rules in the `neutral_sites` pipeline — the pinned `neutral_sites.parquet` from #272 is left untouched:

- **`annotate_pentanuc`** → `results/neutral_sites_pentanuc.parquet` `[chrom, pos, ref, pentanuc]` — the central 5-mer (`[pos-2, pos+2]`, variant-centered) read from the genome.
- **`subsample_neutral`** → `results/subsampled/neutral_sites_n{n}.parquet` — at most `n` sites per 5-mer, seeded. `n` is a path wildcard so several caps coexist and `evals_v2` pins one by revision.

Both are model-independent → they live here (the genome is already wired into this pipeline), are pinned + seeded for cross-checkpoint comparability, and are kept **site-level / alt-agnostic** so the LLR path (3 alts) and the entropy atom (#269, 4-allele marginal) share one artifact. `evals_v2` stage-3 stays a pure GPU "score → bin → table" step.

## Subsample unit

Sites **per 5-mer**, not per `(5-mer, alt)` bin: each site is scored against all 3 non-ref alts, so its three bins share its sites → `n` sites/5-mer give `n` observations in *each* bin, at `3n` variant-scorings per 5-mer. So the subsample groups by the **1,024 five-mers**; the calibration table bins by the **3,072 `pentanuc_mut` cells**; the ×3 is the alts. Budget ≈ `3,072·n` variants/checkpoint (the convergence pilot on #270 sized this: `n ≈ 1000` → per-bin mean-LLR SE ≈ 0.03; `n = 100` is the cheap floor).

## What's here

- **Library (tested):** `annotate_pentanucleotide`, `subsample_per_context` in `sites.py` (+9 unit tests).
- **Rules:** `subsample.smk`, wired into `common.smk` + `Snakefile`; `subsample_seed` in config.
- **README:** new "Calibration subsampling" section + build/pin commands.

## Verification

- `uv run pytest tests/pipelines/neutral_sites/` → 29 passed; pre-commit clean (ruff / snakefmt / mypy).
- DAG dry-run resolves `subsample_neutral(n=100)` ← `annotate_pentanuc` ← the pinned neutral set.
- Ran the library functions on the **real** neutral set: `n=100` → 102,288 sites, `n=1000` → 945,222 (both match the independent budget computation), `max` per-5-mer `== n`, deterministic.

**No model run / no pipeline execution in this PR** — producing + pinning a subsampled artifact is a deliberate run step (documented in the README). Background + sizing live in the #270 pilot comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
