### PR TITLE
evals_v2: add functional/non-functional LL-gap eval + scaling-ladder VEP analysis

### DIFF
--- a/plots/llgap_vs_vep_scaling.py
+++ b/plots/llgap_vs_vep_scaling.py
@@ -1,22 +1,23 @@
-"""Issue #274 figure: loss-vs-VEP and LL-gap-vs-VEP across the scaling ladder.
+"""Issue #274 figure: overall-LL-vs-VEP and LL-gap-vs-VEP across the scaling ladder.
 
-Two side-by-side panels over the 8 `dna-bolinas-scaling-v0.5` sizes (46M→4B):
-  left  — validation loss (x) vs Mendelian AUPRC (y), one series per variant type
-  right — macro LL gap (x)   vs Mendelian AUPRC (y), one series per variant type
-Spearman ρ per variant type is shown in each panel's legend, so the question
-"does the gap track VEP better than loss?" is read off directly.
+Two panels over the 8 `dna-bolinas-scaling-v0.5` sizes (46M→4B), for one
+validation-interval region (default CDS — the weak-loss-correlation regime):
+  left  — overall LL (x) vs Mendelian AUPRC (y), one series per variant type
+  right — LL gap (x)     vs Mendelian AUPRC (y), one series per variant type
+Pearson r per variant is shown in each legend (Pearson separates the predictors
+that Spearman ties; see scripts/issue274_scaling_correlation.py). The W&B
+validation loss is intentionally NOT shown — it is `lowercase_weight=0.01`
+(functional-dominated), so the clean equal-weight overall LL is the baseline.
 
-Self-contained recipe (repo convention): pulls loss + in-training VEP from W&B
-and the LL gap from the evals_v2 `ll_gap` summary; if `--metrics-prefix` is
-given and present, uses the official evals_v2 Mendelian AUPRC as the y-axis
-instead of the in-training AUPRC. Reuses the loaders in
-`scripts/issue274_scaling_correlation.py`. Emits SVG + PNG to
-`plots/output/llgap_vs_vep_scaling/`.
+Self-contained recipe; reuses the loaders in
+`scripts/issue274_scaling_correlation.py`. Uses the official evals_v2 AUPRC when
+`--metrics-prefix` is given and present, else the in-training AUPRC. Emits
+SVG + PNG to `plots/output/llgap_vs_vep_scaling/`.
 
 Usage:
     uv run python plots/llgap_vs_vep_scaling.py \
         --gap-summary s3://oa-bolinas/snakemake/analysis/evals_v2/results/ll_gap/summary.parquet \
-        --metrics-prefix s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics
+        --metrics-prefix s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics --region cds
 """
 
 from __future__ import annotations
@@ -26,24 +27,22 @@ import sys
 from pathlib import Path
 
 import numpy as np
-from scipy.stats import spearmanr
+from scipy.stats import pearsonr
 
-# Reuse the analysis loaders (single source of truth for schema/merge).
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 from issue274_scaling_correlation import (  # noqa: E402
     VARIANTS,
     load_evals_v2_vep,
-    load_gap_by_size,
-    pull_wandb_baseline,
+    load_gap_quantities,
+    pull_wandb_auprc,
 )
 
 OUT_DIR = Path(__file__).resolve().parent / "output" / "llgap_vs_vep_scaling"
 
 
 def build_points(gap_summary: str, metrics_prefix: str | None, score_type: str):
-    """Merged per-size frame + the AUPRC column prefix to plot (official if present)."""
-    df = pull_wandb_baseline().merge(
-        load_gap_by_size(gap_summary), on="size", validate="1:1"
+    df = pull_wandb_auprc().merge(
+        load_gap_quantities(gap_summary), on="size", validate="1:1"
     )
     prefix, label = "intrain_auprc_", "in-training AUPRC"
     if metrics_prefix:
@@ -59,6 +58,9 @@ def main() -> None:
     ap.add_argument("--gap-summary", required=True)
     ap.add_argument("--metrics-prefix", default=None)
     ap.add_argument("--score-type", default="minus_llr_avg")
+    ap.add_argument(
+        "--region", default="cds", choices=["cds", "upstream", "downstream", "macro"]
+    )
     args = ap.parse_args()
 
     import matplotlib
@@ -70,11 +72,11 @@ def main() -> None:
     df, prefix, vep_label = build_points(
         args.gap_summary, args.metrics_prefix, args.score_type
     )
+    r = args.region
+    predictors = [(f"LL_all_{r}", "overall LL"), (f"gap_{r}", "LL gap")]
 
-    predictors = [("eval_loss", "validation loss"), ("gap_macro", "macro LL gap")]
     fig, axes = plt.subplots(1, 2, figsize=(11, 5), sharey=True)
     cmap = plt.get_cmap("tab10")
-
     for ax, (xcol, xlabel) in zip(axes, predictors):
         x = df[xcol].to_numpy(dtype=float)
         for i, v in enumerate(VARIANTS):
@@ -83,7 +85,7 @@ def main() -> None:
                 continue
             y = df[ycol].to_numpy(dtype=float)
             order = np.argsort(x)
-            rho, _ = spearmanr(x, y)
+            pr = pearsonr(x, y).statistic
             ax.plot(
                 x[order],
                 y[order],
@@ -91,24 +93,29 @@ def main() -> None:
                 ms=4,
                 lw=1,
                 color=cmap(i % 10),
-                label=f"{v.replace('_variant', '')} (ρ={rho:+.2f})",
+                label=f"{v.replace('_variant', '')} (r={pr:+.2f})",
             )
-        ax.set_xlabel(xlabel)
+        ax.set_xlabel(f"{xlabel} ({r})")
         ax.grid(True, alpha=0.3)
     axes[0].set_ylabel(vep_label)
-    axes[0].set_title("loss vs VEP")
-    axes[1].set_title("LL gap vs VEP")
+    axes[0].set_title(f"overall LL vs VEP ({r})")
+    axes[1].set_title(f"LL gap vs VEP ({r})")
     axes[1].legend(
-        fontsize=7, loc="center left", bbox_to_anchor=(1.0, 0.5), title="variant"
+        fontsize=7,
+        loc="center left",
+        bbox_to_anchor=(1.0, 0.5),
+        title="variant (Pearson r)",
     )
-    fig.suptitle(f"Scaling ladder (46M→4B, n=8): {vep_label} vs loss and LL gap (#274)")
+    fig.suptitle(
+        f"Scaling ladder (46M→4B, n=8): {vep_label} vs overall LL and LL gap — {r} (#274)"
+    )
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
-    svg = OUT_DIR / "figure.svg"
+    svg = OUT_DIR / f"figure_{r}.svg"
     fig.savefig(svg, bbox_inches="tight", dpi=200)
-    fig.savefig(OUT_DIR / "figure.png", bbox_inches="tight", dpi=200)
+    fig.savefig(svg.with_suffix(".png"), bbox_inches="tight", dpi=200)
     plt.close(fig)
-    print(f"wrote {svg} (+ .png); VEP = {vep_label}")
+    print(f"wrote {svg} (+ .png); VEP = {vep_label}, region = {r}")
 
 
 if __name__ == "__main__":

--- a/plots/llgap_vs_vep_scaling.py
+++ b/plots/llgap_vs_vep_scaling.py
@@ -1,0 +1,115 @@
+"""Issue #274 figure: loss-vs-VEP and LL-gap-vs-VEP across the scaling ladder.
+
+Two side-by-side panels over the 8 `dna-bolinas-scaling-v0.5` sizes (46M→4B):
+  left  — validation loss (x) vs Mendelian AUPRC (y), one series per variant type
+  right — macro LL gap (x)   vs Mendelian AUPRC (y), one series per variant type
+Spearman ρ per variant type is shown in each panel's legend, so the question
+"does the gap track VEP better than loss?" is read off directly.
+
+Self-contained recipe (repo convention): pulls loss + in-training VEP from W&B
+and the LL gap from the evals_v2 `ll_gap` summary; if `--metrics-prefix` is
+given and present, uses the official evals_v2 Mendelian AUPRC as the y-axis
+instead of the in-training AUPRC. Reuses the loaders in
+`scripts/issue274_scaling_correlation.py`. Emits SVG + PNG to
+`plots/output/llgap_vs_vep_scaling/`.
+
+Usage:
+    uv run python plots/llgap_vs_vep_scaling.py \
+        --gap-summary s3://oa-bolinas/snakemake/analysis/evals_v2/results/ll_gap/summary.parquet \
+        --metrics-prefix s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+from scipy.stats import spearmanr
+
+# Reuse the analysis loaders (single source of truth for schema/merge).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from issue274_scaling_correlation import (  # noqa: E402
+    VARIANTS,
+    load_evals_v2_vep,
+    load_gap_by_size,
+    pull_wandb_baseline,
+)
+
+OUT_DIR = Path(__file__).resolve().parent / "output" / "llgap_vs_vep_scaling"
+
+
+def build_points(gap_summary: str, metrics_prefix: str | None, score_type: str):
+    """Merged per-size frame + the AUPRC column prefix to plot (official if present)."""
+    df = pull_wandb_baseline().merge(
+        load_gap_by_size(gap_summary), on="size", validate="1:1"
+    )
+    prefix, label = "intrain_auprc_", "in-training AUPRC"
+    if metrics_prefix:
+        v2 = load_evals_v2_vep(metrics_prefix, score_type)
+        if v2 is not None:
+            df = df.merge(v2, on="size", validate="1:1")
+            prefix, label = "v2_auprc_", f"evals_v2 AUPRC ({score_type})"
+    return df, prefix, label
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--gap-summary", required=True)
+    ap.add_argument("--metrics-prefix", default=None)
+    ap.add_argument("--score-type", default="minus_llr_avg")
+    args = ap.parse_args()
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    matplotlib.rcParams["svg.fonttype"] = "none"
+    import matplotlib.pyplot as plt
+
+    df, prefix, vep_label = build_points(
+        args.gap_summary, args.metrics_prefix, args.score_type
+    )
+
+    predictors = [("eval_loss", "validation loss"), ("gap_macro", "macro LL gap")]
+    fig, axes = plt.subplots(1, 2, figsize=(11, 5), sharey=True)
+    cmap = plt.get_cmap("tab10")
+
+    for ax, (xcol, xlabel) in zip(axes, predictors):
+        x = df[xcol].to_numpy(dtype=float)
+        for i, v in enumerate(VARIANTS):
+            ycol = f"{prefix}{v}"
+            if ycol not in df.columns or df[ycol].isna().any():
+                continue
+            y = df[ycol].to_numpy(dtype=float)
+            order = np.argsort(x)
+            rho, _ = spearmanr(x, y)
+            ax.plot(
+                x[order],
+                y[order],
+                marker="o",
+                ms=4,
+                lw=1,
+                color=cmap(i % 10),
+                label=f"{v.replace('_variant', '')} (ρ={rho:+.2f})",
+            )
+        ax.set_xlabel(xlabel)
+        ax.grid(True, alpha=0.3)
+    axes[0].set_ylabel(vep_label)
+    axes[0].set_title("loss vs VEP")
+    axes[1].set_title("LL gap vs VEP")
+    axes[1].legend(
+        fontsize=7, loc="center left", bbox_to_anchor=(1.0, 0.5), title="variant"
+    )
+    fig.suptitle(f"Scaling ladder (46M→4B, n=8): {vep_label} vs loss and LL gap (#274)")
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    svg = OUT_DIR / "figure.svg"
+    fig.savefig(svg, bbox_inches="tight", dpi=200)
+    fig.savefig(OUT_DIR / "figure.png", bbox_inches="tight", dpi=200)
+    plt.close(fig)
+    print(f"wrote {svg} (+ .png); VEP = {vep_label}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plots/llgap_vs_vep_scaling.py
+++ b/plots/llgap_vs_vep_scaling.py
@@ -78,12 +78,12 @@ def main() -> None:
     cmap = plt.get_cmap("tab10")
     for ax, (xcol, xlabel) in zip(axes, predictors):
         x = df[xcol].to_numpy(dtype=float)
+        order = np.argsort(x)
         for i, v in enumerate(VARIANTS):
             ycol = f"{prefix}{v}"
             if ycol not in df.columns or df[ycol].isna().any():
                 continue
             y = df[ycol].to_numpy(dtype=float)
-            order = np.argsort(x)
             ax.plot(
                 x[order],
                 y[order],

--- a/plots/llgap_vs_vep_scaling.py
+++ b/plots/llgap_vs_vep_scaling.py
@@ -27,7 +27,6 @@ import sys
 from pathlib import Path
 
 import numpy as np
-from scipy.stats import pearsonr
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 from issue274_scaling_correlation import (  # noqa: E402
@@ -85,7 +84,6 @@ def main() -> None:
                 continue
             y = df[ycol].to_numpy(dtype=float)
             order = np.argsort(x)
-            pr = pearsonr(x, y).statistic
             ax.plot(
                 x[order],
                 y[order],
@@ -93,7 +91,7 @@ def main() -> None:
                 ms=4,
                 lw=1,
                 color=cmap(i % 10),
-                label=f"{v.replace('_variant', '')} (r={pr:+.2f})",
+                label=v.replace("_variant", ""),
             )
         ax.set_xlabel(f"{xlabel} ({r})")
         ax.grid(True, alpha=0.3)
@@ -104,7 +102,7 @@ def main() -> None:
         fontsize=7,
         loc="center left",
         bbox_to_anchor=(1.0, 0.5),
-        title="variant (Pearson r)",
+        title="variant",
     )
     fig.suptitle(
         f"Scaling ladder (46M→4B, n=8): {vep_label} vs overall LL and LL gap — {r} (#274)"

--- a/scripts/issue274_scaling_correlation.py
+++ b/scripts/issue274_scaling_correlation.py
@@ -71,6 +71,14 @@ PRED_LABEL = {
     "LL_lower": "LL non-functional",
     "gap": "LL gap",
 }
+# Region-matched variant sets: correlate each region's LLs only against the
+# variant types that live in that region (issue #274 follow-up). The full grid
+# (all regions × variants) is still saved; this drives the focused print.
+REGION_VARIANTS = {
+    "cds": ["missense_variant", "synonymous_variant", "splicing"],
+    "upstream": ["tss_proximal", "5_prime_UTR_variant"],  # tss_proximal ≈ promoter
+    "downstream": ["3_prime_UTR_variant"],
+}
 
 _SIZE_RE = re.compile(r"(h\d+-p[\dA-Za-z]+)")
 
@@ -178,26 +186,29 @@ def decomposition(df: pd.DataFrame, auprc_prefix: str, vep_label: str) -> pd.Dat
     return pd.DataFrame(rows)
 
 
-def _print_region(result: pd.DataFrame, region: str, variants: list[str]) -> None:
+def _print_matched(result: pd.DataFrame) -> None:
+    """Print each region-matched (region → variant) pair's 4 predictor
+    correlations as Pearson r / Spearman ρ."""
+    hdr = ["LL_all", "LL_func", "LL_nonf", "LL_gap"]
     for label, sub in result.groupby("vep_source"):
-        sub = sub[sub["region"] == region]
-        print(f"\n=== VEP={label} | region={region} | Pearson / Spearman (n=8) ===")
-        print(
-            f"{'predictor':18}"
-            + "".join(f"{v.replace('_variant', ''):>16}" for v in variants)
-        )
-        for q in PREDICTORS:
-            lab = PRED_LABEL[q]
-            cells = []
+        print(f"\n=== VEP={label} | region-matched | Pearson r / Spearman ρ (n=8) ===")
+        print(f"{'region → variant':24}" + "".join(f"{h:>16}" for h in hdr))
+        for region, variants in REGION_VARIANTS.items():
             for v in variants:
-                row = sub[(sub["predictor"] == lab) & (sub["variant"] == v)]
-                if len(row):
+                cells = []
+                for q in PREDICTORS:
+                    row = sub[
+                        (sub["region"] == region)
+                        & (sub["predictor"] == PRED_LABEL[q])
+                        & (sub["variant"] == v)
+                    ]
                     cells.append(
-                        f"{row.pearson.iloc[0]:+.2f} / {row.spearman.iloc[0]:+.2f}"
+                        f"{row.pearson.iloc[0]:+.2f}/{row.spearman.iloc[0]:+.2f}"
+                        if len(row)
+                        else "—"
                     )
-                else:
-                    cells.append("—")
-            print(f"{lab:18}" + "".join(f"{c:>16}" for c in cells))
+                name = f"{region}→{v.replace('_variant', '')}"
+                print(f"{name:24}" + "".join(f"{c:>16}" for c in cells))
 
 
 def main() -> None:
@@ -228,8 +239,8 @@ def main() -> None:
     Path(args.out).parent.mkdir(parents=True, exist_ok=True)
     result.to_parquet(args.out, index=False)
 
-    # Focused print: the CDS region vs the CDS-relevant + overall variants.
-    _print_region(result, "cds", ["missense_variant", "synonymous_variant", "all"])
+    # Focused print: region-matched (region → variant) pairs.
+    _print_matched(result)
     print(f"\nsaved full grid (all regions × predictors × variants) → {args.out}")
 
 

--- a/scripts/issue274_scaling_correlation.py
+++ b/scripts/issue274_scaling_correlation.py
@@ -90,8 +90,10 @@ def size_token(name: str) -> str:
 
 
 def pull_wandb_auprc(entity: str = WANDB_ENTITY) -> pd.DataFrame:
-    """Per-size in-training Mendelian AUPRC (+ params) from W&B. (eval_loss is
-    pulled only as a reference column — it is NOT used as a predictor.)"""
+    """Per-size in-training Mendelian AUPRC (+ params) from W&B. The W&B
+    `eval/loss` is intentionally NOT pulled — it is the `lowercase_weight=0.01`
+    (functional-dominated) loss, a confounded baseline; the clean overall LL
+    (`LL_all`) is the baseline instead."""
     import wandb
 
     api = wandb.Api()
@@ -108,7 +110,6 @@ def pull_wandb_auprc(entity: str = WANDB_ENTITY) -> pd.DataFrame:
         d: dict[str, object] = {
             "size": size_token(s),
             "params": r.summary.get("parameter_count"),
-            "wandb_eval_loss_ref": r.summary.get("eval/loss"),  # reference only
         }
         for v in VARIANTS:
             d[f"intrain_auprc_{v}"] = r.summary.get(
@@ -145,8 +146,16 @@ def load_evals_v2_vep(metrics_prefix: str, score_type: str) -> pd.DataFrame | No
         path = f"{metrics_prefix}/scaling-v0.5-{s}-step-215573/mendelian_traits.parquet"
         try:
             m = pl.read_parquet(path).to_pandas()
-        except Exception:
-            return None
+        except Exception as e:
+            # Genuinely-absent metrics (not built yet) → fall back to in-training.
+            # Any other error (corrupt parquet, S3 auth, schema drift) must
+            # surface rather than be silently misread as "not present yet".
+            if any(
+                s in str(e).lower()
+                for s in ("not found", "no such", "does not exist", "404", "nosuchkey")
+            ):
+                return None
+            raise
         m = m[m["score_type"] == score_type]
         d: dict[str, object] = {"size": size_token(s)}
         for v in VARIANTS:
@@ -222,7 +231,12 @@ def main() -> None:
     df = pull_wandb_auprc().merge(
         load_gap_quantities(args.gap_summary), on="size", validate="1:1"
     )
-    assert df["gap_cds"].notna().all(), "missing gap — run `snakemake ll_gap`"
+    # Require every (predictor × region) cell. A partial summary (e.g. one sky
+    # cell failed) would otherwise yield silent-NaN correlations and a skipna
+    # macro mean over the wrong number of regions.
+    _need = [f"{q}_{r}" for q in PREDICTORS for r in ("cds", "upstream", "downstream")]
+    _missing = [c for c in _need if df[c].isna().any()]
+    assert not _missing, f"missing LL cells (run `snakemake ll_gap`): {_missing}"
 
     tables = [decomposition(df, "intrain_auprc_", "in_training")]
     if args.metrics_prefix:

--- a/scripts/issue274_scaling_correlation.py
+++ b/scripts/issue274_scaling_correlation.py
@@ -1,15 +1,26 @@
-"""Issue #274: does the functional/non-functional LL gap predict VEP better than
-loss across the 8-model parameter-scaling ladder?
+"""Issue #274: which likelihood signal best predicts VEP across the scaling ladder?
 
-Computes Spearman ρ of VEP AUPRC vs two predictors — validation loss and the LL
-gap — per Mendelian variant type, across the 8 `dna-bolinas-scaling-v0.5` sizes
-(46M→4B, step-215573). Everything is reproducible from W&B + the evals_v2
-pipeline outputs (no external/blog data):
+For the 8-model `dna-bolinas-scaling-v0.5` ladder (46M→4B, step-215573) this
+correlates Mendelian VEP AUPRC against **4 likelihood predictors**, each derived
+from the evals_v2 `ll_gap` eval (per validation-interval region):
 
-  - loss + in-training Mendelian AUPRC: W&B (eric-czech/marin scaling runs).
-  - LL gap per (model, region): the evals_v2 `ll_gap` summary parquet (S3/local).
-  - [primary VEP] evals_v2 Mendelian AUPRC per (model, variant): the
-    `results/metrics/<model>/mendelian_traits.parquet` parquets (S3/local).
+  - ``LL_all``   — equal-weight mean log-prob over all target tokens (clean −perplexity)
+  - ``LL_upper`` — mean log-prob on functional (uppercase / phyloP-conserved) tokens
+  - ``LL_lower`` — mean log-prob on non-functional (lowercase) tokens
+  - ``gap``      — LL_upper − LL_lower
+
+We deliberately **exclude the W&B `eval/loss`**: training's base val spec uses
+``lowercase_weight=0.01``, so that "loss" is functional-position-dominated (not a
+clean equal-weight loss) and would be a confounded baseline. ``LL_all`` is the
+clean overall-LL baseline instead.
+
+Both Pearson r and Spearman ρ are reported (n=8): Spearman ties the
+monotonic-in-scale predictors, Pearson separates them by value shape.
+
+Inputs (reproducible, no external data):
+  - in-training Mendelian AUPRC: W&B (eric-czech/marin scaling runs).
+  - LL quantities per (model, region): the evals_v2 `ll_gap` summary parquet.
+  - [primary VEP] official evals_v2 Mendelian AUPRC: `results/metrics/<model>/mendelian_traits.parquet`.
 
 Usage:
     uv run python scripts/issue274_scaling_correlation.py \
@@ -27,7 +38,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import polars as pl
-from scipy.stats import spearmanr
+from scipy.stats import pearsonr, spearmanr
 
 WANDB_ENTITY = "eric-czech/marin"
 SIZES = [
@@ -40,8 +51,6 @@ SIZES = [
     "h2432-p2B",
     "h2944-p4B",
 ]
-# Mendelian TraitGym variant types (in-training lm_eval naming; evals_v2 uses the
-# same consequence names as subsets).
 VARIANTS = [
     "missense_variant",
     "5_prime_UTR_variant",
@@ -53,32 +62,28 @@ VARIANTS = [
     "non_coding_transcript_exon_variant",
     "all",
 ]
-# Which gap region best matches each variant type's locus (for the region-matched
-# comparison). cds = v5, upstream/promoter = v1, downstream/3'UTR = v15.
-VARIANT_REGION = {
-    "missense_variant": "cds",
-    "synonymous_variant": "cds",
-    "splicing": "cds",
-    "5_prime_UTR_variant": "upstream",
-    "tss_proximal": "upstream",
-    "3_prime_UTR_variant": "downstream",
-    "non_coding_transcript_exon_variant": "downstream",
-    "distal": "macro",
-    "all": "macro",
+REGIONS = ["cds", "upstream", "downstream", "macro"]
+# The 4 likelihood predictors (all from the ll_gap eval; W&B loss excluded).
+PREDICTORS = ["LL_all", "LL_upper", "LL_lower", "gap"]
+PRED_LABEL = {
+    "LL_all": "LL (overall)",
+    "LL_upper": "LL functional",
+    "LL_lower": "LL non-functional",
+    "gap": "LL gap",
 }
 
 _SIZE_RE = re.compile(r"(h\d+-p[\dA-Za-z]+)")
 
 
 def size_token(name: str) -> str:
-    """Extract the `h<width>-p<size>` token from a run/model/dir name."""
     m = _SIZE_RE.search(name)
     assert m, f"no size token in {name!r}"
     return m.group(1)
 
 
-def pull_wandb_baseline(entity: str = WANDB_ENTITY) -> pd.DataFrame:
-    """Per-size loss (overall + per region) and in-training Mendelian AUPRC from W&B."""
+def pull_wandb_auprc(entity: str = WANDB_ENTITY) -> pd.DataFrame:
+    """Per-size in-training Mendelian AUPRC (+ params) from W&B. (eval_loss is
+    pulled only as a reference column — it is NOT used as a predictor.)"""
     import wandb
 
     api = wandb.Api()
@@ -93,52 +98,49 @@ def pull_wandb_baseline(entity: str = WANDB_ENTITY) -> pd.DataFrame:
         assert len(cands) == 1, f"{dn}: expected 1 final run, got {len(cands)}"
         r = cands[0]
         d: dict[str, object] = {
-            "size": s,
+            "size": size_token(s),
             "params": r.summary.get("parameter_count"),
-            "eval_loss": r.summary.get("eval/loss"),
-            "loss_cds": r.summary.get("eval/val_cds/loss"),
-            "loss_upstream": r.summary.get("eval/val_upstream/loss"),
-            "loss_downstream": r.summary.get("eval/val_downstream/loss"),
+            "wandb_eval_loss_ref": r.summary.get("eval/loss"),  # reference only
         }
         for v in VARIANTS:
             d[f"intrain_auprc_{v}"] = r.summary.get(
                 f"lm_eval/traitgym_mendelian_v2_255/{v}/auprc"
             )
         rows.append(d)
-    df = pd.DataFrame(rows).sort_values("params").reset_index(drop=True)
-    assert df["eval_loss"].notna().all(), "missing eval_loss for some size"
-    return df
+    return pd.DataFrame(rows).sort_values("params").reset_index(drop=True)
 
 
-def load_gap_by_size(gap_summary_path: str) -> pd.DataFrame:
-    """Pivot the ll_gap summary to one row per size: gap per region + macro gap."""
+def load_gap_quantities(gap_summary_path: str) -> pd.DataFrame:
+    """Per-size LL quantities per region: e.g. `gap_cds`, `LL_upper_cds`, …, plus
+    a `<q>_macro` (mean over the 3 regions) for each quantity."""
     g = pl.read_parquet(gap_summary_path).to_pandas()
-    # Keep only the scaling ladder; the summary also holds the m5.1 gate row,
-    # which has no h<width>-p<size> token.
     g = g[g["model"].str.contains(r"scaling-v0\.5-h\d+-p", regex=True)].copy()
     g["size"] = g["model"].map(size_token)
-    wide = g.pivot(index="size", columns="region", values="gap")
-    wide.columns = [f"gap_{c}" for c in wide.columns]
-    wide["gap_macro"] = wide.mean(axis=1)  # mean of the per-region gaps
-    return wide.reset_index()
+    out: pd.DataFrame | None = None
+    for q in PREDICTORS:
+        w = g.pivot(index="size", columns="region", values=q)
+        w.columns = [f"{q}_{r}" for r in w.columns]
+        out = w if out is None else out.join(w)
+    assert out is not None
+    for q in PREDICTORS:
+        out[f"{q}_macro"] = out[[f"{q}_cds", f"{q}_upstream", f"{q}_downstream"]].mean(
+            axis=1
+        )
+    return out.reset_index()
 
 
 def load_evals_v2_vep(metrics_prefix: str, score_type: str) -> pd.DataFrame | None:
-    """Per-size evals_v2 Mendelian AUPRC per variant subset, for one score_type.
-
-    Returns one row per size with `v2_auprc_<variant>` columns, or None if the
-    metrics parquets aren't present yet.
-    """
+    """Per-size official evals_v2 Mendelian AUPRC per variant subset, for one
+    score_type. None if the metrics parquets aren't all present yet."""
     rows = []
     for s in SIZES:
-        model = f"scaling-v0.5-{s}-step-215573"
-        path = f"{metrics_prefix}/{model}/mendelian_traits.parquet"
+        path = f"{metrics_prefix}/scaling-v0.5-{s}-step-215573/mendelian_traits.parquet"
         try:
             m = pl.read_parquet(path).to_pandas()
         except Exception:
             return None
         m = m[m["score_type"] == score_type]
-        d: dict[str, object] = {"size": s}
+        d: dict[str, object] = {"size": size_token(s)}
         for v in VARIANTS:
             subset = "_global_" if v == "all" else v
             hit = m[m["subset"] == subset]["value"]
@@ -147,100 +149,88 @@ def load_evals_v2_vep(metrics_prefix: str, score_type: str) -> pd.DataFrame | No
     return pd.DataFrame(rows)
 
 
-def rho_comparison(df: pd.DataFrame, auprc_prefix: str, label: str) -> pd.DataFrame:
-    """For each variant: ρ(loss, AUPRC), ρ(macro gap, AUPRC), ρ(matched-region gap,
-    AUPRC), across the 8 sizes. `auprc_prefix` selects the VEP column family."""
-    out = []
-    for v in VARIANTS:
-        y = df[f"{auprc_prefix}{v}"].to_numpy(dtype=float)
-        if np.isnan(y).any():
-            continue
-        loss = df["eval_loss"].to_numpy(dtype=float)
-        gap_macro = df["gap_macro"].to_numpy(dtype=float)
-        region = VARIANT_REGION[v]
-        gap_m = df["gap_macro" if region == "macro" else f"gap_{region}"].to_numpy(
-            dtype=float
+def decomposition(df: pd.DataFrame, auprc_prefix: str, vep_label: str) -> pd.DataFrame:
+    """Pearson r + Spearman ρ of every (region × predictor) vs every variant's
+    AUPRC, across the 8 sizes."""
+    rows = []
+    for region in REGIONS:
+        for q in PREDICTORS:
+            x = df[f"{q}_{region}"].to_numpy(dtype=float)
+            for v in VARIANTS:
+                col = f"{auprc_prefix}{v}"
+                if col not in df.columns or df[col].isna().any():
+                    continue
+                y = df[col].to_numpy(dtype=float)
+                pear = pearsonr(x, y)
+                spear = spearmanr(x, y)
+                rows.append(
+                    {
+                        "vep_source": vep_label,
+                        "region": region,
+                        "predictor": PRED_LABEL[q],
+                        "variant": v,
+                        "pearson": pear.statistic,
+                        "pearson_p": pear.pvalue,
+                        "spearman": spear.statistic,
+                        "spearman_p": spear.pvalue,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def _print_region(result: pd.DataFrame, region: str, variants: list[str]) -> None:
+    for label, sub in result.groupby("vep_source"):
+        sub = sub[sub["region"] == region]
+        print(f"\n=== VEP={label} | region={region} | Pearson / Spearman (n=8) ===")
+        print(
+            f"{'predictor':18}"
+            + "".join(f"{v.replace('_variant', ''):>16}" for v in variants)
         )
-        r_loss, p_loss = spearmanr(loss, y)
-        r_macro, p_macro = spearmanr(gap_macro, y)
-        r_match, p_match = spearmanr(gap_m, y)
-        out.append(
-            {
-                "vep_source": label,
-                "variant": v,
-                "rho_loss": r_loss,
-                "p_loss": p_loss,
-                "rho_gap_macro": r_macro,
-                "p_gap_macro": p_macro,
-                "matched_region": region,
-                "rho_gap_matched": r_match,
-                "p_gap_matched": p_match,
-                "gap_wins": abs(r_match) > abs(r_loss),
-            }
-        )
-    return pd.DataFrame(out)
+        for q in PREDICTORS:
+            lab = PRED_LABEL[q]
+            cells = []
+            for v in variants:
+                row = sub[(sub["predictor"] == lab) & (sub["variant"] == v)]
+                if len(row):
+                    cells.append(
+                        f"{row.pearson.iloc[0]:+.2f} / {row.spearman.iloc[0]:+.2f}"
+                    )
+                else:
+                    cells.append("—")
+            print(f"{lab:18}" + "".join(f"{c:>16}" for c in cells))
 
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument(
-        "--gap-summary", required=True, help="ll_gap summary.parquet (S3 or local)"
-    )
-    ap.add_argument(
-        "--metrics-prefix",
-        default=None,
-        help="evals_v2 results/metrics prefix (S3 or local) for the primary VEP",
-    )
-    ap.add_argument(
-        "--score-type",
-        default="minus_llr_avg",
-        help="evals_v2 score_type column to read AUPRC from",
-    )
+    ap.add_argument("--gap-summary", required=True)
+    ap.add_argument("--metrics-prefix", default=None)
+    ap.add_argument("--score-type", default="minus_llr_avg")
     ap.add_argument("--out", default="scratch/issue274/correlation.parquet")
     args = ap.parse_args()
 
-    base = pull_wandb_baseline()
-    gap = load_gap_by_size(args.gap_summary)
-    df = base.merge(gap, on="size", how="left", validate="1:1")
-    assert df["gap_macro"].notna().all(), (
-        "missing gap for some size — run `snakemake ll_gap`"
+    df = pull_wandb_auprc().merge(
+        load_gap_quantities(args.gap_summary), on="size", validate="1:1"
     )
+    assert df["gap_cds"].notna().all(), "missing gap — run `snakemake ll_gap`"
 
-    tables = [rho_comparison(df, "intrain_auprc_", "in_training")]
+    tables = [decomposition(df, "intrain_auprc_", "in_training")]
     if args.metrics_prefix:
         v2 = load_evals_v2_vep(args.metrics_prefix, args.score_type)
         if v2 is not None:
-            df = df.merge(v2, on="size", how="left", validate="1:1")
-            tables.append(
-                rho_comparison(df, "v2_auprc_", f"evals_v2:{args.score_type}")
-            )
+            df = df.merge(v2, on="size", validate="1:1")
+            tables.append(decomposition(df, "v2_auprc_", f"evals_v2:{args.score_type}"))
         else:
-            print("[warn] evals_v2 metrics not found yet — in-training VEP only")
+            print(
+                "[warn] official evals_v2 metrics not all present yet — in-training only"
+            )
 
     result = pd.concat(tables, ignore_index=True)
     Path(args.out).parent.mkdir(parents=True, exist_ok=True)
     result.to_parquet(args.out, index=False)
 
-    pd.set_option("display.width", 200)
-    pd.set_option("display.max_columns", 20)
-    for label, sub in result.groupby("vep_source"):
-        print(f"\n=== VEP = {label}  (n=8 sizes; ρ = Spearman) ===")
-        show = sub[
-            [
-                "variant",
-                "rho_loss",
-                "rho_gap_macro",
-                "matched_region",
-                "rho_gap_matched",
-                "gap_wins",
-            ]
-        ].round(3)
-        print(show.to_string(index=False))
-        wins = int(sub["gap_wins"].sum())
-        print(
-            f"  matched-region gap beats loss (|ρ|) on {wins}/{len(sub)} variant types"
-        )
-    print(f"\nsaved {args.out}")
+    # Focused print: the CDS region vs the CDS-relevant + overall variants.
+    _print_region(result, "cds", ["missense_variant", "synonymous_variant", "all"])
+    print(f"\nsaved full grid (all regions × predictors × variants) → {args.out}")
 
 
 if __name__ == "__main__":

--- a/scripts/issue274_scaling_correlation.py
+++ b/scripts/issue274_scaling_correlation.py
@@ -1,0 +1,247 @@
+"""Issue #274: does the functional/non-functional LL gap predict VEP better than
+loss across the 8-model parameter-scaling ladder?
+
+Computes Spearman ρ of VEP AUPRC vs two predictors — validation loss and the LL
+gap — per Mendelian variant type, across the 8 `dna-bolinas-scaling-v0.5` sizes
+(46M→4B, step-215573). Everything is reproducible from W&B + the evals_v2
+pipeline outputs (no external/blog data):
+
+  - loss + in-training Mendelian AUPRC: W&B (eric-czech/marin scaling runs).
+  - LL gap per (model, region): the evals_v2 `ll_gap` summary parquet (S3/local).
+  - [primary VEP] evals_v2 Mendelian AUPRC per (model, variant): the
+    `results/metrics/<model>/mendelian_traits.parquet` parquets (S3/local).
+
+Usage:
+    uv run python scripts/issue274_scaling_correlation.py \
+        --gap-summary s3://oa-bolinas/snakemake/analysis/evals_v2/results/ll_gap/summary.parquet \
+        --metrics-prefix s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics \
+        --out scratch/issue274/correlation.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import polars as pl
+from scipy.stats import spearmanr
+
+WANDB_ENTITY = "eric-czech/marin"
+SIZES = [
+    "h640-p46M",
+    "h768-p76M",
+    "h896-p128M",
+    "h1152-p255M",
+    "h1408-p476M",
+    "h1920-p1B",
+    "h2432-p2B",
+    "h2944-p4B",
+]
+# Mendelian TraitGym variant types (in-training lm_eval naming; evals_v2 uses the
+# same consequence names as subsets).
+VARIANTS = [
+    "missense_variant",
+    "5_prime_UTR_variant",
+    "3_prime_UTR_variant",
+    "splicing",
+    "synonymous_variant",
+    "tss_proximal",
+    "distal",
+    "non_coding_transcript_exon_variant",
+    "all",
+]
+# Which gap region best matches each variant type's locus (for the region-matched
+# comparison). cds = v5, upstream/promoter = v1, downstream/3'UTR = v15.
+VARIANT_REGION = {
+    "missense_variant": "cds",
+    "synonymous_variant": "cds",
+    "splicing": "cds",
+    "5_prime_UTR_variant": "upstream",
+    "tss_proximal": "upstream",
+    "3_prime_UTR_variant": "downstream",
+    "non_coding_transcript_exon_variant": "downstream",
+    "distal": "macro",
+    "all": "macro",
+}
+
+_SIZE_RE = re.compile(r"(h\d+-p[\dA-Za-z]+)")
+
+
+def size_token(name: str) -> str:
+    """Extract the `h<width>-p<size>` token from a run/model/dir name."""
+    m = _SIZE_RE.search(name)
+    assert m, f"no size token in {name!r}"
+    return m.group(1)
+
+
+def pull_wandb_baseline(entity: str = WANDB_ENTITY) -> pd.DataFrame:
+    """Per-size loss (overall + per region) and in-training Mendelian AUPRC from W&B."""
+    import wandb
+
+    api = wandb.Api()
+    rows = []
+    for s in SIZES:
+        dn = f"dna-bolinas-scaling-v0.5-{s}"
+        cands = [
+            r
+            for r in api.runs(entity, filters={"display_name": dn})
+            if r.summary.get("global_step") == 215573
+        ]
+        assert len(cands) == 1, f"{dn}: expected 1 final run, got {len(cands)}"
+        r = cands[0]
+        d: dict[str, object] = {
+            "size": s,
+            "params": r.summary.get("parameter_count"),
+            "eval_loss": r.summary.get("eval/loss"),
+            "loss_cds": r.summary.get("eval/val_cds/loss"),
+            "loss_upstream": r.summary.get("eval/val_upstream/loss"),
+            "loss_downstream": r.summary.get("eval/val_downstream/loss"),
+        }
+        for v in VARIANTS:
+            d[f"intrain_auprc_{v}"] = r.summary.get(
+                f"lm_eval/traitgym_mendelian_v2_255/{v}/auprc"
+            )
+        rows.append(d)
+    df = pd.DataFrame(rows).sort_values("params").reset_index(drop=True)
+    assert df["eval_loss"].notna().all(), "missing eval_loss for some size"
+    return df
+
+
+def load_gap_by_size(gap_summary_path: str) -> pd.DataFrame:
+    """Pivot the ll_gap summary to one row per size: gap per region + macro gap."""
+    g = pl.read_parquet(gap_summary_path).to_pandas()
+    # Keep only the scaling ladder; the summary also holds the m5.1 gate row,
+    # which has no h<width>-p<size> token.
+    g = g[g["model"].str.contains(r"scaling-v0\.5-h\d+-p", regex=True)].copy()
+    g["size"] = g["model"].map(size_token)
+    wide = g.pivot(index="size", columns="region", values="gap")
+    wide.columns = [f"gap_{c}" for c in wide.columns]
+    wide["gap_macro"] = wide.mean(axis=1)  # mean of the per-region gaps
+    return wide.reset_index()
+
+
+def load_evals_v2_vep(metrics_prefix: str, score_type: str) -> pd.DataFrame | None:
+    """Per-size evals_v2 Mendelian AUPRC per variant subset, for one score_type.
+
+    Returns one row per size with `v2_auprc_<variant>` columns, or None if the
+    metrics parquets aren't present yet.
+    """
+    rows = []
+    for s in SIZES:
+        model = f"scaling-v0.5-{s}-step-215573"
+        path = f"{metrics_prefix}/{model}/mendelian_traits.parquet"
+        try:
+            m = pl.read_parquet(path).to_pandas()
+        except Exception:
+            return None
+        m = m[m["score_type"] == score_type]
+        d: dict[str, object] = {"size": s}
+        for v in VARIANTS:
+            subset = "_global_" if v == "all" else v
+            hit = m[m["subset"] == subset]["value"]
+            d[f"v2_auprc_{v}"] = float(hit.iloc[0]) if len(hit) else np.nan
+        rows.append(d)
+    return pd.DataFrame(rows)
+
+
+def rho_comparison(df: pd.DataFrame, auprc_prefix: str, label: str) -> pd.DataFrame:
+    """For each variant: ρ(loss, AUPRC), ρ(macro gap, AUPRC), ρ(matched-region gap,
+    AUPRC), across the 8 sizes. `auprc_prefix` selects the VEP column family."""
+    out = []
+    for v in VARIANTS:
+        y = df[f"{auprc_prefix}{v}"].to_numpy(dtype=float)
+        if np.isnan(y).any():
+            continue
+        loss = df["eval_loss"].to_numpy(dtype=float)
+        gap_macro = df["gap_macro"].to_numpy(dtype=float)
+        region = VARIANT_REGION[v]
+        gap_m = df["gap_macro" if region == "macro" else f"gap_{region}"].to_numpy(
+            dtype=float
+        )
+        r_loss, p_loss = spearmanr(loss, y)
+        r_macro, p_macro = spearmanr(gap_macro, y)
+        r_match, p_match = spearmanr(gap_m, y)
+        out.append(
+            {
+                "vep_source": label,
+                "variant": v,
+                "rho_loss": r_loss,
+                "p_loss": p_loss,
+                "rho_gap_macro": r_macro,
+                "p_gap_macro": p_macro,
+                "matched_region": region,
+                "rho_gap_matched": r_match,
+                "p_gap_matched": p_match,
+                "gap_wins": abs(r_match) > abs(r_loss),
+            }
+        )
+    return pd.DataFrame(out)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--gap-summary", required=True, help="ll_gap summary.parquet (S3 or local)"
+    )
+    ap.add_argument(
+        "--metrics-prefix",
+        default=None,
+        help="evals_v2 results/metrics prefix (S3 or local) for the primary VEP",
+    )
+    ap.add_argument(
+        "--score-type",
+        default="minus_llr_avg",
+        help="evals_v2 score_type column to read AUPRC from",
+    )
+    ap.add_argument("--out", default="scratch/issue274/correlation.parquet")
+    args = ap.parse_args()
+
+    base = pull_wandb_baseline()
+    gap = load_gap_by_size(args.gap_summary)
+    df = base.merge(gap, on="size", how="left", validate="1:1")
+    assert df["gap_macro"].notna().all(), (
+        "missing gap for some size — run `snakemake ll_gap`"
+    )
+
+    tables = [rho_comparison(df, "intrain_auprc_", "in_training")]
+    if args.metrics_prefix:
+        v2 = load_evals_v2_vep(args.metrics_prefix, args.score_type)
+        if v2 is not None:
+            df = df.merge(v2, on="size", how="left", validate="1:1")
+            tables.append(
+                rho_comparison(df, "v2_auprc_", f"evals_v2:{args.score_type}")
+            )
+        else:
+            print("[warn] evals_v2 metrics not found yet — in-training VEP only")
+
+    result = pd.concat(tables, ignore_index=True)
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    result.to_parquet(args.out, index=False)
+
+    pd.set_option("display.width", 200)
+    pd.set_option("display.max_columns", 20)
+    for label, sub in result.groupby("vep_source"):
+        print(f"\n=== VEP = {label}  (n=8 sizes; ρ = Spearman) ===")
+        show = sub[
+            [
+                "variant",
+                "rho_loss",
+                "rho_gap_macro",
+                "matched_region",
+                "rho_gap_matched",
+                "gap_wins",
+            ]
+        ].round(3)
+        print(show.to_string(index=False))
+        wins = int(sub["gap_wins"].sum())
+        print(
+            f"  matched-region gap beats loss (|ρ|) on {wins}/{len(sub)} variant types"
+        )
+    print(f"\nsaved {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -173,6 +173,18 @@ snakemake calibration                                                # all confi
 snakemake results/calibration/<model>/llr_neutral_mean_n100.parquet  # one model
 ```
 
+- **LL gap** (functional vs non-functional log-likelihood, #274) — `snakemake ll_gap`.
+  For each `(model, region)` in the `ll_gap:` config it scores the model's mean
+  log-likelihood on uppercase (phyloP-functional) vs lowercase (non-functional)
+  target tokens over the mixed-case `genomes-v5` validation intervals
+  (`cds`/`upstream`/`downstream` = v5/v1/v15), then aggregates to
+  `results/ll_gap/summary.parquet` (`LL_upper`, `LL_lower`, `gap` per cell). A
+  metric rather than an interpretation, but kept off `rule all` for the same
+  reason. FWD strand only — matches the training-logged
+  `val_*_{functional,nonfunctional}` loss. For one sky cluster per cell, build
+  the per-cell `results/ll_gap/scores/{model}/{region}.parquet` targets, then
+  gather with `snakemake ll_gap`.
+
 ### Parallel sky-cluster sweep (one cluster per target)
 
 For a grid of independent targets — e.g. all checkpoints of one model arm,
@@ -220,6 +232,7 @@ Two unavoidable AWS-side failure modes worth knowing about:
 | `nuc_dep` | Optional; nucleotide-dependency maps (#237, off `rule all`). `{combines, ord, batch_size, dpi, models: [...], loci: {...}}`. See `rules/interpretation.smk`. |
 | `umap_embeddings` | Optional; embedding UMAP (#246, off `rule all`). `{dataset, layer_index, n_center_bp, random_state, dpi, models: [...]}` — `models` reuse the `models:` registry (each needs `window_size`). Build needs `--group umap` (+ `--group genome-s3`). See `rules/embedding_umap.smk`. |
 | `calibration` | Optional; cLLR mutation-rate calibration tables (#267/#270, off `rule all`). `{neutral_sites_s3_prefix, subsample_n, scoreable_window, min_bin_count, rc, models: [...]}` — scores the pre-filtered + subsampled neutral set (`neutral_sites_n{subsample_n}_w{scoreable_window}.parquet`) → per-model `llr_neutral_mean`. See `rules/calibration.smk`. |
+| `ll_gap` | Optional; functional/non-functional LL gap (#274, off `rule all`). `{split, datasets: [{name, hf_repo, hf_revision}], models: [...]}` — `datasets` are mixed-case `seq` HF datasets (the v5/v1/v15 validation intervals; NOT the variant `datasets:` above); `models` reuse the `models:` registry. See `rules/ll_gap.smk`. |
 
 ## Library
 
@@ -235,7 +248,11 @@ Pipeline rules are thin glue around:
 - `marin_dna.pipelines.evals.calibration.compute_llr_neutral_mean` — checkpoint +
   neutral sites → per-cell `llr_neutral_mean` calibration table (cLLR stage 3);
   `expand_sites_to_variants` / `aggregate_llr_neutral_mean` are the tested pure pieces.
+- `marin_dna.pipelines.evals.ll_gap.compute_hf_ll_gap` — HF checkpoint +
+  mixed-case `seq` dataset → per-sequence functional/non-functional LL atoms
+  (`ll_sum_upper`, `ll_sum_lower`, `n_upper`, `n_lower`); `aggregate_ll_gap`
+  collapses them to token-weighted `LL_upper` / `LL_lower` / `gap`.
 
 These are tested at `tests/pipelines/evals/test_metrics.py`,
 `tests/pipelines/evals/test_inference.py`, `tests/pipelines/evals/test_calibration.py`,
-and `tests/model/test_scoring.py`.
+`tests/pipelines/evals/test_ll_gap.py`, and `tests/model/test_scoring.py`.

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -288,6 +288,45 @@ models:
     window_size: 255
     datasets: [mendelian_traits]
 
+  # Parameter-scaling ladder v0.5 (issue #274) — 8 sizes, all at step-215573
+  # (~84.77B tokens; batch 1536 x seq 256; identical optimizer hparams). The
+  # Mendelian VEP scored here is the y-axis for the LL-gap-vs-loss analysis; the
+  # LL gap itself rides the same registry via the `ll_gap:` section below. The
+  # 4B is `h2944` (NOT the separate short/crashed `dna-bolinas-4b-v0.*` search).
+  # 255 bp DNA + BOS.
+  - name: scaling-v0.5-h640-p46M-step-215573
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h640-p46M-353f3d/hf/step-215573
+    window_size: 255
+    datasets: [mendelian_traits]
+  - name: scaling-v0.5-h768-p76M-step-215573
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h768-p76M-8dbaca/hf/step-215573
+    window_size: 255
+    datasets: [mendelian_traits]
+  - name: scaling-v0.5-h896-p128M-step-215573
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h896-p128M-43ec40/hf/step-215573
+    window_size: 255
+    datasets: [mendelian_traits]
+  - name: scaling-v0.5-h1152-p255M-step-215573
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h1152-p255M-c72f29/hf/step-215573
+    window_size: 255
+    datasets: [mendelian_traits]
+  - name: scaling-v0.5-h1408-p476M-step-215573
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h1408-p476M-85cce6/hf/step-215573
+    window_size: 255
+    datasets: [mendelian_traits]
+  - name: scaling-v0.5-h1920-p1B-step-215573
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h1920-p1B-0dc6f4/hf/step-215573
+    window_size: 255
+    datasets: [mendelian_traits]
+  - name: scaling-v0.5-h2432-p2B-step-215573
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h2432-p2B-f5f484/hf/step-215573
+    window_size: 255
+    datasets: [mendelian_traits]
+  - name: scaling-v0.5-h2944-p4B-step-215573
+    gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h2944-p4B-fa02c3/hf/step-215573
+    window_size: 255
+    datasets: [mendelian_traits]
+
   # exp21 — animal-promoters-yolo (issue #21, wandb animal-promoters-yolo-r01-213a8e).
   # 512 bp context, no BOS. Scoped to mendelian_traits only: complex signal
   # was weak in #21, and the matched-pair mendelian dataset is the one of
@@ -944,3 +983,38 @@ umap_embeddings:
   batch_size: 128
   models:
     - mix-v0.9-p1B-i24-exp135-m5.1-step-59158   # exp135-1B-m5.1 (255+BOS) — first pass, single model
+
+# Functional/non-functional LL gap (issue #274) — off `rule all`; build with
+# `snakemake ll_gap` (or one `results/ll_gap/scores/<model>/<region>.parquet`
+# per sky cluster, then `snakemake ll_gap` to gather). For each (model, region)
+# it scores the mean log-likelihood on uppercase (phyloP-functional) vs
+# lowercase (non-functional) target tokens over a mixed-case validation-interval
+# dataset, then aggregates to a per-(model, region) gap. These `datasets` are HF
+# `seq` datasets (the v5/v1/v15 sets the training runs used for
+# val_cds/val_upstream/val_downstream) — NOT the variant `datasets:` above.
+# `models` reuse the `models:` registry. FWD strand only (matches the
+# training-logged gap). m5.1 leads the list as the validation gate: it logged
+# `val_cds_{functional,nonfunctional}/loss` in W&B, so -LL_upper/-LL_lower must
+# reproduce those before the ladder gaps are trusted.
+ll_gap:
+  split: validation
+  datasets:
+    - name: cds          # v5 — CDS
+      hf_repo: bolinas-dna/genomes-v5-validation-intervals-v5_255_255
+      hf_revision: daff592f213aaa1cab1711d477a79ff6b1bc4ef4
+    - name: upstream     # v1 — promoter / upstream
+      hf_repo: bolinas-dna/genomes-v5-validation-intervals-v1_255_255
+      hf_revision: a761bc0b663a9827303f3112e4667d53d5326fac
+    - name: downstream   # v15 — 3' UTR / downstream
+      hf_repo: bolinas-dna/genomes-v5-validation-intervals-v15_255_255
+      hf_revision: d7b27eecd68453934ebb3e7e6e78d5401789faa5
+  models:
+    - mix-v0.9-p1B-i24-exp135-m5.1-step-59158   # validation gate (has the W&B gap)
+    - scaling-v0.5-h640-p46M-step-215573
+    - scaling-v0.5-h768-p76M-step-215573
+    - scaling-v0.5-h896-p128M-step-215573
+    - scaling-v0.5-h1152-p255M-step-215573
+    - scaling-v0.5-h1408-p476M-step-215573
+    - scaling-v0.5-h1920-p1B-step-215573
+    - scaling-v0.5-h2432-p2B-step-215573
+    - scaling-v0.5-h2944-p4B-step-215573

--- a/snakemake/analysis/evals_v2/workflow/Snakefile
+++ b/snakemake/analysis/evals_v2/workflow/Snakefile
@@ -12,6 +12,7 @@ include: "rules/metrics.smk"
 include: "rules/interpretation.smk"
 include: "rules/embedding_umap.smk"
 include: "rules/calibration.smk"
+include: "rules/ll_gap.smk"
 
 
 rule all:

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -181,3 +181,30 @@ CALIBRATION_MODELS = CALIBRATION_CFG.get("models", [])
 # Fail fast: every calibration model is a known checkpoint.
 for _m in CALIBRATION_MODELS:
     assert _m in MODELS, f"calibration model {_m!r} not found in `models`"
+
+
+# --- LL gap (functional vs non-functional log-likelihood, issue #274) --------
+# Optional `ll_gap:` config section; targets kept off `rule all` (see
+# rules/ll_gap.smk). Reuses the `models:` registry. Its `datasets` are mixed-case
+# validation-interval HF datasets (a `seq` column, uppercase = phyloP-functional)
+# — distinct from the variant `datasets:` list above.
+LL_GAP_CFG = config.get("ll_gap", {})
+LL_GAP_MODELS = LL_GAP_CFG.get("models", [])
+LL_GAP_DATASETS = [d["name"] for d in LL_GAP_CFG.get("datasets", [])]
+
+
+def get_ll_gap_dataset_config(name):
+    for d in LL_GAP_CFG.get("datasets", []):
+        if d["name"] == name:
+            return d
+    raise ValueError(f"ll_gap dataset {name!r} not found in config")
+
+
+# Fail fast: every ll_gap model is a known checkpoint, and every ll_gap dataset
+# pins an HF repo + revision (so a data bump triggers re-execution).
+for _m in LL_GAP_MODELS:
+    assert _m in MODELS, f"ll_gap model {_m!r} not found in `models`"
+for _d in LL_GAP_CFG.get("datasets", []):
+    assert "hf_repo" in _d and "hf_revision" in _d, (
+        f"ll_gap dataset {_d.get('name')!r} needs `hf_repo` + `hf_revision`"
+    )

--- a/snakemake/analysis/evals_v2/workflow/rules/ll_gap.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/ll_gap.smk
@@ -1,0 +1,88 @@
+"""Functional/non-functional LL-gap eval (issue #274).
+
+A GPU per-(model, region) scoring rule + a CPU summary gather, parallel to the
+embedding-UMAP eval (rules/embedding_umap.smk) and kept OFF the default
+``rule all`` (metrics-only) so it never perturbs score/metric reruns. Build:
+
+    snakemake ll_gap                                          # summary over all models x regions
+    snakemake results/ll_gap/scores/<model>/<region>.parquet  # one cell (one sky cluster)
+
+``compute_hf_ll_gap`` reuses the existing ``download_model`` rule for the
+checkpoint and pulls the mixed-case validation-interval sequences from
+HuggingFace (uppercase = phyloP-functional, lowercase = non-functional). FWD
+strand only — this matches the training-logged ``val_*_{functional,nonfunctional}``
+loss the m5.1 gate is checked against.
+"""
+
+
+rule compute_ll_gap:
+    input:
+        checkpoint="results/checkpoints/{model}",
+    output:
+        "results/ll_gap/scores/{model}/{region}.parquet",
+    wildcard_constraints:
+        model="|".join(LL_GAP_MODELS),
+        region="|".join(LL_GAP_DATASETS),
+    threads: config["inference"]["num_workers"]
+    params:
+        # Output-affecting fields (snakemake `params` rerun trigger); batch_size
+        # is execution-only and read inside `run:`.
+        window_size=lambda wc: get_model_config(wc.model)["window_size"],
+        hf_repo=lambda wc: get_ll_gap_dataset_config(wc.region)["hf_repo"],
+        hf_revision=lambda wc: get_ll_gap_dataset_config(wc.region)["hf_revision"],
+        split=LL_GAP_CFG.get("split", "validation"),
+    run:
+        from marin_dna.pipelines.evals.ll_gap import compute_hf_ll_gap
+
+        batch_size = get_model_batch_size(wildcards.model)
+        seqs = load_dataset(
+            params.hf_repo, split=params.split, revision=params.hf_revision
+        ).to_pandas()
+        out = compute_hf_ll_gap(
+            checkpoint_path=input.checkpoint,
+            sequences=seqs,
+            window_size=int(params.window_size),
+            batch_size=batch_size,
+            num_workers=config["inference"]["num_workers"],
+            torch_compile=config["inference"].get("torch_compile", False),
+        )
+        out.to_parquet(output[0], index=False)
+        print(
+            f"[ll_gap] {wildcards.model}/{wildcards.region}: {len(out)} seqs "
+            f"(upper={int(out['n_upper'].sum())}, lower={int(out['n_lower'].sum())})"
+        )
+
+
+rule ll_gap:
+    """Aggregate every (model, region) score-atom parquet into one summary
+(token-weighted LL_upper / LL_lower / gap per cell). Off `rule all` —
+build with `snakemake ll_gap`."""
+    input:
+        [
+            f"results/ll_gap/scores/{model}/{region}.parquet"
+            for model in LL_GAP_MODELS
+            for region in LL_GAP_DATASETS
+        ],
+    output:
+        "results/ll_gap/summary.parquet",
+    run:
+        from marin_dna.pipelines.evals.ll_gap import aggregate_ll_gap
+
+        rows = []
+        for path in input:
+            # results/ll_gap/scores/<model>/<region>.parquet
+            model = Path(path).parent.name
+            region = Path(path).stem
+            atoms = pd.read_parquet(path)[
+                ["ll_sum_upper", "ll_sum_lower", "n_upper", "n_lower"]
+            ].to_numpy()
+            rows.append(
+                {"model": model, "region": region, **aggregate_ll_gap(atoms)}
+            )
+        summary = (
+            pd.DataFrame(rows)
+            .sort_values(["model", "region"])
+            .reset_index(drop=True)
+        )
+        summary.to_parquet(output[0], index=False)
+        print(f"[ll_gap] summary: {len(summary)} (model x region) rows")

--- a/src/marin_dna/pipelines/evals/evo2.py
+++ b/src/marin_dna/pipelines/evals/evo2.py
@@ -25,6 +25,10 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import torch.nn as nn
 
+# aggregate_ll_gap is model-agnostic; it lives in the ll_gap module (issue #274)
+# and is re-exported here so existing `from ...evo2 import aggregate_ll_gap` works.
+from marin_dna.pipelines.evals.ll_gap import aggregate_ll_gap  # noqa: F401
+
 if TYPE_CHECKING:
     from datasets import Dataset
 
@@ -244,41 +248,3 @@ def compute_evo2_ll(
     )
     assert np.isfinite(pred).all(), "non-finite values in Evo2 LL prediction"
     return pred
-
-
-def aggregate_ll_gap(pred: np.ndarray) -> dict[str, float]:
-    """Collapse a ``[N, 4]`` per-row LL prediction into dataset-wide
-    token-weighted means and the LL gap.
-
-    Cast to fp64 *before* summing — fp32 accumulation drift over ~10^6
-    target tokens is non-trivial.
-
-    Args:
-        pred: ``[N, 4]`` of ``(ll_sum_upper, ll_sum_lower, n_upper, n_lower)``.
-
-    Returns:
-        Dict with ``LL_all``, ``LL_upper``, ``LL_lower``, ``gap``,
-        ``n_upper``, ``n_lower``. ``LL_*`` are mean log-likelihoods per
-        target token (negative; closer to 0 is better — ``compute_ll_clm``
-        returns raw ``log p``, not NLL). ``gap = LL_upper - LL_lower``,
-        positive when uppercase (functional) bases are easier to predict
-        than lowercase.
-    """
-    pred = np.asarray(pred)
-    assert pred.ndim == 2 and pred.shape[1] == 4, (
-        f"expected [N, 4] pred, got {pred.shape}"
-    )
-    S_u, S_l, n_u, n_l = pred.astype(np.float64).sum(axis=0)
-    assert n_u > 0, "no upper (functional) target tokens — check case mask"
-    assert n_l > 0, "no lower (non-functional) target tokens — check case mask"
-    LL_upper = float(S_u / n_u)
-    LL_lower = float(S_l / n_l)
-    LL_all = float((S_u + S_l) / (n_u + n_l))
-    return {
-        "LL_all": LL_all,
-        "LL_upper": LL_upper,
-        "LL_lower": LL_lower,
-        "gap": LL_upper - LL_lower,
-        "n_upper": int(n_u),
-        "n_lower": int(n_l),
-    }

--- a/src/marin_dna/pipelines/evals/ll_gap.py
+++ b/src/marin_dna/pipelines/evals/ll_gap.py
@@ -1,0 +1,164 @@
+"""Functional/non-functional LL-gap eval for HF causal LMs (issue #274).
+
+The **LL gap** is the mean log-likelihood the model assigns to uppercase
+(phyloP-functional / conserved) target tokens minus the mean LL on lowercase
+(non-functional) target tokens, over a mixed-case validation-interval dataset.
+A positive gap means functional bases are easier to predict — a self-supervised
+proxy for "captures functional vs non-functional sequence structure" (issue #8).
+
+This is the model-agnostic core: the computation kernel
+(``marin_dna.model.runner.run_ll_clm`` → ``compute_ll_clm`` over
+``transform_ll_clm``) is shared with the Evo2 path; only the model loader
+differs. ``compute_hf_ll_gap`` loads an HF ``AutoModelForCausalLM`` directly (no
+Evo2 shims). ``aggregate_ll_gap`` (used by both paths) lives here because it is
+pure numpy and not Evo2-specific; ``pipelines.evals.evo2`` re-exports it for
+backward compatibility.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from datasets import Dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from marin_dna.model.runner import run_ll_clm
+
+
+def compute_hf_ll_gap(
+    checkpoint_path: str | Path,
+    sequences: pd.DataFrame,
+    window_size: int,
+    *,
+    batch_size: int = 128,
+    num_workers: int = 4,
+    torch_compile: bool = False,
+) -> pd.DataFrame:
+    """Per-sequence functional/non-functional LL atoms for an HF causal LM.
+
+    Loads the checkpoint and runs ``run_ll_clm`` (FWD strand) over the mixed-case
+    ``seq`` column. ``transform_ll_clm`` uppercases before tokenizing (the model
+    only ever sees uppercase, as in training), prepends BOS if the tokenizer
+    defines it, and carries an ``is_upper`` mask aligned to source positions;
+    ``compute_ll_clm`` slices that mask to the causal-shifted target positions
+    and buckets the per-token log-probs into upper/lower sums + counts.
+
+    Returns per-row **sums and counts**, not means — an all-upper or all-lower
+    row would divide by zero. Aggregate across rows with :func:`aggregate_ll_gap`.
+
+    Args:
+        checkpoint_path: Local HF checkpoint dir (``config.json`` + weights +
+            tokenizer). ``AutoModelForCausalLM`` / ``AutoTokenizer`` satisfy the
+            duck-typed interface ``marin_dna.model.runner`` expects.
+        sequences: DataFrame with a mixed-case ``seq`` column (and optionally an
+            ``id`` column, carried through). Row order is preserved.
+        window_size: Expected DNA length of every ``seq`` (the model's training
+            context, e.g. 255 for 255+BOS runs). Asserted, to catch a context
+            mismatch before an expensive forward pass.
+        batch_size: Per-device eval batch size.
+        num_workers: Dataloader workers.
+        torch_compile: Whether to ``torch.compile`` the forward pass.
+
+    Returns:
+        DataFrame with columns ``[id?, ll_sum_upper, ll_sum_lower, n_upper,
+        n_lower]`` — one row per input sequence, same order. ``ll_sum_*`` are
+        summed ``log p`` over target tokens of that case (negative; closer to 0
+        is better); ``n_*`` are the target-token counts.
+    """
+    checkpoint_path = Path(checkpoint_path)
+    assert "seq" in sequences.columns, (
+        f"sequences missing 'seq' column; got {list(sequences.columns)}"
+    )
+    n = len(sequences)
+    assert n > 0, "empty sequences frame"
+    seq_lens = sequences["seq"].str.len()
+    assert (seq_lens == window_size).all(), (
+        f"every seq must be window_size={window_size} bp; got lengths "
+        f"{sorted(seq_lens.unique())[:5]}"
+    )
+
+    # AutoTokenizer / AutoModelForCausalLM satisfy the duck-typed interface
+    # marin_dna.model.runner expects — no adapter wrappers needed.
+    tokenizer: Any = AutoTokenizer.from_pretrained(checkpoint_path)
+    model: Any = AutoModelForCausalLM.from_pretrained(
+        checkpoint_path, trust_remote_code=True
+    )
+
+    hf_dataset = Dataset.from_pandas(sequences[["seq"]], preserve_index=False)
+    pred = run_ll_clm(
+        model,
+        tokenizer,
+        hf_dataset,
+        data_transform_on_the_fly=True,
+        inference_kwargs={
+            "per_device_eval_batch_size": batch_size,
+            "torch_compile": torch_compile,
+            "bf16_full_eval": True,
+            "dataloader_num_workers": num_workers,
+            "remove_unused_columns": False,
+        },
+    )
+
+    pred = np.asarray(pred)
+    # Defensive reshape: on some HF Trainer / device combinations run_ll_clm has
+    # returned a flat [N*4] array instead of [N, 4] (see compute_evo2_ll). Row-
+    # major reshape preserves per-row order.
+    if pred.ndim == 1 and pred.shape[0] == n * 4:
+        pred = pred.reshape(n, 4)
+    assert pred.shape == (n, 4), (
+        f"LL pred shape mismatch: got {pred.shape}, expected ({n}, 4)"
+    )
+    assert np.isfinite(pred).all(), "non-finite values in HF LL prediction"
+
+    out = pd.DataFrame(
+        {
+            "ll_sum_upper": pred[:, 0].astype(np.float64),
+            "ll_sum_lower": pred[:, 1].astype(np.float64),
+            "n_upper": pred[:, 2].astype(np.int64),
+            "n_lower": pred[:, 3].astype(np.int64),
+        }
+    )
+    if "id" in sequences.columns:
+        out.insert(0, "id", sequences["id"].to_numpy())
+    return out
+
+
+def aggregate_ll_gap(pred: np.ndarray) -> dict[str, float]:
+    """Collapse a ``[N, 4]`` per-row LL prediction into dataset-wide
+    token-weighted means and the LL gap.
+
+    Cast to fp64 *before* summing — fp32 accumulation drift over ~10^6
+    target tokens is non-trivial.
+
+    Args:
+        pred: ``[N, 4]`` of ``(ll_sum_upper, ll_sum_lower, n_upper, n_lower)``.
+
+    Returns:
+        Dict with ``LL_all``, ``LL_upper``, ``LL_lower``, ``gap``,
+        ``n_upper``, ``n_lower``. ``LL_*`` are mean log-likelihoods per
+        target token (negative; closer to 0 is better — ``compute_ll_clm``
+        returns raw ``log p``, not NLL). ``gap = LL_upper - LL_lower``,
+        positive when uppercase (functional) bases are easier to predict
+        than lowercase.
+    """
+    pred = np.asarray(pred)
+    assert pred.ndim == 2 and pred.shape[1] == 4, (
+        f"expected [N, 4] pred, got {pred.shape}"
+    )
+    S_u, S_l, n_u, n_l = pred.astype(np.float64).sum(axis=0)
+    assert n_u > 0, "no upper (functional) target tokens — check case mask"
+    assert n_l > 0, "no lower (non-functional) target tokens — check case mask"
+    LL_upper = float(S_u / n_u)
+    LL_lower = float(S_l / n_l)
+    LL_all = float((S_u + S_l) / (n_u + n_l))
+    return {
+        "LL_all": LL_all,
+        "LL_upper": LL_upper,
+        "LL_lower": LL_lower,
+        "gap": LL_upper - LL_lower,
+        "n_upper": int(n_u),
+        "n_lower": int(n_l),
+    }

--- a/src/marin_dna/pipelines/evals/ll_gap.py
+++ b/src/marin_dna/pipelines/evals/ll_gap.py
@@ -107,6 +107,10 @@ def compute_hf_ll_gap(
     # returned a flat [N*4] array instead of [N, 4] (see compute_evo2_ll). Row-
     # major reshape preserves per-row order.
     if pred.ndim == 1 and pred.shape[0] == n * 4:
+        print(
+            f"[ll_gap] WARNING: run_ll_clm returned flat shape {pred.shape}; "
+            f"reshaping to ({n}, 4). If this recurs, investigate the gather path."
+        )
         pred = pred.reshape(n, 4)
     assert pred.shape == (n, 4), (
         f"LL pred shape mismatch: got {pred.shape}, expected ({n}, 4)"

--- a/tests/pipelines/evals/test_ll_gap.py
+++ b/tests/pipelines/evals/test_ll_gap.py
@@ -1,0 +1,108 @@
+"""Tests for the HF LL-gap eval (issue #274).
+
+The real forward pass needs a GPU + a downloaded checkpoint, so the model,
+tokenizer, and compute kernel are mocked — this exercises the DataFrame
+contract, the ``id`` passthrough, the ``window_size`` guard, the missing-column
+guard, and the flat-array reshape. The aggregator math is covered more fully in
+``test_evo2.py`` (same ``aggregate_ll_gap``, re-exported there).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from marin_dna.pipelines.evals.ll_gap import aggregate_ll_gap, compute_hf_ll_gap
+
+
+def _seqs(n: int = 3, length: int = 8) -> pd.DataFrame:
+    """n identical mixed-case seqs of the given length (``ACGTacgt`` repeated)."""
+    base = ("ACGTacgt" * ((length // 8) + 1))[:length]
+    return pd.DataFrame({"id": [f"r{i}" for i in range(n)], "seq": [base] * n})
+
+
+def _patched_load():
+    """Patch the heavy HF loaders so no checkpoint is ever downloaded."""
+    return (
+        patch(
+            "marin_dna.pipelines.evals.ll_gap.AutoTokenizer.from_pretrained",
+            return_value=object(),
+        ),
+        patch(
+            "marin_dna.pipelines.evals.ll_gap.AutoModelForCausalLM.from_pretrained",
+            return_value=object(),
+        ),
+    )
+
+
+def test_compute_hf_ll_gap_returns_atoms_with_id():
+    seqs = _seqs(n=3, length=8)
+    pred = np.array(
+        [[-2.0, -5.0, 4, 3], [-1.0, -4.0, 4, 3], [-3.0, -6.0, 4, 3]], dtype=float
+    )
+    tok, model = _patched_load()
+    with (
+        tok,
+        model,
+        patch("marin_dna.pipelines.evals.ll_gap.run_ll_clm", return_value=pred),
+    ):
+        out = compute_hf_ll_gap("/unused", seqs, window_size=8, batch_size=2)
+
+    assert list(out.columns) == [
+        "id",
+        "ll_sum_upper",
+        "ll_sum_lower",
+        "n_upper",
+        "n_lower",
+    ]
+    assert len(out) == 3
+    np.testing.assert_array_equal(out["id"].values, seqs["id"].values)
+    np.testing.assert_array_equal(out["ll_sum_upper"].values, pred[:, 0])
+    np.testing.assert_array_equal(out["n_upper"].values, pred[:, 2].astype(int))
+    # Sums kept as fp64, counts as int64.
+    assert out["ll_sum_upper"].dtype == np.float64
+    assert out["n_upper"].dtype == np.int64
+
+
+def test_compute_hf_ll_gap_reshapes_flat_array():
+    """A flat ``[N*4]`` return (seen on some Trainer/device combos) is row-major
+    reshaped back to ``[N, 4]`` preserving row order."""
+    seqs = _seqs(n=2, length=8)
+    flat = np.array([-1.0, -2.0, 4, 3, -1.5, -2.5, 4, 3])  # [N*4]
+    tok, model = _patched_load()
+    with (
+        tok,
+        model,
+        patch("marin_dna.pipelines.evals.ll_gap.run_ll_clm", return_value=flat),
+    ):
+        out = compute_hf_ll_gap("/unused", seqs, window_size=8, batch_size=2)
+
+    assert len(out) == 2
+    np.testing.assert_array_equal(out["ll_sum_upper"].values, [-1.0, -1.5])
+    np.testing.assert_array_equal(out["ll_sum_lower"].values, [-2.0, -2.5])
+
+
+def test_compute_hf_ll_gap_window_size_mismatch_raises():
+    seqs = _seqs(n=2, length=8)
+    with pytest.raises(AssertionError, match="window_size"):
+        compute_hf_ll_gap("/unused", seqs, window_size=255, batch_size=2)
+
+
+def test_compute_hf_ll_gap_requires_seq_column():
+    seqs = pd.DataFrame({"id": ["a"], "sequence": ["ACGTacgt"]})
+    with pytest.raises(AssertionError, match="seq"):
+        compute_hf_ll_gap("/unused", seqs, window_size=8)
+
+
+def test_aggregate_ll_gap_canonical_import_and_gap_sign():
+    """aggregate_ll_gap is importable from its model-agnostic home and the gap
+    convention is ``LL_upper - LL_lower`` (positive ⇒ functional easier)."""
+    pred = np.array([[-2.0, 0.0, 4.0, 0.0], [0.0, -9.0, 0.0, 6.0]], dtype=np.float32)
+    out = aggregate_ll_gap(pred)
+    assert out["LL_upper"] == -0.5
+    assert out["LL_lower"] == -1.5
+    assert out["gap"] == 1.0
+    assert out["n_upper"] == 4 and out["n_lower"] == 6


### PR DESCRIPTION
## Summary

Adds the **functional/non-functional LL-gap** eval (the #8 quantity — mean log-likelihood on phyloP-functional vs non-functional positions) to `evals_v2` as a first-class, reusable eval, and uses it for the parameter-scaling-ladder LL↔VEP analysis tracked in #274.

Closes #274. Spun off #279 (missense VEP degrading with scale) as a standalone follow-up.

## What's included

- **Library:** `compute_hf_ll_gap` (model-agnostic, reuses the existing `run_ll_clm` kernel) in `src/marin_dna/pipelines/evals/ll_gap.py`; `aggregate_ll_gap` relocated there from the Evo2 module (re-exported for back-compat). Unit-tested in `tests/pipelines/evals/test_ll_gap.py`.
- **Pipeline:** new `snakemake ll_gap` target (`rules/ll_gap.smk`, off `rule all`, mirroring the embedding-UMAP eval) + an `ll_gap:` config section (pinned v5/v1/v15 validation-interval datasets; m5.1 leads the model list as a validation gate). evals_v2 README updated.
- **Registry:** the 8 `dna-bolinas-scaling-v0.5` checkpoints (46M→4B, step-215573) added to the evals_v2 model registry (`datasets: [mendelian_traits]`) for the VEP y-axis.
- **Analysis:** `scripts/issue274_scaling_correlation.py` (4 LL predictors × region × variant; Pearson + Spearman) and `plots/llgap_vs_vep_scaling.py`.

## Validation

- **m5.1 gate:** the offline functional/non-functional LL reproduces m5.1's W&B-logged `val_cds_{functional,nonfunctional}/loss` to **±0.0001** across all three regions.
- `uv run pytest tests/pipelines/evals` → 328 passed; ruff clean.

## Notes

- `ll_gap` is off `rule all` (built explicitly), so it never perturbs the metrics DAG. The 8 scaling models add Mendelian VEP targets to `rule all` (already computed and on S3).
- The scientific findings (region-matched correlations + figure) live in #274's Results — this PR is the code + data plumbing behind them.

## Test plan

- `uv run pytest tests/pipelines/evals` (328 pass)
- `cd snakemake/analysis/evals_v2 && uv run snakemake -n ll_gap` (DAG: 27 score cells + gather)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

