### PR TITLE
evals_v2: cLLR llr_neutral_mean calibration tables (stage 3, #270)

### DIFF
--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -142,10 +142,11 @@ name:
 ### Calibration tables (cLLR, #267/#270)
 
 `snakemake calibration` builds a per-checkpoint **mutation-rate calibration**
-table — also kept **off `rule all`**. It scores the pinned, subsampled
-neutral-site set from [`snakemake/neutral_sites`](../../neutral_sites/)
-(`neutral_sites_n{n}.parquet`, default `n=100`) with the same fast LLR bundle as
-`compute_scores` (FWD+RC), then bins by `pentanuc_mut = 5mer + "_" + alt`:
+table — also kept **off `rule all`**. It scores the pinned, **pre-filtered +
+subsampled** neutral-site set from [`snakemake/neutral_sites`](../../neutral_sites/)
+(`neutral_sites_n{n}_w{w}.parquet`, default `n=100`, `w=scoreable_window=512`) with
+the same fast LLR bundle as `compute_scores` (FWD+RC), then bins by
+`pentanuc_mut = 5mer + "_" + alt`:
 
 ```
 results/calibration/{model}/llr_neutral_mean_n{n}.parquet
@@ -157,12 +158,15 @@ llr_neutral_std_avg, subsample_n]` (~3072 cells = 1024 five-mers × 3 alts). Sta
 **Entropy calibration** (the 4-forward marginal atom) is a separate, deferred
 path — this rule is LLR-only.
 
-The neutral set is staged via snakemake `storage()` (boto3, fork-safe), so it
-arrives as a **local** file: `pd.read_parquet("s3://…")` in the rule's parent
-process would initialize s3fs and deadlock the forked DataLoader workers that read
-the genome (the genome stays the only in-worker s3fs read). Configured under
-`calibration:` in `config.yaml` (`models`, `subsample_n`, `min_bin_count`,
-`neutral_sites_s3_prefix`, `rc`). Build:
+The neutral set is **ACGT-window-filtered upstream** (in `neutral_sites`, once per
+window, reused by every model — see that pipeline's README), so this rule does **no
+genome filtering**; it asserts `scoreable_window >= the model's window_size` so the
+clean set is valid for the model. The set is staged via snakemake `storage()`
+(boto3, fork-safe), so it arrives as a **local** file: `pd.read_parquet("s3://…")`
+in the rule's parent process would initialize s3fs and deadlock the forked
+DataLoader workers that read the genome (the genome stays the only in-worker s3fs
+read). Configured under `calibration:` in `config.yaml` (`models`, `subsample_n`,
+`scoreable_window`, `min_bin_count`, `neutral_sites_s3_prefix`, `rc`). Build:
 
 ```bash
 snakemake calibration                                                # all configured calibration models
@@ -215,7 +219,7 @@ Two unavoidable AWS-side failure modes worth knowing about:
 | `inference.*` | Batch size, workers, `data_transform_on_the_fly`, `torch_compile`; `rc` (also score the reverse-complement strand — doubles inference time); `n_bootstrap` (AUPRC bootstrap iterations per subset × score_type); `bootstrap_seed` (reproducibility seed; bumping triggers metrics re-execution). |
 | `nuc_dep` | Optional; nucleotide-dependency maps (#237, off `rule all`). `{combines, ord, batch_size, dpi, models: [...], loci: {...}}`. See `rules/interpretation.smk`. |
 | `umap_embeddings` | Optional; embedding UMAP (#246, off `rule all`). `{dataset, layer_index, n_center_bp, random_state, dpi, models: [...]}` — `models` reuse the `models:` registry (each needs `window_size`). Build needs `--group umap` (+ `--group genome-s3`). See `rules/embedding_umap.smk`. |
-| `calibration` | Optional; cLLR mutation-rate calibration tables (#267/#270, off `rule all`). `{neutral_sites_s3_prefix, subsample_n, min_bin_count, rc, models: [...]}` — scores the subsampled neutral set → per-model `llr_neutral_mean`. See `rules/calibration.smk`. |
+| `calibration` | Optional; cLLR mutation-rate calibration tables (#267/#270, off `rule all`). `{neutral_sites_s3_prefix, subsample_n, scoreable_window, min_bin_count, rc, models: [...]}` — scores the pre-filtered + subsampled neutral set (`neutral_sites_n{subsample_n}_w{scoreable_window}.parquet`) → per-model `llr_neutral_mean`. See `rules/calibration.smk`. |
 
 ## Library
 

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -139,6 +139,36 @@ name:
     --env SNAKEMAKE_ARGS="-- umap"
   ```
 
+### Calibration tables (cLLR, #267/#270)
+
+`snakemake calibration` builds a per-checkpoint **mutation-rate calibration**
+table — also kept **off `rule all`**. It scores the pinned, subsampled
+neutral-site set from [`snakemake/neutral_sites`](../../neutral_sites/)
+(`neutral_sites_n{n}.parquet`, default `n=100`) with the same fast LLR bundle as
+`compute_scores` (FWD+RC), then bins by `pentanuc_mut = 5mer + "_" + alt`:
+
+```
+results/calibration/{model}/llr_neutral_mean_n{n}.parquet
+```
+
+columns `[pentanuc_mut, pentanuc, ref, alt, n_sites, llr_neutral_mean_{fwd,rc,avg},
+llr_neutral_std_avg, subsample_n]` (~3072 cells = 1024 five-mers × 3 alts). Stage 4
+(#271) subtracts it: `calibrated LLR = LLR − llr_neutral_mean(pentanuc_mut)`.
+**Entropy calibration** (the 4-forward marginal atom) is a separate, deferred
+path — this rule is LLR-only.
+
+The neutral set is staged via snakemake `storage()` (boto3, fork-safe), so it
+arrives as a **local** file: `pd.read_parquet("s3://…")` in the rule's parent
+process would initialize s3fs and deadlock the forked DataLoader workers that read
+the genome (the genome stays the only in-worker s3fs read). Configured under
+`calibration:` in `config.yaml` (`models`, `subsample_n`, `min_bin_count`,
+`neutral_sites_s3_prefix`, `rc`). Build:
+
+```bash
+snakemake calibration                                                # all configured calibration models
+snakemake results/calibration/<model>/llr_neutral_mean_n100.parquet  # one model
+```
+
 ### Parallel sky-cluster sweep (one cluster per target)
 
 For a grid of independent targets — e.g. all checkpoints of one model arm,
@@ -185,6 +215,7 @@ Two unavoidable AWS-side failure modes worth knowing about:
 | `inference.*` | Batch size, workers, `data_transform_on_the_fly`, `torch_compile`; `rc` (also score the reverse-complement strand — doubles inference time); `n_bootstrap` (AUPRC bootstrap iterations per subset × score_type); `bootstrap_seed` (reproducibility seed; bumping triggers metrics re-execution). |
 | `nuc_dep` | Optional; nucleotide-dependency maps (#237, off `rule all`). `{combines, ord, batch_size, dpi, models: [...], loci: {...}}`. See `rules/interpretation.smk`. |
 | `umap_embeddings` | Optional; embedding UMAP (#246, off `rule all`). `{dataset, layer_index, n_center_bp, random_state, dpi, models: [...]}` — `models` reuse the `models:` registry (each needs `window_size`). Build needs `--group umap` (+ `--group genome-s3`). See `rules/embedding_umap.smk`. |
+| `calibration` | Optional; cLLR mutation-rate calibration tables (#267/#270, off `rule all`). `{neutral_sites_s3_prefix, subsample_n, min_bin_count, rc, models: [...]}` — scores the subsampled neutral set → per-model `llr_neutral_mean`. See `rules/calibration.smk`. |
 
 ## Library
 
@@ -197,6 +228,10 @@ Pipeline rules are thin glue around:
 - `marin_dna.pipelines.evals.metrics.compute_qtl_metrics` — score columns
   → global AUPRC + positives-only Pearson/Spearman vs `effect_size`
   (the `eval_protocol: qtl_global` path for caqtl/dsqtl).
+- `marin_dna.pipelines.evals.calibration.compute_llr_neutral_mean` — checkpoint +
+  neutral sites → per-cell `llr_neutral_mean` calibration table (cLLR stage 3);
+  `expand_sites_to_variants` / `aggregate_llr_neutral_mean` are the tested pure pieces.
 
-Both are tested at `tests/pipelines/evals/test_metrics.py`,
-`tests/pipelines/evals/test_inference.py`, and `tests/model/test_scoring.py`.
+These are tested at `tests/pipelines/evals/test_metrics.py`,
+`tests/pipelines/evals/test_inference.py`, `tests/pipelines/evals/test_calibration.py`,
+and `tests/model/test_scoring.py`.

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -858,16 +858,22 @@ inference:
 # cLLR mutation-rate calibration tables (stage 3, #267/#270). Off `rule all`;
 # build with `snakemake calibration` (or a single
 # results/calibration/<model>/llr_neutral_mean_n{n}.parquet target). Scores the
-# pinned subsampled neutral set with the fast LLR bundle (FWD+RC) and bins by
-# pentanuc_mut → per-checkpoint llr_neutral_mean table. Entropy calibration is a
-# separate, deferred path. See rules/calibration.smk.
+# pinned, pre-filtered + subsampled neutral set with the fast LLR bundle (FWD+RC)
+# and bins by pentanuc_mut → per-checkpoint llr_neutral_mean table. The neutral set
+# is ACGT-window-filtered upstream (neutral_sites pipeline); this rule does no
+# genome filtering. Entropy calibration is a separate, deferred path. See
+# rules/calibration.smk.
 # ---------------------------------------------------------------------------
 calibration:
   # S3 prefix of the neutral-sites pipeline's subsampled artifacts. The rule
-  # appends `/neutral_sites_n{n}.parquet` (n from the target wildcard).
+  # appends `/neutral_sites_n{n}_w{scoreable_window}.parquet`.
   neutral_sites_s3_prefix: s3://oa-bolinas/snakemake/neutral_sites/results/subsampled
-  subsample_n: 100        # per-5-mer cap; pins neutral_sites_n100.parquet and the
-                          # `calibration` collector's target names.
+  subsample_n: 100        # per-5-mer cap; selects neutral_sites_n100_w{w}.parquet
+                          # and names the `calibration` collector's targets.
+  scoreable_window: 512   # the neutral set is pre-filtered so every w-bp window is
+                          # all-ACGT; 512 = the largest model window, so ONE set is
+                          # valid for every model (255/256/512). Must be >= each
+                          # scored model's window_size (asserted in the rule).
   min_bin_count: 10       # hard floor on observations per pentanuc_mut cell. At
                           # n=100 the true min is 41 (CpG-depleted 5-mers); the
                           # ACGT-window pre-filter shaves a few gap-adjacent sites,

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -855,6 +855,28 @@ inference:
 
 
 # ---------------------------------------------------------------------------
+# cLLR mutation-rate calibration tables (stage 3, #267/#270). Off `rule all`;
+# build with `snakemake calibration` (or a single
+# results/calibration/<model>/llr_neutral_mean_n{n}.parquet target). Scores the
+# pinned subsampled neutral set with the fast LLR bundle (FWD+RC) and bins by
+# pentanuc_mut → per-checkpoint llr_neutral_mean table. Entropy calibration is a
+# separate, deferred path. See rules/calibration.smk.
+# ---------------------------------------------------------------------------
+calibration:
+  # S3 prefix of the neutral-sites pipeline's subsampled artifacts. The rule
+  # appends `/neutral_sites_n{n}.parquet` (n from the target wildcard).
+  neutral_sites_s3_prefix: s3://oa-bolinas/snakemake/neutral_sites/results/subsampled
+  subsample_n: 100        # per-5-mer cap; pins neutral_sites_n100.parquet and the
+                          # `calibration` collector's target names.
+  min_bin_count: 30       # hard floor on observations per pentanuc_mut cell. At
+                          # n=100 the true min is 41 (CpG-depleted 5-mers); 30
+                          # catches a broken/empty cell without false-firing.
+  rc: true                # FWD+RC average, matching the eval convention.
+  models:
+    - mix-v0.9-p1B-i24-exp135-m5.1-step-59158   # exp135-1B-m5.1 (our winner / pilot model)
+
+
+# ---------------------------------------------------------------------------
 # Nucleotide dependency maps (categorical Jacobian) — interpretation, #237.
 #
 # NOT a metric: these targets are kept off `rule all`. Build explicitly:

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -868,9 +868,11 @@ calibration:
   neutral_sites_s3_prefix: s3://oa-bolinas/snakemake/neutral_sites/results/subsampled
   subsample_n: 100        # per-5-mer cap; pins neutral_sites_n100.parquet and the
                           # `calibration` collector's target names.
-  min_bin_count: 30       # hard floor on observations per pentanuc_mut cell. At
-                          # n=100 the true min is 41 (CpG-depleted 5-mers); 30
-                          # catches a broken/empty cell without false-firing.
+  min_bin_count: 10       # hard floor on observations per pentanuc_mut cell. At
+                          # n=100 the true min is 41 (CpG-depleted 5-mers); the
+                          # ACGT-window pre-filter shaves a few gap-adjacent sites,
+                          # so 10 catches a broken/empty cell without false-firing
+                          # on legitimate post-filter depletion.
   rc: true                # FWD+RC average, matching the eval convention.
   models:
     - mix-v0.9-p1B-i24-exp135-m5.1-step-59158   # exp135-1B-m5.1 (our winner / pilot model)

--- a/snakemake/analysis/evals_v2/workflow/Snakefile
+++ b/snakemake/analysis/evals_v2/workflow/Snakefile
@@ -11,6 +11,7 @@ include: "rules/inference.smk"
 include: "rules/metrics.smk"
 include: "rules/interpretation.smk"
 include: "rules/embedding_umap.smk"
+include: "rules/calibration.smk"
 
 
 rule all:

--- a/snakemake/analysis/evals_v2/workflow/rules/calibration.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/calibration.smk
@@ -42,10 +42,28 @@ rule compute_llr_neutral_mean:
         # batch_size is execution-only (numerics are batch-size-invariant modulo
         # float-reduction noise) — read here, not declared in `params:`, so tuning
         # it doesn't force a re-run. Same convention as compute_scores.
+        import shlex
+
         batch_size = get_model_batch_size(wildcards.model)
 
-        # LOCAL read (storage staged it) — never pd.read_parquet("s3://…") here.
-        sites = pd.read_parquet(input.neutral)
+        # Drop neutral sites whose model-window contains a non-ACGT base (assembly-gap
+        # N near telomeres/centromeres): the scoring kernel asserts ACGT on the
+        # downstream window, so an N trips a CUDA device-side assert. FWD checks the
+        # right flank and RC the left, so the *whole* window must be clean. This MUST
+        # run in a CHILD process — it reads the genome (initializing s3fs), and doing
+        # that here would deadlock the DataLoader workers compute_variant_scores forks
+        # below. The child writes the filtered sites to a local parquet.
+        filtered = output[0] + ".acgt_sites.parquet"
+        shell(
+            "python -m marin_dna.pipelines.evals.calibration "
+            f"--sites {shlex.quote(str(input.neutral))} "
+            f"--genome {shlex.quote(str(config['genome_path']))} "
+            f"--window {int(params.window_size)} "
+            f"--out {shlex.quote(filtered)}"
+        )
+
+        # LOCAL read — never pd.read_parquet("s3://…") in this (forking) process.
+        sites = pd.read_parquet(filtered)
         table = compute_llr_neutral_mean(
             checkpoint_path=input.checkpoint,
             sites=sites,

--- a/snakemake/analysis/evals_v2/workflow/rules/calibration.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/calibration.smk
@@ -1,0 +1,77 @@
+"""cLLR mutation-rate calibration tables (stage 3, #267/#270).
+
+Score the pinned, subsampled neutral-site set (built by ``snakemake/neutral_sites``)
+with the fast 2-forward LLR bundle (FWD+RC) and bin by ``pentanuc_mut`` into a
+per-checkpoint ``llr_neutral_mean`` table that stage 4 (#271) subtracts to
+calibrate variant LLRs. Entropy calibration is a separate, deferred path.
+
+GPU-bound — runs on the same SkyPilot GPU node as ``compute_scores``. Kept OFF
+``rule all`` (a few-models analysis, like ``nuc_dep`` / ``umap``); build by name:
+
+    snakemake calibration                    # every configured calibration model
+    snakemake results/calibration/<model>/llr_neutral_mean_n100.parquet
+"""
+
+
+rule compute_llr_neutral_mean:
+    input:
+        checkpoint="results/checkpoints/{model}",
+        # The neutral set lives in another pipeline's S3 prefix. `storage()` uses
+        # the boto3-backed s3 plugin (no s3fs async loop), so it stages to a LOCAL
+        # path that `pd.read_parquet` reads *without* initializing s3fs in this
+        # parent process — which would otherwise deadlock the forked DataLoader
+        # workers that read the genome lazily in-worker (see issue #270 /
+        # `compute_variant_scores`). The `{n}` wildcard ties the input cap to the
+        # output name so several caps can coexist.
+        neutral=lambda wc: storage(
+            f"{config['calibration']['neutral_sites_s3_prefix']}/neutral_sites_n{wc.n}.parquet"
+        ),
+    output:
+        "results/calibration/{model}/llr_neutral_mean_n{n}.parquet",
+    wildcard_constraints:
+        model="|".join(MODELS),
+        n=r"\d+",
+    params:
+        # 255 for BOS checkpoints, 256/512 for older runs (same as compute_scores).
+        window_size=lambda wc: get_model_config(wc.model)["window_size"],
+        # FWD+RC to match the eval; falls back to the global inference default.
+        rc=config["calibration"].get("rc", config["inference"]["rc"]),
+        min_bin_count=config["calibration"]["min_bin_count"],
+    threads: config["inference"]["num_workers"]
+    run:
+        # batch_size is execution-only (numerics are batch-size-invariant modulo
+        # float-reduction noise) — read here, not declared in `params:`, so tuning
+        # it doesn't force a re-run. Same convention as compute_scores.
+        batch_size = get_model_batch_size(wildcards.model)
+
+        # LOCAL read (storage staged it) — never pd.read_parquet("s3://…") here.
+        sites = pd.read_parquet(input.neutral)
+        table = compute_llr_neutral_mean(
+            checkpoint_path=input.checkpoint,
+            sites=sites,
+            # S3 URI; pyfaidx reads by byte-range lazily inside each worker.
+            genome_path=config["genome_path"],
+            window_size=params.window_size,
+            subsample_n=int(wildcards.n),
+            min_bin_count=params.min_bin_count,
+            batch_size=batch_size,
+            num_workers=config["inference"]["num_workers"],
+            rc=params.rc,
+            data_transform_on_the_fly=config["inference"]["data_transform_on_the_fly"],
+            torch_compile=config["inference"]["torch_compile"],
+        )
+        table.to_parquet(output[0], index=False)
+        print(
+            f"[evals_v2] calibration {wildcards.model} n={wildcards.n}: "
+            f"{len(table)} cells -> {output[0]}"
+        )
+
+
+rule calibration:
+    """Aggregate convenience target: the llr_neutral_mean table for every
+    configured calibration model. Not part of `rule all`."""
+    input:
+        [
+            f"results/calibration/{model}/llr_neutral_mean_n{config['calibration']['subsample_n']}.parquet"
+            for model in CALIBRATION_MODELS
+        ],

--- a/snakemake/analysis/evals_v2/workflow/rules/calibration.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/calibration.smk
@@ -1,12 +1,15 @@
 """cLLR mutation-rate calibration tables (stage 3, #267/#270).
 
-Score the pinned, subsampled neutral-site set (built by ``snakemake/neutral_sites``)
-with the fast 2-forward LLR bundle (FWD+RC) and bin by ``pentanuc_mut`` into a
-per-checkpoint ``llr_neutral_mean`` table that stage 4 (#271) subtracts to
-calibrate variant LLRs. Entropy calibration is a separate, deferred path.
+Score the pinned, **pre-filtered + subsampled** neutral-site set (built once by
+``snakemake/neutral_sites``: ACGT-window-filtered, then ``n`` sites per 5-mer) with
+the fast 2-forward LLR bundle (FWD+RC) and bin by ``pentanuc_mut`` into a
+per-checkpoint ``llr_neutral_mean`` table that stage 4 (#271) subtracts to calibrate
+variant LLRs. Entropy calibration is a separate, deferred path.
 
-GPU-bound — runs on the same SkyPilot GPU node as ``compute_scores``. Kept OFF
-``rule all`` (a few-models analysis, like ``nuc_dep`` / ``umap``); build by name:
+The N-window filtering is model-independent and lives upstream (one set per window,
+reused by every model), so this GPU rule never touches the genome for filtering — it
+just reads the clean set and scores. Kept OFF ``rule all`` (a few-models analysis,
+like ``nuc_dep`` / ``umap``); build by name:
 
     snakemake calibration                    # every configured calibration model
     snakemake results/calibration/<model>/llr_neutral_mean_n100.parquet
@@ -16,15 +19,15 @@ GPU-bound — runs on the same SkyPilot GPU node as ``compute_scores``. Kept OFF
 rule compute_llr_neutral_mean:
     input:
         checkpoint="results/checkpoints/{model}",
-        # The neutral set lives in another pipeline's S3 prefix. `storage()` uses
-        # the boto3-backed s3 plugin (no s3fs async loop), so it stages to a LOCAL
-        # path that `pd.read_parquet` reads *without* initializing s3fs in this
-        # parent process — which would otherwise deadlock the forked DataLoader
-        # workers that read the genome lazily in-worker (see issue #270 /
-        # `compute_variant_scores`). The `{n}` wildcard ties the input cap to the
-        # output name so several caps can coexist.
+        # Pre-filtered (ACGT-window, at `scoreable_window`) + subsampled neutral set
+        # from the neutral_sites pipeline — built once per window and reused by every
+        # model, so this rule does no genome filtering. `storage()` (boto3, no s3fs
+        # async loop) stages it to a LOCAL path, so `pd.read_parquet` never inits s3fs
+        # in this process — which would deadlock the DataLoader workers that read the
+        # genome lazily in-worker (issue #270 / `compute_variant_scores`).
         neutral=lambda wc: storage(
-            f"{config['calibration']['neutral_sites_s3_prefix']}/neutral_sites_n{wc.n}.parquet"
+            f"{config['calibration']['neutral_sites_s3_prefix']}/"
+            f"neutral_sites_n{wc.n}_w{config['calibration']['scoreable_window']}.parquet"
         ),
     output:
         "results/calibration/{model}/llr_neutral_mean_n{n}.parquet",
@@ -37,33 +40,24 @@ rule compute_llr_neutral_mean:
         # FWD+RC to match the eval; falls back to the global inference default.
         rc=config["calibration"].get("rc", config["inference"]["rc"]),
         min_bin_count=config["calibration"]["min_bin_count"],
+        scoreable_window=config["calibration"]["scoreable_window"],
     threads: config["inference"]["num_workers"]
     run:
         # batch_size is execution-only (numerics are batch-size-invariant modulo
         # float-reduction noise) — read here, not declared in `params:`, so tuning
         # it doesn't force a re-run. Same convention as compute_scores.
-        import shlex
-
         batch_size = get_model_batch_size(wildcards.model)
 
-        # Drop neutral sites whose model-window contains a non-ACGT base (assembly-gap
-        # N near telomeres/centromeres): the scoring kernel asserts ACGT on the
-        # downstream window, so an N trips a CUDA device-side assert. FWD checks the
-        # right flank and RC the left, so the *whole* window must be clean. This MUST
-        # run in a CHILD process — it reads the genome (initializing s3fs), and doing
-        # that here would deadlock the DataLoader workers compute_variant_scores forks
-        # below. The child writes the filtered sites to a local parquet.
-        filtered = output[0] + ".acgt_sites.parquet"
-        shell(
-            "python -m marin_dna.pipelines.evals.calibration "
-            f"--sites {shlex.quote(str(input.neutral))} "
-            f"--genome {shlex.quote(str(config['genome_path']))} "
-            f"--window {int(params.window_size)} "
-            f"--out {shlex.quote(filtered)}"
+        # The pinned neutral set is ACGT-clean for windows up to `scoreable_window`;
+        # a model with a wider window could see an N the kernel rejects. Fail fast.
+        assert params.scoreable_window >= params.window_size, (
+            f"scoreable_window {params.scoreable_window} < model window_size "
+            f"{params.window_size}: neutral set not guaranteed scoreable — "
+            f"build a wider-window neutral_sites_n{wildcards.n}_w… set"
         )
 
-        # LOCAL read — never pd.read_parquet("s3://…") in this (forking) process.
-        sites = pd.read_parquet(filtered)
+        # LOCAL read (storage staged it); the set is already filtered + subsampled.
+        sites = pd.read_parquet(input.neutral)
         table = compute_llr_neutral_mean(
             checkpoint_path=input.checkpoint,
             sites=sites,

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from datasets import load_dataset
 
+from marin_dna.pipelines.evals.calibration import compute_llr_neutral_mean
 from marin_dna.pipelines.evals.conservation import (
     QTL_VARIANT_COLUMNS,
     REQUIRED_VARIANT_COLUMNS,
@@ -169,3 +170,14 @@ for _m in UMAP_MODELS:
     assert _ws >= _nc, (
         f"umap_embeddings model {_m!r} window_size {_ws} < n_center_bp {_nc}"
     )
+
+
+# --- cLLR calibration tables (mutation-rate calibration, #267/#270) ----------
+# Optional `calibration:` config section; targets kept off `rule all`
+# (see rules/calibration.smk). Reuses the `models:` registry.
+CALIBRATION_CFG = config.get("calibration", {})
+CALIBRATION_MODELS = CALIBRATION_CFG.get("models", [])
+
+# Fail fast: every calibration model is a known checkpoint.
+for _m in CALIBRATION_MODELS:
+    assert _m in MODELS, f"calibration model {_m!r} not found in `models`"

--- a/snakemake/neutral_sites/README.md
+++ b/snakemake/neutral_sites/README.md
@@ -49,20 +49,31 @@ Replicates GPN-Star's hg38 calibration inputs exactly
 Pin destination (uploaded at the end of a run; consumed by `evals_v2`):
 `s3://oa-bolinas/snakemake/neutral_sites/results/neutral_sites.parquet`.
 
-## Calibration subsampling (#267 / #270)
+## Calibration set (#267 / #270)
 
 For mutation-rate calibration every neutral site is scored against its 3 non-ref
-alts and binned by pentanucleotide. Two **additive** rules (downstream of the
-pinned `neutral_sites.parquet`, which is left untouched) prepare a reduced set so
-the per-checkpoint scoring in `evals_v2` need not cover all 5.94M × 3 ≈ 18M
-variants:
+alts and binned by pentanucleotide. Three **additive** rules (downstream of the
+pinned `neutral_sites.parquet`, which is left untouched) build the
+calibration-ready set so the per-checkpoint scoring in `evals_v2` need not cover
+all 5.94M × 3 ≈ 18M variants — and, crucially, so the genome-dependent work runs
+**once here**, not per checkpoint:
 
-- `annotate_pentanuc` → `results/neutral_sites_pentanuc.parquet`
-  `[chrom, pos, ref, pentanuc]` — the central 5-mer (window `[pos-2, pos+2]`,
-  variant-centered) read from the genome; model-independent.
-- `subsample_neutral` → `results/subsampled/neutral_sites_n{n}.parquet` — at most
-  `n` sites **per 5-mer**, seeded by `subsample_seed`. `n` is a path wildcard so
-  several caps coexist and `evals_v2` pins one by revision.
+1. `annotate_pentanuc` → `results/neutral_sites_pentanuc.parquet`
+   `[chrom, pos, ref, pentanuc]` — the central 5-mer (window `[pos-2, pos+2]`,
+   variant-centered).
+2. `filter_scoreable` → `results/scoreable/neutral_sites_pentanuc_w{w}.parquet` —
+   drop any site whose centered **`w`-bp** window isn't all-ACGT (an `N` from an
+   assembly gap, or a window running off the chromosome). The gLM scoring kernel
+   asserts ACGT over the variant's window, and FWD scores the right flank while RC
+   scores the left, so a site must have its *whole* window clean to be scoreable on
+   both strands. `w` is a path wildcard — use the **largest** model window (512), so
+   one filtered set is valid for every model (a 512-clean window is 255/256-clean).
+3. `subsample_neutral` → `results/subsampled/neutral_sites_n{n}_w{w}.parquet` — at
+   most `n` **scoreable** sites per 5-mer, seeded by `subsample_seed`. `n` and `w`
+   are path wildcards so caps/windows coexist; `evals_v2` pins one by revision.
+
+Filtering runs **before** subsampling, so each 5-mer keeps a full `n` of *clean*
+sites (not `n` minus whatever the filter would later remove).
 
 **The subsample unit is sites per 5-mer, not per `(5-mer, alt)` bin.** A site's
 three alt-bins share its sites, so `n` sites/5-mer yield `n` observations in
@@ -73,9 +84,22 @@ SE ≈ 0.03; `n = 100` is the cheap floor (SE ≈ 0.10). The set is kept site-le
 alt-agnostic so the LLR path (3 alts) and the entropy atom (#269, 4-allele
 marginal) consume one artifact.
 
+The genome is read **genome-wide** here (one whole-chromosome span per rule), where
+pyfaidx on the bgzipped reference is pathologically slow — so `stage_genome_fasta`
+downloads an **uncompressed** FASTA (`genome_fasta_path`, kept in S3 next to the
+`.gz`) and mmaps it. Build that uncompressed reference once (idempotent; skipped if
+present):
+
+```bash
+zcat Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz > …fa
+python -c "import pyfaidx; pyfaidx.Faidx('…fa')"   # builds …fa.fai
+aws s3 cp …fa  s3://…/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa
+aws s3 cp …fa.fai s3://…/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.fai
+```
+
 Pin destination (consumed by `evals_v2`'s `compute_llr_neutral_mean` rule —
 [`snakemake/analysis/evals_v2`](../analysis/evals_v2/), `snakemake calibration`):
-`s3://oa-bolinas/snakemake/neutral_sites/results/subsampled/neutral_sites_n{n}.parquet`.
+`s3://oa-bolinas/snakemake/neutral_sites/results/subsampled/neutral_sites_n{n}_w{w}.parquet`.
 
 ## Where to run
 
@@ -110,10 +134,12 @@ uv run --group genome-s3 snakemake
 aws s3 cp results/neutral_sites.parquet \
   s3://oa-bolinas/snakemake/neutral_sites/results/neutral_sites.parquet
 
-# Build + pin a subsampled set (cap = n sites per 5-mer; n is a path wildcard).
-uv run --group genome-s3 snakemake results/subsampled/neutral_sites_n100.parquet
-aws s3 cp results/subsampled/neutral_sites_n100.parquet \
-  s3://oa-bolinas/snakemake/neutral_sites/results/subsampled/neutral_sites_n100.parquet
+# Build + pin the calibration-ready set (n sites/5-mer, ACGT-clean for a w-bp
+# window; n and w are path wildcards). Needs the uncompressed reference in S3 (see
+# "Calibration set" above).
+uv run --group genome-s3 snakemake results/subsampled/neutral_sites_n100_w512.parquet
+aws s3 cp results/subsampled/neutral_sites_n100_w512.parquet \
+  s3://oa-bolinas/snakemake/neutral_sites/results/subsampled/neutral_sites_n100_w512.parquet
 ```
 
 ### On SkyPilot (the intended path)
@@ -135,6 +161,9 @@ Rules are thin glue around `marin_dna.pipelines.neutral_sites.sites`:
 - `enumerate_positions` — neutral intervals → per-base `(chrom, pos, ref)`.
 - `annotate_pentanucleotide` — neutral sites → `+ pentanuc` (central 5-mer; one
   read per chromosome, asserts 5-mer center == `ref`).
+- `filter_acgt_window_sites` — drop sites whose centered `window_size` window isn't
+  all-ACGT (so the gLM scoring kernel, which asserts ACGT over the window, never
+  trips on an assembly-gap `N`); one read per chromosome.
 - `subsample_per_context` — keep at most `n` sites per 5-mer, seeded + deterministic.
 
 Tests: [`tests/pipelines/neutral_sites/test_sites.py`](../../tests/pipelines/neutral_sites/test_sites.py).

--- a/snakemake/neutral_sites/README.md
+++ b/snakemake/neutral_sites/README.md
@@ -73,7 +73,8 @@ SE ≈ 0.03; `n = 100` is the cheap floor (SE ≈ 0.10). The set is kept site-le
 alt-agnostic so the LLR path (3 alts) and the entropy atom (#269, 4-allele
 marginal) consume one artifact.
 
-Pin destination (consumed by `evals_v2`):
+Pin destination (consumed by `evals_v2`'s `compute_llr_neutral_mean` rule —
+[`snakemake/analysis/evals_v2`](../analysis/evals_v2/), `snakemake calibration`):
 `s3://oa-bolinas/snakemake/neutral_sites/results/subsampled/neutral_sites_n{n}.parquet`.
 
 ## Where to run

--- a/snakemake/neutral_sites/config/config.yaml
+++ b/snakemake/neutral_sites/config/config.yaml
@@ -6,6 +6,13 @@
 # The S3 path requires `--group genome-s3` at install (pyfaidx + s3fs).
 genome_path: s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz
 
+# Plain (uncompressed) FASTA + .fai, kept in S3 next to the bgzipped reference.
+# The pentanuc / scoreable-window rules read the genome **genome-wide** (one whole-
+# chromosome span each), where pyfaidx on the bgzipped file is pathologically slow;
+# `stage_genome_fasta` downloads this plain file once and mmaps it instead. Produced
+# once with `zcat …fa.gz > …fa && python -c "import pyfaidx; pyfaidx.Faidx('…fa')"`.
+genome_fasta_path: s3://oa-bolinas/data/genomes/homo_sapiens/GRCh38/ensembl-release-115/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa
+
 # Source files — exactly what GPN-Star used for the hg38 calibration
 # (songlab-cal/gpn analysis/gpn-star/.../Snakefile_hg38 CALIBRATION_CONFIGS),
 # via UCSC https mirrors of GPN's ftp URLs (byte-identical files).

--- a/snakemake/neutral_sites/config/config.yaml
+++ b/snakemake/neutral_sites/config/config.yaml
@@ -38,8 +38,8 @@ chroms: ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16",
 # bigWig scan granularity (bases per pyBigWig read).
 window_size: 1000000
 
-# Seed for the per-5-mer subsampling (rules/subsample.smk). The sampled cap `n`
-# is a path wildcard (`neutral_sites_n{n}.parquet`); this seed fixes which sites
-# are drawn so the subsampled set is reproducible across runs and shared by every
-# checkpoint's calibration.
+# Seed for the per-5-mer subsampling (rules/subsample.smk). The cap `n` and the
+# scoreable window `w` are path wildcards (`neutral_sites_n{n}_w{w}.parquet`); this
+# seed fixes which sites are drawn so the subsampled set is reproducible across runs
+# and shared by every checkpoint's calibration.
 subsample_seed: 270

--- a/snakemake/neutral_sites/workflow/Snakefile
+++ b/snakemake/neutral_sites/workflow/Snakefile
@@ -9,10 +9,11 @@ include: "rules/neutral.smk"
 include: "rules/subsample.smk"
 
 
-# Default target is the full neutral set. The pentanucleotide-annotated and
-# per-5-mer-subsampled artifacts (rules/subsample.smk) are requested explicitly
-# by path, e.g. `snakemake results/subsampled/neutral_sites_n100.parquet`, since
-# the cap `n` is a deliberate choice (see README) — not built by `all`.
+# Default target is the full neutral set. The pentanucleotide-annotated,
+# ACGT-window-filtered, and per-5-mer-subsampled artifacts (rules/subsample.smk)
+# are requested explicitly by path, e.g.
+# `snakemake results/subsampled/neutral_sites_n100_w512.parquet`, since the cap
+# `n` and window `w` are deliberate choices (see README) — not built by `all`.
 rule all:
     input:
         "results/neutral_sites.parquet",

--- a/snakemake/neutral_sites/workflow/rules/common.smk
+++ b/snakemake/neutral_sites/workflow/rules/common.smk
@@ -5,6 +5,7 @@ from marin_dna.pipelines.evals.conservation import CONSERVATION_TRACKS
 from marin_dna.pipelines.neutral_sites.sites import (
     annotate_pentanucleotide,
     enumerate_positions,
+    filter_acgt_window_sites,
     parse_rmsk,
     scan_neutral_intervals,
     subsample_per_context,

--- a/snakemake/neutral_sites/workflow/rules/subsample.smk
+++ b/snakemake/neutral_sites/workflow/rules/subsample.smk
@@ -1,27 +1,50 @@
-"""Pentanucleotide annotation + per-5-mer subsampling for cLLR calibration (#267/#270).
+"""Pentanucleotide annotation, ACGT-window filtering, and per-5-mer subsampling
+for cLLR calibration (#267/#270).
 
-Both steps are model-independent (pure functions of genome + position + seed), so
-they live here rather than in the GPU eval pipeline. The subsampled artifact is
-pinned + seeded → every checkpoint calibrates on the same neutral sites, and it is
-kept site-level / alt-agnostic so the LLR path (3 alts) and the entropy atom
-(#269, 4-allele marginal) consume one set.
+All three steps are model-independent (pure functions of genome + position +
+window + seed), so the calibration-ready set is built and pinned **here**, once,
+and reused by every checkpoint in the GPU eval pipeline (evals_v2) — never
+re-filtered per model. The artifact is seeded + kept site-level / alt-agnostic so
+the LLR path (3 alts) and the entropy atom (#269, 4-allele marginal) consume one set.
+
+Order matters: filter to scoreable sites **before** subsampling, so each 5-mer's
+``n`` sites are drawn from its *clean* sites (a full ``n`` per cell, not ``n`` minus
+whatever the filter later removes).
+
+Genome reads go through a plain (uncompressed) FASTA (`stage_genome_fasta`):
+pyfaidx random access on the bgzipped reference is pathologically slow for the
+genome-wide spans these rules touch (one whole-chromosome read each), so we mmap a
+plain file instead. The plain FASTA + its `.fai` are kept in S3 next to the
+bgzipped reference (`genome_fasta_path`) so this is a one-time *download*, never a
+re-decompress.
 """
+
+
+rule stage_genome_fasta:
+    """Download the plain (uncompressed) reference FASTA + .fai from S3 for fast,
+    genome-wide pyfaidx access (mmap). The uncompressed reference lives in S3 next
+    to the bgzipped one precisely so this is a download, not a per-run `zcat`.
+    Local-only scratch (`temp`): the ~3 GB file is removed once its consumers finish."""
+    output:
+        temp("results/genome.fa"),
+    shell:
+        "aws s3 cp {config[genome_fasta_path]} {output} && "
+        "aws s3 cp {config[genome_fasta_path]}.fai {output}.fai"
 
 
 rule annotate_pentanuc:
     """Attach each neutral site's central pentanucleotide (5-mer) from the genome.
 
-Additive (consumes the pinned neutral set, leaves it untouched); the genome is
-already wired into this pipeline, so context extraction belongs here."""
+Additive (consumes the pinned neutral set, leaves it untouched); reads the plain
+FASTA once per chromosome and asserts the 5-mer center == ref."""
     input:
-        "results/neutral_sites.parquet",
+        sites="results/neutral_sites.parquet",
+        genome="results/genome.fa",
     output:
         "results/neutral_sites_pentanuc.parquet",
     run:
-        sites = pd.read_parquet(input[0])
-        # Genome is the get_seq callable (same as enumerate_positions); reads
-        # once per chromosome and asserts the 5-mer center == ref.
-        out = annotate_pentanucleotide(sites, Genome(config["genome_path"]))
+        sites = pd.read_parquet(input.sites)
+        out = annotate_pentanucleotide(sites, Genome(input.genome))
         assert len(out) > 0, "empty pentanuc-annotated neutral set"
         out.to_parquet(output[0], index=False)
         print(
@@ -30,17 +53,45 @@ already wired into this pipeline, so context extraction belongs here."""
         )
 
 
-rule subsample_neutral:
-    """Subsample to at most {n} neutral sites per 5-mer (seeded, deterministic).
+rule filter_scoreable:
+    """Drop sites whose centered {w}-bp model window isn't all-ACGT (assembly-gap N
+    or off-chromosome edge).
 
-`n` is a path wildcard so several caps coexist (e.g. n100, n1000) and evals_v2
-pins one by revision — see README."""
+The gLM scoring kernel asserts ACGT over the variant's window, so an N trips it;
+filtering here (once) lets every checkpoint reuse one scoreable set. `w` is a path
+wildcard — use the largest model window (512) so the set is valid for all models (a
+window clean at 512 bp is clean at 255/256). Runs before `subsample_neutral`."""
     input:
-        "results/neutral_sites_pentanuc.parquet",
+        sites="results/neutral_sites_pentanuc.parquet",
+        genome="results/genome.fa",
     output:
-        "results/subsampled/neutral_sites_n{n}.parquet",
+        "results/scoreable/neutral_sites_pentanuc_w{w}.parquet",
+    wildcard_constraints:
+        w=r"\d+",
+    run:
+        sites = pd.read_parquet(input.sites)
+        out = filter_acgt_window_sites(sites, Genome(input.genome), int(wildcards.w))
+        assert len(out) > 0, "every site filtered out — wrong window/genome?"
+        out.to_parquet(output[0], index=False)
+        print(
+            f"[filter_scoreable] w={wildcards.w}: {len(out):,} scoreable sites "
+            f"({out['pentanuc'].nunique()} distinct 5-mers) -> {output[0]}"
+        )
+
+
+rule subsample_neutral:
+    """Subsample to at most {n} scoreable sites per 5-mer (seeded, deterministic),
+    from the window-{w} ACGT-filtered set.
+
+`n` and `w` are path wildcards so several caps / windows coexist; evals_v2 pins one
+(by `subsample_n` + `scoreable_window`) — see README."""
+    input:
+        "results/scoreable/neutral_sites_pentanuc_w{w}.parquet",
+    output:
+        "results/subsampled/neutral_sites_n{n}_w{w}.parquet",
     wildcard_constraints:
         n=r"\d+",
+        w=r"\d+",
     run:
         sites = pd.read_parquet(input[0])
         n_cap = int(wildcards.n)
@@ -49,8 +100,8 @@ pins one by revision — see README."""
         n_depleted = int((per < n_cap).sum())  # 5-mers with fewer than n sites
         out.to_parquet(output[0], index=False)
         print(
-            f"[subsample_neutral] n={n_cap} seed={config['subsample_seed']}: "
-            f"{len(out):,} sites across {len(per)} 5-mers "
-            f"(<= {per.max()} per 5-mer; {n_depleted} 5-mers below the cap, "
+            f"[subsample_neutral] n={n_cap} w={wildcards.w} "
+            f"seed={config['subsample_seed']}: {len(out):,} sites across {len(per)} "
+            f"5-mers (<= {per.max()} per 5-mer; {n_depleted} 5-mers below the cap, "
             f"min {per.min()}) -> {output[0]}"
         )

--- a/snakemake/neutral_sites/workflow/rules/subsample.smk
+++ b/snakemake/neutral_sites/workflow/rules/subsample.smk
@@ -21,15 +21,18 @@ re-decompress.
 
 
 rule stage_genome_fasta:
-    """Download the plain (uncompressed) reference FASTA + .fai from S3 for fast,
+    """Download the plain (uncompressed) reference FASTA from S3 for fast,
     genome-wide pyfaidx access (mmap). The uncompressed reference lives in S3 next
     to the bgzipped one precisely so this is a download, not a per-run `zcat`.
+    The `.fai` is **built locally** by the first ``Genome(...)`` open (a few seconds
+    for a standard fixed-width FASTA) rather than fetched as a separate S3 object —
+    so the index is always consistent with this exact file (no stale/partial-`.fai`
+    → wrong-byte-offset risk) and there's no untracked sidecar for `temp` to leak.
     Local-only scratch (`temp`): the ~3 GB file is removed once its consumers finish."""
     output:
         temp("results/genome.fa"),
     shell:
-        "aws s3 cp {config[genome_fasta_path]} {output} && "
-        "aws s3 cp {config[genome_fasta_path]}.fai {output}.fai"
+        "aws s3 cp {config[genome_fasta_path]} {output}"
 
 
 rule annotate_pentanuc:

--- a/src/marin_dna/pipelines/evals/calibration.py
+++ b/src/marin_dna/pipelines/evals/calibration.py
@@ -24,8 +24,10 @@ boundary), as produced by ``enumerate_positions``.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from marin_dna.data.dna import NUCLEOTIDES
@@ -227,3 +229,122 @@ def compute_llr_neutral_mean(
     return aggregate_llr_neutral_mean(
         scored, min_bin_count=min_bin_count, subsample_n=subsample_n
     )
+
+
+def filter_acgt_window_sites(
+    sites: pd.DataFrame,
+    get_seq: Callable[[str, int, int], str],
+    window_size: int,
+) -> pd.DataFrame:
+    """Drop neutral sites whose ``window_size`` model context contains a non-ACGT base.
+
+    The scoring kernel gathers the LLR over the **downstream** window positions and
+    asserts every target is one of A/C/G/T (``_token_id_to_nuc_idx``); an ``N`` from
+    an assembly gap near a telomere/centromere trips it (a CUDA device-side assert
+    under ``torch.compile``). Crucially the eval never hits this — its variants are
+    gene-centric — but genome-wide neutral sites do, and because FWD checks only the
+    right flank while RC checks the left, a site needs its **whole** window clean to
+    score on both strands. So keep only sites whose centered ``window_size`` window
+    (the same interval ``_get_variant_window`` extracts: ``[pos-1-window_size//2,
+    …+window_size)``, 0-based) is entirely ACGT. Sites whose window runs off the
+    chromosome (``N``-padded) are dropped too — they can't be scored anyway.
+
+    Reads the reference **once per chromosome** (over the span covering every site's
+    window), like :func:`annotate_pentanucleotide` — a per-site read against an
+    ``s3://`` genome would be millions of round-trips. **Must be called in a process
+    that will not subsequently fork DataLoader workers** (reading an ``s3://`` genome
+    here initializes s3fs, which deadlocks forked workers); the calibration rule runs
+    it in a separate subprocess for exactly this reason.
+
+    Args:
+        sites: ``[chrom, pos, ref, pentanuc, …]`` — bare ``chrom``, 1-based ``pos``.
+        get_seq: ``(chrom, start, end) -> str`` over the reference (0-based half-open,
+            bare chrom names; N-padded past chromosome ends). E.g. a ``Genome``.
+        window_size: the model's DNA context window.
+
+    Returns:
+        The subset of ``sites`` (all columns, order preserved) whose full window is
+        ACGT. Every kept window is all-ACGT by construction.
+    """
+    for col in ("chrom", "pos"):
+        assert col in sites.columns, f"sites missing column {col!r}"
+    assert window_size > 0, f"window_size must be positive, got {window_size}"
+    left_flank = window_size // 2  # matches _get_variant_window / in_seq_var_pos("+")
+
+    sites = sites.reset_index(drop=True)
+    keep = np.zeros(len(sites), dtype=bool)
+    acgt = np.frombuffer(b"ACGT", dtype=np.uint8)
+    for chrom, sub in sites.groupby("chrom", sort=False):
+        center0 = sub["pos"].to_numpy() - 1  # 1-based -> 0-based
+        win_start = center0 - left_flank
+        win_end = win_start + window_size
+        read_lo = max(0, int(win_start.min()))  # clamp; off-start sites dropped below
+        hi = int(win_end.max())
+        span = get_seq(str(chrom), read_lo, hi).upper()
+        arr = np.frombuffer(span.encode("ascii"), dtype=np.uint8)
+        assert arr.size == hi - read_lo, (
+            f"reference returned {arr.size} bp for {chrom}:{read_lo}-{hi} "
+            f"(expected {hi - read_lo})"
+        )
+        # Prefix sum of non-ACGT counts → a window is clean iff its count is 0.
+        bad = ~np.isin(arr, acgt)
+        csum = np.concatenate([[0], np.cumsum(bad)])
+        s_idx = win_start - read_lo
+        e_idx = win_end - read_lo
+        in_bounds = (win_start >= 0) & (win_end <= read_lo + arr.size)
+        s_clip = np.clip(s_idx, 0, arr.size)
+        e_clip = np.clip(e_idx, 0, arr.size)
+        n_bad = csum[e_clip] - csum[s_clip]
+        keep[sub.index.to_numpy()] = in_bounds & (n_bad == 0)
+
+    out = sites.loc[keep].reset_index(drop=True)
+    n_drop = len(sites) - len(out)
+    msg = (
+        f"[filter_acgt_window] window={window_size}: kept {len(out):,}/{len(sites):,} "
+        f"({n_drop} dropped for non-ACGT or off-chromosome windows)"
+    )
+    # If 5-mer context is present, report the post-filter per-5-mer minimum — this
+    # equals the per-calibration-cell observation count (each 5-mer's 3 alt-cells
+    # share its sites), so it previews whether any cell will fall below the
+    # downstream min_bin_count *before* the expensive scoring runs.
+    if "pentanuc" in out.columns and len(out):
+        per = out.groupby("pentanuc").size()
+        msg += f"; per-5-mer count min={int(per.min())} (n 5-mers={len(per)})"
+    print(msg)
+    return out
+
+
+def _filter_cli() -> None:
+    """Subprocess entry: filter a neutral parquet by ACGT window, write a new parquet.
+
+    Run in its own process by the ``compute_llr_neutral_mean`` rule so the genome's
+    s3fs initialization never touches the scoring process that forks DataLoader
+    workers. Reads ``--sites`` locally, opens ``--genome`` (S3 ok — this process
+    won't fork), and writes the filtered sites to ``--out``.
+    """
+    import argparse
+
+    from marin_dna.data.genome import Genome
+
+    parser = argparse.ArgumentParser(description=filter_acgt_window_sites.__doc__)
+    parser.add_argument(
+        "--sites", required=True, help="input neutral-sites parquet (local)"
+    )
+    parser.add_argument(
+        "--genome", required=True, help="reference FASTA (local or s3:// URI)"
+    )
+    parser.add_argument("--window", type=int, required=True, help="model window_size")
+    parser.add_argument("--out", required=True, help="output filtered parquet (local)")
+    args = parser.parse_args()
+
+    sites = pd.read_parquet(args.sites)
+    filtered = filter_acgt_window_sites(sites, Genome(args.genome), args.window)
+    assert len(filtered) > 0, (
+        "every neutral site was filtered out — wrong window/genome?"
+    )
+    filtered.to_parquet(args.out, index=False)
+    print(f"[filter_acgt_window] wrote {len(filtered):,} sites -> {args.out}")
+
+
+if __name__ == "__main__":
+    _filter_cli()

--- a/src/marin_dna/pipelines/evals/calibration.py
+++ b/src/marin_dna/pipelines/evals/calibration.py
@@ -5,12 +5,19 @@ variant LLRs against the local background mutation rate::
 
     calibrated LLR = LLR − llr_neutral_mean(pentanuc_mut)
 
-The pipeline scores a pinned, subsampled neutral-site set (``snakemake/neutral_sites``
-→ ``neutral_sites_n{n}.parquet``, columns ``[chrom, pos, ref, pentanuc]``) with the
-**fast 2-forward LLR bundle** (:func:`marin_dna.pipelines.evals.inference.compute_variant_scores`,
-FWD+RC), then bins by ``pentanuc_mut = pentanuc + "_" + alt``. Each neutral site is
-scored against its 3 non-ref alts, so a 5-mer's three calibration cells draw from
-the same sites.
+The pipeline scores a pinned, **scoreable** subsampled neutral-site set
+(``snakemake/neutral_sites`` → ``neutral_sites_n{n}_w{w}.parquet``, columns
+``[chrom, pos, ref, pentanuc]``) with the **fast 2-forward LLR bundle**
+(:func:`marin_dna.pipelines.evals.inference.compute_variant_scores`, FWD+RC), then
+bins by ``pentanuc_mut = pentanuc + "_" + alt``. Each neutral site is scored against
+its 3 non-ref alts, so a 5-mer's three calibration cells draw from the same sites.
+
+The neutral set is pre-filtered upstream (``filter_acgt_window_sites`` at window
+``w``) so every site's ``w``-bp window is all-ACGT — the scoring kernel asserts ACGT
+on the window, and genome-wide neutral sites near assembly gaps otherwise trip it.
+That filtering is model-independent (one set per window, ``w`` = the largest model
+window) and lives in the neutral-sites pipeline, so this GPU step never reads the
+genome for filtering and just consumes the clean set.
 
 Entropy calibration (``entropy_neutral_mean``, via the 4-forward marginal atom
 :func:`marin_dna.model.scoring.compute_marginal_clm`) is a **separate, deferred**
@@ -24,10 +31,8 @@ boundary), as produced by ``enumerate_positions``.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 
 from marin_dna.data.dna import NUCLEOTIDES
@@ -229,122 +234,3 @@ def compute_llr_neutral_mean(
     return aggregate_llr_neutral_mean(
         scored, min_bin_count=min_bin_count, subsample_n=subsample_n
     )
-
-
-def filter_acgt_window_sites(
-    sites: pd.DataFrame,
-    get_seq: Callable[[str, int, int], str],
-    window_size: int,
-) -> pd.DataFrame:
-    """Drop neutral sites whose ``window_size`` model context contains a non-ACGT base.
-
-    The scoring kernel gathers the LLR over the **downstream** window positions and
-    asserts every target is one of A/C/G/T (``_token_id_to_nuc_idx``); an ``N`` from
-    an assembly gap near a telomere/centromere trips it (a CUDA device-side assert
-    under ``torch.compile``). Crucially the eval never hits this — its variants are
-    gene-centric — but genome-wide neutral sites do, and because FWD checks only the
-    right flank while RC checks the left, a site needs its **whole** window clean to
-    score on both strands. So keep only sites whose centered ``window_size`` window
-    (the same interval ``_get_variant_window`` extracts: ``[pos-1-window_size//2,
-    …+window_size)``, 0-based) is entirely ACGT. Sites whose window runs off the
-    chromosome (``N``-padded) are dropped too — they can't be scored anyway.
-
-    Reads the reference **once per chromosome** (over the span covering every site's
-    window), like :func:`annotate_pentanucleotide` — a per-site read against an
-    ``s3://`` genome would be millions of round-trips. **Must be called in a process
-    that will not subsequently fork DataLoader workers** (reading an ``s3://`` genome
-    here initializes s3fs, which deadlocks forked workers); the calibration rule runs
-    it in a separate subprocess for exactly this reason.
-
-    Args:
-        sites: ``[chrom, pos, ref, pentanuc, …]`` — bare ``chrom``, 1-based ``pos``.
-        get_seq: ``(chrom, start, end) -> str`` over the reference (0-based half-open,
-            bare chrom names; N-padded past chromosome ends). E.g. a ``Genome``.
-        window_size: the model's DNA context window.
-
-    Returns:
-        The subset of ``sites`` (all columns, order preserved) whose full window is
-        ACGT. Every kept window is all-ACGT by construction.
-    """
-    for col in ("chrom", "pos"):
-        assert col in sites.columns, f"sites missing column {col!r}"
-    assert window_size > 0, f"window_size must be positive, got {window_size}"
-    left_flank = window_size // 2  # matches _get_variant_window / in_seq_var_pos("+")
-
-    sites = sites.reset_index(drop=True)
-    keep = np.zeros(len(sites), dtype=bool)
-    acgt = np.frombuffer(b"ACGT", dtype=np.uint8)
-    for chrom, sub in sites.groupby("chrom", sort=False):
-        center0 = sub["pos"].to_numpy() - 1  # 1-based -> 0-based
-        win_start = center0 - left_flank
-        win_end = win_start + window_size
-        read_lo = max(0, int(win_start.min()))  # clamp; off-start sites dropped below
-        hi = int(win_end.max())
-        span = get_seq(str(chrom), read_lo, hi).upper()
-        arr = np.frombuffer(span.encode("ascii"), dtype=np.uint8)
-        assert arr.size == hi - read_lo, (
-            f"reference returned {arr.size} bp for {chrom}:{read_lo}-{hi} "
-            f"(expected {hi - read_lo})"
-        )
-        # Prefix sum of non-ACGT counts → a window is clean iff its count is 0.
-        bad = ~np.isin(arr, acgt)
-        csum = np.concatenate([[0], np.cumsum(bad)])
-        s_idx = win_start - read_lo
-        e_idx = win_end - read_lo
-        in_bounds = (win_start >= 0) & (win_end <= read_lo + arr.size)
-        s_clip = np.clip(s_idx, 0, arr.size)
-        e_clip = np.clip(e_idx, 0, arr.size)
-        n_bad = csum[e_clip] - csum[s_clip]
-        keep[sub.index.to_numpy()] = in_bounds & (n_bad == 0)
-
-    out = sites.loc[keep].reset_index(drop=True)
-    n_drop = len(sites) - len(out)
-    msg = (
-        f"[filter_acgt_window] window={window_size}: kept {len(out):,}/{len(sites):,} "
-        f"({n_drop} dropped for non-ACGT or off-chromosome windows)"
-    )
-    # If 5-mer context is present, report the post-filter per-5-mer minimum — this
-    # equals the per-calibration-cell observation count (each 5-mer's 3 alt-cells
-    # share its sites), so it previews whether any cell will fall below the
-    # downstream min_bin_count *before* the expensive scoring runs.
-    if "pentanuc" in out.columns and len(out):
-        per = out.groupby("pentanuc").size()
-        msg += f"; per-5-mer count min={int(per.min())} (n 5-mers={len(per)})"
-    print(msg)
-    return out
-
-
-def _filter_cli() -> None:
-    """Subprocess entry: filter a neutral parquet by ACGT window, write a new parquet.
-
-    Run in its own process by the ``compute_llr_neutral_mean`` rule so the genome's
-    s3fs initialization never touches the scoring process that forks DataLoader
-    workers. Reads ``--sites`` locally, opens ``--genome`` (S3 ok — this process
-    won't fork), and writes the filtered sites to ``--out``.
-    """
-    import argparse
-
-    from marin_dna.data.genome import Genome
-
-    parser = argparse.ArgumentParser(description=filter_acgt_window_sites.__doc__)
-    parser.add_argument(
-        "--sites", required=True, help="input neutral-sites parquet (local)"
-    )
-    parser.add_argument(
-        "--genome", required=True, help="reference FASTA (local or s3:// URI)"
-    )
-    parser.add_argument("--window", type=int, required=True, help="model window_size")
-    parser.add_argument("--out", required=True, help="output filtered parquet (local)")
-    args = parser.parse_args()
-
-    sites = pd.read_parquet(args.sites)
-    filtered = filter_acgt_window_sites(sites, Genome(args.genome), args.window)
-    assert len(filtered) > 0, (
-        "every neutral site was filtered out — wrong window/genome?"
-    )
-    filtered.to_parquet(args.out, index=False)
-    print(f"[filter_acgt_window] wrote {len(filtered):,} sites -> {args.out}")
-
-
-if __name__ == "__main__":
-    _filter_cli()

--- a/src/marin_dna/pipelines/evals/calibration.py
+++ b/src/marin_dna/pipelines/evals/calibration.py
@@ -1,0 +1,229 @@
+"""Per-checkpoint mutation-rate calibration tables (cLLR stage 3, #267/#270).
+
+Builds the ``llr_neutral_mean`` table that stage 4 (#271) subtracts to calibrate
+variant LLRs against the local background mutation rate::
+
+    calibrated LLR = LLR − llr_neutral_mean(pentanuc_mut)
+
+The pipeline scores a pinned, subsampled neutral-site set (``snakemake/neutral_sites``
+→ ``neutral_sites_n{n}.parquet``, columns ``[chrom, pos, ref, pentanuc]``) with the
+**fast 2-forward LLR bundle** (:func:`marin_dna.pipelines.evals.inference.compute_variant_scores`,
+FWD+RC), then bins by ``pentanuc_mut = pentanuc + "_" + alt``. Each neutral site is
+scored against its 3 non-ref alts, so a 5-mer's three calibration cells draw from
+the same sites.
+
+Entropy calibration (``entropy_neutral_mean``, via the 4-forward marginal atom
+:func:`marin_dna.model.scoring.compute_marginal_clm`) is a **separate, deferred**
+path — this module is LLR-only.
+
+The central pentanucleotide is precomputed upstream (``annotate_pentanucleotide``
+in ``snakemake/neutral_sites``), so here we only expand to alts and aggregate.
+Coordinates follow the eval datasets: 1-based ``pos`` (the scoring path's tool
+boundary), as produced by ``enumerate_positions``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from marin_dna.data.dna import NUCLEOTIDES
+from marin_dna.pipelines.evals.inference import compute_variant_scores
+
+
+def expand_sites_to_variants(sites: pd.DataFrame) -> pd.DataFrame:
+    """Expand neutral ``(chrom, pos, ref, pentanuc)`` sites to one row per non-ref alt.
+
+    Each site yields 3 SNV rows (``alt`` ∈ ``{A,C,G,T} \\ {ref}``), tagged with the
+    calibration cell key ``pentanuc_mut = pentanuc + "_" + alt``. The subsample
+    unit upstream is the **5-mer**, so a site's three cells share its sites; the
+    binning here is by the 3,072 ``pentanuc_mut`` cells (1,024 five-mers × 3 alts).
+
+    Args:
+        sites: ``[chrom, pos, ref, pentanuc]`` — bare ``chrom``, 1-based ``pos``,
+            ``ref`` ∈ {A,C,G,T}, ``pentanuc`` the central 5-mer (center == ref).
+
+    Returns:
+        ``[chrom, pos, ref, alt, pentanuc, pentanuc_mut]`` — exactly ``3 * len(sites)``
+        rows, ``alt != ref`` on every row.
+    """
+    for col in ("chrom", "pos", "ref", "pentanuc"):
+        assert col in sites.columns, f"sites missing column {col!r}"
+    assert len(sites) > 0, "empty neutral-site set"
+
+    pentanuc = sites["pentanuc"].astype(str)
+    # The 5-mer must be ACGT-only and centered on ref — both guaranteed by the
+    # upstream annotate_pentanucleotide, re-checked here so a wrong/stale input
+    # parquet fails loud rather than mislabeling every calibration bin.
+    assert pentanuc.str.fullmatch("[ACGT]{5}").all(), (
+        "pentanuc must be a 5-mer over ACGT — wrong/degenerate neutral input?"
+    )
+    assert (pentanuc.str[2].to_numpy() == sites["ref"].to_numpy()).all(), (
+        "pentanuc center base != ref — centering/coordinate bug in the neutral set"
+    )
+
+    base = sites[["chrom", "pos", "ref", "pentanuc"]]
+    parts: list[pd.DataFrame] = []
+    for alt in NUCLEOTIDES:
+        sub = base.loc[base["ref"] != alt].copy()
+        sub["alt"] = alt
+        parts.append(sub)
+    variants = pd.concat(parts, ignore_index=True)
+    variants["pentanuc_mut"] = variants["pentanuc"] + "_" + variants["alt"]
+    variants = variants[["chrom", "pos", "ref", "alt", "pentanuc", "pentanuc_mut"]]
+
+    assert len(variants) == 3 * len(sites), (
+        f"expected {3 * len(sites)} variants, got {len(variants)}"
+    )
+    assert (variants["ref"] != variants["alt"]).all(), "ref == alt leaked in"
+    return variants.reset_index(drop=True)
+
+
+def aggregate_llr_neutral_mean(
+    scored: pd.DataFrame,
+    *,
+    min_bin_count: int,
+    subsample_n: int,
+) -> pd.DataFrame:
+    """Bin per-variant LLRs into the per-cell ``llr_neutral_mean`` calibration table.
+
+    Averages raw LLR over the neutral sites in each ``pentanuc_mut`` cell, on the
+    forward, reverse-complement, and FWD+RC-averaged strands. ``_avg`` follows the
+    eval convention (``marin_dna`` evals_v2 metrics rule): average the *raw* LLR
+    per variant first (``llr_avg = (llr_fwd + llr_rc) / 2``), then take the cell
+    mean — equivalently ``llr_neutral_mean_avg = (mean_fwd + mean_rc) / 2``.
+
+    Args:
+        scored: expanded variants (from :func:`expand_sites_to_variants`) joined
+            with per-strand atoms — must carry ``pentanuc_mut, pentanuc, ref, alt,
+            llr_fwd, llr_rc``.
+        min_bin_count: hard floor on observations per cell; asserts ``min(n_sites)
+            >= min_bin_count`` so an unexpectedly empty/sparse cell fails fast.
+        subsample_n: the upstream per-5-mer cap (recorded as a column for provenance).
+
+    Returns:
+        One row per cell, sorted by ``pentanuc_mut``::
+
+            [pentanuc_mut, pentanuc, ref, alt, n_sites,
+             llr_neutral_mean_fwd, llr_neutral_mean_rc, llr_neutral_mean_avg,
+             llr_neutral_std_avg, subsample_n]
+    """
+    for col in ("pentanuc_mut", "pentanuc", "ref", "alt", "llr_fwd", "llr_rc"):
+        assert col in scored.columns, f"scored frame missing column {col!r}"
+    assert len(scored) > 0, "empty scored frame"
+    assert scored[["llr_fwd", "llr_rc"]].notna().all().all(), (
+        "NaN in per-strand LLR columns"
+    )
+
+    scored = scored.copy()
+    # Average raw LLR first (eval `_avg` semantics), then bin.
+    scored["llr_avg"] = (scored["llr_fwd"] + scored["llr_rc"]) / 2.0
+
+    table = (
+        scored.groupby(["pentanuc_mut", "pentanuc", "ref", "alt"], sort=True)
+        .agg(
+            llr_neutral_mean_fwd=("llr_fwd", "mean"),
+            llr_neutral_mean_rc=("llr_rc", "mean"),
+            llr_neutral_mean_avg=("llr_avg", "mean"),
+            llr_neutral_std_avg=("llr_avg", "std"),
+            n_sites=("llr_avg", "size"),
+        )
+        .reset_index()
+    )
+    table["subsample_n"] = subsample_n
+
+    # The 3 mean columns must be finite; std is NaN only for size-1 cells, which
+    # the min_bin_count assert below rules out for any sane floor (>= 2).
+    mean_cols = ["llr_neutral_mean_fwd", "llr_neutral_mean_rc", "llr_neutral_mean_avg"]
+    assert table[mean_cols].notna().all().all(), "NaN in a per-cell mean LLR"
+
+    counts = table["n_sites"]
+    assert int(counts.min()) >= min_bin_count, (
+        f"a calibration cell has only {int(counts.min())} obs "
+        f"(< min_bin_count={min_bin_count}) — neutral set too sparse for this cap"
+    )
+
+    # Log the cell-count distribution + any cell below the cap (data-limited
+    # 5-mers, mostly CpG-depleted; their SE = s/sqrt(count) regardless of cap).
+    below = table[table["n_sites"] < subsample_n]
+    print(
+        f"[calibration] {len(table)} cells; n_sites "
+        f"min={int(counts.min())} median={int(counts.median())} max={int(counts.max())}; "
+        f"{len(below)} cell(s) below the cap n={subsample_n}"
+    )
+
+    cols = [
+        "pentanuc_mut",
+        "pentanuc",
+        "ref",
+        "alt",
+        "n_sites",
+        "llr_neutral_mean_fwd",
+        "llr_neutral_mean_rc",
+        "llr_neutral_mean_avg",
+        "llr_neutral_std_avg",
+        "subsample_n",
+    ]
+    return table[cols].sort_values("pentanuc_mut").reset_index(drop=True)
+
+
+def compute_llr_neutral_mean(
+    checkpoint_path: str | Path,
+    sites: pd.DataFrame,
+    genome_path: str | Path,
+    window_size: int,
+    *,
+    subsample_n: int,
+    min_bin_count: int,
+    batch_size: int = 512,
+    num_workers: int = 4,
+    rc: bool = True,
+    data_transform_on_the_fly: bool = True,
+    torch_compile: bool = False,
+) -> pd.DataFrame:
+    """Score a neutral-site set with the LLR bundle and bin into a calibration table.
+
+    Thin orchestrator over :func:`expand_sites_to_variants`,
+    :func:`marin_dna.pipelines.evals.inference.compute_variant_scores`, and
+    :func:`aggregate_llr_neutral_mean`. Bins in a single pass — only the small
+    per-cell table is returned (the ~3·N raw per-variant rows are never persisted).
+
+    Args:
+        checkpoint_path: Local HF checkpoint dir.
+        sites: neutral sites ``[chrom, pos, ref, pentanuc]`` (read **locally** by the
+            caller — never ``pd.read_parquet("s3://…")`` in a process that later
+            forks DataLoader workers; that deadlocks the in-worker genome reads).
+        genome_path: GRCh38 reference (S3 URI ok — opened lazily inside each worker).
+        window_size: DNA context window for the model (per-model ``window_size``).
+        subsample_n: upstream per-5-mer cap (recorded for provenance).
+        min_bin_count: hard floor on observations per cell.
+        batch_size, num_workers, data_transform_on_the_fly, torch_compile: passed to
+            ``compute_variant_scores``.
+        rc: must be True — calibration averages FWD+RC to match the eval.
+
+    Returns:
+        The ``llr_neutral_mean`` table (see :func:`aggregate_llr_neutral_mean`).
+    """
+    assert rc, (
+        "calibration scores FWD+RC (rc must be True) to match the eval convention"
+    )
+    variants = expand_sites_to_variants(sites)
+    scores = compute_variant_scores(
+        checkpoint_path=checkpoint_path,
+        dataset=variants[["chrom", "pos", "ref", "alt"]],
+        genome_path=genome_path,
+        context_size=window_size,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        data_transform_on_the_fly=data_transform_on_the_fly,
+        torch_compile=torch_compile,
+        rc=rc,
+    )
+    assert len(scores) == len(variants), (len(scores), len(variants))
+    scored = pd.concat(
+        [variants.reset_index(drop=True), scores.reset_index(drop=True)], axis=1
+    )
+    return aggregate_llr_neutral_mean(
+        scored, min_bin_count=min_bin_count, subsample_n=subsample_n
+    )

--- a/src/marin_dna/pipelines/neutral_sites/sites.py
+++ b/src/marin_dna/pipelines/neutral_sites/sites.py
@@ -406,3 +406,88 @@ def subsample_per_context(sites: pd.DataFrame, n: int, seed: int) -> pd.DataFram
     out = sites.loc[np.sort(np.concatenate(keep))].reset_index(drop=True)
     assert out.groupby("pentanuc").size().max() <= n, "a 5-mer exceeded the cap"
     return out
+
+
+def filter_acgt_window_sites(
+    sites: pd.DataFrame,
+    get_seq: Callable[[str, int, int], str],
+    window_size: int,
+) -> pd.DataFrame:
+    """Drop neutral sites whose centered ``window_size`` window isn't entirely ACGT.
+
+    The gLM scoring kernel (evals_v2) gathers the LLR over the variant's downstream
+    window positions and asserts every target is one of A/C/G/T; an ``N`` from an
+    assembly gap near a telomere/centromere trips it. Eval variants never hit this
+    (they're gene-centric), but genome-wide neutral sites near gaps do — and because
+    the forward pass checks only the right flank while the reverse-complement checks
+    the left, a site needs its **whole** window clean to be scoreable on both strands.
+
+    So this drops any site whose centered window — the same interval the scoring
+    transform extracts, ``[pos-1-window_size//2, …+window_size)`` 0-based (matching
+    ``_get_variant_window`` / ``in_seq_var_pos("+")``) — contains a non-ACGT base, or
+    runs off the chromosome (``N``-padded; unscoreable anyway). Run this **before**
+    :func:`subsample_per_context` so each 5-mer is subsampled from its *clean* sites,
+    and at the **largest** model window in use (e.g. 512) so one filtered set serves
+    every checkpoint (a window clean at 512 bp is clean at 255/256).
+
+    Reads the reference **once per chromosome** (over the span covering every site's
+    window), like :func:`annotate_pentanucleotide`. Pass a ``get_seq`` over a plain
+    (decompressed) FASTA: pyfaidx random access on the bgzipped reference is
+    pathologically slow for these whole-chromosome spans.
+
+    Args:
+        sites: ``[chrom, pos, …]`` — bare ``chrom``, 1-based ``pos`` (extra columns,
+            e.g. ``ref``/``pentanuc``, are preserved).
+        get_seq: ``(chrom, start, end) -> str`` over the reference (0-based half-open,
+            bare chrom names; N-padded past chromosome ends).
+        window_size: the (largest) model DNA context window to guarantee scoreable.
+
+    Returns:
+        The subset of ``sites`` (all columns, row order preserved) whose full window
+        is ACGT — clean by construction.
+    """
+    for col in ("chrom", "pos"):
+        assert col in sites.columns, f"sites missing column {col!r}"
+    assert window_size > 0, f"window_size must be positive, got {window_size}"
+    left_flank = window_size // 2  # matches _get_variant_window / in_seq_var_pos("+")
+
+    sites = sites.reset_index(drop=True)
+    keep = np.zeros(len(sites), dtype=bool)
+    acgt = np.frombuffer(b"ACGT", dtype=np.uint8)
+    for chrom, sub in sites.groupby("chrom", sort=False):
+        center0 = sub["pos"].to_numpy() - 1  # 1-based -> 0-based
+        win_start = center0 - left_flank
+        win_end = win_start + window_size
+        read_lo = max(0, int(win_start.min()))  # clamp; off-start sites dropped below
+        hi = int(win_end.max())
+        span = get_seq(str(chrom), read_lo, hi).upper()
+        arr = np.frombuffer(span.encode("ascii"), dtype=np.uint8)
+        assert arr.size == hi - read_lo, (
+            f"reference returned {arr.size} bp for {chrom}:{read_lo}-{hi} "
+            f"(expected {hi - read_lo})"
+        )
+        # Prefix sum of non-ACGT counts → a window is clean iff its count is 0.
+        bad = ~np.isin(arr, acgt)
+        csum = np.concatenate([[0], np.cumsum(bad)])
+        s_idx = win_start - read_lo
+        e_idx = win_end - read_lo
+        in_bounds = (win_start >= 0) & (win_end <= read_lo + arr.size)
+        s_clip = np.clip(s_idx, 0, arr.size)
+        e_clip = np.clip(e_idx, 0, arr.size)
+        n_bad = csum[e_clip] - csum[s_clip]
+        keep[sub.index.to_numpy()] = in_bounds & (n_bad == 0)
+
+    out = sites.loc[keep].reset_index(drop=True)
+    n_drop = len(sites) - len(out)
+    msg = (
+        f"[filter_acgt_window] window={window_size}: kept {len(out):,}/{len(sites):,} "
+        f"({n_drop} dropped for non-ACGT or off-chromosome windows)"
+    )
+    # If 5-mer context is present, also report the post-filter per-5-mer minimum —
+    # this is the per-calibration-cell observation count after subsampling, so it
+    # previews whether any cell will be sparse downstream.
+    if "pentanuc" in out.columns and len(out):
+        per = out.groupby("pentanuc").size()
+        msg += f"; per-5-mer count min={int(per.min())} (n 5-mers={len(per)})"
+    print(msg)
+    return out

--- a/tests/pipelines/evals/test_calibration.py
+++ b/tests/pipelines/evals/test_calibration.py
@@ -1,0 +1,199 @@
+"""Tests for the cLLR stage-3 calibration-table helpers (#270).
+
+The pure pieces (``expand_sites_to_variants``, ``aggregate_llr_neutral_mean``)
+are tested directly; the orchestrator ``compute_llr_neutral_mean`` is tested with
+``compute_variant_scores`` patched, so no model/genome/GPU is touched (mirrors
+``tests/pipelines/evals/test_inference.py``)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from marin_dna.pipelines.evals.calibration import (
+    aggregate_llr_neutral_mean,
+    compute_llr_neutral_mean,
+    expand_sites_to_variants,
+)
+
+EXPECTED_TABLE_COLUMNS = [
+    "pentanuc_mut",
+    "pentanuc",
+    "ref",
+    "alt",
+    "n_sites",
+    "llr_neutral_mean_fwd",
+    "llr_neutral_mean_rc",
+    "llr_neutral_mean_avg",
+    "llr_neutral_std_avg",
+    "subsample_n",
+]
+
+
+def _sites() -> pd.DataFrame:
+    """Three neutral sites with distinct refs; pentanuc center == ref."""
+    return pd.DataFrame(
+        {
+            "chrom": ["1", "1", "2"],
+            "pos": [100, 200, 300],
+            "ref": ["A", "C", "G"],
+            "pentanuc": ["TTATT", "GGCGG", "AAGAA"],
+        }
+    )
+
+
+# --- expand_sites_to_variants ----------------------------------------------
+
+
+def test_expand_three_alts_per_site():
+    variants = expand_sites_to_variants(_sites())
+    assert len(variants) == 3 * 3
+    assert list(variants.columns) == [
+        "chrom",
+        "pos",
+        "ref",
+        "alt",
+        "pentanuc",
+        "pentanuc_mut",
+    ]
+    # Exactly 3 rows per original site, never alt == ref.
+    assert (variants["ref"] != variants["alt"]).all()
+    assert (variants.groupby(["chrom", "pos"]).size() == 3).all()
+    # pentanuc_mut formatting + the alts for the ref-A site.
+    a_site = variants[(variants["chrom"] == "1") & (variants["pos"] == 100)]
+    assert set(a_site["alt"]) == {"C", "G", "T"}
+    assert set(a_site["pentanuc_mut"]) == {"TTATT_C", "TTATT_G", "TTATT_T"}
+
+
+def test_expand_rejects_center_ref_mismatch():
+    bad = _sites()
+    bad.loc[0, "pentanuc"] = "TTCTT"  # center C != ref A
+    with pytest.raises(AssertionError, match="center"):
+        expand_sites_to_variants(bad)
+
+
+def test_expand_rejects_non_acgt_pentanuc():
+    bad = _sites()
+    bad.loc[0, "pentanuc"] = "TTANT"  # N flank
+    with pytest.raises(AssertionError, match="ACGT"):
+        expand_sites_to_variants(bad)
+
+
+def test_expand_rejects_missing_column():
+    with pytest.raises(AssertionError, match="pentanuc"):
+        expand_sites_to_variants(_sites().drop(columns=["pentanuc"]))
+
+
+# --- aggregate_llr_neutral_mean --------------------------------------------
+
+
+def _scored() -> pd.DataFrame:
+    """Two cells: AAAAA_C (3 obs) and TTTTT_G (2 obs), with hand-checkable LLRs."""
+    return pd.DataFrame(
+        {
+            "pentanuc_mut": ["AAAAA_C", "AAAAA_C", "AAAAA_C", "TTTTT_G", "TTTTT_G"],
+            "pentanuc": ["AAAAA", "AAAAA", "AAAAA", "TTTTT", "TTTTT"],
+            "ref": ["A", "A", "A", "T", "T"],
+            "alt": ["C", "C", "C", "G", "G"],
+            "llr_fwd": [1.0, 2.0, 3.0, -1.0, -3.0],
+            "llr_rc": [1.0, 0.0, 1.0, 1.0, 1.0],
+        }
+    )
+
+
+def test_aggregate_means_and_counts():
+    table = aggregate_llr_neutral_mean(_scored(), min_bin_count=2, subsample_n=100)
+    assert list(table.columns) == EXPECTED_TABLE_COLUMNS
+    assert list(table["pentanuc_mut"]) == ["AAAAA_C", "TTTTT_G"]  # sorted
+
+    cpg = table[table["pentanuc_mut"] == "AAAAA_C"].iloc[0]
+    assert cpg["n_sites"] == 3
+    assert cpg["llr_neutral_mean_fwd"] == pytest.approx(2.0)  # mean(1,2,3)
+    assert cpg["llr_neutral_mean_rc"] == pytest.approx(2.0 / 3.0)  # mean(1,0,1)
+    # avg = mean of per-variant (fwd+rc)/2 = mean(1,1,2) = 4/3
+    assert cpg["llr_neutral_mean_avg"] == pytest.approx(4.0 / 3.0)
+    # and equals (mean_fwd + mean_rc)/2
+    assert cpg["llr_neutral_mean_avg"] == pytest.approx(
+        (cpg["llr_neutral_mean_fwd"] + cpg["llr_neutral_mean_rc"]) / 2
+    )
+    assert cpg["llr_neutral_std_avg"] == pytest.approx(np.std([1, 1, 2], ddof=1))
+    assert (table["subsample_n"] == 100).all()
+
+    tg = table[table["pentanuc_mut"] == "TTTTT_G"].iloc[0]
+    assert tg["n_sites"] == 2
+    assert tg["llr_neutral_mean_avg"] == pytest.approx(-0.5)  # mean(0, -1)
+
+
+def test_aggregate_min_bin_count_assertion():
+    # TTTTT_G has only 2 obs; a floor of 3 must trip.
+    with pytest.raises(AssertionError, match="min_bin_count"):
+        aggregate_llr_neutral_mean(_scored(), min_bin_count=3, subsample_n=100)
+
+
+def test_aggregate_nan_guard():
+    bad = _scored()
+    bad.loc[0, "llr_fwd"] = np.nan
+    with pytest.raises(AssertionError, match="NaN"):
+        aggregate_llr_neutral_mean(bad, min_bin_count=2, subsample_n=100)
+
+
+# --- compute_llr_neutral_mean (orchestrator, mocked scoring) ---------------
+
+
+def test_compute_llr_neutral_mean_end_to_end():
+    # Two sites sharing one 5-mer → 3 cells (one per alt), each with 2 obs.
+    sites = pd.DataFrame(
+        {
+            "chrom": ["1", "1"],
+            "pos": [100, 200],
+            "ref": ["A", "A"],
+            "pentanuc": ["TTATT", "TTATT"],
+        }
+    )
+    # 6 variants (2 sites × 3 alts); canned per-strand atoms (order matches the
+    # alt-major concat in expand_sites_to_variants, but the test only checks
+    # shape / columns / counts, not which value lands in which cell).
+    canned = pd.DataFrame(
+        {
+            "llr_fwd": [0.0, 0.0, 1.0, 1.0, 2.0, 2.0],
+            "llr_rc": [0.0, 0.0, 1.0, 1.0, 2.0, 2.0],
+            "jsd_fwd": [0.0] * 6,
+            "jsd_rc": [0.0] * 6,
+        }
+    )
+    with patch(
+        "marin_dna.pipelines.evals.calibration.compute_variant_scores",
+        return_value=canned,
+    ) as mock_score:
+        table = compute_llr_neutral_mean(
+            checkpoint_path="ckpt",
+            sites=sites,
+            genome_path="s3://genome.fa.gz",
+            window_size=255,
+            subsample_n=2,
+            min_bin_count=2,
+            rc=True,
+        )
+    mock_score.assert_called_once()
+    assert mock_score.call_args.kwargs["rc"] is True
+    assert mock_score.call_args.kwargs["context_size"] == 255
+    assert list(table.columns) == EXPECTED_TABLE_COLUMNS
+    assert len(table) == 3  # TTATT_{C,G,T}
+    assert (table["n_sites"] == 2).all()
+    assert set(table["pentanuc_mut"]) == {"TTATT_C", "TTATT_G", "TTATT_T"}
+
+
+def test_compute_llr_neutral_mean_requires_rc():
+    with pytest.raises(AssertionError, match="rc must be True"):
+        compute_llr_neutral_mean(
+            checkpoint_path="ckpt",
+            sites=_sites(),
+            genome_path="g",
+            window_size=255,
+            subsample_n=100,
+            min_bin_count=1,
+            rc=False,
+        )

--- a/tests/pipelines/evals/test_calibration.py
+++ b/tests/pipelines/evals/test_calibration.py
@@ -17,7 +17,6 @@ from marin_dna.pipelines.evals.calibration import (
     aggregate_llr_neutral_mean,
     compute_llr_neutral_mean,
     expand_sites_to_variants,
-    filter_acgt_window_sites,
 )
 
 EXPECTED_TABLE_COLUMNS = [
@@ -197,57 +196,4 @@ def test_compute_llr_neutral_mean_requires_rc():
             subsample_n=100,
             min_bin_count=1,
             rc=False,
-        )
-
-
-# --- filter_acgt_window_sites ----------------------------------------------
-
-
-class _FakeGenome:
-    """Minimal ``get_seq(chrom, start, end)`` with N-padding past the end (like Genome).
-
-    The filter clamps the read start to >= 0, so ``start`` is never negative here.
-    """
-
-    def __init__(self, seqs: dict[str, str]):
-        self.seqs = seqs
-
-    def __call__(self, chrom: str, start: int, end: int) -> str:
-        seg = self.seqs[chrom][start:end]
-        return seg + "N" * ((end - start) - len(seg))  # right-pad N past chrom end
-
-
-def test_filter_acgt_window_sites():
-    # 30 bp chrom with N at 0-based indices 10 and 25; window_size=5 → left_flank=2,
-    # so site pos's window is 0-based [pos-3, pos+2).
-    seq = list("ACGTACGTACGTACGTACGTACGTACGTAC")
-    seq[10] = "N"
-    seq[25] = "N"
-    seq = "".join(seq)
-    genome = _FakeGenome({"1": seq})
-    sites = pd.DataFrame(
-        {
-            "chrom": ["1"] * 6,
-            # 5: clean | 8: clean | 13: N upstream (FWD-ok/RC-fail case) |
-            # 24: N downstream | 2: window off left edge | 29: window off right edge
-            "pos": [5, 8, 13, 24, 2, 29],
-            "ref": [seq[p - 1] for p in [5, 8, 13, 24, 2, 29]],
-        }
-    )
-    out = filter_acgt_window_sites(sites, genome, window_size=5)
-    assert set(out["pos"]) == {5, 8}
-    assert list(out.columns) == list(sites.columns)  # columns/order preserved
-
-
-def test_filter_acgt_window_sites_all_clean_kept():
-    genome = _FakeGenome({"1": "ACGT" * 50})  # 200 bp, no N
-    sites = pd.DataFrame({"chrom": ["1"] * 3, "pos": [50, 100, 150]})
-    out = filter_acgt_window_sites(sites, genome, window_size=11)
-    assert len(out) == 3
-
-
-def test_filter_acgt_window_sites_requires_columns():
-    with pytest.raises(AssertionError, match="pos"):
-        filter_acgt_window_sites(
-            pd.DataFrame({"chrom": ["1"]}), _FakeGenome({"1": "ACGT"}), window_size=5
         )

--- a/tests/pipelines/evals/test_calibration.py
+++ b/tests/pipelines/evals/test_calibration.py
@@ -17,6 +17,7 @@ from marin_dna.pipelines.evals.calibration import (
     aggregate_llr_neutral_mean,
     compute_llr_neutral_mean,
     expand_sites_to_variants,
+    filter_acgt_window_sites,
 )
 
 EXPECTED_TABLE_COLUMNS = [
@@ -196,4 +197,57 @@ def test_compute_llr_neutral_mean_requires_rc():
             subsample_n=100,
             min_bin_count=1,
             rc=False,
+        )
+
+
+# --- filter_acgt_window_sites ----------------------------------------------
+
+
+class _FakeGenome:
+    """Minimal ``get_seq(chrom, start, end)`` with N-padding past the end (like Genome).
+
+    The filter clamps the read start to >= 0, so ``start`` is never negative here.
+    """
+
+    def __init__(self, seqs: dict[str, str]):
+        self.seqs = seqs
+
+    def __call__(self, chrom: str, start: int, end: int) -> str:
+        seg = self.seqs[chrom][start:end]
+        return seg + "N" * ((end - start) - len(seg))  # right-pad N past chrom end
+
+
+def test_filter_acgt_window_sites():
+    # 30 bp chrom with N at 0-based indices 10 and 25; window_size=5 → left_flank=2,
+    # so site pos's window is 0-based [pos-3, pos+2).
+    seq = list("ACGTACGTACGTACGTACGTACGTACGTAC")
+    seq[10] = "N"
+    seq[25] = "N"
+    seq = "".join(seq)
+    genome = _FakeGenome({"1": seq})
+    sites = pd.DataFrame(
+        {
+            "chrom": ["1"] * 6,
+            # 5: clean | 8: clean | 13: N upstream (FWD-ok/RC-fail case) |
+            # 24: N downstream | 2: window off left edge | 29: window off right edge
+            "pos": [5, 8, 13, 24, 2, 29],
+            "ref": [seq[p - 1] for p in [5, 8, 13, 24, 2, 29]],
+        }
+    )
+    out = filter_acgt_window_sites(sites, genome, window_size=5)
+    assert set(out["pos"]) == {5, 8}
+    assert list(out.columns) == list(sites.columns)  # columns/order preserved
+
+
+def test_filter_acgt_window_sites_all_clean_kept():
+    genome = _FakeGenome({"1": "ACGT" * 50})  # 200 bp, no N
+    sites = pd.DataFrame({"chrom": ["1"] * 3, "pos": [50, 100, 150]})
+    out = filter_acgt_window_sites(sites, genome, window_size=11)
+    assert len(out) == 3
+
+
+def test_filter_acgt_window_sites_requires_columns():
+    with pytest.raises(AssertionError, match="pos"):
+        filter_acgt_window_sites(
+            pd.DataFrame({"chrom": ["1"]}), _FakeGenome({"1": "ACGT"}), window_size=5
         )

--- a/tests/pipelines/neutral_sites/test_sites.py
+++ b/tests/pipelines/neutral_sites/test_sites.py
@@ -13,6 +13,7 @@ from marin_dna.pipelines.neutral_sites.sites import (
     annotate_pentanucleotide,
     contiguous_runs,
     enumerate_positions,
+    filter_acgt_window_sites,
     neutral_mask,
     parse_rmsk,
     scan_neutral_intervals,
@@ -335,3 +336,55 @@ class TestSubsamplePerContext:
         src = self._sites()
         out = subsample_per_context(src, n=100, seed=0)
         assert len(out) == len(src)
+
+
+class _FakeGenome:
+    """Minimal ``get_seq(chrom, start, end)`` with N-padding past the end (like Genome).
+
+    ``filter_acgt_window_sites`` clamps the read start to >= 0, so ``start`` is never
+    negative here.
+    """
+
+    def __init__(self, seqs: dict[str, str]):
+        self.seqs = seqs
+
+    def __call__(self, chrom: str, start: int, end: int) -> str:
+        seg = self.seqs[chrom][start:end]
+        return seg + "N" * ((end - start) - len(seg))  # right-pad N past chrom end
+
+
+class TestFilterAcgtWindowSites:
+    def test_drops_n_and_edge_windows(self):
+        # 30 bp chrom with N at 0-based indices 10 and 25; window_size=5 → left_flank=2,
+        # so site pos's window is 0-based [pos-3, pos+2).
+        seq = list("ACGTACGTACGTACGTACGTACGTACGTAC")
+        seq[10] = "N"
+        seq[25] = "N"
+        seq = "".join(seq)
+        genome = _FakeGenome({"1": seq})
+        sites = pd.DataFrame(
+            {
+                "chrom": ["1"] * 6,
+                # 5: clean | 8: clean | 13: N upstream (FWD-ok/RC-fail case) |
+                # 24: N downstream | 2: window off left edge | 29: window off right edge
+                "pos": [5, 8, 13, 24, 2, 29],
+                "ref": [seq[p - 1] for p in [5, 8, 13, 24, 2, 29]],
+            }
+        )
+        out = filter_acgt_window_sites(sites, genome, window_size=5)
+        assert set(out["pos"]) == {5, 8}
+        assert list(out.columns) == list(sites.columns)  # columns/order preserved
+
+    def test_all_clean_kept(self):
+        genome = _FakeGenome({"1": "ACGT" * 50})  # 200 bp, no N
+        sites = pd.DataFrame({"chrom": ["1"] * 3, "pos": [50, 100, 150]})
+        out = filter_acgt_window_sites(sites, genome, window_size=11)
+        assert len(out) == 3
+
+    def test_requires_columns(self):
+        with pytest.raises(AssertionError, match="pos"):
+            filter_acgt_window_sites(
+                pd.DataFrame({"chrom": ["1"]}),
+                _FakeGenome({"1": "ACGT"}),
+                window_size=5,
+            )


### PR DESCRIPTION
## Summary

Stage 3 of the cLLR mutation-rate calibration work (#267): score the neutral-site set per checkpoint and emit the per-model `llr_neutral_mean` table that stage 4 (#271) subtracts to calibrate variant LLRs:

```
calibrated LLR = LLR − llr_neutral_mean(pentanuc_mut)
```

Per the #270 scope (this session): **LLR-only** (entropy deferred) and the input is the **pinned n=100 subsampled** neutral set, not the full 5.94M-site set.

## What's added

**`neutral_sites` pipeline (the model-independent, build-once half):**
- `filter_acgt_window_sites` (`sites.py`) — drop sites whose centered `window_size` window isn't all-ACGT. The gLM scoring kernel asserts ACGT over the variant's window; a genome-wide neutral site near an assembly gap carries an `N` there and trips it (a CUDA device-side assert under `torch.compile`). FWD checks the right flank, RC the left, so the **whole** window must be clean.
- Rules `stage_genome_fasta` → `annotate_pentanuc` → `filter_scoreable` (window `w` wildcard) → `subsample_neutral` → `neutral_sites_n{n}_w{w}.parquet`. Filter runs **before** subsampling (each 5-mer keeps a full `n` of clean sites) and at the **largest** model window (512), so **one** pinned set serves every model. Genome reads mmap an **uncompressed** FASTA staged in S3 next to the `.gz` (`genome_fasta_path`) — pyfaidx on bgzip is pathologically slow for the whole-chromosome spans these rules touch.

**`evals_v2` (the per-model GPU half):**
- `src/marin_dna/pipelines/evals/calibration.py` — `expand_sites_to_variants` (site → 3 non-ref alts, `pentanuc_mut = 5mer + "_" + alt`), `aggregate_llr_neutral_mean` (bin → per-cell mean LLR fwd/rc/avg + count), and the orchestrator `compute_llr_neutral_mean` (expand → `compute_variant_scores` fast 2-forward bundle FWD+RC → bin, one pass).
- Rule `compute_llr_neutral_mean` + the off-`rule all` `calibration` collector. It just **reads the pre-filtered set** (no genome read, no per-model filter), asserts `scoreable_window >= the model's window_size`, and stages the set via `storage()` (boto3, fork-safe) so `pd.read_parquet` never inits s3fs in the process that forks DataLoader workers.

**Output** (auto-pinned via the S3 storage provider): `results/calibration/{model}/llr_neutral_mean_n100.parquet`, columns `[pentanuc_mut, pentanuc, ref, alt, n_sites, llr_neutral_mean_{fwd,rc,avg}, llr_neutral_std_avg, subsample_n]` (3072 cells).

## Key decisions

- **The N-window filter is a one-time, model-independent step in `neutral_sites`**, not re-run per checkpoint in evals_v2 — it depends only on (genome, sites, window). It dropped just **123 / 5.94M** sites (≈1 in 48k) at window 512; the n=100 set keeps **min 41 sites/5-mer** (all 1024 five-mers).
- **Entropy calibration deferred.** `entropy_neutral_mean` via the 4-forward marginal atom (#275) is a separate, opt-in path — untouched. The neutral set is kept site-level / alt-agnostic so that path can reuse it later.
- **First model only:** `mix-v0.9-p1B-i24-exp135-m5.1-step-59158` (exp135-1B-m5.1). Extending to more checkpoints is a follow-up. Stays within #270's stage-3 scope — stage 4 (#271) is separate.

## Validation

- `uv run pytest tests/pipelines/{evals/test_calibration,neutral_sites/test_sites}.py` — 42 passing; ruff + mypy clean.
- Both pipelines dry-run to exactly the intended jobs, no unrelated reruns.
- `neutral_sites_n100_w512.parquet` built + pinned on a CPU node (m6i.xlarge); uncompressed reference staged to S3.
- **GPU run** (A10G, exp135-1B): produced the 3072-cell table — `n_sites` ∈ [41, 100], no NaN, CpG contexts positive (C→T mean +1.87) and typical contexts negative, matching the n=1000 convergence pilot. The cluster auto-terminated on idle after pinning the table. Details + sign-check table in the [#270 results comment](https://github.com/Open-Athena/marin-dna/issues/270).

closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
