### PR TITLE
evals_v2: DART-Eval Task 3 cell-type UMAP (dart_umap) — native 255 vs 500 bp context

### DIFF
--- a/scripts/issue298_celltype_probe.py
+++ b/scripts/issue298_celltype_probe.py
@@ -1,0 +1,103 @@
+"""Cell-type linear-probe / kNN on DART task3 gLM embeddings (issue #298).
+
+Reports balanced accuracy of predicting the 5-way cell-type label from the
+embedding — the quantitative companion to the UMAP for detecting small-but-real
+cell-type signal an intermixed scatter hides. Chance (balanced) = 1/5 = 0.20.
+
+Two modes (both with a StandardScaler):
+  - HELD-OUT (preferred): fit on ``train_parquet``, score on ``--eval <parquet>``
+    — the dataset's chromosome-disjoint validation split, so no leakage.
+  - CV fallback (no ``--eval``): ``GroupKFold`` **by chromosome**, keeping folds
+    chromosome-disjoint. A plain random KFold would leak — peaks on the same
+    chromosome share local sequence context, inflating accuracy, which is the very
+    reason DART splits by chromosome — so it is deliberately not offered.
+
+Usage:
+    uv run --group genome-s3 python scripts/issue298_celltype_probe.py \\
+        <train.parquet> --eval <validation.parquet>
+
+Parquet paths may be local or ``s3://…`` (S3 needs the ``genome-s3`` group).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import balanced_accuracy_score, classification_report
+from sklearn.model_selection import GroupKFold, cross_val_score
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+
+def _load(path: str) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    df = pd.read_parquet(path)
+    emb = [c for c in df.columns if c.startswith("emb_")]
+    assert emb, f"no emb_* columns in {path}"
+    X = df[emb].to_numpy(dtype=np.float32)
+    return X, df["label"].to_numpy(), df["chrom"].astype(str).to_numpy()
+
+
+def _models() -> dict:
+    return {
+        "linear probe (logreg)": make_pipeline(
+            StandardScaler(), LogisticRegression(max_iter=2000)
+        ),
+        "kNN (k=15)": make_pipeline(
+            StandardScaler(), KNeighborsClassifier(n_neighbors=15)
+        ),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("train_parquet")
+    ap.add_argument(
+        "--eval",
+        dest="eval_parquet",
+        help="held-out eval parquet (chromosome-disjoint val split); preferred",
+    )
+    ap.add_argument("--folds", type=int, default=5)
+    ap.add_argument("--n-jobs", type=int, default=2)  # shared 4-vCPU box etiquette
+    args = ap.parse_args()
+
+    Xtr, ytr, ctr = _load(args.train_parquet)
+    classes = np.unique(ytr)
+    print(f"train: {len(ytr)} windows x {Xtr.shape[1]} dims; {len(classes)} cell types")
+    print(f"chance (balanced accuracy) = {1 / len(classes):.3f}\n")
+
+    if args.eval_parquet:
+        Xev, yev, _ = _load(args.eval_parquet)
+        print(f"HELD-OUT eval (chromosome-disjoint): {len(yev)} windows\n")
+        for name, clf in _models().items():
+            clf.fit(Xtr, ytr)
+            acc = balanced_accuracy_score(yev, clf.predict(Xev))
+            print(f"{name:24s} held-out balanced_acc = {acc:.4f}")
+        lp = _models()["linear probe (logreg)"]
+        lp.fit(Xtr, ytr)
+        print("\nlinear-probe per-class recall (held-out):")
+        print(classification_report(yev, lp.predict(Xev), digits=3, zero_division=0))
+    else:
+        gkf = GroupKFold(n_splits=args.folds)
+        print(f"GroupKFold-by-chromosome CV ({args.folds} folds, leakage-free):\n")
+        for name, clf in _models().items():
+            s = cross_val_score(
+                clf,
+                Xtr,
+                ytr,
+                groups=ctr,
+                cv=gkf,
+                scoring="balanced_accuracy",
+                n_jobs=args.n_jobs,
+            )
+            print(
+                f"{name:24s} balanced_acc = {s.mean():.4f} ± {s.std():.4f}  "
+                f"folds={np.round(s, 3).tolist()}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -114,7 +114,7 @@ at `s3://oa-bolinas/snakemake/analysis/evals_v2/`.
 
 ### Interpretation targets (off `rule all`)
 
-Two visual-interpretation analyses live alongside the metrics DAG but are kept
+Three visual-interpretation analyses live alongside the metrics DAG but are kept
 **off `rule all`** (so they never perturb score/metric reruns); build them by
 name:
 
@@ -138,6 +138,17 @@ name:
     --env EXTRA_UV_GROUPS="--group umap" \
     --env SNAKEMAKE_ARGS="-- umap"
   ```
+
+- **DART-Eval Task 3 cell-type UMAP** (#298) — `snakemake dart_umap`. The
+  cell-type-discrimination analogue of the embedding UMAP: embeds the
+  `bolinas-dna/evals_dart_task3` 500 bp cell-type peak windows with each
+  `dart_umap.models` checkpoint at every `context_sizes` arm (whole-window
+  pooling — the rule sets `window_size = n_center_bp = ctx`), fits UMAP, and
+  writes `results/plots/dart_umap/{model}/ctx{ctx}/celltype.svg` colored by the
+  5-way cell type. The `context_sizes` sweep compares a model's native context
+  (e.g. 255 bp) against the full 500 bp peak (~2× context, RoPE extrapolation).
+  Same `umap` + `genome-s3` groups as the embedding UMAP (swap `SNAKEMAKE_ARGS`
+  for `-- dart_umap` on a sky cluster).
 
 ### Calibration tables (cLLR, #267/#270)
 
@@ -231,6 +242,7 @@ Two unavoidable AWS-side failure modes worth knowing about:
 | `inference.*` | Batch size, workers, `data_transform_on_the_fly`, `torch_compile`; `rc` (also score the reverse-complement strand — doubles inference time); `n_bootstrap` (AUPRC bootstrap iterations per subset × score_type); `bootstrap_seed` (reproducibility seed; bumping triggers metrics re-execution). |
 | `nuc_dep` | Optional; nucleotide-dependency maps (#237, off `rule all`). `{combines, ord, batch_size, dpi, models: [...], loci: {...}}`. See `rules/interpretation.smk`. |
 | `umap_embeddings` | Optional; embedding UMAP (#246, off `rule all`). `{dataset, layer_index, n_center_bp, random_state, dpi, models: [...]}` — `models` reuse the `models:` registry (each needs `window_size`). Build needs `--group umap` (+ `--group genome-s3`). See `rules/embedding_umap.smk`. |
+| `dart_umap` | Optional; DART-Eval Task 3 cell-type UMAP (#298, off `rule all`). `{dataset, split, context_sizes: [...], layer_index, random_state, dpi, batch_size, models: [...]}` — `models` reuse the `models:` registry; the same model is embedded at each `context_sizes` (whole-window pooling, so context is decoupled from the model's `window_size`). Build needs `--group umap` (+ `--group genome-s3`). See `rules/dart_task3_umap.smk`. |
 | `calibration` | Optional; cLLR mutation-rate calibration tables (#267/#270, off `rule all`). `{neutral_sites_s3_prefix, subsample_n, scoreable_window, min_bin_count, rc, models: [...]}` — scores the pre-filtered + subsampled neutral set (`neutral_sites_n{subsample_n}_w{scoreable_window}.parquet`) → per-model `llr_neutral_mean`. See `rules/calibration.smk`. |
 | `ll_gap` | Optional; functional/non-functional LL gap (#274, off `rule all`). `{split, datasets: [{name, hf_repo, hf_revision}], models: [...]}` — `datasets` are mixed-case `seq` HF datasets (the v5/v1/v15 validation intervals; NOT the variant `datasets:` above); `models` reuse the `models:` registry. See `rules/ll_gap.smk`. |
 

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -144,11 +144,15 @@ name:
   `bolinas-dna/evals_dart_task3` 500 bp cell-type peak windows with each
   `dart_umap.models` checkpoint at every `context_sizes` arm (whole-window
   pooling — the rule sets `window_size = n_center_bp = ctx`), fits UMAP, and
-  writes `results/plots/dart_umap/{model}/ctx{ctx}/celltype.svg` colored by the
-  5-way cell type. The `context_sizes` sweep compares a model's native context
-  (e.g. 255 bp) against the full 500 bp peak (~2× context, RoPE extrapolation).
-  Same `umap` + `genome-s3` groups as the embedding UMAP (swap `SNAKEMAKE_ARGS`
-  for `-- dart_umap` on a sky cluster).
+  writes `results/plots/dart_umap/{model}/{split}/ctx{ctx}/celltype.svg` colored
+  by the 5-way cell type. The `context_sizes` sweep compares a model's native
+  context (e.g. 255 bp) against the full 500 bp peak (~2× context, RoPE
+  extrapolation). `split` is a wildcard (`train|validation|test`): the aggregate
+  `dart_umap` target builds `dart_umap.splits` (default the dev split), and any
+  split is buildable on demand by path — e.g. the denser `train` (17,965 windows
+  vs 1,958) for a more revealing UMAP. Same `umap` + `genome-s3` groups as the
+  embedding UMAP (swap `SNAKEMAKE_ARGS` for `-- dart_umap`, or a single
+  `-- results/plots/dart_umap/<model>/train/ctx255/celltype.svg`, on a sky cluster).
 
 ### Calibration tables (cLLR, #267/#270)
 
@@ -242,7 +246,7 @@ Two unavoidable AWS-side failure modes worth knowing about:
 | `inference.*` | Batch size, workers, `data_transform_on_the_fly`, `torch_compile`; `rc` (also score the reverse-complement strand — doubles inference time); `n_bootstrap` (AUPRC bootstrap iterations per subset × score_type); `bootstrap_seed` (reproducibility seed; bumping triggers metrics re-execution). |
 | `nuc_dep` | Optional; nucleotide-dependency maps (#237, off `rule all`). `{combines, ord, batch_size, dpi, models: [...], loci: {...}}`. See `rules/interpretation.smk`. |
 | `umap_embeddings` | Optional; embedding UMAP (#246, off `rule all`). `{dataset, layer_index, n_center_bp, random_state, dpi, models: [...]}` — `models` reuse the `models:` registry (each needs `window_size`). Build needs `--group umap` (+ `--group genome-s3`). See `rules/embedding_umap.smk`. |
-| `dart_umap` | Optional; DART-Eval Task 3 cell-type UMAP (#298, off `rule all`). `{dataset, split, context_sizes: [...], layer_index, random_state, dpi, batch_size, models: [...]}` — `models` reuse the `models:` registry; the same model is embedded at each `context_sizes` (whole-window pooling, so context is decoupled from the model's `window_size`). Build needs `--group umap` (+ `--group genome-s3`). See `rules/dart_task3_umap.smk`. |
+| `dart_umap` | Optional; DART-Eval Task 3 cell-type UMAP (#298, off `rule all`). `{dataset, splits: [...], context_sizes: [...], layer_index, random_state, dpi, batch_size, models: [...]}` — `models` reuse the `models:` registry; the same model is embedded at each `context_sizes` (whole-window pooling, so context is decoupled from the model's `window_size`). `split` is a rule wildcard (`train\|validation\|test`); `splits` lists which the aggregate target builds. Build needs `--group umap` (+ `--group genome-s3`). See `rules/dart_task3_umap.smk`. |
 | `calibration` | Optional; cLLR mutation-rate calibration tables (#267/#270, off `rule all`). `{neutral_sites_s3_prefix, subsample_n, scoreable_window, min_bin_count, rc, models: [...]}` — scores the pre-filtered + subsampled neutral set (`neutral_sites_n{subsample_n}_w{scoreable_window}.parquet`) → per-model `llr_neutral_mean`. See `rules/calibration.smk`. |
 | `ll_gap` | Optional; functional/non-functional LL gap (#274, off `rule all`). `{split, datasets: [{name, hf_repo, hf_revision}], models: [...]}` — `datasets` are mixed-case `seq` HF datasets (the v5/v1/v15 validation intervals; NOT the variant `datasets:` above); `models` reuse the `models:` registry. See `rules/ll_gap.smk`. |
 

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -1210,6 +1210,26 @@ umap_embeddings:
   models:
     - mix-v0.9-p1B-i24-exp135-m5.1-step-59158   # exp135-1B-m5.1 (255+BOS) — first pass, single model
 
+# DART-Eval Task 3 cell-type UMAP (issue #298) — off `rule all`; build with
+# `snakemake dart_umap` (or one
+# `results/plots/dart_umap/<model>/ctx<N>/celltype.svg` per arm). Embeds the
+# evals_dart_task3 cell-type peak windows with each model at each context size
+# (whole-window mean pooling: the rule sets window_size = n_center_bp = ctx),
+# then UMAP-colors by the 5-way cell-type label. context_sizes sweeps native
+# 255 bp (exp136's training context) vs the full 500 bp peak (~2x context, RoPE
+# extrapolation / OOD). Validation split for fast iteration. Same `umap` +
+# `genome-s3` groups as umap_embeddings.
+dart_umap:
+  dataset: bolinas-dna/evals_dart_task3
+  split: validation              # smallest split (chr 6 + 21) — fast iteration
+  context_sizes: [255, 500]      # native (255+BOS) vs full 500 bp peak (OOD)
+  layer_index: -1                # last hidden layer (match the GPN-Star UMAP)
+  random_state: 42               # UMAP seed (also forces single-threaded UMAP)
+  dpi: 200                       # scatter raster dpi
+  batch_size: 128                # = inference.batch_size (see umap_embeddings note)
+  models:
+    - exp136-proj_v30-step-9999  # enhancer specialist (Qwen3-0.6B, 255+BOS)
+
 # Functional/non-functional LL gap (issue #274) — off `rule all`; build with
 # `snakemake ll_gap` (or one `results/ll_gap/scores/<model>/<region>.parquet`
 # per sky cluster, then `snakemake ll_gap` to gather). For each (model, region)

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -1221,7 +1221,9 @@ umap_embeddings:
 # `genome-s3` groups as umap_embeddings.
 dart_umap:
   dataset: bolinas-dna/evals_dart_task3
-  split: validation              # smallest split (chr 6 + 21) — fast iteration
+  splits: [validation]           # aggregate target builds the dev split (chr 6+21,
+                                 # 1958 windows); train (17965) / test (5077) are
+                                 # built on demand by path (split is a rule wildcard)
   context_sizes: [255, 500]      # native (255+BOS) vs full 500 bp peak (OOD)
   layer_index: -1                # last hidden layer (match the GPN-Star UMAP)
   random_state: 42               # UMAP seed (also forces single-threaded UMAP)

--- a/snakemake/analysis/evals_v2/workflow/Snakefile
+++ b/snakemake/analysis/evals_v2/workflow/Snakefile
@@ -11,6 +11,7 @@ include: "rules/inference.smk"
 include: "rules/metrics.smk"
 include: "rules/interpretation.smk"
 include: "rules/embedding_umap.smk"
+include: "rules/dart_task3_umap.smk"
 include: "rules/calibration.smk"
 include: "rules/ll_gap.smk"
 

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -172,6 +172,27 @@ for _m in UMAP_MODELS:
     )
 
 
+# --- DART-Eval Task 3 cell-type UMAP (interpretation, issue #298) ------------
+# Optional `dart_umap:` config section; targets kept off `rule all` (see
+# rules/dart_task3_umap.smk). Reuses the `models:` registry. The same model is
+# embedded at each `context_sizes` entry (whole-window pooling: the rule sets
+# window_size = n_center_bp = ctx), so context size is decoupled from the per-
+# model `window_size` (unlike umap_embeddings, which uses the model's native one).
+DART_UMAP_CFG = config.get("dart_umap", {})
+DART_UMAP_MODELS = DART_UMAP_CFG.get("models", [])
+DART_UMAP_CONTEXT_SIZES = DART_UMAP_CFG.get("context_sizes", [])
+
+# Fail fast: every dart_umap model is a known checkpoint; every context size is a
+# positive int. (Whether a context fits a model's position budget is checked at
+# run time against the checkpoint's config.json — see `assert_window_fits`.)
+for _m in DART_UMAP_MODELS:
+    assert _m in MODELS, f"dart_umap model {_m!r} not found in `models`"
+for _c in DART_UMAP_CONTEXT_SIZES:
+    assert isinstance(_c, int) and _c > 0, (
+        f"dart_umap context_sizes entries must be positive ints, got {_c!r}"
+    )
+
+
 # --- cLLR calibration tables (mutation-rate calibration, #267/#270) ----------
 # Optional `calibration:` config section; targets kept off `rule all`
 # (see rules/calibration.smk). Reuses the `models:` registry.

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -181,15 +181,23 @@ for _m in UMAP_MODELS:
 DART_UMAP_CFG = config.get("dart_umap", {})
 DART_UMAP_MODELS = DART_UMAP_CFG.get("models", [])
 DART_UMAP_CONTEXT_SIZES = DART_UMAP_CFG.get("context_sizes", [])
+# HF splits the aggregate `dart_umap` target builds; any of train|validation|test
+# can also be built on demand by path (`split` is a rule wildcard). Default to the
+# dev split only so the aggregate stays cheap (train is ~9x bigger).
+DART_UMAP_SPLITS = DART_UMAP_CFG.get("splits", ["validation"])
 
 # Fail fast: every dart_umap model is a known checkpoint; every context size is a
-# positive int. (Whether a context fits a model's position budget is checked at
-# run time against the checkpoint's config.json — see `assert_window_fits`.)
+# positive int; every split is a real HF split. (Whether a context fits a model's
+# position budget is checked at run time from config.json — see `check_window_fits`.)
 for _m in DART_UMAP_MODELS:
     assert _m in MODELS, f"dart_umap model {_m!r} not found in `models`"
 for _c in DART_UMAP_CONTEXT_SIZES:
     assert isinstance(_c, int) and _c > 0, (
         f"dart_umap context_sizes entries must be positive ints, got {_c!r}"
+    )
+for _s in DART_UMAP_SPLITS:
+    assert _s in ("train", "validation", "test"), (
+        f"dart_umap split {_s!r} must be train|validation|test"
     )
 
 

--- a/snakemake/analysis/evals_v2/workflow/rules/dart_task3_umap.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/dart_task3_umap.smk
@@ -4,14 +4,15 @@ The cell-type-discrimination analogue of rules/embedding_umap.smk: a GPU
 embedding rule + CPU UMAP-fit + CPU plot rule, kept OFF the default ``rule all``
 (metrics-only) so they never perturb score/metric reruns. Build explicitly:
 
-    snakemake dart_umap                                          # every model x ctx
-    snakemake results/plots/dart_umap/<model>/ctx<N>/celltype.svg  # one plot
+    snakemake dart_umap                                                    # every model x split x ctx
+    snakemake results/plots/dart_umap/<model>/<split>/ctx<N>/celltype.svg  # one plot (split = train|validation|test)
 
 The *same* model is embedded at each ``dart_umap.context_sizes`` entry (e.g.
 255 + 500): each arm sets ``window_size = n_center_bp = ctx`` so the model sees
 ``ctx`` bp and every DNA token is mean-pooled (whole-window pooling). 255 bp is
 exp136's native context; 500 bp is the full peak — ~2x the training context
-(RoPE extrapolation), guarded by ``assert_window_fits``.
+(RoPE extrapolation), which ``check_window_fits`` allows with a warning. The
+``{split}`` wildcard selects the HF split (train|validation|test).
 
 Reuses the embedding kernel (``compute_region_embeddings``) + UMAP fit
 (``fit_umap``) from embedding_umap, the ``download_model`` rule for the
@@ -25,16 +26,17 @@ rule compute_dart_embeddings:
     input:
         checkpoint="results/checkpoints/{model}",
     output:
-        "results/interpretation/dart_umap/{model}/ctx{ctx}/embeddings.parquet",
+        "results/interpretation/dart_umap/{model}/{split}/ctx{ctx}/embeddings.parquet",
     wildcard_constraints:
         model="|".join(DART_UMAP_MODELS),
+        split="train|validation|test",
         ctx="|".join(str(c) for c in DART_UMAP_CONTEXT_SIZES),
     threads: config["inference"]["num_workers"]
     params:
         # Output-affecting fields only (snakemake `params` rerun trigger);
-        # batch_size is execution-only and read inside `run:`.
+        # batch_size is execution-only and read inside `run:`. `split` is a
+        # wildcard (in the output path), so it already triggers reruns — no param.
         dataset=DART_UMAP_CFG.get("dataset", "bolinas-dna/evals_dart_task3"),
-        split=DART_UMAP_CFG.get("split", "validation"),
         layer_index=DART_UMAP_CFG.get("layer_index", -1),
     run:
         from marin_dna.pipelines.evals.dart_task3_umap import (
@@ -52,7 +54,7 @@ rule compute_dart_embeddings:
         # a RoPE model over-budget warns + extrapolates (OOD); non-RoPE hard-fails.
         mpe, uses_rope = read_position_limits(input.checkpoint)
         check_window_fits(mpe, ctx, uses_rope=uses_rope)
-        regions = load_dart_regions(params.dataset, split=params.split)
+        regions = load_dart_regions(params.dataset, split=wildcards.split)
         df = compute_region_embeddings(
             checkpoint_path=input.checkpoint,
             # S3 URI; pyfaidx + fsspec/s3fs reads sequence by byte-range.
@@ -69,16 +71,16 @@ rule compute_dart_embeddings:
         )
         df.to_parquet(output[0])
         print(
-            f"[dart_umap] {wildcards.model} ctx{ctx}: {df.shape[0]} windows x "
-            f"{df.shape[1] - 4} embedding dims"
+            f"[dart_umap] {wildcards.model} {wildcards.split} ctx{ctx}: "
+            f"{df.shape[0]} windows x {df.shape[1] - 4} embedding dims"
         )
 
 
 rule fit_dart_umap:
     input:
-        "results/interpretation/dart_umap/{model}/ctx{ctx}/embeddings.parquet",
+        "results/interpretation/dart_umap/{model}/{split}/ctx{ctx}/embeddings.parquet",
     output:
-        "results/interpretation/dart_umap/{model}/ctx{ctx}/umap_coords.parquet",
+        "results/interpretation/dart_umap/{model}/{split}/ctx{ctx}/umap_coords.parquet",
     run:
         from marin_dna.pipelines.evals.embedding_umap import fit_umap
 
@@ -86,16 +88,16 @@ rule fit_dart_umap:
         coords = fit_umap(emb, random_state=DART_UMAP_CFG.get("random_state", 42))
         coords.to_parquet(output[0])
         print(
-            f"[dart_umap] {wildcards.model} ctx{wildcards.ctx}: "
+            f"[dart_umap] {wildcards.model} {wildcards.split} ctx{wildcards.ctx}: "
             f"fit UMAP on {len(coords)} points"
         )
 
 
 rule plot_dart_umap:
     input:
-        "results/interpretation/dart_umap/{model}/ctx{ctx}/umap_coords.parquet",
+        "results/interpretation/dart_umap/{model}/{split}/ctx{ctx}/umap_coords.parquet",
     output:
-        "results/plots/dart_umap/{model}/ctx{ctx}/celltype.svg",
+        "results/plots/dart_umap/{model}/{split}/ctx{ctx}/celltype.svg",
     run:
         from marin_dna.pipelines.evals.dart_task3_umap import plot_dart_umap
 
@@ -104,10 +106,11 @@ rule plot_dart_umap:
 
 
 rule dart_umap:
-    """Cell-type UMAP for every (model, context size). Not in `rule all`."""
+    """Cell-type UMAP for every (model, split, context size). Not in `rule all`."""
     input:
         [
-            f"results/plots/dart_umap/{model}/ctx{ctx}/celltype.svg"
+            f"results/plots/dart_umap/{model}/{split}/ctx{ctx}/celltype.svg"
             for model in DART_UMAP_MODELS
+            for split in DART_UMAP_SPLITS
             for ctx in DART_UMAP_CONTEXT_SIZES
         ],

--- a/snakemake/analysis/evals_v2/workflow/rules/dart_task3_umap.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/dart_task3_umap.smk
@@ -1,0 +1,112 @@
+"""DART-Eval Task 3 cell-type UMAP (interpretation, issue #298).
+
+The cell-type-discrimination analogue of rules/embedding_umap.smk: a GPU
+embedding rule + CPU UMAP-fit + CPU plot rule, kept OFF the default ``rule all``
+(metrics-only) so they never perturb score/metric reruns. Build explicitly:
+
+    snakemake dart_umap                                          # every model x ctx
+    snakemake results/plots/dart_umap/<model>/ctx<N>/celltype.svg  # one plot
+
+The *same* model is embedded at each ``dart_umap.context_sizes`` entry (e.g.
+255 + 500): each arm sets ``window_size = n_center_bp = ctx`` so the model sees
+``ctx`` bp and every DNA token is mean-pooled (whole-window pooling). 255 bp is
+exp136's native context; 500 bp is the full peak — ~2x the training context
+(RoPE extrapolation), guarded by ``assert_window_fits``.
+
+Reuses the embedding kernel (``compute_region_embeddings``) + UMAP fit
+(``fit_umap``) from embedding_umap, the ``download_model`` rule for the
+checkpoint, the GRCh38 reference straight from S3 (needs ``--group genome-s3``),
+and the labeled peak windows from HuggingFace. ``fit_umap`` needs the optional
+``umap`` group (``--group umap``).
+"""
+
+
+rule compute_dart_embeddings:
+    input:
+        checkpoint="results/checkpoints/{model}",
+    output:
+        "results/interpretation/dart_umap/{model}/ctx{ctx}/embeddings.parquet",
+    wildcard_constraints:
+        model="|".join(DART_UMAP_MODELS),
+        ctx="|".join(str(c) for c in DART_UMAP_CONTEXT_SIZES),
+    threads: config["inference"]["num_workers"]
+    params:
+        # Output-affecting fields only (snakemake `params` rerun trigger);
+        # batch_size is execution-only and read inside `run:`.
+        dataset=DART_UMAP_CFG.get("dataset", "bolinas-dna/evals_dart_task3"),
+        split=DART_UMAP_CFG.get("split", "validation"),
+        layer_index=DART_UMAP_CFG.get("layer_index", -1),
+    run:
+        from marin_dna.pipelines.evals.dart_task3_umap import (
+            assert_window_fits,
+            load_dart_regions,
+            read_max_position_embeddings,
+        )
+        from marin_dna.pipelines.evals.embedding_umap import (
+            compute_region_embeddings,
+        )
+
+        ctx = int(wildcards.ctx)
+        # Whole-window pooling: feed `ctx` bp and mean-pool every DNA token
+        # (n_center_bp == window_size). Fail fast if this checkpoint can't hold
+        # ctx (+ BOS) positions before spending GPU time.
+        assert_window_fits(read_max_position_embeddings(input.checkpoint), ctx)
+        regions = load_dart_regions(params.dataset, split=params.split)
+        df = compute_region_embeddings(
+            checkpoint_path=input.checkpoint,
+            # S3 URI; pyfaidx + fsspec/s3fs reads sequence by byte-range.
+            genome_path=config["genome_path"],
+            regions=regions,
+            window_size=ctx,
+            layer_index=int(params.layer_index),
+            n_center_bp=ctx,
+            batch_size=DART_UMAP_CFG.get(
+                "batch_size", config["inference"]["batch_size"]
+            ),
+            num_workers=config["inference"]["num_workers"],
+            torch_compile=config["inference"].get("torch_compile", False),
+        )
+        df.to_parquet(output[0])
+        print(
+            f"[dart_umap] {wildcards.model} ctx{ctx}: {df.shape[0]} windows x "
+            f"{df.shape[1] - 4} embedding dims"
+        )
+
+
+rule fit_dart_umap:
+    input:
+        "results/interpretation/dart_umap/{model}/ctx{ctx}/embeddings.parquet",
+    output:
+        "results/interpretation/dart_umap/{model}/ctx{ctx}/umap_coords.parquet",
+    run:
+        from marin_dna.pipelines.evals.embedding_umap import fit_umap
+
+        emb = pd.read_parquet(input[0])
+        coords = fit_umap(emb, random_state=DART_UMAP_CFG.get("random_state", 42))
+        coords.to_parquet(output[0])
+        print(
+            f"[dart_umap] {wildcards.model} ctx{wildcards.ctx}: "
+            f"fit UMAP on {len(coords)} points"
+        )
+
+
+rule plot_dart_umap:
+    input:
+        "results/interpretation/dart_umap/{model}/ctx{ctx}/umap_coords.parquet",
+    output:
+        "results/plots/dart_umap/{model}/ctx{ctx}/celltype.svg",
+    run:
+        from marin_dna.pipelines.evals.dart_task3_umap import plot_dart_umap
+
+        coords = pd.read_parquet(input[0])
+        plot_dart_umap(coords, output[0], dpi=DART_UMAP_CFG.get("dpi", 200))
+
+
+rule dart_umap:
+    """Cell-type UMAP for every (model, context size). Not in `rule all`."""
+    input:
+        [
+            f"results/plots/dart_umap/{model}/ctx{ctx}/celltype.svg"
+            for model in DART_UMAP_MODELS
+            for ctx in DART_UMAP_CONTEXT_SIZES
+        ],

--- a/snakemake/analysis/evals_v2/workflow/rules/dart_task3_umap.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/dart_task3_umap.smk
@@ -38,9 +38,9 @@ rule compute_dart_embeddings:
         layer_index=DART_UMAP_CFG.get("layer_index", -1),
     run:
         from marin_dna.pipelines.evals.dart_task3_umap import (
-            assert_window_fits,
+            check_window_fits,
             load_dart_regions,
-            read_max_position_embeddings,
+            read_position_limits,
         )
         from marin_dna.pipelines.evals.embedding_umap import (
             compute_region_embeddings,
@@ -48,9 +48,10 @@ rule compute_dart_embeddings:
 
         ctx = int(wildcards.ctx)
         # Whole-window pooling: feed `ctx` bp and mean-pool every DNA token
-        # (n_center_bp == window_size). Fail fast if this checkpoint can't hold
-        # ctx (+ BOS) positions before spending GPU time.
-        assert_window_fits(read_max_position_embeddings(input.checkpoint), ctx)
+        # (n_center_bp == window_size). Guard the position budget before GPU time:
+        # a RoPE model over-budget warns + extrapolates (OOD); non-RoPE hard-fails.
+        mpe, uses_rope = read_position_limits(input.checkpoint)
+        check_window_fits(mpe, ctx, uses_rope=uses_rope)
         regions = load_dart_regions(params.dataset, split=params.split)
         df = compute_region_embeddings(
             checkpoint_path=input.checkpoint,

--- a/src/marin_dna/pipelines/evals/dart_task3_umap.py
+++ b/src/marin_dna/pipelines/evals/dart_task3_umap.py
@@ -74,32 +74,61 @@ def load_dart_regions(dataset_id: str, *, split: str = "validation") -> pd.DataF
     return df
 
 
-def read_max_position_embeddings(checkpoint_path: str | Path) -> int:
-    """Read ``max_position_embeddings`` from a HF checkpoint's ``config.json``."""
+def read_position_limits(checkpoint_path: str | Path) -> tuple[int, bool]:
+    """Return ``(max_position_embeddings, uses_rope)`` from a HF checkpoint config.
+
+    ``uses_rope`` is True when the config declares rotary embeddings
+    (``rope_theta`` or ``rope_scaling``) — our qwen3/llama gLMs all do. A RoPE
+    model computes positions dynamically, so a window longer than
+    ``max_position_embeddings`` *runs* (extrapolating, OOD) rather than erroring or
+    truncating; a model with learned absolute positions would instead index past
+    its table and crash. ``check_window_fits`` uses the flag to decide warn-vs-fail.
+    """
     cfg = json.loads((Path(checkpoint_path) / "config.json").read_text())
     mpe = cfg.get("max_position_embeddings")
     assert mpe is not None, (
         f"checkpoint {checkpoint_path}: config.json has no max_position_embeddings"
     )
-    return int(mpe)
+    uses_rope = cfg.get("rope_theta") is not None or cfg.get("rope_scaling") is not None
+    return int(mpe), bool(uses_rope)
 
 
-def assert_window_fits(
-    max_position_embeddings: int, window_size: int, *, n_special: int = 1
+def check_window_fits(
+    max_position_embeddings: int,
+    window_size: int,
+    *,
+    uses_rope: bool,
+    n_special: int = 1,
 ) -> None:
-    """Fail fast if the model can't hold ``window_size`` DNA tokens (+ specials).
+    """Guard the embedding context against the model's position budget (issue #298).
 
-    The 500 bp arm feeds ``window_size + n_special`` = 501 positions — ~2x
-    exp136's 255 bp training context. Extrapolating *is* the point of the long
-    arm (RoPE handles it), but a checkpoint whose ``max_position_embeddings``
-    caps below ``window_size + n_special`` would silently truncate the window, so
-    check rather than assume (issue #298 sanity check).
+    ``need = window_size + n_special``. If it fits ``max_position_embeddings``,
+    no-op. If it exceeds:
+
+    - **RoPE model** (``uses_rope=True``): positions are computed dynamically, so
+      the forward runs — but positions ``max_position_embeddings…need-1`` are
+      never-trained (extrapolation / OOD). We **warn and proceed**, which is what
+      lets an intentional long-context arm run (e.g. DART 500 bp = 501 tokens on
+      exp136, whose ``max_position_embeddings`` is 256 = its 255 bp + BOS training
+      context).
+    - **non-RoPE model**: the forward would index past the learned absolute-
+      position table and crash, so we **hard-fail** before spending GPU time.
     """
     need = window_size + n_special
-    assert max_position_embeddings >= need, (
-        f"model max_position_embeddings {max_position_embeddings} < {need} "
-        f"({window_size} bp + {n_special} special token(s)); the long-context arm "
-        f"would be truncated"
+    if need <= max_position_embeddings:
+        return
+    detail = (
+        f"window {window_size} bp + {n_special} special = {need} tokens > model "
+        f"max_position_embeddings {max_position_embeddings}"
+    )
+    if uses_rope:
+        print(
+            f"[dart_umap] WARNING: {detail}; RoPE extrapolation — positions "
+            f"{max_position_embeddings}..{need - 1} were never seen in training (OOD)"
+        )
+        return
+    raise AssertionError(
+        f"{detail}; non-RoPE model would index past its learned position table"
     )
 
 

--- a/src/marin_dna/pipelines/evals/dart_task3_umap.py
+++ b/src/marin_dna/pipelines/evals/dart_task3_umap.py
@@ -1,0 +1,168 @@
+"""DART-Eval Task 3 cell-type UMAP — load + plot (issue #298).
+
+The cell-type-discrimination analogue of the GPN-Star region UMAP (#246 / #248):
+embed the ``bolinas-dna/evals_dart_task3`` cell-type peak windows with a gLM and
+project to 2-D, colored by the 5-way cell-type ``label``. The heavy lifting is
+reused from the GPN-Star harness — the embedding kernel
+(``embedding_umap.compute_region_embeddings``) and the UMAP fit
+(``embedding_umap.fit_umap``); this module holds only the DART-specific bits:
+loading the interval dataset (no conservation column, fixed 500 bp peaks),
+guarding the long-context arm against a too-small position budget, and the
+cell-type-colored scatter.
+
+The same model is embedded at several context sizes (the ``context_sizes`` knob,
+e.g. 255 + 500): each arm sets ``window_size = n_center_bp = ctx`` so the model
+sees ``ctx`` bp and every DNA token is mean-pooled (whole-window pooling). The
+255 bp arm is exp136's native context; 500 bp is the full peak — ~2x the
+training context, i.e. RoPE extrapolation (out-of-distribution).
+
+Coordinates are 0-based half-open everywhere (repo convention).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from marin_dna.pipelines.evals.dart_task3 import CELL_TYPES, PEAK_WIDTH
+
+# Plot order + fixed palette (matplotlib ``Cn`` colors) for the 5 ENCODE cell
+# lines, stable across arms/runs so the two context-size UMAPs share colors.
+# Labels are already display-ready (``GM12878`` …), so there is no label→display
+# remap like GPN-Star's region map — the ``label`` column is the hue directly.
+CELLTYPE_ORDER: list[str] = list(CELL_TYPES)
+CELLTYPE_PALETTE: dict[str, str] = {
+    "GM12878": "C0",
+    "H1ESC": "C1",
+    "HEPG2": "C2",
+    "IMR90": "C3",
+    "K562": "C4",
+}
+
+# Interval-only schema (no ``cons``); ``label`` is the cell type (one of CELL_TYPES).
+_CARRY_COLUMNS = ["chrom", "start", "end", "label"]
+
+
+def load_dart_regions(dataset_id: str, *, split: str = "validation") -> pd.DataFrame:
+    """Load the DART Task 3 cell-type peak windows (chrom/start/end/label) from HF.
+
+    Asserts the interval schema, that every window is a 0-based half-open
+    ``PEAK_WIDTH`` (500 bp) interval, and that every label is one of the 5 cell
+    types. Coerces ``chrom`` to ``str`` (Ensembl-style, no ``chr`` prefix) so it
+    flows straight into ``Genome(chrom, start, end)``. Returns the windows ready
+    for ``embedding_umap.compute_region_embeddings``.
+    """
+    from datasets import load_dataset
+
+    df = load_dataset(dataset_id, split=split).to_pandas()
+    missing = set(_CARRY_COLUMNS) - set(df.columns)
+    assert not missing, f"dataset {dataset_id!r} missing columns: {sorted(missing)}"
+    df = df[_CARRY_COLUMNS].copy()
+    df["chrom"] = df["chrom"].astype(str)
+    assert (df["end"] > df["start"]).all(), "every window needs end > start"
+    widths = df["end"] - df["start"]
+    assert (widths == PEAK_WIDTH).all(), (
+        f"every window must be {PEAK_WIDTH} bp; got widths "
+        f"{sorted(set(widths.astype(int).tolist()))}"
+    )
+    bad = sorted(set(df["label"]) - set(CELL_TYPES))
+    assert not bad, f"unexpected cell-type labels: {bad} (known: {CELL_TYPES})"
+    return df
+
+
+def read_max_position_embeddings(checkpoint_path: str | Path) -> int:
+    """Read ``max_position_embeddings`` from a HF checkpoint's ``config.json``."""
+    cfg = json.loads((Path(checkpoint_path) / "config.json").read_text())
+    mpe = cfg.get("max_position_embeddings")
+    assert mpe is not None, (
+        f"checkpoint {checkpoint_path}: config.json has no max_position_embeddings"
+    )
+    return int(mpe)
+
+
+def assert_window_fits(
+    max_position_embeddings: int, window_size: int, *, n_special: int = 1
+) -> None:
+    """Fail fast if the model can't hold ``window_size`` DNA tokens (+ specials).
+
+    The 500 bp arm feeds ``window_size + n_special`` = 501 positions — ~2x
+    exp136's 255 bp training context. Extrapolating *is* the point of the long
+    arm (RoPE handles it), but a checkpoint whose ``max_position_embeddings``
+    caps below ``window_size + n_special`` would silently truncate the window, so
+    check rather than assume (issue #298 sanity check).
+    """
+    need = window_size + n_special
+    assert max_position_embeddings >= need, (
+        f"model max_position_embeddings {max_position_embeddings} < {need} "
+        f"({window_size} bp + {n_special} special token(s)); the long-context arm "
+        f"would be truncated"
+    )
+
+
+def plot_dart_umap(
+    umap_df: pd.DataFrame, output_path: str | Path, *, dpi: int = 200
+) -> None:
+    """Scatter the 2-D UMAP colored by the 5-way cell-type ``label``.
+
+    Same small-file recipe as the GPN-Star region plot
+    (``embedding_umap.plot_umap``): ``figsize=(3, 3)``, point size
+    ``s = 100/sqrt(N)``, ``alpha=0.5``, points ``rasterized=True`` inside an
+    otherwise-vector SVG (axes/text stay vector). Emits ``.svg`` (the artifact to
+    post / upload) plus a ``.png`` sibling (repo convention — ``Read``-back
+    sanity checks).
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    matplotlib.rcParams["svg.fonttype"] = "none"  # keep text as text, not paths
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
+    n = len(umap_df)
+    assert n > 0, "empty UMAP frame"
+    assert {"UMAP1", "UMAP2"} <= set(umap_df.columns), "missing UMAP1/UMAP2 columns"
+    unmapped = sorted(set(umap_df["label"]) - set(CELLTYPE_PALETTE))
+    assert not unmapped, f"unmapped cell-type labels: {unmapped}"
+
+    s = 100.0 / np.sqrt(n)
+    fig, ax = plt.subplots(figsize=(3, 3))
+    hue_kwargs: dict[str, Any] = dict(
+        hue=umap_df["label"], hue_order=CELLTYPE_ORDER, palette=CELLTYPE_PALETTE
+    )
+    sns.scatterplot(
+        x=umap_df["UMAP1"],
+        y=umap_df["UMAP2"],
+        s=s,
+        alpha=0.5,
+        linewidth=0,
+        edgecolor=None,
+        rasterized=True,
+        ax=ax,
+        **hue_kwargs,
+    )
+    # Guard on the legend existing (seaborn omits it for a degenerate hue), then
+    # bump the dots to a readable size/opacity — mirrors plot_umap.
+    if ax.get_legend() is not None:
+        sns.move_legend(ax, "upper left", bbox_to_anchor=(1, 1))
+        leg = ax.get_legend()  # move_legend rebuilds the legend
+        leg.set_title("Cell type")
+        for handle in leg.legend_handles:
+            handle.set_markersize(8)  # type: ignore[attr-defined]  # Line2D handle
+            handle.set_alpha(1.0)
+
+    ax.set_xlabel("UMAP1")
+    ax.set_ylabel("UMAP2")
+    ax.set_xticks([])
+    ax.set_yticks([])
+    sns.despine(ax=ax)
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, bbox_inches="tight", dpi=dpi)
+    if out.suffix == ".svg":
+        fig.savefig(out.with_suffix(".png"), bbox_inches="tight", dpi=dpi)
+    plt.close(fig)

--- a/src/marin_dna/pipelines/evals/embedding_umap.py
+++ b/src/marin_dna/pipelines/evals/embedding_umap.py
@@ -108,9 +108,10 @@ def compute_region_embeddings(
     same loci), so their UMAPs are point-for-point comparable. The pooled center
     is never padding, so this only ever touches flank context.
 
-    Returns a DataFrame of the carried columns (``chrom/start/end/label/cons``)
-    plus ``emb_0…emb_{D-1}``, one row per window (input order, after a
-    ``(chrom, start)`` sort).
+    Returns a DataFrame of the input metadata columns (whatever ``regions``
+    carried — GPN-Star: ``chrom/start/end/label/cons``; DART task3:
+    ``chrom/start/end/label``, no conservation) plus ``emb_0…emb_{D-1}``, one row
+    per window (input order, after a ``(chrom, start)`` sort).
     """
     assert window_size >= n_center_bp, (
         f"window_size {window_size} must be >= n_center_bp {n_center_bp}"
@@ -164,7 +165,9 @@ def compute_region_embeddings(
     assert np.isfinite(emb).all(), "embeddings contain non-finite values"
     emb_df = pd.DataFrame(emb, columns=[f"emb_{i}" for i in range(emb.shape[1])])
     # regions is already 0..N-1 indexed (reset above); concat aligns by position.
-    return pd.concat([regions[_CARRY_COLUMNS], emb_df], axis=1)
+    # Carry every input metadata column so the kernel stays dataset-agnostic: a
+    # dataset without conservation (DART task3) just carries chrom/start/end/label.
+    return pd.concat([regions, emb_df], axis=1)
 
 
 def fit_umap(emb_df: pd.DataFrame, *, random_state: int = 42) -> pd.DataFrame:

--- a/tests/pipelines/evals/test_dart_task3_umap.py
+++ b/tests/pipelines/evals/test_dart_task3_umap.py
@@ -17,9 +17,10 @@ from marin_dna.pipelines.evals.dart_task3 import CELL_TYPES
 from marin_dna.pipelines.evals.dart_task3_umap import (
     CELLTYPE_ORDER,
     CELLTYPE_PALETTE,
-    assert_window_fits,
+    check_window_fits,
     load_dart_regions,
     plot_dart_umap,
+    read_position_limits,
 )
 
 
@@ -99,14 +100,38 @@ def test_load_dart_regions_bad_label_raises(monkeypatch):
 # --- assert_window_fits ------------------------------------------------------
 
 
-def test_assert_window_fits():
-    assert_window_fits(32768, 500)  # roomy budget — ok
-    assert_window_fits(256, 255)  # exp136 native: 255 bp + 1 BOS == 256, ok
-    with pytest.raises(AssertionError, match="would be truncated"):
-        assert_window_fits(256, 500)  # 500 + 1 BOS = 501 > 256
-    with pytest.raises(AssertionError, match="would be truncated"):
-        assert_window_fits(500, 500)  # 501 > 500 (BOS pushes it over)
-    assert_window_fits(500, 500, n_special=0)  # no BOS: 500 <= 500, ok
+def test_read_position_limits(tmp_path: Path):
+    import json
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"max_position_embeddings": 256, "rope_theta": 500000})
+    )
+    assert read_position_limits(tmp_path) == (256, True)  # rope_theta ⇒ uses_rope
+    (tmp_path / "config.json").write_text(
+        json.dumps({"max_position_embeddings": 512})  # no rope fields
+    )
+    assert read_position_limits(tmp_path) == (512, False)
+
+
+def test_check_window_fits_in_budget():
+    # Fits the budget → no-op (no print, no raise), regardless of rope.
+    check_window_fits(32768, 500, uses_rope=True)
+    check_window_fits(256, 255, uses_rope=True)  # exp136 native: 255 bp + BOS == 256
+    check_window_fits(500, 500, uses_rope=False, n_special=0)  # 500 <= 500
+
+
+def test_check_window_fits_rope_extrapolates(capsys):
+    # Over budget + RoPE → warn and PROCEED (the DART 500 bp OOD arm on exp136:
+    # 501 tokens > max_position_embeddings 256). No raise.
+    check_window_fits(256, 500, uses_rope=True)
+    out = capsys.readouterr().out
+    assert "RoPE extrapolation" in out and "OOD" in out
+
+
+def test_check_window_fits_non_rope_hard_fails():
+    # Over budget + non-RoPE would index past the learned position table → fail.
+    with pytest.raises(AssertionError, match="non-RoPE"):
+        check_window_fits(256, 500, uses_rope=False)
 
 
 # --- plot_dart_umap ----------------------------------------------------------

--- a/tests/pipelines/evals/test_dart_task3_umap.py
+++ b/tests/pipelines/evals/test_dart_task3_umap.py
@@ -1,0 +1,178 @@
+"""Tests for ``marin_dna.pipelines.evals.dart_task3_umap`` (#298).
+
+The model-dependent embedding is reused from ``embedding_umap`` (covered there +
+by the pipeline smoke run); here we unit-test the DART-specific bits: the
+cell-type palette consistency, the interval-dataset loader's validation, the
+long-context fit guard, the cell-type scatter, and that the shared embedding
+kernel carries a ``cons``-less (DART) frame.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from marin_dna.pipelines.evals.dart_task3 import CELL_TYPES
+from marin_dna.pipelines.evals.dart_task3_umap import (
+    CELLTYPE_ORDER,
+    CELLTYPE_PALETTE,
+    assert_window_fits,
+    load_dart_regions,
+    plot_dart_umap,
+)
+
+
+def test_celltype_maps_are_consistent():
+    # Order is the canonical CELL_TYPES; the palette covers exactly those labels.
+    assert CELLTYPE_ORDER == list(CELL_TYPES)
+    assert set(CELLTYPE_PALETTE) == set(CELL_TYPES)
+    assert set(CELLTYPE_ORDER) == set(CELLTYPE_PALETTE)
+
+
+# --- load_dart_regions -------------------------------------------------------
+
+
+class _FakeHF:
+    """Stand-in for a ``datasets.Dataset`` exposing only ``.to_pandas()``."""
+
+    def __init__(self, df: pd.DataFrame):
+        self._df = df
+
+    def to_pandas(self) -> pd.DataFrame:
+        return self._df
+
+
+def _patch_load(monkeypatch, df: pd.DataFrame) -> None:
+    import datasets
+
+    monkeypatch.setattr(datasets, "load_dataset", lambda *a, **k: _FakeHF(df))
+
+
+def _valid_source(n: int = 10) -> pd.DataFrame:
+    """A raw evals_dart_task3 frame: 500 bp windows, int chrom, an extra column
+    the loader should drop."""
+    starts = np.arange(n) * 1000
+    half = n // 2
+    return pd.DataFrame(
+        {
+            "chrom": [6] * half + [21] * (n - half),  # int → loader coerces to str
+            "start": starts,
+            "end": starts + 500,
+            "label": [CELL_TYPES[i % len(CELL_TYPES)] for i in range(n)],
+            "extra": 1,  # not in the carry schema — dropped
+        }
+    )
+
+
+def test_load_dart_regions_valid(monkeypatch):
+    _patch_load(monkeypatch, _valid_source(10))
+    out = load_dart_regions("bolinas-dna/evals_dart_task3", split="validation")
+    assert list(out.columns) == ["chrom", "start", "end", "label"]  # extra dropped
+    assert out["chrom"].tolist() == ["6"] * 5 + ["21"] * 5  # coerced to str
+    assert ((out["end"] - out["start"]) == 500).all()
+    assert set(out["label"]) <= set(CELL_TYPES)
+
+
+def test_load_dart_regions_missing_column_raises(monkeypatch):
+    _patch_load(monkeypatch, _valid_source(4).drop(columns=["label"]))
+    with pytest.raises(AssertionError, match="missing columns"):
+        load_dart_regions("x")
+
+
+def test_load_dart_regions_bad_width_raises(monkeypatch):
+    df = _valid_source(4)
+    df.loc[0, "end"] = df.loc[0, "start"] + 400  # 400 bp window
+    _patch_load(monkeypatch, df)
+    with pytest.raises(AssertionError, match="500 bp"):
+        load_dart_regions("x")
+
+
+def test_load_dart_regions_bad_label_raises(monkeypatch):
+    df = _valid_source(4)
+    df.loc[0, "label"] = "NOTACELL"
+    _patch_load(monkeypatch, df)
+    with pytest.raises(AssertionError, match="unexpected cell-type labels"):
+        load_dart_regions("x")
+
+
+# --- assert_window_fits ------------------------------------------------------
+
+
+def test_assert_window_fits():
+    assert_window_fits(32768, 500)  # roomy budget — ok
+    assert_window_fits(256, 255)  # exp136 native: 255 bp + 1 BOS == 256, ok
+    with pytest.raises(AssertionError, match="would be truncated"):
+        assert_window_fits(256, 500)  # 500 + 1 BOS = 501 > 256
+    with pytest.raises(AssertionError, match="would be truncated"):
+        assert_window_fits(500, 500)  # 501 > 500 (BOS pushes it over)
+    assert_window_fits(500, 500, n_special=0)  # no BOS: 500 <= 500, ok
+
+
+# --- plot_dart_umap ----------------------------------------------------------
+
+
+def _coords(n: int = 50, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    starts = np.arange(n) * 500
+    return pd.DataFrame(
+        {
+            "chrom": "6",
+            "start": starts,
+            "end": starts + 500,
+            "label": rng.choice(CELL_TYPES, size=n),
+            "UMAP1": rng.standard_normal(n),
+            "UMAP2": rng.standard_normal(n),
+        }
+    )
+
+
+def test_plot_dart_umap_writes_small_rasterized_svg(tmp_path: Path):
+    out = tmp_path / "celltype.svg"
+    plot_dart_umap(_coords(), out, dpi=150)
+    assert out.exists() and out.with_suffix(".png").exists()
+    svg = out.read_text()
+    assert "<image" in svg  # points rasterized inside the otherwise-vector SVG
+    assert out.stat().st_size < 500_000  # stays small
+
+
+def test_plot_dart_umap_rejects_unmapped_label(tmp_path: Path):
+    df = pd.DataFrame({"label": ["NOTACELL"], "UMAP1": [0.0], "UMAP2": [0.0]})
+    with pytest.raises(AssertionError, match="unmapped cell-type labels"):
+        plot_dart_umap(df, tmp_path / "x.svg")
+
+
+# --- shared embedding kernel carries a cons-less frame -----------------------
+
+
+def test_compute_region_embeddings_carries_without_cons(monkeypatch):
+    """DART task3 has no ``cons`` column; the shared kernel must carry the 4
+    interval columns + emb_*. Loaders + run_window_embeddings mocked (no
+    checkpoint, no GPU). Also exercises the long arm (window_size == n_center_bp
+    == 500, whole-window pooling)."""
+    from marin_dna.pipelines.evals import embedding_umap as eu
+    from marin_dna.pipelines.evals.embedding_umap import compute_region_embeddings
+
+    n = 6
+    starts = [500 * i for i in range(n)]
+    regions = pd.DataFrame(
+        {
+            "chrom": ["6"] * n,
+            "start": starts,
+            "end": [s + 500 for s in starts],
+            "label": [CELL_TYPES[i % len(CELL_TYPES)] for i in range(n)],
+        }
+    )
+    emb_block = np.arange(n * 2, dtype=np.float32).reshape(n, 2)
+    monkeypatch.setattr(eu.AutoTokenizer, "from_pretrained", lambda *a, **k: object())
+    monkeypatch.setattr(eu.AutoModel, "from_pretrained", lambda *a, **k: object())
+    monkeypatch.setattr(eu, "Genome", lambda *a, **k: object())
+    monkeypatch.setattr(eu, "run_window_embeddings", lambda *a, **k: emb_block)
+
+    out = compute_region_embeddings(
+        "/ckpt", "/genome.fa", regions, window_size=500, n_center_bp=500
+    )
+
+    assert list(out.columns) == ["chrom", "start", "end", "label", "emb_0", "emb_1"]
+    assert len(out) == n  # nothing dropped
+    np.testing.assert_array_equal(out[["emb_0", "emb_1"]].to_numpy(), emb_block)


### PR DESCRIPTION
🤖 Implements the [#298](https://github.com/Open-Athena/marin-dna/issues/298) harness — embed the DART-Eval Task 3 cell-type peak windows (`bolinas-dna/evals_dart_task3`, #293/#294) with a gLM and UMAP-color by the 5-way cell type, the cell-type-discrimination analogue of the GPN-Star region UMAP (#246/#248). The same model is embedded at each `context_sizes` arm, comparing a model's **native context (255 bp)** against the **full 500 bp peak** (~2× training context → RoPE extrapolation / OOD).

**Harness + config only** — the GPU embedding run and the resulting UMAPs are a follow-up posted to #298, which stays open.

## What's here

- **New module** [`dart_task3_umap.py`](https://github.com/Open-Athena/marin-dna/blob/3d22edf6570b93e12aa4fc63336d2d158e08d1c9/src/marin_dna/pipelines/evals/dart_task3_umap.py): [`load_dart_regions`](https://github.com/Open-Athena/marin-dna/blob/3d22edf6570b93e12aa4fc63336d2d158e08d1c9/src/marin_dna/pipelines/evals/dart_task3_umap.py#L50) (interval schema, no `cons` column; asserts 500 bp width + the 5 cell types), the cell-type palette, [`plot_dart_umap`](https://github.com/Open-Athena/marin-dna/blob/3d22edf6570b93e12aa4fc63336d2d158e08d1c9/src/marin_dna/pipelines/evals/dart_task3_umap.py#L106), and [`assert_window_fits`](https://github.com/Open-Athena/marin-dna/blob/3d22edf6570b93e12aa4fc63336d2d158e08d1c9/src/marin_dna/pipelines/evals/dart_task3_umap.py#L87) + `read_max_position_embeddings` (fail fast if a checkpoint's `max_position_embeddings` can't hold the long arm's `ctx + BOS` positions).
- **New rules** [`dart_task3_umap.smk`](https://github.com/Open-Athena/marin-dna/blob/3d22edf6570b93e12aa4fc63336d2d158e08d1c9/snakemake/analysis/evals_v2/workflow/rules/dart_task3_umap.smk) (`compute_dart_embeddings` → `fit_dart_umap` → `plot_dart_umap` → `dart_umap`), kept **off `rule all`**; plus the Snakefile include, `common.smk` `DART_UMAP_*` plumbing, and the `dart_umap` config block (`exp136-proj_v30-step-9999`, `context_sizes: [255, 500]`, validation split).
- **Whole-window pooling**: each arm sets `window_size = n_center_bp = ctx`, decoupling context size from the model's native `window_size` (`_center_token_bounds` yields `[n_prefix, n_prefix + window_size)` for both strands → every DNA token pooled).
- **Reuse, not fork**: [`compute_region_embeddings` now carries all input metadata columns](https://github.com/Open-Athena/marin-dna/blob/3d22edf6570b93e12aa4fc63336d2d158e08d1c9/src/marin_dna/pipelines/evals/embedding_umap.py#L166-L170) (byte-identical output for GPN-Star, whose `regions` is exactly `chrom/start/end/label/cons`), so a `cons`-less dataset reuses the kernel + `fit_umap` unchanged.

## Design decisions (settled on #298)

- **Pool the whole window** — the 255-arm summarizes the central 255 bp it is fed; the 500-arm summarizes the full peak.
- **UMAP only** for this first pass — no quantitative separation metric yet.

## Verification

- `uv run pytest tests/pipelines/evals/test_dart_task3_umap.py tests/pipelines/evals/test_embedding_umap.py` → **15 passed, 1 skipped** (the `umap`-group fit test). The existing GPN-Star tests still pass — the carry generalization is backward-compatible.
- `snakemake -n dart_umap` → clean **7-job DAG** (compute×2 → fit×2 → plot×2 → `dart_umap`); `download_model` for exp136 already present, no unrelated reruns.

## Run it (follow-up)

```bash
sky launch sky/run.yaml -c evals-dart-umap \
  --env EXTRA_UV_GROUPS="--group umap" \
  --env SNAKEMAKE_ARGS="-- dart_umap"
```

Tracked in #298 · related #246 / #248 (harness), #293 / #294 (dataset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Status — closed, unmerged

Investigation complete and written up in **#298** (closed) — see its [closing summary](https://github.com/Open-Athena/marin-dna/issues/298#issuecomment-4652813597) for findings + a commit-pinned permalink index. This PR is **closed without merging**; the branch (and GitHub's `refs/pull/299/head`) keep its commits — and every permalink — reachable even unmerged. Follow-up commits since the original description: `429b036` (RoPE OOD-guard relaxation → `check_window_fits`), `d0c63f8` (`split` rule wildcard `train|validation|test`), `714abae` (cell-type linear-probe / kNN script).

