### PR TITLE
dashboard: read GPN-Star metrics from S3 (single source of truth); drop split col

### DIFF
--- a/dashboard/src/protocols/gpn-star.md
+++ b/dashboard/src/protocols/gpn-star.md
@@ -17,7 +17,7 @@ import {PillSelect, ComparisonPicker, labeledRow} from "../components/controls.j
 ```js
 const FAMILY = "gpn_star";
 // `[baseline, alternative]`; heatmap shows `alternative − baseline`. No
-// FWD/RC variants on this gist-sourced family, hence the single pair.
+// FWD/RC variants for this family (GPN-Star averages strands upstream), hence the single pair.
 const COMPARISONS = [["cLLR", "LLR"]];
 const DATASETS = ["mendelian_traits", "complex_traits"];
 const DATASET_LABEL = {

--- a/snakemake/gpn_star_eval/README.md
+++ b/snakemake/gpn_star_eval/README.md
@@ -6,8 +6,10 @@ on the matched-pair eval datasets ([#161 Mendelian](https://github.com/Open-Athe
 [#162 Complex traits](https://github.com/Open-Athena/marin-dna/issues/162)).
 Same metric, dataset revisions, and bootstrap config as
 [`evals_v2`](../analysis/evals_v2), so these rows are directly comparable to our
-own models — and they **reproduce the GPN-Star numbers the dashboard reads** from
-the #145 metrics gist.
+own models. **This pipeline's S3 metrics parquet is the dashboard's GPN-Star
+source** (`leaderboard._parquet_path` case `gpn_star`) — the pipeline is the
+single source of truth; the old #145 metrics gist is kept only as a provenance
+record.
 
 GPN-Star scoring runs in [songlab-cal/TraitGym](https://github.com/songlab-cal/TraitGym),
 not this repo. Predictions are pulled from a gist (commit pinned in
@@ -60,7 +62,9 @@ results/
 ├── scores/{dataset}.parquet    # 3 × N rows: variant cols + scores per model
 └── metrics/{dataset}.parquet   # AUPRC per (model, score_type, subset);
                                  # cols [score_type, subset, value, se,
-                                 #       n_groups, n_rows, model, dataset, split]
+                                 #       n_groups, n_rows, model, dataset]
+                                 # (no `split` col — train only; the dashboard
+                                 #  reads this parquet, filtering model+score_type)
 ```
 
 ## Conventions

--- a/snakemake/gpn_star_eval/workflow/rules/metrics.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/metrics.smk
@@ -1,14 +1,15 @@
 """Per-dataset AUPRC + cluster-bootstrap SE on the 4 score columns × 3 models.
 
 Output schema (one row per ``(model, score_type, subset)``):
-``[score_type, subset, value, se, n_groups, n_rows, model, dataset, split]``.
+``[score_type, subset, value, se, n_groups, n_rows, model, dataset]``.
 Includes ``_global_`` and ``_macro_avg_`` sentinel subset rows from
 ``compute_auprc_metrics`` (``n_min`` from config). AUPRC + cluster bootstrap on
 ``match_group`` matches evals_v2, so these rows are directly comparable to our
-models on the same dataset revisions — and they reproduce the GPN-Star numbers
-the dashboard reads from the #145 metrics gist. (The previous PairwiseAccuracy
-path asserted 1 pos + 1 neg per ``match_group`` and would fail on the 1:9 k=9
-datasets.)
+models on the same dataset revisions. The dashboard reads this parquet directly
+(``leaderboard._parquet_path`` case ``gpn_star``), filtering by ``model`` +
+``score_type`` — there is no ``split`` column (all rows are the train split, the
+only split this pipeline emits). (The previous PairwiseAccuracy path asserted
+1 pos + 1 neg per ``match_group`` and would fail on the 1:9 k=9 datasets.)
 """
 
 
@@ -49,7 +50,6 @@ rule compute_metrics:
 
         out = pd.concat(per_model, ignore_index=True)
         out["dataset"] = wildcards.dataset
-        out["split"] = config["split"]
         out.to_parquet(output[0], index=False)
         print(
             f"[gpn_star_eval] {wildcards.dataset}: {len(out)} metric rows "

--- a/src/marin_dna/pipelines/evals/leaderboard.py
+++ b/src/marin_dna/pipelines/evals/leaderboard.py
@@ -12,8 +12,8 @@ AUPRC + cluster-bootstrap SE on 1:9 matched negatives.
     filter by ``score_name`` (the track).
   - ``snakemake/alphagenome_eval/``   → one parquet per dataset, filter by
     ``score_type`` + ``split``.
-  - gist (gpn_star)                   → one parquet per dataset with V/M/P
-    stacked, filter by ``score_type`` + ``split`` + ``model``.
+  - ``snakemake/gpn_star_eval/``      → one parquet per dataset with V/M/P
+    stacked, filter by ``score_type`` + ``model``.
 
 Model registry (display name, family, training metadata, etc.) lives in
 ``dashboard/models.yaml`` and is loaded via ``models.load_models``.
@@ -44,20 +44,13 @@ SPLIT = "train"
 # the two dataset names are stable and this keeps the loader self-contained.
 QTL_DATASETS: frozenset[str] = frozenset({"caqtl", "dsqtl"})
 
-# `family: gpn_star` AUPRC metrics live on a gist commit (issue #145, last
-# comment) — one parquet per dataset with V/M/P stacked and a `model`
-# column to filter on. Polars `read_parquet` handles https URLs natively
-# via fsspec, so the path resolver just hands back a stable URL string.
-# Bump this commit when a new AUPRC re-run is uploaded. Distinct from
-# `gpn_star.GPN_STAR_GIST_BASE`, which points at the per-variant
-# *prediction* gist; this one is the *metrics* gist.
-GPN_STAR_METRICS_GIST_OWNER = "gonzalobenegas"
-GPN_STAR_METRICS_GIST_ID = "3649e68fb63ca1f3443e4486078eb4d8"
-GPN_STAR_METRICS_GIST_COMMIT = "cba23a7fd89222cc72bcdddf3f37e86ee5c1075c"
-GPN_STAR_METRICS_GIST_BASE = (
-    f"https://gist.githubusercontent.com/{GPN_STAR_METRICS_GIST_OWNER}/"
-    f"{GPN_STAR_METRICS_GIST_ID}/raw/{GPN_STAR_METRICS_GIST_COMMIT}"
-)
+# `family: gpn_star` AUPRC metrics now come from the S3 pipeline
+# (`snakemake/gpn_star_eval`, refreshed in #278), same as the conservation /
+# alphagenome / marin_dna families — one parquet per dataset with V/M/P stacked
+# and a `model` column to filter on. The pipeline is the single source of truth;
+# the old metrics gist (`3649e68f@cba23a7`) is kept only as the #145 provenance
+# record, no longer read here. (Distinct from `gpn_star.GPN_STAR_GIST_BASE`,
+# the per-variant *prediction* gist, which the pipeline still consumes as input.)
 
 # `family: evo2` AUPRC metrics gist. Same gist as gpn_star, different
 # pinned commit. Bump `EVO2_METRICS_GIST_COMMIT` when re-uploading; see
@@ -202,7 +195,7 @@ def _parquet_path(method: Model, dataset: str) -> str:
         case "alphagenome":
             return f"{S3}/snakemake/alphagenome_eval/results/metrics/{dataset}.parquet"
         case "gpn_star":
-            return f"{GPN_STAR_METRICS_GIST_BASE}/{dataset}.GPN-Star.parquet"
+            return f"{S3}/snakemake/gpn_star_eval/results/metrics/{dataset}.parquet"
         case "evo2":
             short = EVO2_DATASET_SHORT[dataset]
             return f"{EVO2_METRICS_GIST_BASE}/{short}_{method.id}_train_metrics.parquet"

--- a/tests/pipelines/evals/test_leaderboard.py
+++ b/tests/pipelines/evals/test_leaderboard.py
@@ -103,13 +103,10 @@ def test_score_type_for_returns_dataset_specific_column():
     assert score_type_for("gpn_star", "LLR", "mendelian_traits") == "minus_llr"
 
 
-def test_gpn_star_parquet_path_resolves_to_pinned_gist():
-    """The gist URL has the pinned commit + the dataset-stacked filename."""
-    from marin_dna.pipelines.evals.leaderboard import (
-        GPN_STAR_METRICS_GIST_BASE,
-        GPN_STAR_METRICS_GIST_COMMIT,
-        _parquet_path,
-    )
+def test_gpn_star_parquet_path_resolves_to_s3():
+    """GPN-Star metrics now come from the S3 pipeline output (snakemake/
+    gpn_star_eval), not the gist — same source pattern as the other S3 families."""
+    from marin_dna.pipelines.evals.leaderboard import _parquet_path
 
     method = _mk_method(
         id="GPN-Star-M",
@@ -120,10 +117,12 @@ def test_gpn_star_parquet_path_resolves_to_pinned_gist():
     )
     mendelian = _parquet_path(method, "mendelian_traits")
     complex_ = _parquet_path(method, "complex_traits")
-    assert mendelian.startswith(GPN_STAR_METRICS_GIST_BASE), mendelian
-    assert GPN_STAR_METRICS_GIST_COMMIT in mendelian
-    assert mendelian.endswith("/mendelian_traits.GPN-Star.parquet")
-    assert complex_.endswith("/complex_traits.GPN-Star.parquet")
+    assert mendelian == (
+        "s3://oa-bolinas/snakemake/gpn_star_eval/results/metrics/mendelian_traits.parquet"
+    )
+    assert complex_ == (
+        "s3://oa-bolinas/snakemake/gpn_star_eval/results/metrics/complex_traits.parquet"
+    )
 
 
 def test_fetch_method_metrics_unknown_protocol_raises(monkeypatch: pytest.MonkeyPatch):
@@ -149,12 +148,10 @@ def test_fetch_method_metrics_unknown_protocol_raises(monkeypatch: pytest.Monkey
 def test_normalized_rows_emits_one_block_per_protocol(monkeypatch: pytest.MonkeyPatch):
     """gpn_star has cLLR + LLR protocols; both must appear in normalized_rows.
 
-    Source is the AUPRC-schema gist (issue #145 last comment). The dashboard
+    Source is the S3 pipeline output (``snakemake/gpn_star_eval``). The dashboard
     sees a single `n` column derived from `n_rows` (per-subset / global) or
     `n_groups` (macro_avg).
     """
-    from marin_dna.pipelines.evals.leaderboard import GPN_STAR_METRICS_GIST_BASE
-
     methods = (
         _mk_method(
             id="GPN-Star-M",
@@ -166,11 +163,12 @@ def test_normalized_rows_emits_one_block_per_protocol(monkeypatch: pytest.Monkey
     )
     _patch_methods(monkeypatch, methods)
 
+    # No `split` column — the gpn_star S3 parquet is train-only and the read
+    # path filters by model + score_type, not split.
     def gpn_rows(score_type, value):
         return [
             {
                 "score_type": score_type,
-                "split": "train",
                 "model": "GPN-Star-M",
                 "subset": "missense_variant",
                 "value": value,
@@ -180,7 +178,6 @@ def test_normalized_rows_emits_one_block_per_protocol(monkeypatch: pytest.Monkey
             },
             {
                 "score_type": score_type,
-                "split": "train",
                 "model": "GPN-Star-M",
                 "subset": GLOBAL_SUBSET,
                 "value": value,
@@ -190,7 +187,6 @@ def test_normalized_rows_emits_one_block_per_protocol(monkeypatch: pytest.Monkey
             },
             {
                 "score_type": score_type,
-                "split": "train",
                 "model": "GPN-Star-M",
                 "subset": MACRO_AVG_SUBSET,
                 "value": value,
@@ -205,7 +201,10 @@ def test_normalized_rows_emits_one_block_per_protocol(monkeypatch: pytest.Monkey
     )
     _patch_read_parquet(
         monkeypatch,
-        {f"{GPN_STAR_METRICS_GIST_BASE}/mendelian_traits.GPN-Star.parquet": gpn_df},
+        {
+            "s3://oa-bolinas/snakemake/gpn_star_eval/results/metrics/"
+            "mendelian_traits.parquet": gpn_df
+        },
     )
     df = normalized_rows("mendelian_traits")
     assert set(df["protocol"].unique().to_list()) == {"cLLR", "LLR"}


### PR DESCRIPTION
## Summary

GPN-Star metrics were living in **two places**: the dashboard read a manually-uploaded metrics gist, while the `gpn_star_eval` pipeline wrote numerically-identical metrics to S3 (after #278). Two sources = drift risk — which is exactly what bit us this week (the gist was current while the committed pipeline had gone stale).

This points the dashboard at the **S3 pipeline output**, the same source pattern as the `conservation` / `alphagenome` / `marin_dna` families. The pipeline is now the single source of truth; the [#145](https://github.com/Open-Athena/marin-dna/issues/145) metrics gist stays only as a provenance record. (`evo2` keeps its gist — it has no snakemake pipeline.)

It also drops the redundant **`split` column** from the gpn_star metrics parquet: the gpn_star read path filters by `model` + `score_type` and *never* on `split` (unlike the marin_dna/alphagenome/evo2 paths), so the column was dead weight. Removing it makes the S3 schema match what the reader expects, so the gist→S3 switch is a pure path change.

## Changes

- **`leaderboard.py`**: `_parquet_path` `gpn_star` → `s3://…/gpn_star_eval/results/metrics/{dataset}.parquet`; remove the now-dead `GPN_STAR_METRICS_GIST_*` constants; update the module docstring.
- **`gpn_star_eval/metrics.smk`**: drop the `split` column (+ docstring).
- **README** + **`test_leaderboard.py`** updated; S3 outputs regenerated (no-`split`).

## Verification

- The S3 parquet now has columns `[score_type, subset, value, se, n_groups, n_rows, model, dataset]` — no `split`.
- The real dashboard read path (`fetch_method_metrics`, reading live S3) returns the correct AUPRC for all V/M/P × LLR/cLLR — e.g. `GPN-Star-V` cLLR global **0.4834**, M **0.4788**, P **0.3919** — **byte-identical to the prior gist values**. So there's no visible dashboard change; this is pure plumbing + cleanup.
- `ruff` clean; **332 evals tests pass**; no remaining references to the removed constants.

Follow-up to #278 / #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
