### PR TITLE
evals_sge: deterministic row order in the assay-facts join (maintain_order)

### DIFF
--- a/src/marin_dna/pipelines/evals/sge.py
+++ b/src/marin_dna/pipelines/evals/sge.py
@@ -255,6 +255,11 @@ def attach_assay_facts(data: pl.DataFrame, assay_facts: pl.DataFrame) -> pl.Data
         assay_facts.select("mavedb_urn", pl.col("^assay_.*$")),
         on="mavedb_urn",
         how="left",
+        # Preserve the variants' row order: a polars left join doesn't guarantee
+        # output order, so without this the built parquet's row order is
+        # non-deterministic (it shifts with global hash state — e.g. across test
+        # orderings, which is how this surfaced). #293.
+        maintain_order="left",
     )
 
 


### PR DESCRIPTION
🤖 A standalone reproducibility fix, split out of #294 (DART-Eval Task 3) where it was an unrelated drive-by.

## The bug

[`attach_assay_facts`](https://github.com/Open-Athena/marin-dna/blob/0474237d3a237fcd3d257344cb25434353054ecf/src/marin_dna/pipelines/evals/sge.py#L243-L264) is the SGE dataset's final build step — a left-join attaching each study's `assay_*` keyword columns onto the variants. It was called **without `maintain_order`**, so polars may return the joined rows in hash-table order. The per-gene `.sort(COORDINATES)` in `annotate_sge_variants` runs *before* this join (the join is the last op in `sge_dataset_unsplit`), and nothing re-imposes order afterward — so the built `sge.parquet`'s row order is **non-deterministic across builds** (it shifts with polars' global hash state).

It surfaced because a new test module in #293/#294 perturbed that global state and flipped this function's order-asserting unit test (`test_join_adds_assay_columns_by_urn`).

## The fix

One line — `maintain_order="left"` on the join — preserving the variants' (coordinate-sorted, gene-blocked) row order.

## Impact

- **Same rows, same values** — only the row *order* changes, and only to become deterministic.
- **No effect on any eval metric** (AUPRC / correlation are computed over the set, order-independent).
- **No HF re-upload required.** The existing [`bolinas-dna/evals_sge`](https://huggingface.co/datasets/bolinas-dna/evals_sge) artifact's content is unchanged; this only makes *future* rebuilds byte-stable.

Introduced in #291; surfaced while implementing #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
