### PR TITLE
gpn_star_eval: refresh to current-revision predictions + AUPRC

### DIFF
--- a/snakemake/gpn_star_eval/README.md
+++ b/snakemake/gpn_star_eval/README.md
@@ -104,6 +104,6 @@ Pipeline rules are thin glue around `marin_dna.pipelines.evals.gpn_star`:
 - `predictions_url(dataset, model)` — gist raw URL for one prediction parquet.
 - `GPN_STAR_MODELS`, `GPN_STAR_MODEL_INFO`, `GPN_STAR_SCORE_COLUMN` — metadata.
 
-Tests at [`tests/pipelines/evals/test_gpn_star.py`](../../../tests/pipelines/evals/test_gpn_star.py)
+Tests at [`tests/pipelines/evals/test_gpn_star.py`](../../tests/pipelines/evals/test_gpn_star.py)
 cover alignment, NaN detection, chrom-dtype handling, and the predictions-URL
 helper.

--- a/snakemake/gpn_star_eval/README.md
+++ b/snakemake/gpn_star_eval/README.md
@@ -1,47 +1,55 @@
 # gpn_star_eval — GPN-Star V/M/P baseline on matched-pair eval datasets
 
-PairwiseAccuracy ± binomial SE for the three GPN-Star variants
+AUPRC ± cluster-bootstrap SE for the three GPN-Star variants
 (V = vertebrate-100way, M = mammal-447way, P = primate-243way; all 200M params)
 on the matched-pair eval datasets ([#161 Mendelian](https://github.com/Open-Athena/marin-dna/issues/161),
-[#162 Complex traits](https://github.com/Open-Athena/marin-dna/issues/162),
-[#172 eQTL](https://github.com/Open-Athena/marin-dna/issues/172)).
+[#162 Complex traits](https://github.com/Open-Athena/marin-dna/issues/162)).
+Same metric, dataset revisions, and bootstrap config as
+[`evals_v2`](../analysis/evals_v2), so these rows are directly comparable to our
+own models — and they **reproduce the GPN-Star numbers the dashboard reads** from
+the #145 metrics gist.
 
 GPN-Star scoring runs in [songlab-cal/TraitGym](https://github.com/songlab-cal/TraitGym),
 not this repo. Predictions are pulled from a gist (commit pinned in
-`marin_dna.evals.gpn_star.GPN_STAR_GIST_BASE`); see
-[#145 comment](https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4444680280)
-for the upstream definition. This pipeline is the align + aggregate step:
-load HF eval dataset, row-align with the predictions parquet, compute PA per
-subset.
+`marin_dna.pipelines.evals.gpn_star.GPN_STAR_GIST_BASE`); see the
+[#145 calibration definition](https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4444680280)
+and the [current-revision upload](https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4489509362).
+This pipeline is the align + aggregate step: load HF eval dataset, row-align with
+the predictions parquet, compute AUPRC per subset.
+
+eQTL (#172) was retired in the 1:9 / k=9 migration (#194) and has no
+current-revision GPN-Star upload, so it is not evaluated here.
 
 ## What it does
 
-For each `dataset` in `config["datasets"]`:
+For each `dataset` in `config["datasets"]` (a `{name, hf_revision}` list pinned
+to the k=9 HF commits):
 
 1. **Score** — for each of the 3 model variants, load the GPN-Star prediction
    parquet (`predictions_url`), align row-by-row with the HF dataset's `train`
-   split, derive `minus_llr` and `minus_llr_calibrated` for the leaderboard
-   convention. Output: one long parquet per dataset, `model` column
-   distinguishing V / M / P.
+   split **at the pinned revision**, derive `minus_llr` and
+   `minus_llr_calibrated` for the leaderboard convention. Output: one long
+   parquet per dataset, `model` column distinguishing V / M / P.
 
    Row alignment is asserted element-wise, no key-based merge — TraitGym's
    `bolinas_pack_predictions` rule builds the predictions parquet by
-   horizontal-concat with HF row order, so a `split == "train"` filter is
-   sufficient.
+   horizontal-concat with HF row order, so a `split == "train"` filter on the
+   matching revision is sufficient (and `score_variants_gpn_star` fails loud if
+   it ever isn't).
 
-2. **Compute** PairwiseAccuracy ± SE per consequence subset on all 4 score
-   columns (`minus_llr`, `abs_llr`, `minus_llr_calibrated`,
-   `abs_llr_calibrated`). Output: metrics parquet keyed by
-   `(model, score_type, subset)`, plus the `_global_` / `_macro_avg_`
-   sentinel rows from `compute_pairwise_metrics` (n_min=30).
+2. **Compute** AUPRC + cluster-bootstrap SE (cluster = `match_group`) per
+   consequence subset on all 4 score columns (`minus_llr`, `abs_llr`,
+   `minus_llr_calibrated`, `abs_llr_calibrated`). Output: metrics parquet keyed
+   by `(model, score_type, subset)`, plus the `_global_` / `_macro_avg_`
+   sentinel rows from `compute_auprc_metrics` (`n_min` from config). Baseline
+   AUPRC ≈ 0.10 under 1:9.
 
-Downstream consumers (e.g. `snakemake/evals/scratch/leaderboard_gen.py`)
-filter by `score_type` to pick the leaderboard-convention column:
+Downstream consumers filter by `score_type` to pick the leaderboard-convention
+column:
 
 - **Mendelian:** `minus_llr_calibrated` (pathogenic ⇒ alt depleted under
   purifying selection ⇒ negative LLR ⇒ positive `minus_llr`).
-- **Complex traits / eQTL:** `abs_llr_calibrated` (direction-agnostic
-  magnitude).
+- **Complex traits:** `abs_llr_calibrated` (direction-agnostic magnitude).
 
 ## Outputs
 
@@ -50,25 +58,30 @@ S3 bucket `s3://oa-bolinas/snakemake/gpn_star_eval/`:
 ```
 results/
 ├── scores/{dataset}.parquet    # 3 × N rows: variant cols + scores per model
-└── metrics/{dataset}.parquet   # PA per (model, score_type, subset)
+└── metrics/{dataset}.parquet   # AUPRC per (model, score_type, subset);
+                                 # cols [score_type, subset, value, se,
+                                 #       n_groups, n_rows, model, dataset, split]
 ```
 
 ## Conventions
 
 - **Train split only.** Test held out for the final-eval pass (matches the
   other matched-pair pipelines in this repo).
+- **Pinned revisions.** Each dataset's `hf_revision` mirrors `evals_v2` so the
+  prediction parquets row-align deterministically and the AUPRC is computed on
+  exactly the variants our models are scored on.
 - **Calibration happens upstream.** `*_calibrated` columns are the producer's
-  pentanucleotide-context background-subtracted variant; see
+  pentanucleotide-context background-subtracted variant; see the
   [#145 comment](https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4444680280)
   for the formula.
 - **Reverse-complement averaging happens upstream.** GPN-Star averages
-  forward + RC strand predictions. The `exp*` gLM rows in this repo's
-  leaderboards are forward-only — RC averaging is a planned addition.
+  forward + RC strand predictions.
 
 ## Usage
 
-Pure CPU, ~20 s wallclock for all 3 datasets. Network: ~12 MB (downloads
-9 prediction parquets from the pinned gist).
+Pure CPU, no GPU. Network: a few MB (downloads 6 prediction parquets from the
+pinned gist). The bootstrap dominates wallclock (~3 min CPU per dataset at
+`n_bootstrap: 1000`).
 
 ```bash
 cd snakemake/gpn_star_eval
@@ -84,13 +97,13 @@ No SkyPilot launch yaml — the workload is too small to be worth it.
 
 ## Library
 
-Pipeline rules are thin glue around `marin_dna.evals.gpn_star`:
+Pipeline rules are thin glue around `marin_dna.pipelines.evals.gpn_star`:
 
 - `score_variants_gpn_star(hf_df, predictions, split)` — load + row-align
   predictions, derive `minus_*` columns. Asserts row-count + key-order match.
 - `predictions_url(dataset, model)` — gist raw URL for one prediction parquet.
 - `GPN_STAR_MODELS`, `GPN_STAR_MODEL_INFO`, `GPN_STAR_SCORE_COLUMN` — metadata.
 
-Tests at [`tests/evals/test_gpn_star.py`](../../tests/evals/test_gpn_star.py)
+Tests at [`tests/pipelines/evals/test_gpn_star.py`](../../../tests/pipelines/evals/test_gpn_star.py)
 cover alignment, NaN detection, chrom-dtype handling, and the predictions-URL
 helper.

--- a/snakemake/gpn_star_eval/config/config.yaml
+++ b/snakemake/gpn_star_eval/config/config.yaml
@@ -1,25 +1,40 @@
 input_hf_prefix: bolinas-dna/evals
 split: train
 
+# Matched-pair eval datasets, pinned to the k=9 / AUPRC revisions this repo's
+# evals_v2 targets (mirrors snakemake/analysis/evals_v2/config/config.yaml). The
+# GPN-Star prediction parquets (gist in `marin_dna.pipelines.evals.gpn_star`) are
+# row-aligned to exactly these revisions, so the `split == "train"` filter aligns
+# element-wise with `load_dataset(..., revision=...)`. eQTL was retired
+# (#172/#194) and has no current-revision GPN-Star upload, so it is not evaluated.
 datasets:
-  - mendelian_traits
-  - complex_traits
-  - eqtl
+  - name: mendelian_traits
+    hf_revision: 4aed58e50c5dea0b878a665007af2ef9e5108e9f  # PR #194 k=9 rebuild
+  - name: complex_traits
+    hf_revision: 22f86a89c65cb8f3007ac3cc2739f40efefa4340  # PR #194 k=9 rebuild
 
 # GPN-Star model variants (3 in current set). Model decoding lives in
-# `marin_dna.evals.gpn_star.GPN_STAR_MODEL_INFO`; source URLs are derived via
-# `marin_dna.evals.gpn_star.predictions_url`.
+# `marin_dna.pipelines.evals.gpn_star.GPN_STAR_MODEL_INFO`; source URLs are
+# derived via `marin_dna.pipelines.evals.gpn_star.predictions_url`.
 models:
   - V
   - M
   - P
 
-# Score columns evaluated against `compute_pairwise_metrics`. The 4 entries
-# below produce both the leaderboard-convention column (calibrated) and its
-# uncalibrated counterpart per dataset, so the same metrics parquet powers
-# both the live leaderboards and the #145 eval comment's parallel reporting.
+# Score columns evaluated by `compute_auprc_metrics`. The 4 entries below produce
+# both the leaderboard-convention column (calibrated) and its uncalibrated
+# counterpart per dataset, so the same metrics parquet powers both the live
+# leaderboards and the #145 eval comment's parallel reporting.
 score_columns:
   - minus_llr
   - abs_llr
   - minus_llr_calibrated
   - abs_llr_calibrated
+
+# AUPRC + cluster-bootstrap SE, matching evals_v2 (the 1:9 / AUPRC migration in
+# #194/#195/#199) so GPN-Star rows are directly comparable to our models on the
+# same dataset revisions. The old PairwiseAccuracy path asserted 1:1 and would
+# fail on these 1:9 datasets.
+n_bootstrap: 1000
+bootstrap_seed: 0   # 0 -> reproducible across re-runs
+n_min: 30           # min n_groups per subset to enter the macro average

--- a/snakemake/gpn_star_eval/workflow/Snakefile
+++ b/snakemake/gpn_star_eval/workflow/Snakefile
@@ -2,9 +2,9 @@
 
 Pulls externally-produced GPN-Star prediction parquets (songlab-cal/TraitGym
 `bolinas_pack_predictions` rule, pinned to a gist via
-``marin_dna.evals.gpn_star.GPN_STAR_GIST_BASE``), row-aligns with the HF eval
-dataset's train split, computes PairwiseAccuracy ± SE per consequence subset.
-Train split only.
+``marin_dna.pipelines.evals.gpn_star.GPN_STAR_GIST_BASE``), row-aligns with the
+HF eval dataset's train split at the pinned revision, computes AUPRC +
+cluster-bootstrap SE per consequence subset (matching evals_v2). Train split only.
 """
 
 

--- a/snakemake/gpn_star_eval/workflow/rules/common.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/common.smk
@@ -5,8 +5,12 @@ from datasets import load_dataset
 
 from marin_dna.pipelines.evals.conservation import REQUIRED_VARIANT_COLUMNS
 from marin_dna.pipelines.evals.gpn_star import predictions_url, score_variants_gpn_star
-from marin_dna.pipelines.evals.metrics import compute_pairwise_metrics
+from marin_dna.pipelines.evals.metrics import compute_auprc_metrics
 
-DATASETS = config["datasets"]
+# `datasets` is a list of {name, hf_revision} (revisions pinned to the k=9 /
+# AUPRC HF commits). Names drive the wildcards; the revision map pins
+# `load_dataset` so the prediction parquets row-align deterministically.
+DATASETS = [d["name"] for d in config["datasets"]]
+HF_REVISION = {d["name"]: d["hf_revision"] for d in config["datasets"]}
 MODELS = config["models"]
 SCORE_COLUMNS = config["score_columns"]

--- a/snakemake/gpn_star_eval/workflow/rules/metrics.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/metrics.smk
@@ -1,9 +1,14 @@
-"""Per-dataset PairwiseAccuracy ± SE on the 4 score columns × 3 models.
+"""Per-dataset AUPRC + cluster-bootstrap SE on the 4 score columns × 3 models.
 
 Output schema (one row per ``(model, score_type, subset)``):
-``[score_type, subset, value, se, n_pairs, n_ties, model, dataset, split]``.
+``[score_type, subset, value, se, n_groups, n_rows, model, dataset, split]``.
 Includes ``_global_`` and ``_macro_avg_`` sentinel subset rows from
-``compute_pairwise_metrics`` (n_min=30).
+``compute_auprc_metrics`` (``n_min`` from config). AUPRC + cluster bootstrap on
+``match_group`` matches evals_v2, so these rows are directly comparable to our
+models on the same dataset revisions — and they reproduce the GPN-Star numbers
+the dashboard reads from the #145 metrics gist. (The previous PairwiseAccuracy
+path asserted 1 pos + 1 neg per ``match_group`` and would fail on the 1:9 k=9
+datasets.)
 """
 
 
@@ -31,11 +36,13 @@ rule compute_metrics:
         for m in MODELS:
             model = f"GPN-Star-{m}"
             sub = df[df["model"] == model]
-            metrics = compute_pairwise_metrics(
-                dataset=sub[list(REQUIRED_VARIANT_COLUMNS)],
+            metrics = compute_auprc_metrics(
+                dataset=sub[["label", "subset", "match_group"]],
                 scores=sub[SCORE_COLUMNS],
                 score_columns=SCORE_COLUMNS,
-                n_min=30,
+                n_bootstrap=config["n_bootstrap"],
+                rng=config["bootstrap_seed"],
+                n_min=config["n_min"],
             )
             metrics["model"] = model
             per_model.append(metrics)

--- a/snakemake/gpn_star_eval/workflow/rules/score.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/score.smk
@@ -20,7 +20,11 @@ rule score_variants:
         dataset="|".join(DATASETS),
     run:
         hf_path = f"{config['input_hf_prefix']}_{wildcards.dataset}"
-        hf = load_dataset(hf_path, split=config["split"]).to_pandas()
+        hf = load_dataset(
+            hf_path,
+            split=config["split"],
+            revision=HF_REVISION[wildcards.dataset],
+        ).to_pandas()
         for col in REQUIRED_VARIANT_COLUMNS:
             assert col in hf.columns, f"HF dataset missing column {col!r}"
 

--- a/src/marin_dna/pipelines/evals/gpn_star.py
+++ b/src/marin_dna/pipelines/evals/gpn_star.py
@@ -40,10 +40,18 @@ GPN_STAR_MODEL_INFO: dict[str, tuple[str, str]] = {
 
 # Prediction parquets uploaded by the producer to a gist; pinned commit so the
 # raw URL is stable. Replace if the producer re-uploads.
+#
+# Pinned to the **current-revision** upload (issue #145 comment
+# https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4489509362):
+# row-aligned to evals_mendelian_traits@4aed58e / evals_complex_traits@22f86a89
+# (the k=9 / AUPRC revisions this repo's evals_v2 targets). The earlier upload
+# (gist facb982f @ 35bfb2f) is the pre-#194 1:1 revision and is NOT compatible
+# with the current HF datasets — the alignment assert in score_variants_gpn_star
+# would fire. eQTL was retired (#172/#194) and is not in this gist.
 GPN_STAR_GIST_BASE: str = (
     "https://gist.githubusercontent.com/gonzalobenegas/"
-    "facb982f19878b46f8bc4f7f4564416f/raw/"
-    "35bfb2fa160ae0d83811e024b777d429caae43d1"
+    "db282f89aa00244fbb7437dce0f069ef/raw/"
+    "02484d50d9bfd80337e313652b26f98a9362b6b1"
 )
 
 # Per-dataset leaderboard score column. The calibrated variant is what each
@@ -57,9 +65,14 @@ GPN_STAR_SCORE_COLUMN: dict[str, str] = {
 
 
 def predictions_url(dataset: str, model: str) -> str:
-    """Return the gist raw URL for one GPN-Star prediction parquet."""
+    """Return the gist raw URL for one GPN-Star prediction parquet.
+
+    The current-revision upload names files ``bolinas_{dataset}_GPN-Star-{model}``
+    (underscore separator); the earlier 1:1-revision upload used a ``.`` before
+    ``GPN-Star``. See ``GPN_STAR_GIST_BASE``.
+    """
     assert model in GPN_STAR_MODELS, f"unknown GPN-Star model {model!r}"
-    return f"{GPN_STAR_GIST_BASE}/bolinas_{dataset}.GPN-Star-{model}.parquet"
+    return f"{GPN_STAR_GIST_BASE}/bolinas_{dataset}_GPN-Star-{model}.parquet"
 
 
 def score_variants_gpn_star(

--- a/src/marin_dna/pipelines/evals/gpn_star.py
+++ b/src/marin_dna/pipelines/evals/gpn_star.py
@@ -55,12 +55,11 @@ GPN_STAR_GIST_BASE: str = (
 )
 
 # Per-dataset leaderboard score column. The calibrated variant is what each
-# leaderboard issue (#161 / #162 / #172) renders. The uncalibrated counterpart
-# is reported in #145 for context.
+# leaderboard issue (#161 / #162) renders. The uncalibrated counterpart is
+# reported in #145 for context. (eQTL #172 retired in #194 — no current upload.)
 GPN_STAR_SCORE_COLUMN: dict[str, str] = {
     "mendelian_traits": "minus_llr_calibrated",
     "complex_traits": "abs_llr_calibrated",
-    "eqtl": "abs_llr_calibrated",
 }
 
 

--- a/tests/pipelines/evals/test_gpn_star.py
+++ b/tests/pipelines/evals/test_gpn_star.py
@@ -287,11 +287,14 @@ def test_score_variants_missing_pred_column() -> None:
 
 
 def test_predictions_url_format() -> None:
+    # Current-revision upload uses an underscore before ``GPN-Star`` (the earlier
+    # 1:1-revision upload used a dot). Datasets are mendelian + complex (eQTL
+    # retired, #172/#194).
     assert predictions_url("mendelian_traits", "V") == (
-        f"{GPN_STAR_GIST_BASE}/bolinas_mendelian_traits.GPN-Star-V.parquet"
+        f"{GPN_STAR_GIST_BASE}/bolinas_mendelian_traits_GPN-Star-V.parquet"
     )
-    assert predictions_url("eqtl", "P") == (
-        f"{GPN_STAR_GIST_BASE}/bolinas_eqtl.GPN-Star-P.parquet"
+    assert predictions_url("complex_traits", "P") == (
+        f"{GPN_STAR_GIST_BASE}/bolinas_complex_traits_GPN-Star-P.parquet"
     )
 
 

--- a/tests/pipelines/evals/test_gpn_star.py
+++ b/tests/pipelines/evals/test_gpn_star.py
@@ -306,11 +306,10 @@ def test_predictions_url_unknown_model() -> None:
 def test_score_column_per_dataset_convention() -> None:
     # Mendelian uses signed (pathogenic ⇒ alt depleted under purifying selection).
     assert GPN_STAR_SCORE_COLUMN["mendelian_traits"] == "minus_llr_calibrated"
-    # Complex / eQTL use magnitude (direction-agnostic; eQTLs can go either way).
+    # Complex uses magnitude (direction-agnostic).
     assert GPN_STAR_SCORE_COLUMN["complex_traits"] == "abs_llr_calibrated"
-    assert GPN_STAR_SCORE_COLUMN["eqtl"] == "abs_llr_calibrated"
-    # No surprise datasets.
-    assert set(GPN_STAR_SCORE_COLUMN) == {"mendelian_traits", "complex_traits", "eqtl"}
+    # No surprise datasets (eQTL #172 retired in #194).
+    assert set(GPN_STAR_SCORE_COLUMN) == {"mendelian_traits", "complex_traits"}
 
 
 def test_model_info_keys_match_models_tuple() -> None:


### PR DESCRIPTION
## Summary

The committed `gpn_star_eval` pipeline no longer reproduced the GPN-Star numbers the dashboard shows. Two stale pins, both predating the 1:9 / AUPRC migration (#194/#195/#199):

1. **Prediction gist** — `gpn_star.py` pinned the pre-#194 upload (`facb982f` @ `35bfb2f`, HF revision `15e85bba`, 9,820 train, 1:1 matching), with the old `.GPN-Star` filename. The dashboard's GPN-Star AUPRC actually comes from the **2026-05-19 re-upload** on the k=9 revisions ([#145 comment](https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4489509362), gist `db282f89` @ `02484d5`, `_GPN-Star` filename, row-aligned to `evals_mendelian_traits@4aed58e` / `evals_complex_traits@22f86a89`).
2. **Metric** — the pipeline computed **PairwiseAccuracy**, which asserts 1 pos + 1 neg per `match_group` and **fails on the 1:9 datasets**; the dashboard numbers are **AUPRC + cluster-bootstrap** (`compute_auprc_metrics`).

Net effect: a re-run today downloaded the stale predictions and **crashed** on `score_variants_gpn_star`'s row-count assert (16,140 HF vs 9,820 preds) — fail-loud, no silent corruption, but the committed pipeline couldn't regenerate the dashboard's GPN-Star rows. (The dashboard *display* was never wrong — it reads the pre-computed #145 metrics gist, which was made on the correct revision and is byte-equivalent to songlab's official predictions.)

This PR converges the pipeline onto what actually backs the dashboard.

## Changes

- **`gpn_star.py`**: `GPN_STAR_GIST_BASE` → current-revision gist (`db282f89` @ `02484d5`); `predictions_url` filename `bolinas_{ds}.GPN-Star-{m}` → `bolinas_{ds}_GPN-Star-{m}`.
- **`config.yaml`**: `datasets` → `{name, hf_revision}` pinned to `4aed58e` / `22f86a89` (mirrors evals_v2); **drop retired eqtl** (#172/#194 — no current-revision upload); add `n_bootstrap` / `bootstrap_seed` / `n_min`.
- **`score.smk`**: pin `load_dataset(revision=…)` so predictions row-align deterministically.
- **`metrics.smk`**: PairwiseAccuracy → `compute_auprc_metrics`; output schema `n_pairs/n_ties` → `n_groups/n_rows`.
- **`common.smk` / `Snakefile` / `README`**: docstrings + dataset-list handling updated; `test_gpn_star` URL test updated.

## Verification

- **Reproduces the dashboard**: running the edited code path (`predictions_url` → `score_variants_gpn_star` → `compute_auprc_metrics`) matches the #145 metrics-gist AUPRC to **±0.0000** for V/M/P, global + macro (mendelian).

  ```
  model  subset       score                 pipeline    gist       Δ
  GPN-V  _global_     minus_llr               0.4777   0.4777  +0.0000
  GPN-V  _global_     minus_llr_calibrated    0.4834   0.4834  +0.0000
  GPN-M  _global_     minus_llr               0.4705   0.4705  +0.0000
  GPN-P  _global_     minus_llr_calibrated    0.3919   0.3919  +0.0000
  …  (all 12 rows Δ = +0.0000; worst |Δ| = 0)
  ```
- `predictions_url("mendelian_traits","V")` downloads cleanly: 25,630 rows / 16,140 train.
- Forced dry-run builds a clean 5-job DAG (2× score + 2× metrics + all) over mendelian + complex.
- `ruff` clean; **332 evals tests pass** (`tests/pipelines/evals/`).

## Note (not in scope)

The stale S3 outputs (`s3://oa-bolinas/snakemake/gpn_star_eval/results/*`, 2026-05-13 PA-era) still exist, so a plain `snakemake` is a no-op — regenerating them needs `--forceall` (or deleting them first). The dashboard reads the gist (not S3), so this is an artifact-refresh follow-up, not a dashboard fix; happy to run it on request.

Found while investigating the cLLR work in #271. Context: #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
