### PR TITLE
evals: DART-Eval Task 3 cell-type peak dataset (evals_dart_task3) — interval, 3-way split

### DIFF
--- a/snakemake/evals/README.md
+++ b/snakemake/evals/README.md
@@ -20,6 +20,7 @@ commit `e59d612e9`, so HGMD pathogenic SNVs are included as a positive source.
 | `caqtl` | DART-Eval African caQTLs (ATAC), GRCh38 | Significant caQTLs in peaks | Control variants in peaks (no matching) |
 | `dsqtl` | DART-Eval Yoruban dsQTLs (DNase), hg19→GRCh38 | Significant dsQTLs in peaks | Control variants in peaks (no matching) |
 | `sge` | Saturation genome editing function scores (BRCA1; #289 phase 1) | — *(no label: a continuous experimental function score per SNV)* | — |
+| `dart_task3` | DART-Eval Task 3 cell-type ATAC peaks — 500 bp intervals, **not variants** (#293) | — *(no pos/neg: 5-class cell-type label — GM12878 / H1ESC / HEPG2 / IMR90 / K562)* | — |
 
 Only `mendelian_traits` has a corresponding `_harness_255` eval-harness
 variant. A 255 bp window centered on each variant is materialized into
@@ -144,6 +145,56 @@ MaveDB record once (`build_mavedb_metadata`) and emits two study-level artifacts
 
 ```bash
 uv run --group hgvs snakemake results/dataset/sge/{train,test}.parquet
+```
+
+### DART-Eval Task 3 (cell-type peaks) — `dart_task3`
+
+`dart_task3` is [DART-Eval](https://github.com/kundajelab/DART-Eval) **Task 3**
+("Discriminating Cell-Type-Specific Elements", issue #293): a cell-type-specific
+**chromatin-accessibility peak** dataset — the embedding/interpretation
+counterpart to the Task-5 QTL datasets above. Each row is a **500 bp** ATAC-seq
+consensus-peak window (±250 bp around the summit, GRCh38), labeled by the
+**cell type** it is differentially accessible in — one of 5 cell lines
+(`GM12878`, `H1ESC`, `HEPG2`, `IMR90`, `K562`). The window set is DART-Eval's
+`input_data/top_5000_deseq_peaks.tsv` — the top-5,000 DESeq2
+differentially-accessible peaks per cell type (the subset they feed their
+zero-shot clustering / UMAP): **25,000 windows, 5,000 balanced per cell type**,
+with unique peak coordinates.
+
+It is an **interval dataset, not variants**, so it bypasses all the variant
+machinery — no ref/alt, no `consequence`/`distance_*` annotation, no matching, no
+subsampling — and uses its **own rules and output namespace**
+(`workflow/rules/dart_task3.smk`, `results/dart_task3/…`). The full 500 bp peak is
+stored (never pre-cropped to a model's context window), so the embedding context /
+pooling choice stays an open downstream decision.
+
+**Splits.** Unlike the rest of the pipeline (odd/even 2-way), `dart_task3` uses
+DART-Eval's canonical **3-way** chromosome holdout, shipped one file per split (HF
+convention: `train.parquet` / `validation.parquet` / `test.parquet`, no in-row
+`split` column):
+
+| File | Chromosomes |
+|---|---|
+| `train.parquet` | 1, 2, 3, 4, 7, 8, 9, 11, 12, 13, 15, 16, 17, 19, X, Y |
+| `validation.parquet` | 6, 21 |
+| `test.parquet` | 5, 10, 14, 18, 20, 22 |
+
+`dart_task3_dataset` parses the TSV (`parse_dart_task3`), runs a build-time sanity
+check (all 5 cell types, ~25k windows: `assert_full_dataset`), and routes windows
+to the 3 splits (`split_frames`) — all in
+`src/marin_dna/pipelines/evals/dart_task3.py`, so the logic is unit-tested. There
+is **no** `results/qc/` artifact (no matching).
+
+Like caqtl/dsqtl it needs **Synapse auth** (the same PAT mechanism): set
+`SYNAPSE_AUTH_TOKEN` (the source file is pinned in `config.yaml` as
+`dart_eval.task3_synapse_id: syn62161401`). It is deliberately **not** in
+`rule all` / `upload_all` (its own 3-split target); build and upload it
+explicitly:
+
+```bash
+export SYNAPSE_AUTH_TOKEN=...   # Synapse PAT
+uv run snakemake dart_task3                       # build the 3 split parquets
+uv run snakemake results/dart_task3/upload.done   # upload to bolinas-dna/evals_dart_task3
 ```
 
 ## Matching scheme

--- a/snakemake/evals/config/config.yaml
+++ b/snakemake/evals/config/config.yaml
@@ -114,6 +114,11 @@ complex_traits:
 dart_eval:
   caqtl_synapse_id: syn60756043
   dsqtl_synapse_id: syn60756039
+  # Task 3 cell-type peak dataset (#293): DART-Eval's top-5,000-per-cell-type
+  # `input_data/top_5000_deseq_peaks.tsv` (25,000 x 500 bp peaks, 5,000 balanced
+  # per cell line) — the subset they feed their zero-shot clustering / UMAP.
+  # Synapse project syn60581042.
+  task3_synapse_id: syn62161401
 
 # ----- SGE (saturation genome editing) variant-effect dataset (issue #289) -----
 # Per-SNV experimental function scores from endogenous SGE assays; no matching /

--- a/snakemake/evals/workflow/Snakefile
+++ b/snakemake/evals/workflow/Snakefile
@@ -13,6 +13,7 @@ include: "rules/mendelian_traits.smk"
 include: "rules/complex_traits.smk"
 include: "rules/dart_eval.smk"
 include: "rules/sge.smk"
+include: "rules/dart_task3.smk"
 
 
 # `rule all` builds the local split parquets + matching diagnostics but does

--- a/snakemake/evals/workflow/rules/dart_task3.smk
+++ b/snakemake/evals/workflow/rules/dart_task3.smk
@@ -1,0 +1,117 @@
+from marin_dna.pipelines.evals import hf_readme
+from marin_dna.pipelines.evals.dart_task3 import (
+    SPLIT_CHROMS as DART_TASK3_SPLIT_CHROMS,
+    assert_full_dataset,
+    parse_dart_task3,
+    split_frames,
+)
+
+# DART-Eval Task 3 ("Discriminating Cell-Type-Specific Elements", issue #293): a
+# 500 bp ATAC-seq consensus-peak INTERVAL dataset with 5-class cell-type labels
+# (top_5000_deseq_peaks.tsv: the top-5,000 DESeq2 differentially-accessible peaks
+# per cell type, 25,000 windows = 5,000 balanced per cell line).
+# Because it is intervals — not variants — it bypasses the variant machinery
+# (check_ref_alt, consequence/TSS/exon annotation, materialize, matching/QC) AND
+# the generic split_dataset_by_chrom / hf_upload rules: it has a 3-way split
+# (train/validation/test) on DART-Eval's canonical chromosome holdout, not the
+# pipeline's odd/even 2-way split. It lives in its own `results/dart_task3/...`
+# output namespace so it never collides with the `{dataset}` wildcard of the
+# generic rules. See snakemake/evals/README.md and the dart_task3 library module.
+
+# train, validation, test (canonical 3-way order).
+DART_TASK3_SPLITS = list(DART_TASK3_SPLIT_CHROMS)
+
+
+rule dart_task3_download:
+    """Download the top-5,000-per-cell-type peaks TSV (top_5000_deseq_peaks.tsv)
+from Synapse over plain HTTP using a Personal Access Token (no synapseclient
+dependency). Requires a free Synapse account; export the PAT as
+SYNAPSE_AUTH_TOKEN before running."""
+    output:
+        "results/dart_task3/peaks.tsv",
+    params:
+        syn_id=config["dart_eval"]["task3_synapse_id"],
+    shell:
+        'test -n "$SYNAPSE_AUTH_TOKEN" || {{ echo "ERROR: set SYNAPSE_AUTH_TOKEN (a Synapse Personal Access Token) to download DART-Eval data" >&2; exit 1; }}; '
+        'curl -fL -H "Authorization: Bearer $SYNAPSE_AUTH_TOKEN" '
+        '"https://repo-prod.prod.sagebase.org/repo/v1/entity/{params.syn_id}/file" '
+        "-o {output}"
+
+
+rule dart_task3_dataset:
+    """Parse top_5000_deseq_peaks.tsv into the interval schema (chrom/start/end/
+label) and route windows to train/validation/test by DART-Eval's canonical
+chromosome split. No annotation, no matching, no subsampling. The parse +
+split logic (and its asserts) live in the library so they are unit-tested."""
+    input:
+        tsv="results/dart_task3/peaks.tsv",
+    output:
+        expand("results/dart_task3/dataset/{split}.parquet", split=DART_TASK3_SPLITS),
+    run:
+        # infer_schema_length=None: scan the whole TSV for dtype inference (the
+        # file is bounded; avoids mis-inferring a column from a short first chunk).
+        raw = pl.read_csv(input.tsv, separator="\t", infer_schema_length=None)
+        V = parse_dart_task3(raw)
+        # Build sanity on the COMPLETE set before splitting/uploading: all 5 cell
+        # types present, balanced, 25,000 windows (a truncated download or wrong
+        # file trips this).
+        assert_full_dataset(V)
+        frames = split_frames(V)
+        # expand() preserves DART_TASK3_SPLITS order, so output[i] <-> split[i].
+        for split, path in zip(DART_TASK3_SPLITS, output):
+            frames[split].write_parquet(path)
+
+
+rule dart_task3_upload:
+    """Upload the 3 split parquets + a generated dataset card to
+bolinas-dna/evals_dart_task3. Dedicated (not the generic hf_upload) because
+of the 3-way split and the interval-specific card."""
+    input:
+        train="results/dart_task3/dataset/train.parquet",
+        validation="results/dart_task3/dataset/validation.parquet",
+        test="results/dart_task3/dataset/test.parquet",
+    output:
+        touch("results/dart_task3/upload.done"),
+    params:
+        repo_name=f"{config['output_hf_prefix']}_dart_task3",
+    run:
+        api = HfApi()
+        api.create_repo(params.repo_name, repo_type="dataset", exist_ok=True)
+        readme = hf_readme.render_dart_task3(
+            sha=GIT_SHA,
+            train_path=input.train,
+            validation_path=input.validation,
+            test_path=input.test,
+        )
+        # Single atomic commit: README + all 3 splits land together, so the repo
+        # is never in a half-updated state (mirrors the generic hf_upload). The
+        # split inputs are the paths snakemake localized for this rule (the S3
+        # storage provider deletes the bare `results/...` copy after the producer).
+        ops = [
+            CommitOperationAdd(
+                path_in_repo="README.md", path_or_fileobj=readme.encode()
+            ),
+            CommitOperationAdd(
+                path_in_repo="train.parquet", path_or_fileobj=str(input.train)
+            ),
+            CommitOperationAdd(
+                path_in_repo="validation.parquet",
+                path_or_fileobj=str(input.validation),
+            ),
+            CommitOperationAdd(
+                path_in_repo="test.parquet", path_or_fileobj=str(input.test)
+            ),
+        ]
+        api.create_commit(
+            repo_id=params.repo_name,
+            repo_type="dataset",
+            operations=ops,
+            commit_message=f"Upload dart_task3 dataset ({len(ops)} files)",
+        )
+
+
+rule dart_task3:
+    """Convenience target: build the 3 split parquets (no upload). Upload
+separately with `snakemake results/dart_task3/upload.done`."""
+    input:
+        expand("results/dart_task3/dataset/{split}.parquet", split=DART_TASK3_SPLITS),

--- a/src/marin_dna/pipelines/evals/dart_task3.py
+++ b/src/marin_dna/pipelines/evals/dart_task3.py
@@ -1,0 +1,195 @@
+"""DART-Eval Task 3 cell-type-specific peak dataset (interval, not variant).
+
+Parsing + chromosome-split for the DART-Eval **Task 3** benchmark
+("Discriminating Cell-Type-Specific Elements"), brought into ``snakemake/evals``
+as a standalone HF dataset (``bolinas-dna/evals_dart_task3``). Unlike the Task-5
+QTL datasets (``caqtl``/``dsqtl`` in ``dart_eval.py``) these are **500 bp
+interval windows, not variants** — no ref/alt, no consequence/VEP annotation, no
+matching/subsampling, no liftover.
+
+Source (DART-Eval, Patel *et al.* NeurIPS 2024 D&B;
+https://github.com/kundajelab/DART-Eval), Synapse project ``syn60581042``. We
+consume their **top-5,000-per-cell-type** file
+``input_data/top_5000_deseq_peaks.tsv`` (``syn62161401``) — the balanced subset
+DART-Eval feeds their zero-shot **clustering / UMAP** baseline. It is the top
+5,000 DESeq2 differentially-accessible peaks for each of 5 ATAC-seq cell lines
+(GM12878, H1ESC, HEPG2, IMR90, K562) → **25,000** windows, exactly 5,000 per cell
+type, each a **500 bp** consensus-peak window (±250 bp around the ATAC summit),
+GRCh38. Every peak coordinate is unique (a peak in two cell types' top-5,000
+would dual-count, but none do).
+
+(The larger ``processed_inputs/peaks_by_cell_label_unique_dataloader_format.tsv``
+— 216,746 windows — is DART-Eval's *full* cell-type-specific set for the
+supervised probing/fine-tuning task; the top-5,000 file here is the strict subset
+used for the unsupervised clustering view.)
+
+The source columns are ``Chr, Start, End, Cell Type``; the parser projects them
+onto the standard ``chrom, start, end, label`` schema and asserts loudly if the
+real file deviates so a schema drift can't silently corrupt the dataset.
+Coordinates are **0-based, half-open** (verified: every peak matches the
+0-based dataloader-format file exactly) — the same convention as this codebase —
+so they flow through unchanged.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+# The 5 ATAC-seq cell lines = the classification labels. Casing matches
+# DART-Eval's source TSV; a real-file drift trips the membership assert in
+# `parse_dart_task3` (fail fast rather than silently mislabel).
+CELL_TYPES = ["GM12878", "H1ESC", "HEPG2", "IMR90", "K562"]
+
+# Every consensus peak is a fixed 500 bp window (±250 bp around the summit).
+PEAK_WIDTH = 500
+
+# Top 5,000 differentially-accessible peaks selected per cell type.
+TOP_K_PER_CELL_TYPE = 5000
+
+# Required columns of the top_5000_deseq_peaks.tsv source.
+DART_TASK3_REQUIRED = ["Chr", "Start", "End", "Cell Type"]
+
+# DART-Eval canonical Task-3 chromosome split — a 3-way holdout taken verbatim
+# from their training scripts (e.g.
+# `experiments/task_3_peak_classification/train/{hyenadna,nucleotide_transformer}.py`).
+# Distinct from the evals pipeline's default odd/even 2-way `SPLIT_CHROMS`; kept
+# identical to DART-Eval so any future Task-3 numbers stay comparable to theirs.
+# The three lists partition all of chr1..22,X,Y disjointly.
+SPLIT_CHROMS = {
+    "train": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "7",
+        "8",
+        "9",
+        "11",
+        "12",
+        "13",
+        "15",
+        "16",
+        "17",
+        "19",
+        "X",
+        "Y",
+    ],
+    "validation": ["6", "21"],
+    "test": ["5", "10", "14", "18", "20", "22"],
+}
+
+
+def _strip_chr(col: pl.Expr) -> pl.Expr:
+    """Drop a leading ``chr`` so chromosome names match our convention
+    (``"1"``..``"22"``, ``"X"``, ``"Y"``)."""
+    return col.cast(pl.Utf8).str.replace(r"^chr", "")
+
+
+def _require_columns(df: pl.DataFrame, cols: list[str]) -> None:
+    missing = [c for c in cols if c not in df.columns]
+    assert not missing, (
+        f"DART-Eval Task 3 TSV missing expected columns {missing}; got {df.columns}"
+    )
+
+
+def parse_dart_task3(df: pl.DataFrame) -> pl.DataFrame:
+    """Parse a raw ``top_5000_deseq_peaks.tsv`` frame into the standard interval
+    schema.
+
+    Projects ``Chr, Start, End, Cell Type`` onto ``chrom`` (``chr`` stripped) /
+    ``start`` / ``end`` (0-based, half-open) / ``label`` (cell type), sorted by
+    ``chrom, start``. Asserts the invariants that must hold for a valid Task-3
+    window set: labels are a subset of the 5 cell types, every window is exactly
+    ``PEAK_WIDTH`` bp, coordinates are non-negative. (Full-dataset checks — all 5
+    cell types present, balanced 5,000-per-type, ~25k unique rows — live in
+    ``assert_full_dataset`` so this stays usable on subsets/fixtures.)
+    """
+    _require_columns(df, DART_TASK3_REQUIRED)
+    out = df.select(
+        _strip_chr(pl.col("Chr")).alias("chrom"),
+        pl.col("Start").cast(pl.Int64).alias("start"),
+        pl.col("End").cast(pl.Int64).alias("end"),
+        pl.col("Cell Type").cast(pl.Utf8).alias("label"),
+    ).sort(["chrom", "start"])
+
+    assert out["label"].null_count() == 0, "DART-Eval Task 3: null labels"
+    bad = set(out["label"].unique().to_list()) - set(CELL_TYPES)
+    assert not bad, (
+        f"DART-Eval Task 3: unexpected cell-type labels {sorted(bad)} "
+        f"(allowed {CELL_TYPES})"
+    )
+    widths = out.select((pl.col("end") - pl.col("start")).alias("w"))["w"]
+    assert (widths == PEAK_WIDTH).all(), (
+        f"DART-Eval Task 3: not every window is {PEAK_WIDTH} bp "
+        f"(widths seen: {sorted(set(widths.to_list()))[:5]})"
+    )
+    assert (out["start"] >= 0).all(), "DART-Eval Task 3: negative start coordinate"
+    return out
+
+
+def split_frames(df: pl.DataFrame) -> dict[str, pl.DataFrame]:
+    """Partition a parsed frame into ``{train, validation, test}`` by the
+    DART-Eval canonical chromosome split.
+
+    Asserts every chromosome present is covered by the canonical split and that
+    the partition is exact (no row dropped or double-counted) — the split lists
+    are disjoint, so each row lands in exactly one frame.
+    """
+    canonical = set().union(*SPLIT_CHROMS.values())
+    present = set(df["chrom"].unique().to_list())
+    extra = present - canonical
+    assert not extra, (
+        f"DART-Eval Task 3: chromosomes {sorted(extra)} are outside the canonical "
+        f"Task-3 split (covers {sorted(canonical)})"
+    )
+    frames = {
+        split: df.filter(pl.col("chrom").is_in(chroms))
+        for split, chroms in SPLIT_CHROMS.items()
+    }
+    total = sum(f.height for f in frames.values())
+    assert total == df.height, (
+        f"DART-Eval Task 3: split partition is not exact "
+        f"(sum {total} != input {df.height})"
+    )
+    return frames
+
+
+def assert_full_dataset(
+    df: pl.DataFrame, *, min_rows: int = 20_000, max_rows: int = 25_000
+) -> None:
+    """Build-time sanity for the *complete* parsed dataset (not subsets).
+
+    Guards the real upload: all 5 cell types present, each within the documented
+    top-5,000-per-cell-type cap, peak coordinates unique (no dual-counted peak),
+    and the total near DART-Eval's 25,000 (5,000 x 5). A gross parse/source error
+    (wrong file, truncated download, label drift) trips one of these before
+    anything is pushed to HuggingFace.
+    """
+    labels = set(df["label"].unique().to_list())
+    assert labels == set(CELL_TYPES), (
+        f"DART-Eval Task 3: expected all 5 cell types {CELL_TYPES}, got {sorted(labels)}"
+    )
+    per = df.group_by("label").len().sort("label")
+    counts = dict(zip(per["label"].to_list(), per["len"].to_list()))
+    # n >= 1 is already guaranteed by the all-5-cell-types assert above, so only
+    # the top-K upper cap is a live check here.
+    for ct, n in counts.items():
+        assert n <= TOP_K_PER_CELL_TYPE, (
+            f"DART-Eval Task 3: cell type {ct!r} has {n} peaks "
+            f"(exceeds the top-{TOP_K_PER_CELL_TYPE} cap)"
+        )
+    # Balanced by construction (top-K selected per cell type) — enforce it so the
+    # card's "5,000 balanced per cell type" claim can never silently go stale.
+    assert len(set(counts.values())) == 1, (
+        f"DART-Eval Task 3: cell types are not balanced (counts {counts}); "
+        f"the top-{TOP_K_PER_CELL_TYPE} selection should give equal counts"
+    )
+    n_unique = df.select(["chrom", "start", "end"]).unique().height
+    assert n_unique == df.height, (
+        f"DART-Eval Task 3: {df.height - n_unique} duplicate peak coordinates "
+        "(a peak in >1 cell type's top-5,000 would dual-count)"
+    )
+    assert min_rows <= df.height <= max_rows, (
+        f"DART-Eval Task 3: total {df.height} rows outside expected "
+        f"[{min_rows}, {max_rows}] (DART-Eval ships 25,000)"
+    )

--- a/src/marin_dna/pipelines/evals/hf_readme.py
+++ b/src/marin_dna/pipelines/evals/hf_readme.py
@@ -962,6 +962,132 @@ If you use this benchmark, please cite the source SGE studies:
 """
 
 
+def render_dart_task3(
+    sha: str,
+    train_path: str | Path,
+    validation_path: str | Path,
+    test_path: str | Path,
+) -> str:
+    """Dataset card for the DART-Eval Task 3 cell-type-specific peak dataset.
+
+    An **interval** dataset (not variants): each row is a 500 bp ATAC-seq
+    consensus-peak window labeled by the cell type it is differentially
+    accessible in (5-class). No ref/alt, no consequence annotation, no
+    matching/subsampling. Split by file on DART-Eval's canonical 3-way
+    chromosome holdout, so this takes a `validation_path` the generic `render()`
+    (train/test only) can't supply — the upload rule calls it directly.
+    """
+    splits = {
+        "train": pl.read_parquet(train_path),
+        "validation": pl.read_parquet(validation_path),
+        "test": pl.read_parquet(test_path),
+    }
+    totals = {s: df.height for s, df in splits.items()}
+    total = sum(totals.values())
+    cell_types = sorted(
+        set().union(*(set(df["label"].unique().to_list()) for df in splits.values()))
+    )
+
+    def _n(split: str, ct: str) -> int:
+        return splits[split].filter(pl.col("label") == ct).height
+
+    ct_rows = "\n".join(
+        f"| `{ct}` | {_n('train', ct):,} | {_n('validation', ct):,} "
+        f"| {_n('test', ct):,} | {_n('train', ct) + _n('validation', ct) + _n('test', ct):,} |"
+        for ct in cell_types
+    )
+
+    # Minimal tag set (biology, genomics, dna) per the bolinas-dna dataset-card
+    # convention — no fine-grained extras.
+    return f"""{_frontmatter()}
+
+# evals_dart_task3
+
+Cell-type-specific **chromatin-accessibility peak** dataset from
+[DART-Eval](https://github.com/kundajelab/DART-Eval) **Task 3** ("Discriminating
+Cell-Type-Specific Elements"). Each row is a **500 bp** ATAC-seq consensus-peak
+window (±250 bp around the summit, GRCh38), labeled by the **cell type** it is
+differentially accessible in. The benchmark question: can a model embedding
+distinguish cell types from the sequence alone?
+
+**Interval dataset, not variants** — no ref/alt, no consequence annotation, **no
+matching and no subsampling**. The window set is DART-Eval's
+`input_data/top_5000_deseq_peaks.tsv` — the **top 5,000 DESeq2
+differentially-accessible peaks per cell type** (the subset they feed their
+zero-shot clustering / UMAP), **25,000 windows, 5,000 balanced per cell type**,
+with unique peak coordinates.
+
+## Description
+
+| | |
+|---|---|
+| Element | 500 bp ATAC-seq consensus peak (±250 bp around the summit; window midpoint = summit) |
+| Label | One of 5 cell lines: `GM12878`, `H1ESC`, `HEPG2`, `IMR90`, `K562` |
+| Selection | Top 5,000 DESeq2 differentially-accessible peaks per cell type (25,000 total, balanced) |
+| Assay | ATAC-seq chromatin accessibility (ENCODE) |
+| Source data | DART-Eval, Synapse [`syn62161401`](https://www.synapse.org/Synapse:syn62161401) (`top_5000_deseq_peaks.tsv`), project `syn60581042` |
+| Genome build | GRCh38 |
+| Coordinates | **0-based, half-open** (`end - start == 500`) |
+| Matching | none (no subsampling) |
+
+The full 500 bp peak is stored (never pre-cropped to a model's context window),
+so the embedding context / pooling choice stays an open downstream decision.
+
+## Splits
+
+DART-Eval's canonical **3-way** chromosome holdout (verbatim from their Task-3
+training scripts), shipped one file per split. Per-split counts follow the
+peaks' genomic distribution.
+
+| File | Windows | Chromosomes |
+|---|---:|---|
+| `train.parquet` | {totals["train"]:,} | 1, 2, 3, 4, 7, 8, 9, 11, 12, 13, 15, 16, 17, 19, X, Y |
+| `validation.parquet` | {totals["validation"]:,} | 6, 21 |
+| `test.parquet` | {totals["test"]:,} | 5, 10, 14, 18, 20, 22 |
+| **total** | **{total:,}** | |
+
+### Windows per cell type
+
+| Cell type | train | validation | test | total |
+|---|---:|---:|---:|---:|
+{ct_rows}
+
+## Columns
+
+| Column | Type | Description |
+|---|---|---|
+| `chrom` | str | Chromosome (no `chr` prefix), GRCh38 |
+| `start` | int | Window start — 0-based, inclusive |
+| `end` | int | Window end — 0-based, exclusive (`end - start == 500`) |
+| `label` | str | Cell type the peak is differentially accessible in |
+
+## Provenance
+
+Built by the [`marin-dna`]({REPO_ROOT_URL}) eval pipeline at commit
+[`{sha[:7]}`]({REPO_ROOT_URL}/tree/{sha}/snakemake/evals).
+
+- Curation pipeline: {_pipeline_link(sha)}
+- Rules: {_file_link(sha, "snakemake/evals/workflow/rules/dart_task3.smk")}
+- Parsing + splitting: {_file_link(sha, "src/marin_dna/pipelines/evals/dart_task3.py")}
+
+## License
+
+Released under the terms of its upstream sources. The peak set is redistributed
+from [DART-Eval](https://github.com/kundajelab/DART-Eval) (Task 3) and derives
+from **ENCODE** ATAC-seq in the 5 cell lines (freely redistributable under the
+[ENCODE data-use policy](https://www.encodeproject.org/help/citing-encode/));
+DART-Eval ships no explicit license, so consult it and ENCODE for redistribution
+and commercial-use terms.
+
+## Citation
+
+If you use this benchmark, please cite the upstream sources:
+
+- DART-Eval — Patel *et al.* 2024, [arXiv 2412.05430](https://arxiv.org/abs/2412.05430) (NeurIPS D&B 2024)
+- ENCODE Project Consortium — the ATAC-seq data for GM12878, H1ESC, HEPG2, IMR90, K562
+"""
+
+
 def render(
     dataset: str,
     sha: str,

--- a/tests/pipelines/evals/test_dart_task3.py
+++ b/tests/pipelines/evals/test_dart_task3.py
@@ -1,0 +1,198 @@
+"""Tests for DART-Eval Task 3 cell-type-specific peak parsing + splitting."""
+
+import polars as pl
+import pytest
+
+from marin_dna.pipelines.evals import hf_readme
+from marin_dna.pipelines.evals.dart_task3 import (
+    CELL_TYPES,
+    PEAK_WIDTH,
+    SPLIT_CHROMS,
+    assert_full_dataset,
+    parse_dart_task3,
+    split_frames,
+)
+
+
+def _row(chrom: str, start: int, label: str) -> dict:
+    """One row in the source (top_5000_deseq_peaks.tsv) format."""
+    return {"Chr": chrom, "Start": start, "End": start + PEAK_WIDTH, "Cell Type": label}
+
+
+# --------------------------------------------------------------------------- #
+# parse_dart_task3
+# --------------------------------------------------------------------------- #
+class TestParseDartTask3:
+    def _raw(self) -> pl.DataFrame:
+        return pl.DataFrame(
+            [
+                _row("chr6", 5000, "K562"),
+                _row("chr1", 1000, "GM12878"),
+                _row("chr5", 2000, "H1ESC"),
+            ]
+        )
+
+    def test_schema_and_strip_chr(self) -> None:
+        out = parse_dart_task3(self._raw())
+        assert out.columns == ["chrom", "start", "end", "label"]
+        # `chr` stripped and sorted by (chrom, start): 1, 5, 6.
+        assert out["chrom"].to_list() == ["1", "5", "6"]
+        assert out["label"].to_list() == ["GM12878", "H1ESC", "K562"]
+
+    def test_width_invariant(self) -> None:
+        out = parse_dart_task3(self._raw())
+        assert ((out["end"] - out["start"]) == PEAK_WIDTH).all()
+
+    def test_coordinates_are_zero_based_half_open(self) -> None:
+        # start passes through unchanged (0-based half-open in the source).
+        out = parse_dart_task3(pl.DataFrame([_row("chr1", 1000, "K562")]))
+        assert out["start"].to_list() == [1000]
+        assert out["end"].to_list() == [1500]
+
+    def test_missing_column_raises(self) -> None:
+        with pytest.raises(AssertionError, match="missing expected columns"):
+            parse_dart_task3(self._raw().drop("Start"))
+
+    def test_bad_label_raises(self) -> None:
+        bad = pl.DataFrame([_row("chr1", 1000, "HeLa")])
+        with pytest.raises(AssertionError, match="unexpected cell-type labels"):
+            parse_dart_task3(bad)
+
+    def test_wrong_width_raises(self) -> None:
+        bad = self._raw().with_columns(pl.col("End") - 1)
+        with pytest.raises(AssertionError, match=f"not every window is {PEAK_WIDTH}"):
+            parse_dart_task3(bad)
+
+
+# --------------------------------------------------------------------------- #
+# split_frames
+# --------------------------------------------------------------------------- #
+class TestSplitFrames:
+    def _parsed(self) -> pl.DataFrame:
+        # One window per split (chr1->train, chr6->validation, chr5->test) plus
+        # an extra train chrom (Y) to check multi-chrom routing.
+        return pl.DataFrame(
+            {
+                "chrom": ["1", "6", "5", "Y"],
+                "start": [0, 0, 0, 0],
+                "end": [PEAK_WIDTH] * 4,
+                "label": ["GM12878", "K562", "H1ESC", "IMR90"],
+            }
+        )
+
+    def test_partition_is_exact_and_routed(self) -> None:
+        frames = split_frames(self._parsed())
+        assert set(frames) == {"train", "validation", "test"}
+        assert frames["train"]["chrom"].to_list() == ["1", "Y"]
+        assert frames["validation"]["chrom"].to_list() == ["6"]
+        assert frames["test"]["chrom"].to_list() == ["5"]
+        assert sum(f.height for f in frames.values()) == 4
+
+    def test_unknown_chrom_raises(self) -> None:
+        bad = self._parsed().with_columns(
+            pl.when(pl.col("chrom") == "Y")
+            .then(pl.lit("MT"))
+            .otherwise(pl.col("chrom"))
+            .alias("chrom")
+        )
+        with pytest.raises(AssertionError, match="outside the canonical"):
+            split_frames(bad)
+
+    def test_canonical_split_partitions_all_chroms_disjointly(self) -> None:
+        all_chroms = [str(i) for i in range(1, 23)] + ["X", "Y"]
+        union = set().union(*SPLIT_CHROMS.values())
+        assert union == set(all_chroms)
+        # disjoint: lengths sum to 24 with no overlap.
+        assert sum(len(v) for v in SPLIT_CHROMS.values()) == len(all_chroms)
+
+
+# --------------------------------------------------------------------------- #
+# assert_full_dataset
+# --------------------------------------------------------------------------- #
+class TestAssertFullDataset:
+    def _frame(self, counts: dict[str, int]) -> pl.DataFrame:
+        # Globally unique coordinates (distinct start range per cell type) so the
+        # uniqueness check passes for the well-formed fixtures.
+        rows = []
+        for ci, (ct, n) in enumerate(counts.items()):
+            rows.extend(_row("chr1", ci * 10_000_000 + i * 1000, ct) for i in range(n))
+        return parse_dart_task3(pl.DataFrame(rows))
+
+    def test_passes_with_all_five(self) -> None:
+        df = self._frame({ct: 2 for ct in CELL_TYPES})
+        assert_full_dataset(df, min_rows=5, max_rows=20)  # no raise
+
+    def test_missing_celltype_raises(self) -> None:
+        df = self._frame({ct: 2 for ct in CELL_TYPES[:4]})
+        with pytest.raises(AssertionError, match="expected all 5 cell types"):
+            assert_full_dataset(df, min_rows=1, max_rows=20)
+
+    def test_over_cap_raises(self) -> None:
+        counts = {ct: 1 for ct in CELL_TYPES}
+        counts["K562"] = 5001
+        df = self._frame(counts)
+        with pytest.raises(AssertionError, match="top-5000 cap"):
+            assert_full_dataset(df, min_rows=1, max_rows=100_000)
+
+    def test_imbalanced_raises(self) -> None:
+        # All under the cap and unique, but not equal across cell types.
+        df = self._frame({"GM12878": 3, "H1ESC": 2, "HEPG2": 2, "IMR90": 2, "K562": 2})
+        with pytest.raises(AssertionError, match="not balanced"):
+            assert_full_dataset(df, min_rows=1, max_rows=100)
+
+    def test_duplicate_coords_raise(self) -> None:
+        # Two cell types sharing the exact same peak coordinate.
+        df = parse_dart_task3(
+            pl.DataFrame([_row("chr1", 1000, "GM12878"), _row("chr1", 1000, "K562")])
+        )
+        # add the other three so the cell-type and count checks pass first
+        df = pl.concat([df, self._frame({ct: 1 for ct in ["H1ESC", "HEPG2", "IMR90"]})])
+        with pytest.raises(AssertionError, match="duplicate peak coordinates"):
+            assert_full_dataset(df, min_rows=1, max_rows=100)
+
+    def test_row_count_out_of_range_raises(self) -> None:
+        df = self._frame({ct: 2 for ct in CELL_TYPES})
+        with pytest.raises(AssertionError, match="outside expected"):
+            assert_full_dataset(df, min_rows=50, max_rows=100)
+
+
+# --------------------------------------------------------------------------- #
+# hf_readme.render_dart_task3
+# --------------------------------------------------------------------------- #
+class TestRenderCard:
+    def _write(self, path, chrom: str, label: str, n: int) -> None:
+        pl.DataFrame(
+            {
+                "chrom": [chrom] * n,
+                "start": [1000 * i for i in range(n)],
+                "end": [1000 * i + PEAK_WIDTH for i in range(n)],
+                "label": [label] * n,
+            }
+        ).write_parquet(path)
+
+    def test_render_smoke(self, tmp_path) -> None:
+        train = tmp_path / "train.parquet"
+        validation = tmp_path / "validation.parquet"
+        test = tmp_path / "test.parquet"
+        # 3 train + 2 validation + 1 test = 6 windows, all labeled K562.
+        self._write(train, "1", "K562", 3)
+        self._write(validation, "6", "K562", 2)
+        self._write(test, "5", "K562", 1)
+
+        md = hf_readme.render_dart_task3(
+            sha="abc1234def",
+            train_path=train,
+            validation_path=validation,
+            test_path=test,
+        )
+        assert "# evals_dart_task3" in md
+        assert "biology" in md and "genomics" in md and "dna" in md  # frontmatter tags
+        # Per-cell-type row: K562 with 3 / 2 / 1 / 6.
+        assert "| `K562` | 3 | 2 | 1 | 6 |" in md
+        # Split totals + canonical chrom lists.
+        assert "| `train.parquet` | 3 |" in md
+        assert "| `validation.parquet` | 2 | 6, 21 |" in md
+        assert "**total** | **6**" in md
+        # Provenance permalink pinned to the sha.
+        assert "abc1234" in md
+        assert "src/marin_dna/pipelines/evals/dart_task3.py" in md


### PR DESCRIPTION
🤖 Implements the `dart_task3` dataset pipeline for #293 — DART-Eval **Task 3** ("Discriminating Cell-Type-Specific Elements"): 500 bp ATAC-seq peaks labeled by cell type (5 classes), the embedding/interpretation counterpart to the Task-5 caQTL/dsQTL VEP datasets.

## Source — validated 1:1 against the real Synapse file

DART-Eval's **`input_data/top_5000_deseq_peaks.tsv`** ([`syn62161401`](https://www.synapse.org/Synapse:syn62161401), project `syn60581042`) — the **top 5,000 DESeq2 differentially-accessible peaks per cell type** they feed their zero-shot clustering / UMAP. **25,000 windows, 5,000 balanced per cell line** (GM12878 / H1ESC / HEPG2 / IMR90 / K562), 500 bp, GRCh38, unique coordinates.

> Earlier drafts of #293 said "~24,991 windows / `peaks_by_cell_label_unique_dataloader_format.tsv`" — that was a conflation: the `_dataloader_format` file is DART-Eval's **full** 216,746-row supervised set, while this top-5,000 file is the balanced **clustering subset**. We went with the subset per #293's UMAP motivation.

## What this adds

Self-contained, **interval-native** dataset in `snakemake/evals` (skips the variant machinery — no ref/alt, consequence/TSS/exon annotation, `materialize`, matching/QC):

- **Parser** — [`dart_task3.py`](https://github.com/Open-Athena/marin-dna/blob/e3bccd17f960df1ef81a845df101299c135819e0/src/marin_dna/pipelines/evals/dart_task3.py): `parse_dart_task3` (`Chr/Start/End/Cell Type` → `chrom/start/end/label`), `split_frames` (canonical 3-way chrom split), `assert_full_dataset` (all 5 types, balanced ≤5,000, unique coords, ~25k). Unit-tested — [`test_dart_task3.py`](https://github.com/Open-Athena/marin-dna/blob/e3bccd17f960df1ef81a845df101299c135819e0/tests/pipelines/evals/test_dart_task3.py) (15 tests).
- **Rules** — [`dart_task3.smk`](https://github.com/Open-Athena/marin-dna/blob/e3bccd17f960df1ef81a845df101299c135819e0/snakemake/evals/workflow/rules/dart_task3.smk): `dart_task3_download` (Synapse PAT) → `dart_task3_dataset` → `dart_task3_upload` → `bolinas-dna/evals_dart_task3`. Own `results/dart_task3/…` namespace (no `{dataset}`-wildcard collision with the generic rules).
- **Dataset card** — `render_dart_task3` in [`hf_readme.py`](https://github.com/Open-Athena/marin-dna/blob/e3bccd17f960df1ef81a845df101299c135819e0/src/marin_dna/pipelines/evals/hf_readme.py).
- **Config** — `dart_eval.task3_synapse_id: syn62161401`. **Docs** — README dataset-table row + Task-3 subsection.

## Design decisions (agreed in #293)

- **Minimal schema** `chrom / start / end / label`; the full 500 bp peak is stored (never pre-cropped) → embedding context size stays an open downstream axis.
- **Split by file** `train.parquet` / `validation.parquet` / `test.parquet`, DART-Eval's canonical **3-way** chromosome holdout.
- **Scope = dataset artifact only.** Embedding UMAP (would reuse #246) + DART-Eval metrics deferred.

## Splits (real counts)

| File | Windows | Chromosomes |
|---|---:|---|
| `train.parquet` | 17,965 | 1, 2, 3, 4, 7, 8, 9, 11, 12, 13, 15, 16, 17, 19, X, Y |
| `validation.parquet` | 1,958 | 6, 21 |
| `test.parquet` | 5,077 | 5, 10, 14, 18, 20, 22 |
| **total** | **25,000** | |

## Companion fix (merged)

The new `test_dart_task3` module shifted polars' global hash-join ordering and surfaced a latent non-determinism in the just-merged SGE code (#291): `attach_assay_facts` left-joined without `maintain_order`. Split into its own PR and **merged as #295**.

## Testing

- `uv run pytest tests/pipelines/evals/` → **381 passed, 4 skipped** (15 new `dart_task3` tests).
- Parser + `assert_full_dataset` + `split_frames` validated end-to-end against the real Synapse file (25,000 → 17,965 / 1,958 / 5,077).
- `snakemake -n dart_task3` / `-n results/dart_task3/upload.done`: DAG resolves to exactly the three `dart_task3_*` jobs.

Closes #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
