### PR TITLE
exp284: epoch-reshuffling (slice-mix) on the TSS-region 0.25B specialist

### DIFF
--- a/experiments/exp284_tss_reshuffle.py
+++ b/experiments/exp284_tss_reshuffle.py
@@ -28,19 +28,19 @@ Readout: per-step (10 HF checkpoints, ep ~2 → ~21) mendelian AUPRC on the 5′
 tss_proximal subsets + the ``val_tss_pc`` LL gap, ON vs OFF — does reshuffle help,
 and does the benefit grow with epoch count?
 
-How the slice-mix is wired (see ``_run_train_with_marin_dna_imports``): the
-executor graph and ``_build_data_mixture`` are byte-identical to exp255 — a
-standard single-component cache-backed config. The reshuffle is a *worker-side*
-transform applied after ``materialize`` resolves the tokenize-cache path and
-before levanter builds the data loader: ``inject_slice_mix`` loads the one
-training component (via levanter's own ``build_caches`` + ``build_token_datasets``,
-which route through the DNA-patched ``dataset_for_component`` so per-token loss
-weights are preserved), slices it into ``NUM_SLICES`` block-shuffled
-``DirectDatasetComponent``s, keeps the validation components untouched, and sets
-``shuffle=False``. ``run_levanter_train_lm`` then re-materializes (a safe no-op on
-the now placeholder-free config — ``materialize`` is idempotent and treats the
-live sliced datasets as inert leaves) and keeps all marin orchestration (HF
-export, run id, output-path baking).
+How the slice-mix is wired: ``_build_data_mixture`` returns a
+``SliceMixLmDataConfig`` (a thin ``LmDataConfig`` subclass) rather than a plain
+config — every other field is byte-identical to exp255's TSS arm (same tokenize
+caches + eval), so the executor graph and provenance are unchanged and exp255's
+no-reshuffle run (#256) stays a matched baseline. The reshuffle lives in that
+subclass's ``train_set`` override: it loads the single training component (via
+levanter's own ``build_caches`` + ``build_token_datasets``, which route through
+the DNA-patched ``dataset_for_component`` so per-token loss weights are
+preserved), slices it into ``NUM_SLICES`` block-shuffled pieces, and re-mixes
+them with ``MixtureDataset`` (size-proportional weights). It must live in
+``train_set`` (not a pre-train worker hook) because levanter calls
+``data.train_set(...)`` only *after* ``levanter.initialize`` — building the
+slices any earlier touches JAX before ``jax.distributed.initialize`` and raises.
 
 In-training validation is held fixed — the same **family-projection** recipes
 exp255 uses:
@@ -93,6 +93,7 @@ Reference templates:
   * Eval-task wiring — ``experiments/parity/exp179_eval_only.py``.
 """
 
+import dataclasses
 import logging
 import os
 from datetime import timedelta
@@ -124,6 +125,7 @@ from marin.training.training import TrainLmOnPodConfig, run_levanter_train_lm
 
 from marin_dna.levanter.defaults import dna_effective_seq_len
 from marin_dna.levanter.formats import DNALmDatasetFormat
+from marin_dna.levanter.slice_mix import SliceMixLmDataConfig
 from marin_dna.pipelines.evals.lm_eval.task_configs import MENDELIAN_TRAITS_255
 
 # =============================================================================
@@ -375,9 +377,19 @@ def _build_data_mixture(strategy: str, dataset: str) -> LmDataConfig:
             components[key] = _tokenize(
                 f"marin_dna-zoonomia-v1-{key}-char-bos", val_dataset, fmt
             )
-    return lm_mixture_data_config(
+    base = lm_mixture_data_config(
         components=components,
         weights={strategy: 1.0},
+    )
+    # Wrap the (standard, cache-backed) config in the slice-mix subclass: same
+    # fields + the reshuffle knobs. The reshuffle runs inside
+    # ``SliceMixLmDataConfig.train_set`` (post jax-init); the executor graph,
+    # tokenize caches, and provenance are byte-identical to exp255's TSS arm, so
+    # exp255's no-reshuffle run (#256) stays a matched baseline.
+    return SliceMixLmDataConfig(
+        **{f.name: getattr(base, f.name) for f in dataclasses.fields(base)},
+        num_slices=NUM_SLICES,
+        slice_mix_seed=SLICE_MIX_SEED,
     )
 
 
@@ -437,7 +449,7 @@ def _hf_save_steps(num_train_steps: int) -> int:
 
 
 def _run_train_with_marin_dna_imports(pod_config: TrainLmOnPodConfig) -> None:
-    """Worker entrypoint: bake in the marin_dna imports + inject the slice-mix.
+    """Worker entrypoint: bake in the marin_dna imports the TPU worker needs.
 
     Iris's ``Entrypoint.from_callable`` cloudpickles ``__main__`` by-value,
     capturing function bytecode but NOT re-importing modules on the worker.
@@ -450,32 +462,19 @@ def _run_train_with_marin_dna_imports(pod_config: TrainLmOnPodConfig) -> None:
     the data config (exp255 smoke5 confirmed this). Exp179_eval_only.py:91-96
     has the same pattern. Fix: bake the imports into the worker function body.
 
-    Epoch-reshuffling injection (issue #284). ``_build_data_mixture`` produced a
-    standard exp255-style single-component cache-backed config (so the executor
-    graph + provenance stay unchanged). Here, on the worker, we turn the
-    reshuffle ON: ``materialize`` first resolves the tokenize-cache placeholder
-    to a concrete path (the cache already exists — built by the upstream tokenize
-    step), then ``inject_slice_mix`` loads that one training component and
-    rewrites it into ``NUM_SLICES`` block-shuffled ``DirectDatasetComponent``s
-    that ``MixtureDataset`` re-interleaves fresh each epoch. ``materialize`` must
-    run before the injection (the cache must exist to be sliced) and after the
-    formats import (the slice build routes through the DNA-patched
-    ``dataset_for_component``, preserving per-token loss weights).
-    ``run_levanter_train_lm`` then runs normally — its own internal
-    ``materialize`` is a safe no-op on the now placeholder-free config
-    (idempotent; the live sliced datasets are inert leaves to the config walk),
-    and it keeps the full marin orchestration (HF export, run id, path baking).
+    The epoch reshuffle itself is NOT here — it lives in
+    ``SliceMixLmDataConfig.train_set`` (the ``data`` config built by
+    ``_build_data_mixture``), which levanter calls *after* ``levanter.initialize``
+    (post ``jax.distributed.initialize``). An earlier attempt that built the
+    slices here on the worker raised "jax.distributed.initialize() must be called
+    before any JAX calls that might initialise the XLA backend", because
+    constructing the block-shuffled slices touches JAX eagerly. The formats
+    import below still must precede training so the patched
+    ``dataset_for_component`` is installed before ``train_set`` runs.
     """
     import marin_dna.levanter.formats  # noqa: F401  # registers "dna" + patches dataset_for_component
     import marin_dna.pipelines.evals.lm_eval  # noqa: F401  # patches lm_eval TaskManager
-    from marin.execution.executor import materialize
 
-    from marin_dna.levanter.slice_mix import inject_slice_mix
-
-    pod_config = materialize(pod_config)
-    pod_config = inject_slice_mix(
-        pod_config, num_slices=NUM_SLICES, seed=SLICE_MIX_SEED
-    )
     run_levanter_train_lm(pod_config)
 
 

--- a/experiments/exp284_tss_reshuffle.py
+++ b/experiments/exp284_tss_reshuffle.py
@@ -1,0 +1,624 @@
+# Copyright The Marin Authors / Bolinas Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Epoch-reshuffling stopgap on the TSS-region 0.25B specialist (issue #284).
+
+A single-arm follow-up to #255 / #256 (exp255). exp255 trains 0.25B order-cohort
+region specialists, each on **one** training dataset epoched many times at fixed
+5K × 8192 compute. The smallest arm — ``v4_tss_region_and_utr5_order`` (the
+promoter / TSS region, 1,965,838 post-RC rows → **20.8 epochs**) — is the extreme
+of that regime, and the subject here.
+
+The problem (marin#2869): levanter's data path applies a single, fixed
+block-shuffle permutation and does NOT reshuffle on restart, so a single-dataset
+specialist sees the identical batch sequence every epoch (~21× here). The stopgap
+(Eric Czech's gist) slices that one tokenized dataset into ``NUM_SLICES`` disjoint
+block-shuffled components and re-mixes them, so ``MixtureDataset``'s per-block
+dataset-id permutation re-interleaves the slices fresh each epoch — batch
+composition almost never repeats — via the cheap block-shuffle (no global
+per-epoch reshuffle). See ``marin_dna.levanter.slice_mix``.
+
+This experiment is exp255's ``v4_tss_region_and_utr5_order`` arm with the
+slice-mix data path turned ON and **nothing else changed** — same dataset
+(``bolinas-dna/zoonomia-v1-v4_tss_region_and_utr5-order``, reusing exp255's
+tokenize cache), geometry, optimizer, 8192 batch, 5K steps, the 5 ``val_*``
+LL-gap recipes, and the ``mendelian_traits_255`` AUPRC eval. The matched
+no-reshuffle baseline is exp255's existing run for this arm (#256, no re-run).
+Readout: per-step (10 HF checkpoints, ep ~2 → ~21) mendelian AUPRC on the 5′UTR /
+tss_proximal subsets + the ``val_tss_pc`` LL gap, ON vs OFF — does reshuffle help,
+and does the benefit grow with epoch count?
+
+How the slice-mix is wired (see ``_run_train_with_marin_dna_imports``): the
+executor graph and ``_build_data_mixture`` are byte-identical to exp255 — a
+standard single-component cache-backed config. The reshuffle is a *worker-side*
+transform applied after ``materialize`` resolves the tokenize-cache path and
+before levanter builds the data loader: ``inject_slice_mix`` loads the one
+training component (via levanter's own ``build_caches`` + ``build_token_datasets``,
+which route through the DNA-patched ``dataset_for_component`` so per-token loss
+weights are preserved), slices it into ``NUM_SLICES`` block-shuffled
+``DirectDatasetComponent``s, keeps the validation components untouched, and sets
+``shuffle=False``. ``run_levanter_train_lm`` then re-materializes (a safe no-op on
+the now placeholder-free config — ``materialize`` is idempotent and treats the
+live sliced datasets as inert leaves) and keeps all marin orchestration (HF
+export, run id, output-path baking).
+
+In-training validation is held fixed — the same **family-projection** recipes
+exp255 uses:
+  * 5 region-specific ``zoonomia-v1-val_*`` recipes (LL gap) from PR #171,
+    each tokenized functional + nonfunctional (incl. the gene-centric ``val_tss_pc``).
+  * ``mendelian_traits_255`` lm-eval task (PR #186) — per consequence subset +
+    Global + Macro Avg + FWD/RC strand averaging. Online metric is AUPRC +
+    per-variant FWD/RC averaging (#226); in-training headline ``_global_/avg/auprc``,
+    offline evals_v2 leaderboard ``_macro_avg_/avg/auprc`` (#161).
+
+HF checkpoint saving is enabled by setting ``hf_save_steps`` to match the eval
+cadence (every 500 steps). ``hf_save_path`` is auto-set by marin's
+``_update_config_to_use_out_path`` to ``<output_path>/hf``. ``hf_save_dtype``
+stays ``None``, preserving the param dtype (fp32 under our
+``jmp.get_policy("p=f32,c=bfloat16")`` policy) — load at bf16 via
+``torch_dtype=torch.bfloat16``.
+
+Hardware: ``v6e-4`` + ``PDP=1024`` is the cost-optimal target (script defaults;
+PR #250). ``PDP`` is the per-chip microbatch: on the 4-chip v6e-4 slice the full
+per-chip batch is 8192/4 = 2048, which OOMs v6e's ~31 GB HBM, so ``PDP=1024``
+grad-accumulates 2 microbatches of 1024/chip (~24 GB, fits) with the **effective
+batch unchanged at 8192**, and is a no-op on any 8-chip slice, so a re-route
+needs only ``-e TPU_TYPE``. v6e is preemptible → babysit/relaunch; resume is free
+(the slice-mix is rebuilt deterministically from ``SLICE_MIX_SEED`` on the
+worker, and neither TPU type nor PDP is in the output-config hash).
+
+Download/tokenize pattern: option 1 (``HfTokenizeConfig(id=<hf-name>)``). The
+training partition + 5 val recipes reuse exp255/exp232's tokenizations (identical
+names → cache hit), so launch in the region where those caches live (exp255's
+TSS arm ran in ``europe-west4``) to avoid a re-tokenize.
+
+Launch from a CPU box with an iris tunnel open (see ``experiments/README.md``):
+
+    uv run iris --cluster=marin job run \\
+        --no-wait --user gonzalo --job-name exp284-tss-reshuffle-v6e4 \\
+        --cpu 1 --memory 2g --extra marin --region europe-west4 \\
+        -e WANDB_API_KEY "$(grep -A2 api.wandb.ai ~/.netrc | grep password | awk '{print $2}')" \\
+        -e HF_HUB_DOWNLOAD_TIMEOUT 120 -e UV_LOCK_TIMEOUT 7200 \\
+        -e TPU_TYPE v6e-4 -e PDP 1024 -e TPU_RAM 300g \\
+        -- python experiments/exp284_tss_reshuffle.py
+
+Optional knobs: ``-e SLICE_MIX_NUM_SLICES 8`` (default), ``-e SLICE_MIX_SEED 0``.
+
+Reference templates:
+  * Direct parent — ``experiments/exp255_per_region_order.py`` (this is that
+    script's TSS arm with the slice-mix worker-side data path; geometry /
+    optimizer / eval / dataset unchanged).
+  * Tracking issue — #284 (epoch reshuffling); upstream marin#2869; baseline #255 / #256.
+  * Slice-mix helper — ``src/marin_dna/levanter/slice_mix.py``.
+  * Eval-task wiring — ``experiments/parity/exp179_eval_only.py``.
+"""
+
+import logging
+import os
+from datetime import timedelta
+from functools import lru_cache
+
+import jmp
+from fray.cluster import ResourceConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.data.text.datasets import LmDataConfig
+from levanter.eval_harness import LmEvalHarnessConfig
+from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig
+from levanter.main.train_lm import TrainLmConfig
+from levanter.models.qwen import Qwen3Config
+from levanter.optim import AdamConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from levanter.utils.mesh import MeshConfig
+from marin.evaluation.evaluation_config import convert_to_levanter_task_config
+from marin.execution import (
+    ExecutorStep,
+    ensure_versioned,
+    executor_main,
+    this_output_path,
+)
+from marin.execution.remote import remote
+from marin.processing.tokenize import lm_mixture_data_config, tokenize
+from marin.processing.tokenize.tokenize import HfTokenizeConfig
+from marin.training.training import TrainLmOnPodConfig, run_levanter_train_lm
+
+from marin_dna.levanter.defaults import dna_effective_seq_len
+from marin_dna.levanter.formats import DNALmDatasetFormat
+from marin_dna.pipelines.evals.lm_eval.task_configs import MENDELIAN_TRAITS_255
+
+# =============================================================================
+# Constants — issue #284 epoch-reshuffling TSS arm (clone of exp255).
+# =============================================================================
+
+EXP_ISSUE = 284
+VERSION = "v0.1"
+TOKENIZER = "bolinas-dna/tokenizer-char-bos"
+DNA_BASE_SEQ_LEN = 255  # bp (256 - 1 for BOS)
+
+# The single TSS-region order-cohort partition — exp255's smallest, most-epoched
+# arm (1,965,838 post-RC rows → 20.8 epochs at 5K×8192; #230 / #233). Reusing the
+# *same* dataset + tokenize cache as exp255 keeps the no-reshuffle baseline (#256)
+# a byte-identical match — the only difference between the arms is the worker-side
+# slice-mix data path (see ``_run_train_with_marin_dna_imports``). The arm KEY is
+# kept identical to exp255's so the training tokenize cache hits exp255's; the
+# wandb run name + checkpoint path get a distinct ``-reshuffle`` suffix in
+# ``_build_train_step``. SWEEP_DATASETS still selects the arm (one entry here).
+TRAIN_DATASETS: dict[str, str] = {
+    "v4_tss_region_and_utr5_order": "bolinas-dna/zoonomia-v1-v4_tss_region_and_utr5-order",
+}
+
+# Five region-specific validation recipes from PR #171, tokenized functional +
+# nonfunctional for the LL-gap signal. Drops val_utr5 / val_promoter (both
+# subsumed by the gene-centric ±255 bp val_tss_pc); keeps val_enhancer
+# (chromatin-side, not subsumed). These are the FAMILY-projection val sets,
+# byte-identical to exp187/exp232 — the eval is held fixed across cohorts, and
+# the identical names reuse exp187/exp232's tokenization caches (no re-tokenize).
+VAL_DATASETS: tuple[tuple[str, str], ...] = (
+    ("val_cds", "bolinas-dna/zoonomia-v1-val_cds"),
+    ("val_utr3", "bolinas-dna/zoonomia-v1-val_utr3"),
+    ("val_ncrna", "bolinas-dna/zoonomia-v1-val_ncrna"),
+    ("val_enhancer", "bolinas-dna/zoonomia-v1-val_enhancer"),
+    ("val_tss_pc", "bolinas-dna/zoonomia-v1-val_tss_pc"),
+)
+
+# Training masks lowercase positions to 1% loss weight. Zoonomia datasets use
+# ``sequence`` as the text field (vs the older ``seq`` default for genomes-v5).
+TRAIN_FORMAT = DNALmDatasetFormat(text_key="sequence", lowercase_weight=0.01)
+
+# Validation tokenization specs — the two terms of the LL gap (matches exp160 /
+# exp166; deliberately skips the "default" matched-to-training variant).
+VAL_SPECS: tuple[tuple[str, DNALmDatasetFormat], ...] = (
+    ("functional", DNALmDatasetFormat(uppercase_weight=1.0, lowercase_weight=0.0)),
+    ("nonfunctional", DNALmDatasetFormat(uppercase_weight=0.0, lowercase_weight=1.0)),
+)
+
+# Qwen3-0.25B head_dim=128 (1152 / 9 = 128). The ``~255M`` rung of exp109's
+# calibrated scaling ladder (1152→255M, 1408→476M, 1920→1.12B); the 1B that
+# exp187 ran sits two rungs up at hidden=1920. Geometry from marin's
+# ``CompletedAdamHHeuristic._build_model_config(1152)``: num_layers=12,
+# intermediate=hidden×4, n_heads=hidden//128. Identical to exp232.
+HIDDEN_DIM = 1152
+INTERMEDIATE_DIM = HIDDEN_DIM * 4  # 4608
+NUM_HEADS = HIDDEN_DIM // 128  # 9
+NUM_LAYERS = 12
+
+BATCH_SIZE = 8192
+# TPU type is env-overridable (``TPU_TYPE``, comma-separated for fallbacks). The
+# agreed target for this experiment is ``v6e-4`` (default): 4 chips at ~2× the MFU
+# of v6e-8 → ~half the chip-hours for similar wall-clock, and v6e is abundant in
+# ``us-east5-b`` (data-local to the us-east5 cache) while v5p stays capacity-
+# starved (PR #250). Re-route with ``-e TPU_TYPE v6e-8`` / ``v5p-8`` / ``v4-8``
+# (all 8-chip; launch v4-8 with ``--region us-central2``). Resume is free across
+# re-routes — neither TPU type nor PDP is in the output-config hash (PR #250).
+TPU_TYPES: tuple[str, ...] = tuple(
+    t.strip() for t in os.getenv("TPU_TYPE", "v6e-4").split(",") if t.strip()
+)
+
+# Per-device microbatch (`per_device_parallelism`), env-overridable via ``PDP``;
+# default 1024. On the 4-chip v6e-4 slice the full per-chip batch is 8192/4 =
+# 2048, which OOMs v6e's ~31 GB HBM (~43 GB activations); ``PDP=1024`` grad-
+# accumulates 2 microbatches of 1024/chip (~24 GB, fits) with the **effective
+# batch unchanged at 8192** (train_batch_size fixed → mathematically identical
+# step). PDP=1024 is a no-op on any 8-chip slice (8192/8 = 1024/chip already =
+# one microbatch), so it's safe on every 4-8-chip pool — a re-route needs only
+# ``-e TPU_TYPE``. levanter already runs ``gradient_checkpointing=True``; the OOM
+# is activations, not weights, so the microbatch is the lever.
+PER_DEVICE_PARALLELISM: int = int(os.getenv("PDP", "1024"))
+
+# Host RAM request for the TPU pod, env-overridable via ``TPU_RAM``. The default
+# ``300g`` is inherited from exp166's 1B/4B but is oversized for 0.25B — host RAM
+# only buffers the data loader (the model + optimizer states live in TPU HBM), so
+# a few tens of GB suffice. Under a busy cluster a 300g ask can fail to schedule
+# ("Scheduler: Insufficient memory (need 300.0GB, ...)"), so override low (e.g.
+# ``-e TPU_RAM 40g``) to fit available nodes. NOTE: ``resources`` is **not** in
+# the marin executor's output-path hash (only ``versioned()`` values + step deps
+# are — see ``collect_dependencies_and_version``), so changing this is
+# resume-safe — a relaunched arm still loads its existing checkpoint.
+TPU_RAM: str = os.getenv("TPU_RAM", "300g")
+
+# 5K steps × 8192 batch × 256 tokens/seq ≈ 10.5B tokens — identical compute to
+# exp255's TSS arm (#256), the matched no-reshuffle baseline. The TSS -order set
+# is 1,965,838 post-RC rows, so 5K×8192 is ~20.8 epochs — the heavy-epoching
+# regime where epoch reshuffling should matter most (issue #284).
+NUM_TRAIN_STEPS = 5_000
+
+# --- Epoch-reshuffling (slice-mix) knobs (issue #284 / marin#2869) ---
+# Number of disjoint slices the single training dataset is split into. The mixture
+# re-interleaves these K block-shuffled slices with a fresh per-block permutation
+# each epoch, so batch composition almost never repeats across epochs (Eric's
+# stopgap; see ``marin_dna.levanter.slice_mix``). K=8 gives rich cross-epoch
+# interleaving for the ~1.97M-row TSS arm; env-overridable for tuning.
+NUM_SLICES: int = int(os.getenv("SLICE_MIX_NUM_SLICES", "8"))
+# Seed for the per-slice block-shuffle permutations. Resume-stable: the worker
+# rebuilds identical slices on restart, and the mixture's own per-epoch
+# permutation is keyed off the (resume-stable) trainer seed.
+SLICE_MIX_SEED: int = int(os.getenv("SLICE_MIX_SEED", "0"))
+
+# Optimizer hparams from marin PR #5530's exp166 transferred-hparam table
+# (resolved by ``CompletedAdamHHeuristic`` for B=8192, T=5.73e10 — exp166's
+# full-epoch horizon). Inherited verbatim from exp232 / exp187.
+#
+# **CAVEAT** — our T = 5_000 × 8192 × 256 ≈ 1.05e10, ~5× smaller than exp166's
+# horizon. The DNA-calibrated heuristic would resolve slightly different lr /
+# beta2 / epsilon for our regime. We use exp166's values here as a deliberate
+# starting point; the AdamH heuristic is size-independent (keyed on (B, T), both
+# unchanged at 0.25B), so the order arms share exp232's / exp166's optimizer
+# config — only the training species cohort differs. If reviewers want regime-
+# correct hparams, re-resolve via marin's CompletedAdamHHeuristic for
+# (B=8192, T=1.05e10) and pin the resolved values here. Tracked as Q1 in #232.
+LEARNING_RATE = 0.00430097
+BETA1 = 0.66756
+BETA2 = 0.952222
+EPSILON = 6.77142e-15
+MAX_GRAD_NORM = 0.995188
+Z_LOSS_WEIGHT = 4.312883184368223e-06
+INITIALIZER_RANGE = 0.02
+WEIGHT_DECAY = 0.1  # exp160 / exp135 default; the heuristic doesn't tune WD
+WARMUP_FRACTION = 0.1
+DECAY_FRACTION = 0.2
+LR_SCHEDULE = "linear"
+MIN_LR_RATIO = 0.0
+
+# Eval + checkpoint cadence. EVALS_PER_RUN = 10 → first eval at step 500. We
+# match HF-checkpoint cadence to eval cadence so every in-training eval has a
+# reloadable HF artifact for offline analysis (e.g. re-running mendelian eval
+# against a specific step, or the matched-epoch read vs the family baseline).
+EVALS_PER_RUN = 10
+CHECKPOINTS_PER_RUN = 10
+# Levanter resume-checkpoint cadence. Dropped 1h -> 10min: under frequent v6e
+# preemption (busy-hours windows can be ~15-20 min, much of it startup), a 1h
+# interval meant a relaunched arm got preempted before saving any progress and
+# kept resuming the same step (ccre_order stuck at 2500). 10min lets a ~25-min
+# window bank forward progress. Resume-safe — the checkpointer config is not in
+# the marin output-path hash (only ``versioned()`` values + deps are). HF
+# checkpoints stay every 500 steps (``hf_save_steps``) for analysis parity w/ cds.
+CHECKPOINT_TIME_INTERVAL = timedelta(minutes=10)
+
+WANDB_PROJECT = "marin"
+WANDB_GROUP = f"dna-exp{EXP_ISSUE}-{VERSION}"
+
+_EXPECTED_VOCAB_SIZE_WARNING = (
+    f"Tokenizer {TOKENIZER!r} not found in _KNOWN_VOCAB_SIZES"
+)
+logging.getLogger("marin.processing.tokenize.data_configs").addFilter(
+    lambda record: _EXPECTED_VOCAB_SIZE_WARNING not in record.getMessage()
+)
+
+
+# =============================================================================
+# Environment overrides
+# =============================================================================
+
+
+def _selected_datasets() -> dict[str, str]:
+    """Return the subset of TRAIN_DATASETS named in SWEEP_DATASETS (or all)."""
+    raw = os.getenv("SWEEP_DATASETS")
+    if not raw:
+        return dict(TRAIN_DATASETS)
+    requested = tuple(s.strip() for s in raw.split(","))
+    invalid = [n for n in requested if n not in TRAIN_DATASETS]
+    if invalid:
+        raise ValueError(
+            f"Invalid SWEEP_DATASETS {invalid}; available: {sorted(TRAIN_DATASETS)}"
+        )
+    return {n: TRAIN_DATASETS[n] for n in requested}
+
+
+# =============================================================================
+# Builders
+# =============================================================================
+
+
+@lru_cache(maxsize=1)
+def _model_seq_len() -> int:
+    """Model context size = base DNA seq len + special tokens (BOS)."""
+    return dna_effective_seq_len(DNA_BASE_SEQ_LEN, TOKENIZER)
+
+
+# Inherited verbatim from exp160 — small orchestrator footprint for the
+# tokenize step (heavy work runs on zephyr workers).
+_TOKENIZE_RESOURCES = ResourceConfig.with_cpu(cpu=1, ram="12g", disk="10g")
+
+
+def _tokenize(
+    name: str, dataset: str, dataset_format: DNALmDatasetFormat
+) -> ExecutorStep:
+    """Tokenize one HF dataset (option-1 path, same as exp160/exp166)."""
+    config = HfTokenizeConfig(
+        id=dataset,
+        cache_path=this_output_path(),
+        tokenizer=ensure_versioned(TOKENIZER),
+        format=dataset_format,
+    )
+    return ExecutorStep(
+        name=os.path.join("tokenized", name),
+        description=f"Tokenize {dataset!r} with the {TOKENIZER} tokenizer.",
+        fn=remote(
+            tokenize,
+            resources=_TOKENIZE_RESOURCES,
+            # bolinas-dna doesn't define a ``cpu`` extra; route to ``marin``
+            # which transitively installs marin + jax + jmp + tokenizers.
+            pip_dependency_groups=["marin"],
+            env_vars={
+                "TRANSFORMERS_NO_TORCH": "1",
+                "TRANSFORMERS_NO_TORCHVISION": "1",
+                "USE_TORCH": "0",
+                "TORCH_DISABLE_GLOBAL_DEPS": "1",
+                # huggingface_hub's default read_timeout=10s is too short for
+                # bigger parquet manifests; bump to 120s.
+                "HF_HUB_DOWNLOAD_TIMEOUT": "120",
+                # Many concurrent zephyr workers share a uv cache; first build
+                # serializes lm-eval (URL dep). Default 300s isn't enough.
+                "UV_LOCK_TIMEOUT": "7200",
+            },
+        ),
+        config=config,
+    )
+
+
+def _build_data_mixture(strategy: str, dataset: str) -> LmDataConfig:
+    """One training component + cross-product of validation recipes × specs.
+
+    The training component is keyed on ``strategy`` (which carries the ``_order``
+    cohort suffix), so its tokenize cache name is distinct from exp232's family
+    ``v4_<region>`` cache; the val components keep the exp187/exp232 names so
+    their caches are reused (the eval is held fixed across cohorts).
+    """
+    components: dict[str, ExecutorStep] = {
+        strategy: _tokenize(
+            f"marin_dna-zoonomia-v1-{strategy}-char-bos", dataset, TRAIN_FORMAT
+        ),
+    }
+    for region, val_dataset in VAL_DATASETS:
+        for suffix, fmt in VAL_SPECS:
+            key = f"{region}_{suffix}"
+            components[key] = _tokenize(
+                f"marin_dna-zoonomia-v1-{key}-char-bos", val_dataset, fmt
+            )
+    return lm_mixture_data_config(
+        components=components,
+        weights={strategy: 1.0},
+    )
+
+
+def _build_model_config() -> Qwen3Config:
+    """Qwen3-0.25B head_dim=128 (hidden=1152, layers=12, heads=9).
+
+    The ~255M rung of exp109's calibrated ladder; geometry from marin's
+    ``CompletedAdamHHeuristic._build_model_config(1152)`` (num_layers=12,
+    intermediate=4608, n_heads=9). Identical to exp232.
+    """
+    return Qwen3Config(
+        hidden_dim=HIDDEN_DIM,
+        intermediate_dim=INTERMEDIATE_DIM,
+        num_layers=NUM_LAYERS,
+        num_heads=NUM_HEADS,
+        num_kv_heads=NUM_HEADS,
+        max_seq_len=_model_seq_len(),
+        rope=Llama3RotaryEmbeddingsConfig(),
+        initializer_range=INITIALIZER_RANGE,
+    )
+
+
+def _build_optimizer() -> AdamConfig:
+    return AdamConfig(
+        learning_rate=LEARNING_RATE,
+        weight_decay=WEIGHT_DECAY,
+        beta1=BETA1,
+        beta2=BETA2,
+        epsilon=EPSILON,
+        max_grad_norm=MAX_GRAD_NORM,
+        warmup=WARMUP_FRACTION,
+        decay=DECAY_FRACTION,
+        lr_schedule=LR_SCHEDULE,
+        min_lr_ratio=MIN_LR_RATIO,
+    )
+
+
+def _eval_harness_config() -> LmEvalHarnessConfig:
+    """Wire the mendelian eval (AUPRC + Global + Macro Avg + FWD/RC strand
+    averaging; online metric migrated from PA in #226). Same shape as exp179_eval_only.py."""
+    return LmEvalHarnessConfig(
+        task_spec=convert_to_levanter_task_config([MENDELIAN_TRAITS_255]),
+    )
+
+
+def _checkpointer(num_train_steps: int) -> CheckpointerConfig:
+    return CheckpointerConfig(
+        save_interval=CHECKPOINT_TIME_INTERVAL,
+        keep=[dict(every=max(1, num_train_steps // CHECKPOINTS_PER_RUN))],
+    )
+
+
+def _hf_save_steps(num_train_steps: int) -> int:
+    """Match HF-checkpoint cadence to eval cadence — every eval has a paired
+    reloadable HF artifact under ``<this_output_path>/hf/step-<N>/``."""
+    return max(1, num_train_steps // EVALS_PER_RUN)
+
+
+def _run_train_with_marin_dna_imports(pod_config: TrainLmOnPodConfig) -> None:
+    """Worker entrypoint: bake in the marin_dna imports + inject the slice-mix.
+
+    Iris's ``Entrypoint.from_callable`` cloudpickles ``__main__`` by-value,
+    capturing function bytecode but NOT re-importing modules on the worker.
+    Module-top imports in this script (``marin_dna.levanter.formats``,
+    ``marin_dna.pipelines.evals.lm_eval.task_configs``) never fire on the TPU
+    pod, so the side-effecting registrations (``@register_subclass("dna")`` for
+    ``DNALmDatasetFormat`` AND the monkey-patch of ``dataset_for_component``; the
+    lm-eval task-manager patch) never install. Trainer init then fails with
+    ``ValueError: Unknown format DNALmDatasetFormat(...)`` when deserializing
+    the data config (exp255 smoke5 confirmed this). Exp179_eval_only.py:91-96
+    has the same pattern. Fix: bake the imports into the worker function body.
+
+    Epoch-reshuffling injection (issue #284). ``_build_data_mixture`` produced a
+    standard exp255-style single-component cache-backed config (so the executor
+    graph + provenance stay unchanged). Here, on the worker, we turn the
+    reshuffle ON: ``materialize`` first resolves the tokenize-cache placeholder
+    to a concrete path (the cache already exists — built by the upstream tokenize
+    step), then ``inject_slice_mix`` loads that one training component and
+    rewrites it into ``NUM_SLICES`` block-shuffled ``DirectDatasetComponent``s
+    that ``MixtureDataset`` re-interleaves fresh each epoch. ``materialize`` must
+    run before the injection (the cache must exist to be sliced) and after the
+    formats import (the slice build routes through the DNA-patched
+    ``dataset_for_component``, preserving per-token loss weights).
+    ``run_levanter_train_lm`` then runs normally — its own internal
+    ``materialize`` is a safe no-op on the now placeholder-free config
+    (idempotent; the live sliced datasets are inert leaves to the config walk),
+    and it keeps the full marin orchestration (HF export, run id, path baking).
+    """
+    import marin_dna.levanter.formats  # noqa: F401  # registers "dna" + patches dataset_for_component
+    import marin_dna.pipelines.evals.lm_eval  # noqa: F401  # patches lm_eval TaskManager
+    from marin.execution.executor import materialize
+
+    from marin_dna.levanter.slice_mix import inject_slice_mix
+
+    pod_config = materialize(pod_config)
+    pod_config = inject_slice_mix(
+        pod_config, num_slices=NUM_SLICES, seed=SLICE_MIX_SEED
+    )
+    run_levanter_train_lm(pod_config)
+
+
+def _train_remote_env_vars() -> dict[str, str]:
+    """Env vars baked into the train ``remote()`` call.
+
+    Iris workers don't inherit ``-e`` flags from the launcher's ``iris job run``
+    command — the orchestrator passes them to its own process tree, but child
+    tasks (the TPU pod running ``run_levanter_train_lm``) get a fresh env.
+    Per ``experiments/README.md:59-67`` and the working pattern in
+    ``experiments/parity/exp179_eval_only.py:124-130``, capture the key vars
+    from the launcher env here and bake them into the remote spec.
+
+    Missing ``WANDB_API_KEY`` here was the cause of ``/gonzalo/exp187-smoke2``
+    failing with ``wandb.UsageError: No API key configured`` after ~45 min of
+    successful tokenize work.
+    """
+    env: dict[str, str] = {
+        "HF_HUB_DOWNLOAD_TIMEOUT": "120",
+        "UV_LOCK_TIMEOUT": "7200",
+    }
+    # Reject empty WANDB_API_KEY — the launch command's shell ordering can
+    # silently substitute an empty value (``VAR=$(...) cmd -e VAR "$VAR"``
+    # resolves ``$VAR`` *before* the prefix assignment). Wandb's UsageError
+    # in that case is delayed until trainer init on the TPU pod, after ~45
+    # min of tokenize work has succeeded — costly. Fail loud at launch time
+    # instead.
+    wandb_key = os.environ.get("WANDB_API_KEY", "")
+    if wandb_key:
+        env["WANDB_API_KEY"] = wandb_key
+    else:
+        raise RuntimeError(
+            "WANDB_API_KEY is not set in the launcher's environment "
+            "(or is empty). The recommended launch pattern is to use "
+            "inline ``$(...)`` substitution in ``-e WANDB_API_KEY ...`` "
+            "per experiments/README.md — not a ``VAR=... cmd`` prefix, "
+            "which has a shell-ordering bug."
+        )
+    return env
+
+
+def _build_train_step(strategy: str, dataset: str) -> ExecutorStep:
+    steps_per_eval = max(1, NUM_TRAIN_STEPS // EVALS_PER_RUN)
+    run_name = f"dna-exp{EXP_ISSUE}-zoonomia-v1-0p25b-{strategy}-reshuffle-{VERSION}"
+    tags = (
+        "dna",
+        "marin_dna",
+        f"exp{EXP_ISSUE}",
+        "per-region",
+        "zoonomia_v1_v4",
+        "cohort=order",
+        "species=19_order",
+        "epoch_reshuffle=slice_mix",
+        f"num_slices={NUM_SLICES}",
+        VERSION,
+        f"region={strategy}",
+        "scale=0.25b",
+        f"bs={BATCH_SIZE}",
+        f"steps={NUM_TRAIN_STEPS}",
+    )
+
+    # iris's Entrypoint.from_callable cloudpickles __main__ by-value, so a
+    # module-top import of marin_dna.pipelines.evals.lm_eval doesn't fire on the
+    # TPU pod. Per the eval-task wiring pattern in exp179_eval_only.py:91-96,
+    # the in-function noqa import on the train worker happens inside
+    # marin.training.training.run_levanter_train_lm — see that function for the
+    # lm-eval task-manager monkeypatch's installation. We don't need to do
+    # anything special here; the convert_to_levanter_task_config([MENDELIAN_TRAITS_255])
+    # call serializes the task name + class path, which run_levanter_train_lm
+    # resolves on the worker after it imports our task module.
+
+    inner = TrainLmConfig(
+        data=_build_data_mixture(strategy, dataset),
+        model=_build_model_config(),
+        train_seq_len=_model_seq_len(),
+        z_loss_weight=Z_LOSS_WEIGHT,
+        optimizer=_build_optimizer(),
+        eval_harness=_eval_harness_config(),
+        eval_harness_steps=steps_per_eval,
+        # HF checkpoint cadence — one save per eval step. ``hf_save_path`` is
+        # auto-set by marin's ``_update_config_to_use_out_path`` to
+        # ``<output_path>/hf`` (since ``output_path`` is set on the pod config
+        # below); we only need to override the default ``hf_save_steps=10_000``.
+        # ``hf_save_dtype`` stays None → preserves param dtype (fp32 under our
+        # ``p=f32,c=bfloat16`` jmp policy); downstream consumers can cast at
+        # load time via ``from_pretrained(..., torch_dtype=torch.bfloat16)``.
+        hf_save_steps=_hf_save_steps(NUM_TRAIN_STEPS),
+        trainer=TrainerConfig(
+            tracker=WandbConfig(
+                project=WANDB_PROJECT,
+                tags=list(tags),
+                group=WANDB_GROUP,
+                name=run_name,
+                replicate_path=this_output_path(),
+            ),
+            mp=jmp.get_policy("p=f32,c=bfloat16"),
+            train_batch_size=BATCH_SIZE,
+            per_device_parallelism=PER_DEVICE_PARALLELISM,
+            num_train_steps=NUM_TRAIN_STEPS,
+            steps_per_eval=steps_per_eval,
+            checkpointer=_checkpointer(NUM_TRAIN_STEPS),
+            mesh=MeshConfig(axes={"replica": 1, "data": -1, "model": 1}),
+            allow_nondivisible_batch_size=True,
+        ),
+    )
+    pod_config = TrainLmOnPodConfig(
+        train_config=inner,
+        resources=ResourceConfig.with_tpu(TPU_TYPES, ram=TPU_RAM),
+        output_path=this_output_path(),
+    )
+    # The remote() call here IS the TPU worker — Fray's RemoteCallable submits
+    # the job with these resources verbatim. exp179_eval_only.py:140-145 mirrors
+    # this pattern; the old exp160_parity / exp166 pattern of CPU-orchestrator +
+    # TPU-pod-config relies on marin executor magic that no longer fires after
+    # the PR #182 / #186 rebase (smoke4 ran on a CPU worker and JAX raised
+    # "No accelerator found" at trainer.initialize). pip_dependency_groups
+    # explicitly installs ``tpu`` so libtpu is present — without it JAX
+    # silently falls back to CPU and we get the same error.
+    return ExecutorStep(
+        name=os.path.join("checkpoints", run_name),
+        fn=remote(
+            _run_train_with_marin_dna_imports,
+            resources=ResourceConfig.with_tpu(TPU_TYPES, ram=TPU_RAM),
+            pip_dependency_groups=["marin", "tpu"],
+            env_vars=_train_remote_env_vars(),
+        ),
+        config=pod_config,
+    )
+
+
+def main() -> None:
+    selected = _selected_datasets()
+    steps = [
+        _build_train_step(strategy, dataset) for strategy, dataset in selected.items()
+    ]
+    executor_main(
+        steps=steps,
+        description=(
+            f"DNA Bolinas exp{EXP_ISSUE} epoch-reshuffling TSS 0.25B (slice-mix) — "
+            f"{len(selected)}/{len(TRAIN_DATASETS)} arm(s) {VERSION}"
+        ),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/plots/exp284_reshuffle_analysis.py
+++ b/plots/exp284_reshuffle_analysis.py
@@ -1,0 +1,133 @@
+# Copyright The MarinDNA Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""exp284 epoch-reshuffle (ON) vs exp255 no-reshuffle (OFF) — TSS-region 0.25B.
+
+Single-panel figures of the in-training (online, post-#266 → offline-faithful)
+TSS diagonal VEP trajectories for the slice-mix reshuffle run (exp284) vs the
+matched no-reshuffle baseline (exp255's ``v4_tss_region_and_utr5_order`` arm,
+#256), vs training epoch. Both ran 5000 x 8192 on the same dataset/eval; the only
+difference is the per-epoch slice-mix reshuffle (PR #285). Issue #284.
+
+Writes to output/exp284_reshuffle_analysis/:
+  * ll_gap.{png,svg}              val_tss_pc LL gap (nonfunc - func loss)
+  * auprc_5utr.{png,svg}          mendelian 5'UTR AUPRC
+  * auprc_tss_proximal.{png,svg}  mendelian tss_proximal AUPRC
+
+Each run is plotted at its own logged eval steps (preemptions dropped the step-4000
+eval for both, and OFF's final ~5000 eval).
+
+Usage:
+  uv run python plots/exp284_reshuffle_analysis.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import pandas as pd
+import wandb
+
+ON = ("dna-exp284-v0.1", "tss_region_and_utr5_order")  # reshuffle ON
+OFF = ("dna-exp255-v0.1", "tss_region_and_utr5_order")  # no-reshuffle baseline (#256)
+
+EP_ROWS = 1_965_838  # post-RC rows; epoch = step * 8192 / rows
+BATCH = 8192
+MIN_STEP = 500
+
+REC = "val_tss_pc"
+FK, NK = f"eval/{REC}_functional/loss", f"eval/{REC}_nonfunctional/loss"
+A5 = "lm_eval/mendelian_traits_255/5_prime_UTR_variant/avg/auprc"
+ATP = "lm_eval/mendelian_traits_255/tss_proximal/avg/auprc"
+KEYS = [FK, NK, A5, ATP]
+
+OUT = Path(__file__).parent / "output" / "exp284_reshuffle_analysis"
+C_ON, C_OFF = "#1f6feb", "#999999"  # ON solid blue, OFF dashed gray
+
+
+def set_style() -> None:
+    mpl.rcParams.update(
+        {
+            "figure.dpi": 130,
+            "savefig.dpi": 150,
+            "savefig.bbox": "tight",
+            "font.size": 11,
+            "font.family": "DejaVu Sans",
+            "axes.titlesize": 12,
+            "axes.titleweight": "bold",
+            "axes.labelsize": 11,
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "axes.edgecolor": "#5a5a5a",
+            "axes.axisbelow": True,
+            "axes.grid": True,
+            "grid.color": "#e6e6e6",
+            "grid.linewidth": 0.8,
+            "legend.frameon": False,
+            "legend.fontsize": 10,
+            "figure.facecolor": "white",
+            "axes.facecolor": "white",
+        }
+    )
+
+
+def traj(api: wandb.Api, group: str, sub: str) -> pd.DataFrame:
+    """Stitched per-eval-step trajectory: columns _step, epoch, gap, a5, atp."""
+    frames = [
+        r.history(keys=KEYS, samples=10000, pandas=True)
+        for r in api.runs("marin", filters={"group": group})
+        if sub in r.name
+    ]
+    frames = [f for f in frames if len(f)]
+    if not frames:
+        raise SystemExit(f"no wandb runs for group={group!r} sub={sub!r}")
+    df = pd.concat(frames).sort_values("_step").drop_duplicates("_step", keep="last")
+    df = df[df["_step"] >= MIN_STEP].copy()
+    df["epoch"] = df["_step"] * BATCH / EP_ROWS
+    df["gap"] = df[NK] - df[FK]
+    return df.rename(columns={A5: "a5", ATP: "atp"}).reset_index(drop=True)
+
+
+def _save(fig: plt.Figure, name: str) -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    for ext in ("png", "svg"):
+        fig.savefig(OUT / f"{name}.{ext}")
+    plt.close(fig)
+
+
+def _abs_panel(
+    on: pd.DataFrame, off: pd.DataFrame, col: str, title: str, ylab: str, name: str
+) -> None:
+    fig, ax = plt.subplots(figsize=(5.6, 4.2))
+    for df, c, ls, lab in [
+        (on, C_ON, "-", "reshuffle ON (exp284)"),
+        (off, C_OFF, "--", "no-reshuffle OFF (exp255 #256)"),
+    ]:
+        d = df.dropna(subset=[col])
+        ax.plot(d["epoch"], d[col], color=c, ls=ls, lw=2, marker="o", ms=5, label=lab)
+    ax.set_title(title)
+    ax.set_xlabel("training epochs")
+    ax.set_ylabel(ylab)
+    ax.legend(loc="lower right")
+    fig.tight_layout()
+    _save(fig, name)
+
+
+def main() -> None:
+    set_style()
+    api = wandb.Api()
+    on, off = traj(api, *ON), traj(api, *OFF)
+    _abs_panel(
+        on, off, "gap", "val_tss_pc LL gap (nonfunc − func)", "LL gap (nats)", "ll_gap"
+    )
+    _abs_panel(on, off, "a5", "mendelian 5′UTR AUPRC", "AUPRC", "auprc_5utr")
+    _abs_panel(
+        on, off, "atp", "mendelian tss_proximal AUPRC", "AUPRC", "auprc_tss_proximal"
+    )
+    print(f"wrote 3 figures to {OUT}  | ON {len(on)} pts, OFF {len(off)} pts")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue284_relaunch_watcher.sh
+++ b/scripts/issue284_relaunch_watcher.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Detached relaunch-watcher for exp284 TSS epoch-reshuffle (#284, PR #285).
+#
+# v6e is preemptible; marin propagates a GCS-side TPU preemption as
+# "RuntimeError: N step(s) failed" (coordinator `failed`, preemptions=0) and does
+# NOT auto-resume (see snakemake/.../experiments README "Lessons learned"). This
+# loop relaunches on `failed` until training completes (`succeeded`) or
+# MAX_RELAUNCHES. Every relaunch RESUMES from exp284's last checkpoint — resources
+# / TPU-type / PDP / ram are NOT in the marin output-path hash, and the slice-mix
+# data stream is deterministic (SliceMixLmDataConfig: fixed slice seed + trainer
+# seed) — so resume is data-consistent. Backs off to ~hourly probes during
+# sustained no-progress contention; snaps back the moment a window opens (the
+# wandb step advances past the resume point).
+#
+# Run DETACHED so it survives SSH disconnect / session idle:
+#   nohup bash scripts/issue284_relaunch_watcher.sh >> scratch/exp284_watcher.log 2>&1 &
+set -u
+
+WORKTREE=/home/ubuntu/bolinas-dna/.claude/worktrees/flamboyant-feistel-bc4aa7
+cd "$WORKTREE" || { echo "FATAL: cannot cd $WORKTREE"; exit 1; }
+export PATH="/home/ubuntu/.local/bin:/usr/local/bin:/usr/bin:/bin:/snap/bin:$PATH"
+
+NAME_BASE="${WATCH_NAME_BASE:-exp284-tss-reshuffle-v6e4}"
+REGION="${WATCH_REGION:-europe-west4}"          # picks the marin data bucket + zone (reuse exp255's eu caches)
+START_SEQ="${WATCH_START_SEQ:-4}"               # run-3 was the last manual launch; resume-relaunches start at -4
+MAX_RELAUNCHES="${WATCH_MAX_RELAUNCHES:-20}"
+POLL_SECS="${WATCH_POLL_SECS:-300}"
+BACKOFF_AFTER="${WATCH_BACKOFF_AFTER:-3}"       # no-progress relaunches before backing off
+BACKOFF_SECS="${WATCH_BACKOFF_SECS:-2700}"      # ~45min probe interval during saturation
+PROGRESS_MARGIN=100                             # wandb-step advance that counts as "made progress"
+export WANDB_API_KEY="$(grep -A2 api.wandb.ai ~/.netrc | grep password | awk '{print $2}')"
+
+log(){ echo "[$(TZ=America/New_York date '+%m-%d %H:%M:%S') NY] $*"; }
+irisc(){ timeout 150 uv run --no-sync iris --cluster=marin "$@" 2>&1; }
+
+coord_state(){ irisc job summary "$1" | grep -oE 'State: [a-z]+' | awk '{print $2}' | head -1; }
+
+wandb_step(){
+  timeout 120 uv run --no-sync python - <<'PY' 2>/dev/null || echo 0
+import wandb
+api = wandb.Api(); ent = api.default_entity
+runs = list(api.runs(f"{ent}/marin", filters={"group": "dna-exp284-v0.1"}))
+running = [r for r in runs if r.state == "running"] or runs
+if not running:
+    print(0); raise SystemExit
+r = sorted(running, key=lambda x: x.created_at or "", reverse=True)[0]
+print(int(r.summary.get("_step", 0) or 0))
+PY
+}
+
+NO_PROGRESS=0
+LAST_STEP=0
+for SEQ in $(seq "$START_SEQ" "$((START_SEQ + MAX_RELAUNCHES))"); do
+  JOB="/gonzalo/${NAME_BASE}-${SEQ}"
+  log "launching attempt ${SEQ}: ${JOB} (region=${REGION})"
+  irisc job run --no-wait --user gonzalo --job-name "${NAME_BASE}-${SEQ}" \
+    --cpu 1 --memory 2g --extra marin --region "$REGION" \
+    -e WANDB_API_KEY "$WANDB_API_KEY" -e HF_HUB_DOWNLOAD_TIMEOUT 120 -e UV_LOCK_TIMEOUT 7200 \
+    -e TPU_TYPE v6e-4 -e PDP 1024 -e TPU_RAM 300g \
+    -- python experiments/exp284_tss_reshuffle.py | tail -2
+
+  # Poll this attempt until it reaches a terminal state.
+  while true; do
+    sleep "$POLL_SECS"
+    ST="$(coord_state "$JOB")"
+    log "${JOB} state=${ST:-<none>}"
+    case "$ST" in
+      succeeded|completed) log "DONE — exp284 training completed."; exit 0 ;;
+      failed) log "attempt ${SEQ} failed (preemption) -> relaunch+resume"; break ;;
+      *) : ;;  # running / pending / transient empty -> keep polling
+    esac
+  done
+
+  # Progress-aware backoff: only churn fast relaunches when we're actually
+  # banking steps; if a saturated pool keeps preempting before any checkpoint
+  # past the resume point, probe ~hourly instead.
+  STEP="$(wandb_step)"; STEP="${STEP:-0}"
+  if [ "$STEP" -gt "$((LAST_STEP + PROGRESS_MARGIN))" ]; then
+    log "progress: wandb step ${LAST_STEP} -> ${STEP}; prompt relaunch"
+    NO_PROGRESS=0; LAST_STEP="$STEP"
+  else
+    NO_PROGRESS=$((NO_PROGRESS + 1))
+    log "no durable progress (step ~${STEP}, streak ${NO_PROGRESS})"
+  fi
+  if [ "$NO_PROGRESS" -ge "$BACKOFF_AFTER" ]; then
+    log "sustained contention -> backoff ${BACKOFF_SECS}s before next probe"
+    sleep "$BACKOFF_SECS"
+  fi
+  sleep 20
+done
+log "hit MAX_RELAUNCHES (${MAX_RELAUNCHES}); stopping — check capacity / re-route manually."

--- a/src/marin_dna/levanter/slice_mix.py
+++ b/src/marin_dna/levanter/slice_mix.py
@@ -39,8 +39,6 @@ Two pieces:
   components (zero weight) use the inherited cache-backed path unchanged.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/marin_dna/levanter/slice_mix.py
+++ b/src/marin_dna/levanter/slice_mix.py
@@ -27,35 +27,35 @@ Two pieces:
 
 * ``slice_mix_components`` — pure dataset logic (slice + block-shuffle + size
   weights) over any ``AsyncDataset``. Unit-tested against ``ListAsyncDataset``.
-* ``inject_slice_mix`` — worker-side glue: given a *materialized* marin
-  ``TrainLmOnPodConfig`` whose training data is one cache-backed component, load
-  that component's token-sequence dataset (reusing levanter's own
-  ``build_caches`` + ``build_token_datasets``, which route through the DNA-patched
-  ``dataset_for_component`` so per-token loss weights are preserved), slice-mix
-  it, and return a new pod config whose training data is the ``K``
-  ``DirectDatasetComponent`` slices (validation components untouched,
-  ``shuffle=False`` since the slices are already block-shuffled).
-
-The injection must run on the training worker *after* the executor has
-materialized the tokenize cache (the cache must exist to be sliced) and *before*
-levanter builds the data loader — see the experiment's worker entrypoint.
+* ``SliceMixLmDataConfig`` — an ``LmDataConfig`` subclass that overrides
+  ``train_set`` to slice-mix its single training component. The reshuffle MUST
+  live in ``train_set`` (not a pre-train worker hook) because constructing the
+  slices touches JAX eagerly (``BlockShufflingDataset.__init__`` calls
+  ``jax.random.PRNGKey`` / ``jax.device_put`` / ``jax.random.split``), and
+  ``levanter.main.train_lm.main`` only calls ``data.train_set(...)`` *after*
+  ``levanter.initialize`` (i.e. after ``jax.distributed.initialize``). Building
+  the slices any earlier raises "jax.distributed.initialize() must be called
+  before any JAX calls that might initialise the XLA backend". Validation
+  components (zero weight) use the inherited cache-backed path unchanged.
 """
 
 from __future__ import annotations
 
-import dataclasses
-from typing import TYPE_CHECKING, cast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import jax
-from haliax import Axis
 from jaxtyping import PRNGKeyArray
 from levanter.data.dataset import AsyncDataset
-from levanter.data.text import DirectDatasetComponent, LmDataConfig
+from levanter.data.mixture import MixtureDataset
+from levanter.data.text import LmDataConfig
+from levanter.data.text.datasets import NamedLmDataset
 from levanter.utils.thread_utils import blocking_wait
 
 if TYPE_CHECKING:
-    from levanter.main.train_lm import TrainLmConfig
-    from marin.training.training import TrainLmOnPodConfig
+    from haliax import Axis
+    from levanter.models.lm_model import LmExample
+    from levanter.schedule import BatchSchedule
 
 # Match the baseline's hierarchical block-shuffle granularity
 # (``levanter.data.text.DEFAULT_LM_DATA_SHUFFLE``) so each slice is shuffled
@@ -82,6 +82,9 @@ def slice_mix_components(
     ``BlockShufflingDataset`` (via ``AsyncDataset.block_shuffle``), and assigns
     each a mixture weight equal to its fraction of ``n`` (so the expected
     per-epoch coverage is uniform and the weights sum to exactly 1.0).
+
+    NOTE: constructs ``BlockShufflingDataset``s, which eagerly touch JAX — call
+    only after ``jax.distributed.initialize`` (i.e. from within ``train_set``).
 
     Args:
         base: The full (already-tokenized) training dataset to reshuffle.
@@ -132,106 +135,78 @@ def _single_training_component_name(weights: object) -> str:
     """
     if not isinstance(weights, dict):
         raise ValueError(
-            "inject_slice_mix expects fixed dict train_weights with exactly one "
-            f"nonzero entry; got {type(weights).__name__}"
+            "SliceMixLmDataConfig expects fixed dict train_weights with exactly "
+            f"one nonzero entry; got {type(weights).__name__}"
         )
     nonzero = [name for name, w in weights.items() if w and w > 0]
     if len(nonzero) != 1:
         raise ValueError(
-            "inject_slice_mix expects exactly one training component (single-"
+            "SliceMixLmDataConfig expects exactly one training component (single-"
             f"dataset specialist); found {len(nonzero)}: {sorted(nonzero)}"
         )
     return nonzero[0]
 
 
-def inject_slice_mix(
-    pod_config: "TrainLmOnPodConfig",
-    *,
-    num_slices: int,
-    seed: int = 0,
-    io_block_size: int = DEFAULT_IO_BLOCK_SIZE,
-    window_blocks: int = DEFAULT_WINDOW_BLOCKS,
-    mixture_block_size: int | None = None,
-) -> "TrainLmOnPodConfig":
-    """Return a copy of ``pod_config`` with its training data slice-mixed.
+@dataclass(frozen=True)
+class SliceMixLmDataConfig(LmDataConfig):
+    """``LmDataConfig`` that reshuffles its single training component each epoch.
 
-    Must be called on the worker **after** ``materialize`` (the tokenize cache
-    must already exist) and **before** levanter builds the data loader. The
-    training data config must have exactly one cache-backed training component
-    (nonzero ``train_weights``); validation components (zero weight) are carried
-    through untouched.
-
-    The single training component's token-sequence dataset is built via the
-    config's own ``build_caches`` + ``build_token_datasets`` (so it goes through
-    the DNA-patched ``dataset_for_component`` and keeps the per-token loss
-    weights), then sliced into ``num_slices`` block-shuffled
-    ``DirectDatasetComponent``s mixed by size fraction. ``shuffle`` is set to
-    ``False`` because the slices are already block-shuffled; ``stop_strategy``
-    (RESTART) and ``mixture_block_size`` are inherited unless overridden.
-
-    Args:
-        pod_config: A *materialized* ``TrainLmOnPodConfig`` (concrete cache paths).
-        num_slices: Number of disjoint slices ``K`` to mix back together.
-        seed: Seed for the per-slice block-shuffle permutations (resume-stable:
-            the worker rebuilds the identical slices on restart).
-        io_block_size: Per-slice block-shuffle I/O block size.
-        window_blocks: Per-slice block-shuffle window size in blocks.
-        mixture_block_size: Override the mixture block size; ``None`` keeps the
-            config's existing value.
-
-    Returns:
-        A new ``TrainLmOnPodConfig`` with the slice-mixed training data.
+    Identical to ``LmDataConfig`` except ``train_set`` slices the one
+    (nonzero-weight) training component into ``num_slices`` block-shuffled pieces
+    re-mixed by ``MixtureDataset`` (size-proportional weights). Construct it by
+    copying a normal ``lm_mixture_data_config(...)`` output's fields and adding
+    the knobs below; it serializes/cloudpickles like any dataclass, so the marin
+    executor + iris worker handle it transparently. Validation components (zero
+    weight) use the inherited cache-backed path; only ``train_set`` changes.
     """
-    # marin types ``TrainLmOnPodConfig.train_config`` as bare ``object``; it holds
-    # a levanter ``TrainLmConfig`` here, so narrow it for attribute access.
-    train_config = cast("TrainLmConfig", pod_config.train_config)
-    data = train_config.data
-    if not isinstance(data, LmDataConfig):
-        raise TypeError(f"expected LmDataConfig, got {type(data).__name__}")
 
-    train_name = _single_training_component_name(data.train_weights)
+    num_slices: int = 8
+    slice_mix_seed: int = 0
+    slice_io_block_size: int = DEFAULT_IO_BLOCK_SIZE
+    slice_window_blocks: int = DEFAULT_WINDOW_BLOCKS
 
-    # Reuse levanter's own loaders so the base dataset is byte-identical to what
-    # training would otherwise consume: build_caches loads the existing cache
-    # (no rebuild), build_token_datasets routes through the (DNA-patched)
-    # dataset_for_component → per-token loss weights are preserved. For the
-    # "train" split these return only the nonzero-weight component(s).
-    Pos = Axis("position", train_config.train_seq_len)
-    caches = data.build_caches("train")
-    bases = data.build_token_datasets(caches, Pos, split="train")
-    base = bases[train_name]
+    def train_set(
+        self,
+        Pos: "Axis",
+        batch_schedule: "BatchSchedule",
+        *,
+        key: PRNGKeyArray,
+    ) -> AsyncDataset["LmExample"]:
+        # This override only supports the single-dataset specialist; refuse the
+        # train_sets() features it bypasses rather than silently ignore them.
+        for attr in (
+            "num_validation_sequences",
+            "max_train_batches",
+            "experiment_budget",
+            "target_budget",
+        ):
+            if getattr(self, attr) is not None:
+                raise NotImplementedError(
+                    f"SliceMixLmDataConfig.train_set does not support {attr!r}"
+                )
 
-    slice_datasets, slice_weights = slice_mix_components(
-        base,
-        num_slices=num_slices,
-        key=jax.random.PRNGKey(seed),
-        name_prefix=train_name,
-        io_block_size=io_block_size,
-        window_blocks=window_blocks,
-    )
+        train_name = _single_training_component_name(self.train_weights)
+        # Build the single training component's token-seq dataset exactly as the
+        # base path would: build_caches loads the existing cache (no rebuild),
+        # build_token_datasets routes through the DNA-patched dataset_for_component
+        # so per-token loss weights are preserved. (Both return only the nonzero-
+        # weight components for the "train" split.) Runs post jax-init.
+        caches = self.build_caches("train")
+        base = self.build_token_datasets(caches, Pos, split="train")[train_name]
 
-    # Replace the single training component with the K block-shuffled slices;
-    # carry every other (validation, zero-weight) component through unchanged.
-    val_components = {
-        name: comp for name, comp in data.components.items() if name != train_name
-    }
-    new_components: dict = {
-        name: DirectDatasetComponent(datasets={"train": ds})
-        for name, ds in slice_datasets.items()
-    }
-    new_components.update(val_components)
-
-    new_weights = dict(slice_weights)
-    new_weights.update({name: 0.0 for name in val_components})
-
-    new_data = dataclasses.replace(
-        data,
-        components=new_components,
-        train_weights=new_weights,
-        shuffle=False,  # slices are already block-shuffled
-        mixture_block_size=mixture_block_size
-        if mixture_block_size is not None
-        else data.mixture_block_size,
-    )
-    new_train_config = dataclasses.replace(train_config, data=new_data)
-    return dataclasses.replace(pod_config, train_config=new_train_config)
+        slice_datasets, slice_weights = slice_mix_components(
+            base,
+            num_slices=self.num_slices,
+            key=jax.random.PRNGKey(self.slice_mix_seed),
+            name_prefix=train_name,
+            io_block_size=self.slice_io_block_size,
+            window_blocks=self.slice_window_blocks,
+        )
+        mixture = MixtureDataset(
+            datasets=slice_datasets,
+            weights=slice_weights,
+            stop_strategy=self.stop_strategy,
+            key=key,
+            block_size=self.mixture_block_size,
+        )
+        return NamedLmDataset(mixture, Pos)

--- a/src/marin_dna/levanter/slice_mix.py
+++ b/src/marin_dna/levanter/slice_mix.py
@@ -1,0 +1,237 @@
+# Copyright The MarinDNA Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Epoch-reshuffling stopgap for single-dataset training via slice-mixing.
+
+Background (issue #284, marin#2869). When one dataset is trained for many
+epochs, levanter's data path applies a *single, fixed* block-shuffle permutation
+(``PermutationDataset`` / ``BlockShufflingDataset``) and does **not** reshuffle on
+restart — so the model sees the identical batch sequence every epoch. For a
+*single-dataset specialist* (one training component, no other mixture components
+to interleave with) this is unmitigated: e.g. the order-cohort TSS arm trains
+~20.8 epochs over one ~1.97M-row dataset, showing the same ordering ~21x.
+
+The stopgap (Eric Czech's gist, https://gist.github.com/eric-czech/a98dba4416613a208b9af943f6121f75):
+slice the single (already-tokenized) dataset into ``K`` disjoint contiguous
+components, block-shuffle each independently, and re-mix them with weights equal
+to their size fractions. ``MixtureDataset`` (``randomize_blocks=True``,
+``stop_strategy="restart"``) assigns each block a *fresh* dataset-id permutation
+via ``jax.random.fold_in(key, block_index)``; because the block index keeps
+increasing across epochs, the way the ``K`` slices are interleaved differs every
+epoch, so the batch *composition* almost never repeats — using only the cheap,
+fast block-shuffle (no expensive global per-epoch reshuffle). Each slice's own
+internal order is a fixed cycle; the cross-epoch variation comes from the
+re-mixing of the slices. That is exactly the behavior #284 sets out to test.
+
+Two pieces:
+
+* ``slice_mix_components`` — pure dataset logic (slice + block-shuffle + size
+  weights) over any ``AsyncDataset``. Unit-tested against ``ListAsyncDataset``.
+* ``inject_slice_mix`` — worker-side glue: given a *materialized* marin
+  ``TrainLmOnPodConfig`` whose training data is one cache-backed component, load
+  that component's token-sequence dataset (reusing levanter's own
+  ``build_caches`` + ``build_token_datasets``, which route through the DNA-patched
+  ``dataset_for_component`` so per-token loss weights are preserved), slice-mix
+  it, and return a new pod config whose training data is the ``K``
+  ``DirectDatasetComponent`` slices (validation components untouched,
+  ``shuffle=False`` since the slices are already block-shuffled).
+
+The injection must run on the training worker *after* the executor has
+materialized the tokenize cache (the cache must exist to be sliced) and *before*
+levanter builds the data loader — see the experiment's worker entrypoint.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, cast
+
+import jax
+from haliax import Axis
+from jaxtyping import PRNGKeyArray
+from levanter.data.dataset import AsyncDataset
+from levanter.data.text import DirectDatasetComponent, LmDataConfig
+from levanter.utils.thread_utils import blocking_wait
+
+if TYPE_CHECKING:
+    from levanter.main.train_lm import TrainLmConfig
+    from marin.training.training import TrainLmOnPodConfig
+
+# Match the baseline's hierarchical block-shuffle granularity
+# (``levanter.data.text.DEFAULT_LM_DATA_SHUFFLE``) so each slice is shuffled
+# exactly as the no-reshuffle baseline shuffles the whole dataset — the only
+# intended difference between the arms is the per-epoch re-mixing, not the
+# within-slice shuffle strength.
+DEFAULT_IO_BLOCK_SIZE = 256
+DEFAULT_WINDOW_BLOCKS = 512
+
+
+def slice_mix_components(
+    base: AsyncDataset,
+    *,
+    num_slices: int,
+    key: PRNGKeyArray,
+    name_prefix: str,
+    io_block_size: int = DEFAULT_IO_BLOCK_SIZE,
+    window_blocks: int = DEFAULT_WINDOW_BLOCKS,
+) -> tuple[dict[str, AsyncDataset], dict[str, float]]:
+    """Slice ``base`` into ``num_slices`` disjoint block-shuffled components.
+
+    Splits ``[0, n)`` into ``num_slices`` contiguous, non-overlapping ranges
+    (sizes differ by at most one element), wraps each in an independent
+    ``BlockShufflingDataset`` (via ``AsyncDataset.block_shuffle``), and assigns
+    each a mixture weight equal to its fraction of ``n`` (so the expected
+    per-epoch coverage is uniform and the weights sum to exactly 1.0).
+
+    Args:
+        base: The full (already-tokenized) training dataset to reshuffle.
+        num_slices: Number of disjoint slices ``K`` to mix back together.
+        key: PRNG key; split ``num_slices`` ways, one per slice's block-shuffle.
+        name_prefix: Component-name prefix; slices are ``f"{name_prefix}__slice{i}"``.
+        io_block_size: Block-shuffle I/O block size (per slice).
+        window_blocks: Block-shuffle window size in blocks (per slice).
+
+    Returns:
+        ``(datasets, weights)`` keyed by slice component name. ``datasets`` maps
+        to the block-shuffled ``AsyncDataset`` slices; ``weights`` to their size
+        fractions.
+    """
+    if num_slices < 1:
+        raise ValueError(f"num_slices must be >= 1, got {num_slices}")
+    n = blocking_wait(base.async_len())
+    if n < num_slices:
+        raise ValueError(f"dataset length {n} is smaller than num_slices {num_slices}")
+
+    # Contiguous cuts covering [0, n) exactly, so the slice sizes sum to n and
+    # the weights sum to exactly 1.0.
+    cuts = [round(i * n / num_slices) for i in range(num_slices + 1)]
+    assert cuts[0] == 0 and cuts[-1] == n
+    keys = jax.random.split(key, num_slices)
+
+    datasets: dict[str, AsyncDataset] = {}
+    weights: dict[str, float] = {}
+    for i in range(num_slices):
+        start, end = cuts[i], cuts[i + 1]
+        assert end > start, f"empty slice {i}: [{start}, {end}) (n={n}, K={num_slices})"
+        shuffled = base.slice_dataset(start, end).block_shuffle(
+            io_block_size=io_block_size,
+            window_blocks=window_blocks,
+            key=keys[i],
+        )
+        name = f"{name_prefix}__slice{i}"
+        datasets[name] = shuffled
+        weights[name] = (end - start) / n
+    return datasets, weights
+
+
+def _single_training_component_name(weights: object) -> str:
+    """Return the sole component name with nonzero training weight.
+
+    Slice-mixing is defined for a *single*-dataset specialist. Refuse anything
+    else loudly rather than silently reshuffling only one arm of a real mixture.
+    """
+    if not isinstance(weights, dict):
+        raise ValueError(
+            "inject_slice_mix expects fixed dict train_weights with exactly one "
+            f"nonzero entry; got {type(weights).__name__}"
+        )
+    nonzero = [name for name, w in weights.items() if w and w > 0]
+    if len(nonzero) != 1:
+        raise ValueError(
+            "inject_slice_mix expects exactly one training component (single-"
+            f"dataset specialist); found {len(nonzero)}: {sorted(nonzero)}"
+        )
+    return nonzero[0]
+
+
+def inject_slice_mix(
+    pod_config: "TrainLmOnPodConfig",
+    *,
+    num_slices: int,
+    seed: int = 0,
+    io_block_size: int = DEFAULT_IO_BLOCK_SIZE,
+    window_blocks: int = DEFAULT_WINDOW_BLOCKS,
+    mixture_block_size: int | None = None,
+) -> "TrainLmOnPodConfig":
+    """Return a copy of ``pod_config`` with its training data slice-mixed.
+
+    Must be called on the worker **after** ``materialize`` (the tokenize cache
+    must already exist) and **before** levanter builds the data loader. The
+    training data config must have exactly one cache-backed training component
+    (nonzero ``train_weights``); validation components (zero weight) are carried
+    through untouched.
+
+    The single training component's token-sequence dataset is built via the
+    config's own ``build_caches`` + ``build_token_datasets`` (so it goes through
+    the DNA-patched ``dataset_for_component`` and keeps the per-token loss
+    weights), then sliced into ``num_slices`` block-shuffled
+    ``DirectDatasetComponent``s mixed by size fraction. ``shuffle`` is set to
+    ``False`` because the slices are already block-shuffled; ``stop_strategy``
+    (RESTART) and ``mixture_block_size`` are inherited unless overridden.
+
+    Args:
+        pod_config: A *materialized* ``TrainLmOnPodConfig`` (concrete cache paths).
+        num_slices: Number of disjoint slices ``K`` to mix back together.
+        seed: Seed for the per-slice block-shuffle permutations (resume-stable:
+            the worker rebuilds the identical slices on restart).
+        io_block_size: Per-slice block-shuffle I/O block size.
+        window_blocks: Per-slice block-shuffle window size in blocks.
+        mixture_block_size: Override the mixture block size; ``None`` keeps the
+            config's existing value.
+
+    Returns:
+        A new ``TrainLmOnPodConfig`` with the slice-mixed training data.
+    """
+    # marin types ``TrainLmOnPodConfig.train_config`` as bare ``object``; it holds
+    # a levanter ``TrainLmConfig`` here, so narrow it for attribute access.
+    train_config = cast("TrainLmConfig", pod_config.train_config)
+    data = train_config.data
+    if not isinstance(data, LmDataConfig):
+        raise TypeError(f"expected LmDataConfig, got {type(data).__name__}")
+
+    train_name = _single_training_component_name(data.train_weights)
+
+    # Reuse levanter's own loaders so the base dataset is byte-identical to what
+    # training would otherwise consume: build_caches loads the existing cache
+    # (no rebuild), build_token_datasets routes through the (DNA-patched)
+    # dataset_for_component → per-token loss weights are preserved. For the
+    # "train" split these return only the nonzero-weight component(s).
+    Pos = Axis("position", train_config.train_seq_len)
+    caches = data.build_caches("train")
+    bases = data.build_token_datasets(caches, Pos, split="train")
+    base = bases[train_name]
+
+    slice_datasets, slice_weights = slice_mix_components(
+        base,
+        num_slices=num_slices,
+        key=jax.random.PRNGKey(seed),
+        name_prefix=train_name,
+        io_block_size=io_block_size,
+        window_blocks=window_blocks,
+    )
+
+    # Replace the single training component with the K block-shuffled slices;
+    # carry every other (validation, zero-weight) component through unchanged.
+    val_components = {
+        name: comp for name, comp in data.components.items() if name != train_name
+    }
+    new_components: dict = {
+        name: DirectDatasetComponent(datasets={"train": ds})
+        for name, ds in slice_datasets.items()
+    }
+    new_components.update(val_components)
+
+    new_weights = dict(slice_weights)
+    new_weights.update({name: 0.0 for name in val_components})
+
+    new_data = dataclasses.replace(
+        data,
+        components=new_components,
+        train_weights=new_weights,
+        shuffle=False,  # slices are already block-shuffled
+        mixture_block_size=mixture_block_size
+        if mixture_block_size is not None
+        else data.mixture_block_size,
+    )
+    new_train_config = dataclasses.replace(train_config, data=new_data)
+    return dataclasses.replace(pod_config, train_config=new_train_config)

--- a/tests/levanter/test_slice_mix.py
+++ b/tests/levanter/test_slice_mix.py
@@ -19,7 +19,7 @@ from levanter.data.dataset import ListAsyncDataset  # noqa: E402
 from levanter.data.mixture import MixtureDataset  # noqa: E402
 from levanter.utils.thread_utils import blocking_wait  # noqa: E402
 
-from marin_dna.levanter.slice_mix import slice_mix_components  # noqa: E402
+from marin_dna.levanter.slice_mix import SliceMixLmDataConfig, slice_mix_components  # noqa: E402
 
 # Small block-shuffle granularity so even a tiny test dataset is genuinely
 # reshuffled within each slice.
@@ -98,3 +98,22 @@ def test_slice_mix_rejects_bad_num_slices():
         slice_mix_components(
             base, num_slices=8, key=jax.random.PRNGKey(0), name_prefix="t"
         )
+
+
+def test_slice_mix_config_wraps_lmdataconfig():
+    """exp284's construction pattern: copy a plain LmDataConfig's fields + knobs."""
+    import dataclasses
+
+    from levanter.data.text import LmDataConfig
+
+    base = LmDataConfig(tokenizer="gpt2", mixture_block_size=512)
+    cfg = SliceMixLmDataConfig(
+        **{f.name: getattr(base, f.name) for f in dataclasses.fields(base)},
+        num_slices=8,
+        slice_mix_seed=3,
+    )
+    assert isinstance(cfg, LmDataConfig)
+    assert cfg.num_slices == 8 and cfg.slice_mix_seed == 3
+    # parent fields carried through verbatim
+    assert cfg.tokenizer == "gpt2" and cfg.mixture_block_size == 512
+    assert cfg.stop_strategy == base.stop_strategy

--- a/tests/levanter/test_slice_mix.py
+++ b/tests/levanter/test_slice_mix.py
@@ -1,0 +1,100 @@
+# Copyright The MarinDNA Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the epoch-reshuffling slice-mix helper (issue #284).
+
+These exercise the pure, dataset-level logic (``slice_mix_components``) plus the
+end-to-end re-mix behavior through ``MixtureDataset`` — the same invariant Eric's
+gist asserts: batch orderings differ across epochs. The marin/levanter glue in
+``inject_slice_mix`` needs a materialized cache + pod config, so it's covered by
+the experiment's TPU smoke test rather than here.
+"""
+
+import pytest
+
+pytest.importorskip("levanter", reason="install with `uv sync --extra marin` to run")
+
+import jax  # noqa: E402
+from levanter.data.dataset import ListAsyncDataset  # noqa: E402
+from levanter.data.mixture import MixtureDataset  # noqa: E402
+from levanter.utils.thread_utils import blocking_wait  # noqa: E402
+
+from marin_dna.levanter.slice_mix import slice_mix_components  # noqa: E402
+
+# Small block-shuffle granularity so even a tiny test dataset is genuinely
+# reshuffled within each slice.
+_IO_BLOCK = 4
+_WINDOW = 2
+
+
+def _read_all(ds) -> list:
+    n = blocking_wait(ds.async_len())
+    return list(blocking_wait(ds.get_batch(list(range(n)))))
+
+
+def test_slice_mix_components_partition():
+    """Slices are disjoint, cover the whole dataset, and weights are size-proportional."""
+    n, k = 1000, 8
+    base = ListAsyncDataset(list(range(n)))
+    datasets, weights = slice_mix_components(
+        base,
+        num_slices=k,
+        key=jax.random.PRNGKey(0),
+        name_prefix="t",
+        io_block_size=_IO_BLOCK,
+        window_blocks=_WINDOW,
+    )
+
+    assert set(datasets) == set(weights) == {f"t__slice{i}" for i in range(k)}
+    assert weights == pytest.approx({name: 1 / k for name in weights}, abs=1e-3)
+    assert sum(weights.values()) == pytest.approx(1.0)
+
+    # Disjoint cover: the union of all slices is exactly range(n), with no overlap
+    # (block-shuffle only reorders within a slice — it never drops or duplicates).
+    seen: list[int] = []
+    for name in datasets:
+        elems = _read_all(datasets[name])
+        assert len(set(elems)) == len(elems), f"{name} has duplicates"
+        seen.extend(elems)
+    assert sorted(seen) == list(range(n))
+
+
+def test_slice_mix_epoch_reshuffling():
+    """Across two epochs the batch ordering differs (the gist's invariant)."""
+    n, k = 1000, 8
+    base = ListAsyncDataset(list(range(n)))
+    datasets, weights = slice_mix_components(
+        base,
+        num_slices=k,
+        key=jax.random.PRNGKey(0),
+        name_prefix="t",
+        io_block_size=_IO_BLOCK,
+        window_blocks=_WINDOW,
+    )
+    mixture = MixtureDataset(
+        datasets=datasets,
+        weights=weights,
+        block_size=16,
+        key=jax.random.PRNGKey(1),
+        stop_strategy="restart",
+    )
+
+    # Two "epochs" worth of draws (the mixture is infinite under restart; one
+    # conceptual epoch ≈ n draws given size-proportional weights).
+    items = list(blocking_wait(mixture.get_batch(list(range(2 * n)))))
+    assert all(0 <= x < n for x in items), "mixture drew an out-of-range element"
+
+    epoch1, epoch2 = items[0:10], items[n : n + 10]
+    assert epoch1 != epoch2, "epochs are identical — no reshuffling happened"
+
+
+def test_slice_mix_rejects_bad_num_slices():
+    base = ListAsyncDataset(list(range(4)))
+    with pytest.raises(ValueError):
+        slice_mix_components(
+            base, num_slices=0, key=jax.random.PRNGKey(0), name_prefix="t"
+        )
+    with pytest.raises(ValueError):
+        slice_mix_components(
+            base, num_slices=8, key=jax.random.PRNGKey(0), name_prefix="t"
+        )


### PR DESCRIPTION
## Summary

Single-arm follow-up to #255 / #256 (exp255), implementing the epoch-reshuffling experiment tracked in #284. Turns **ON** per-epoch reshuffling for exp255's smallest, most-epoched arm — `v4_tss_region_and_utr5_order` (TSS / promoter, ~20.8 epochs at 5K×8192) — via the slice-mix stopgap (marin#2869, Eric's gist), to test whether reshuffling helps a single-dataset specialist under heavy epoching. The matched no-reshuffle baseline is exp255's existing run for this arm (#256) — no re-run.

Tracking issue: #284 · builds on #255 / #256 · upstream marin#2869.

## What's here

- **`src/marin_dna/levanter/slice_mix.py`** (kept in the bolinas repo for now):
  - [`slice_mix_components`](https://github.com/Open-Athena/marin-dna/blob/4d552888d5c7956feec90f695a572cf9f9742e19/src/marin_dna/levanter/slice_mix.py#L67-L125) — pure dataset logic: slice an `AsyncDataset` into K disjoint contiguous ranges, block-shuffle each (default granularity = the baseline's `DEFAULT_LM_DATA_SHUFFLE`), weight by size fraction.
  - [`SliceMixLmDataConfig`](https://github.com/Open-Athena/marin-dna/blob/4d552888d5c7956feec90f695a572cf9f9742e19/src/marin_dna/levanter/slice_mix.py#L149-L210) — a thin `LmDataConfig` subclass whose [`train_set`](https://github.com/Open-Athena/marin-dna/blob/4d552888d5c7956feec90f695a572cf9f9742e19/src/marin_dna/levanter/slice_mix.py#L166-L210) override slice-mixes the single training component (validation components use the inherited cache-backed path).
- **`tests/levanter/test_slice_mix.py`** — disjoint-partition + the gist's invariant (epoch1 ≠ epoch2) + the subclass field-copy construction + bad-arg guards (`uv run pytest`, 4 passed).
- **`experiments/exp284_tss_reshuffle.py`** — clone of exp255's TSS arm; [`_build_data_mixture`](https://github.com/Open-Athena/marin-dna/blob/4d552888d5c7956feec90f695a572cf9f9742e19/experiments/exp284_tss_reshuffle.py#L361-L399) returns the `SliceMixLmDataConfig` (only behavioral diff).

## How it's wired (and why the baseline stays matched)

The reshuffle lives in `SliceMixLmDataConfig.train_set`, which levanter calls **after** `levanter.initialize` (i.e. after `jax.distributed.initialize`). `_build_data_mixture` returns the subclass with fields **byte-identical to exp255's TSS arm** (same tokenize caches + eval) plus the reshuffle knobs — so the executor graph, caches, and provenance are unchanged and exp255's run (#256) stays a matched baseline. `train_set` loads the single training component (`build_caches` + `build_token_datasets` → DNA-patched `dataset_for_component`, so per-token loss weights are preserved), slices it into `NUM_SLICES`=8 block-shuffled pieces, and re-mixes with `MixtureDataset` (`randomize_blocks=True`, `stop_strategy="restart"` → fresh per-epoch interleaving via `fold_in(key, block_index)`, so batch composition almost never repeats).

> **Why `train_set` and not a worker hook:** an initial attempt that built the slices on the worker *before* `run_levanter_train_lm` crashed at trainer init — constructing `BlockShufflingDataset` touches JAX eagerly (`jax.random.PRNGKey` / `device_put` / `split`) before `jax.distributed.initialize`, raising *"jax.distributed.initialize() must be called before any JAX calls …"*. Moving the build into `train_set` (post-init) fixes it (commit `3dbade0`).

Dataset, geometry, optimizer, 8192 batch, 5K steps, the 5 `val_*` recipes, and the mendelian eval are unchanged, so ON (this PR) vs OFF (#256) isolates epoch reshuffling. Both arms are post-#266 (BOS-faithful).

## Validation

- 4 unit tests pass (slice partition + epoch1≠epoch2 + subclass field-copy construction); ruff + mypy clean.
- Construction smoke: the step assembles with `data` type `SliceMixLmDataConfig` (`train_set` overridden), training weight 1.0 + 10 val (0.0), v6e-4, seq_len 256, 5K×8192, hf_save_steps 500.
- Launched on v6e-4 (`europe-west4`, reusing exp255's tokenize caches); babysitting through the first eval (step 500).

<details><summary>Launch (one job; europe-west4 reuses exp255's tokenize cache)</summary>

```bash
uv run iris --cluster=marin job run \
  --no-wait --user gonzalo --job-name exp284-tss-reshuffle-v6e4 \
  --cpu 1 --memory 2g --extra marin --region europe-west4 \
  -e WANDB_API_KEY "$(grep -A2 api.wandb.ai ~/.netrc | grep password | awk '{print $2}')" \
  -e HF_HUB_DOWNLOAD_TIMEOUT 120 -e UV_LOCK_TIMEOUT 7200 \
  -e TPU_TYPE v6e-4 -e PDP 1024 -e TPU_RAM 300g \
  -- python experiments/exp284_tss_reshuffle.py
```
Optional: `-e SLICE_MIX_NUM_SLICES 8` (default), `-e SLICE_MIX_SEED 0`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

