### PR TITLE
evals_sge v2: harmonized direction, calibrated class, consequence_group/subset + missense/splicing filter

### DIFF
--- a/snakemake/evals/README.md
+++ b/snakemake/evals/README.md
@@ -19,7 +19,7 @@ commit `e59d612e9`, so HGMD pathogenic SNVs are included as a positive source.
 | `complex_traits` | UKBB fine-mapped complex-trait variants | SuSiE+FINEMAP `max(PIP across the traits where this variant was fine-mapped) > 0.9` | `max(PIP) < 0.01` AND no SuSiE/FINEMAP combine-step null PIP among those traits (`label_variants_by_pip(use_null_pip_guard=True)`) |
 | `caqtl` | DART-Eval African caQTLs (ATAC), GRCh38 | Significant caQTLs in peaks | Control variants in peaks (no matching) |
 | `dsqtl` | DART-Eval Yoruban dsQTLs (DNase), hg19→GRCh38 | Significant dsQTLs in peaks | Control variants in peaks (no matching) |
-| `sge` | Saturation genome editing function scores (BRCA1; #289 phase 1) | — *(no label: a continuous experimental function score per SNV)* | — |
+| `sge` | Saturation genome editing function scores (12 genes; #289, #297) | — *(no binary label: a continuous experimental function score per SNV, plus a calibrated `abnormal`/`intermediate`/`normal` class)* | — |
 | `dart_task3` | DART-Eval Task 3 cell-type ATAC peaks — 500 bp intervals, **not variants** (#293) | — *(no pos/neg: 5-class cell-type label — GM12878 / H1ESC / HEPG2 / IMR90 / K562)* | — |
 
 Only `mendelian_traits` has a corresponding `_harness_255` eval-harness
@@ -92,11 +92,15 @@ to the clinical/population/statistical labels above, and one that covers near-ex
 noncoding (splice-region, proximal-intronic) SNVs as well as missense. Like the
 DART-Eval datasets it is **not matched and not subsampled**, but unlike them:
 
-- it carries **no binary `label`** — only the authors' continuous score(s) and discrete
-  class(es), preserved verbatim under an `author_` prefix (no source metadata lost;
-  nothing collides with the pipeline's `consequence` / `distance_*` columns);
+- it carries **no binary `label`**. The authors' continuous score(s) and discrete
+  class(es) are preserved verbatim under an `author_` prefix (no source metadata lost;
+  nothing collides with the pipeline's `consequence` / `distance_*` columns); v2 (#297)
+  adds harmonized, cross-gene columns on top of these (see *Harmonized columns* below);
 - the trivially-deleterious **HIGH-impact `exclude_consequences`** (canonical splice,
-  nonsense, frameshift, …) are **dropped** — those aren't the discriminative signal;
+  nonsense, frameshift, …) are **dropped** — those aren't the discriminative signal —
+  and v2 (#297) further keeps only the **`missense_variant` + `splicing`** consequence
+  groups (config `sge.consequence_group_allowlist`), the two where the SGE assay
+  actually measures function;
 - per-variant provenance is `(gene, mavedb_urn)`: the gene symbol plus the canonical
   MaveDB accession of the source study (a gene can have >1 study, e.g. BRCA2);
 - a common `function_score` column carries each study's headline continuous score (so
@@ -142,6 +146,27 @@ MaveDB record once (`build_mavedb_metadata`) and emits two study-level artifacts
   threshold-source PMIDs) flattened to a **tidy long companion table** (one row per
   gene × calibration × functional class). It is *not* joined per-variant (wrong grain)
   and ships alongside the splits as `calibrations.parquet` in the HF repo.
+
+**Harmonized columns (#297).** After the per-study loaders concat, the build turns the
+study-level calibrations + per-study discrete classes into clean per-variant columns so
+downstream evals don't re-derive them (functions in `sge.py`, called from the rule):
+
+- `consequence_group` + `subset` — the coarse grouping the matched-pair datasets carry
+  (same `consequence_groups` map / `.replace(...)` semantics), so SGE stratifies
+  identically; `subset` is an alias of `consequence_group`.
+- `function_direction` (+1/−1, null if unresolved) + `function_score_aligned`
+  (`= function_direction × function_score`) — harmonizes the per-study score direction
+  (DDX3X's assay is inverted) so "higher = more functional" holds across genes. Direction
+  is read from the **assay** (calibration ranges; the categorical-only gene DDX3X from
+  its author class), never the model.
+- `calibrated_class` ∈ {abnormal, intermediate, normal} + `calibration_scheme` +
+  `acmg_strength` — a per-variant ClinGen/ExCALIBR-calibrated class chosen with an
+  explicit **ExCALIBR-first policy** (`attach_calibrated_class`): prefer the live
+  `ExCALIBR calibration`, never a dated ClinVar snapshot, require finite normal+abnormal
+  ranges, else fall back to a numeric investigator scheme, else the harmonized author
+  class (DDX3X), else null (BRCA2 — no calibration).
+- `author_class_harmonized` — each study's discrete class mapped to a common
+  abnormal/intermediate/normal axis.
 
 ```bash
 uv run --group hgvs snakemake results/dataset/sge/{train,test}.parquet

--- a/snakemake/evals/config/config.yaml
+++ b/snakemake/evals/config/config.yaml
@@ -125,6 +125,14 @@ dart_eval:
 # no subsampling, HIGH-impact `exclude_consequences` dropped, every author column
 # preserved (author_ prefix). Phase 1: BRCA1 only.
 sge:
+  # Build-time consequence_group allowlist (#297 item E): keep only the groups where the
+  # SGE assay actually measures function. The rest (synonymous, UTRs, ncRNA, distal,
+  # tss_proximal, …) are near-uninformative for an SGE benchmark and are dropped for
+  # inference speed + focus. Re-add a group here to score it again; remove the key (or
+  # set it null) to keep every group.
+  consequence_group_allowlist:
+    - missense_variant
+    - splicing
   brca1:
     # Findlay et al. 2018 (Nature 562:217-222) supplementary table — the same file
     # Evo2 bundles. Served from the Nature static-content host. hg19 genomic coords

--- a/snakemake/evals/workflow/rules/sge.smk
+++ b/snakemake/evals/workflow/rules/sge.smk
@@ -4,6 +4,9 @@ from marin_dna.pipelines.evals.sge import (
     SNV_HGVS_RE,
     annotate_sge_variants,
     attach_assay_facts,
+    attach_author_class_harmonized,
+    attach_calibrated_class,
+    attach_function_direction,
     build_mavedb_metadata,
     load_mavedb_genomic_scoreset,
     load_mavedb_transcript_scoreset,
@@ -113,6 +116,7 @@ HIGH-impact, diagonal-concat."""
         mavedb=expand("results/sge/mavedb/{gene}.csv", gene=list(_SGE_MAVEDB)),
         recoded=expand("results/sge/recoded/{gene}.parquet", gene=list(_SGE_TRANSCRIPT)),
         assay_facts="results/sge/assay_facts.parquet",
+        calibrations="results/sge/calibrations.parquet",
         consequences=expand("results/consequences/{chrom}.parquet", chrom=_SGE_CHROMS),
         exon_pc="results/intervals/exon_pc.parquet",
         exon_nc="results/intervals/exon_nc.parquet",
@@ -149,6 +153,8 @@ HIGH-impact, diagonal-concat."""
                 exon_proximal_dist=config["exon_proximal_dist"],
                 tss_proximal_dist=config["tss_proximal_dist"],
                 exclude_consequences=config["exclude_consequences"],
+                consequence_groups=config["consequence_groups"],
+                consequence_group_allowlist=config["sge"]["consequence_group_allowlist"],
                 lift=lift,
                 name=name,
             )
@@ -180,4 +186,13 @@ HIGH-impact, diagonal-concat."""
         # grain to join per-variant.) The join + coverage assert live in the library
         # (attach_assay_facts) so they are unit-tested.
         data = attach_assay_facts(data, pl.read_parquet(input.assay_facts))
+        # #297: turn the study-level calibrations + per-study discrete author classes
+        # into clean per-variant columns (harmonized author class -> calibrated class ->
+        # function-score direction) so the eval drops its sign-align / scheme-pick /
+        # range-membership workarounds. Order matters: the calibrated-class + direction
+        # helpers consult author_class_harmonized for the categorical-only gene (DDX3X).
+        calibrations = pl.read_parquet(input.calibrations)
+        data = attach_author_class_harmonized(data)
+        data = attach_calibrated_class(data, calibrations)
+        data = attach_function_direction(data, calibrations)
         data.write_parquet(output[0])

--- a/snakemake/evals/workflow/rules/sge.smk
+++ b/snakemake/evals/workflow/rules/sge.smk
@@ -154,7 +154,9 @@ HIGH-impact, diagonal-concat."""
                 tss_proximal_dist=config["tss_proximal_dist"],
                 exclude_consequences=config["exclude_consequences"],
                 consequence_groups=config["consequence_groups"],
-                consequence_group_allowlist=config["sge"]["consequence_group_allowlist"],
+                # .get(): a removed key (or YAML null) -> None -> keep every group, as
+                # the config comment promises; a bare [...] subscript would KeyError.
+                consequence_group_allowlist=config["sge"].get("consequence_group_allowlist"),
                 lift=lift,
                 name=name,
             )

--- a/src/marin_dna/pipelines/evals/hf_readme.py
+++ b/src/marin_dna/pipelines/evals/hf_readme.py
@@ -613,7 +613,7 @@ _SGE_STUDY_META = {
         "pmid": None,
         "build": "GRCh38",
         "score_col": "`author_score`",
-        "class_col": "—",
+        "class_col": "`author_functional_consequence`",
     },
     "urn:mavedb:00001259-a-1": {
         "gene": "PALB2",
@@ -621,7 +621,7 @@ _SGE_STUDY_META = {
         "pmid": None,
         "build": "GRCh38",
         "score_col": "`author_score`",
-        "class_col": "—",
+        "class_col": "`author_functional_consequence`",
     },
     "urn:mavedb:00001260-a-1": {
         "gene": "RAD51D",
@@ -629,7 +629,7 @@ _SGE_STUDY_META = {
         "pmid": None,
         "build": "GRCh38",
         "score_col": "`author_score`",
-        "class_col": "—",
+        "class_col": "`author_functional_consequence`",
     },
     "urn:mavedb:00001264-a-1": {
         "gene": "XRCC2",
@@ -645,7 +645,7 @@ _SGE_STUDY_META = {
         "pmid": None,
         "build": "GRCh38",
         "score_col": "`author_score`",
-        "class_col": "—",
+        "class_col": "`author_functional_consequence`",
     },
     "urn:mavedb:00001265-a-1": {
         "gene": "SFPQ",
@@ -653,7 +653,7 @@ _SGE_STUDY_META = {
         "pmid": None,
         "build": "GRCh38",
         "score_col": "`author_score`",
-        "class_col": "—",
+        "class_col": "`author_functional_consequence`",
     },
     # Transcript-targeted (c.->g. recoded with pyhgvs + cdot; intronic recovered).
     "urn:mavedb:00001225-a-1": {
@@ -686,7 +686,7 @@ _SGE_STUDY_META = {
         "pmid": "38057330",
         "build": "GRCh38 (c.→g.)",
         "score_col": "`author_score`",
-        "class_col": "—",
+        "class_col": "`author_sge_prediction_of_variant_function_in_ndd_context`",
     },
     "urn:mavedb:00000675-a-1": {
         "gene": "VHL",
@@ -893,12 +893,13 @@ in genomic coordinates — an axis orthogonal to the clinical/population/statist
 labels of the other `evals_*` datasets, and one that covers near-exon noncoding
 (splice-region, proximal-intronic) SNVs, not just missense.
 
-**No matching, no subsampling, no binary label** — every assayed SNV is kept with its
-continuous author score(s). The trivially-deleterious **HIGH-impact consequences**
-(canonical splice, nonsense, frameshift, …) are **dropped** (`exclude_consequences`);
-they are not the discriminative signal an SGE benchmark is about. **Every original
-author column is preserved** under an `author_` prefix ({n_author} columns), so no
-source metadata is lost.
+**No matching, no subsampling, no binary label.** The trivially-deleterious **HIGH-impact
+consequences** (canonical splice, nonsense, frameshift, …) are dropped
+(`exclude_consequences`), and v2
+([#297](https://github.com/Open-Athena/marin-dna/issues/297)) further keeps only the
+**missense + splicing** consequence groups — the two where the SGE assay actually
+measures function. **Every original author column is preserved** under an `author_`
+prefix ({n_author} columns), so no source metadata is lost.
 
 ## Studies
 
@@ -931,14 +932,23 @@ this is a **gene-level holdout** (e.g. BRCA1·chr17 → train).
 | `gene` | str | Gene symbol. |
 | `assay` | str | `sge`. |
 | `mavedb_urn` | str | Canonical MaveDB accession for the source study (see the table above). |
+| `function_score` | float | Each study's headline continuous functional score (raw, **per-study scale** — pool by rank, not raw value). |
+| `function_direction`, `function_score_aligned` | int / float | Per-gene assay direction (`+1` / `−1`, null if unresolved — BRCA2) and the direction-corrected score (`function_direction × function_score`) so "higher = more functional" holds across genes. Sourced from the assay (calibration ranges / author class), **not** the model. |
+| `calibrated_class` | str | ClinGen/ExCALIBR-calibrated `abnormal` / `intermediate` / `normal` (or null), decided at build with an **ExCALIBR-first policy** (prefers the live calibration; never a dated ClinVar snapshot). |
+| `calibration_scheme`, `acmg_strength` | str | The scheme behind `calibrated_class` (an ExCALIBR / investigator title, or `author_class` for the categorical-only gene) and the matched range's ACMG functional-evidence strength (`SUPPORTING` … `VERY_STRONG`). |
+| `author_class_harmonized` | str | Each study's discrete functional class mapped to a common `abnormal` / `intermediate` / `normal` axis (null where a study ships none — BAP1, VHL, BRCA2). |
 | `author_*` | mixed | **Every original column from the source study, verbatim** (slugified, `author_`-prefixed). The headline variables per study are listed in the table above — e.g. for BRCA1 `author_function_score_mean` (continuous) and `author_func_class` (FUNC/INT/LOF). Original coordinates are kept too (e.g. `author_position_hg19`). |
 | `assay_*` | str | **MaveDB 'assay facts'** — the experiment's controlled-vocabulary keywords (assay readout, mechanism, model system, library mechanism, …), constant per gene. See *Assay characteristics* below; blank for the one unannotated study (BRCA2). |
+| `subset`, `consequence_group` | str | Coarse consequence grouping the eval stratifies on (`subset` is an alias of `consequence_group`, matching the other `evals_*` datasets). The build keeps only the `missense_variant` + `splicing` groups. |
 | `consequence`, `consequence_cre`, `consequence_final` | str | Ensembl VEP consequence (raw, with-CRE-class, and after TSS/exon-proximity recategorization); reference annotations. |
 | `distance_tss_*`, `distance_exon_*`, `*_closest_gene_id` | int / str | Distances to nearest TSS / exon and the Ensembl gene IDs there; reference annotations. |
 
-No binary `label` is imposed — that (and any score harmonization across studies) is an
-eval-time decision; the artifact preserves the authors' continuous scores and discrete
-classes as-is.
+There is still no binary `label`, but v2 ([#297](https://github.com/Open-Athena/marin-dna/issues/297))
+ships harmonized, cross-gene-comparable columns so the eval needn't re-derive them: a
+per-gene `function_direction` / `function_score_aligned`, a calibrated `calibrated_class`
+(ExCALIBR-first policy) with its `calibration_scheme` + `acmg_strength`, and an
+`author_class_harmonized`. The authors' raw `function_score` and every `author_` column
+are preserved verbatim; **per-study scales still differ**, so pool by rank, not raw value.
 
 ## Provenance
 

--- a/src/marin_dna/pipelines/evals/sge.py
+++ b/src/marin_dna/pipelines/evals/sge.py
@@ -31,6 +31,7 @@ import urllib.request
 from collections.abc import Callable
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import polars as pl
 
@@ -260,6 +261,318 @@ def attach_assay_facts(data: pl.DataFrame, assay_facts: pl.DataFrame) -> pl.Data
         # non-deterministic (it shifts with global hash state — e.g. across test
         # orderings, which is how this surfaced). #293.
         maintain_order="left",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Per-variant calibrated functional class, author-class harmonization, and
+# function-score direction (#297). These turn the study-level `calibrations.parquet`
+# + the per-study discrete author classes into clean, cross-gene-comparable per-variant
+# columns, so the eval no longer re-derives them (sign-align hack, scheme-pick
+# heuristic, range-membership) at score time.
+# --------------------------------------------------------------------------- #
+
+# Calibration-scheme selection policy (#297 item C). Prefer the primary ClinGen/ExCALIBR
+# calibration (the VCEP PS3-BS3 framework); never a dated snapshot — e.g.
+# "ExCALIBR calibration (ClinVar 2018)" pins thresholds to a stale ClinVar release.
+_PRIMARY_CALIBRATION = "ExCALIBR calibration"
+# A parenthesized year marks a dated-snapshot scheme ("… (ClinVar 2018)",
+# "… (Feb 2026, All Variants)") — deprioritized vs the live calibration.
+_DATED_SNAPSHOT_RE = re.compile(r"\(\D*\d{4}")
+
+# Per-gene discrete author-class vocab -> harmonized {normal, intermediate, abnormal}
+# (#297 item D). One (column, value-map) per gene; the six functionally_* genes share a
+# column. Genes absent here (BAP1, VHL, BRCA2) ship no discrete author class.
+_FUNCTIONAL_CONSEQUENCE_MAP = {
+    "functionally_normal": "normal",
+    "functionally_abnormal": "abnormal",
+    "indeterminate": "intermediate",
+}
+_AUTHOR_CLASS_MAPS: dict[str, tuple[str, dict[str, str]]] = {
+    "BRCA1": (
+        "author_func_class",
+        {"FUNC": "normal", "INT": "intermediate", "LOF": "abnormal"},
+    ),
+    "RAD51C": (
+        "author_functional_classification",
+        # Depletion screen: depleted = loss of function = abnormal; unchanged = normal;
+        # `enriched` (grows faster than WT) is a distinct non-LOF phenotype -> intermediate.
+        {
+            "unchanged": "normal",
+            "enriched": "intermediate",
+            "slow depleted": "abnormal",
+            "fast depleted": "abnormal",
+        },
+    ),
+    "DDX3X": (
+        "author_sge_prediction_of_variant_function_in_ndd_context",
+        {"normal": "normal", "abnormal": "abnormal"},
+    ),
+    **{
+        g: ("author_functional_consequence", _FUNCTIONAL_CONSEQUENCE_MAP)
+        for g in ("BARD1", "CTCF", "PALB2", "RAD51D", "SFPQ", "XRCC2")
+    },
+}
+
+
+def attach_author_class_harmonized(data: pl.DataFrame) -> pl.DataFrame:
+    """Harmonize each study's discrete functional class to a common
+    ``author_class_harmonized`` ∈ {normal, intermediate, abnormal} (#297 item D).
+
+    Maps each gene's author-class column through :data:`_AUTHOR_CLASS_MAPS`. Asserts
+    every non-null source value is mapped (loud on an unexpected category) and that no
+    *unmapped* gene carries a non-null value in a known class column (so a real author
+    class is never silently dropped). Genes with no discrete class (BAP1, VHL, BRCA2)
+    stay null. Feeds the categorical-gene branch of :func:`attach_calibrated_class` and
+    :func:`attach_function_direction`.
+    """
+    n = data.height
+    gene_arr = np.asarray(data["gene"].to_list(), dtype=object)
+    harm = np.array([None] * n, dtype=object)
+    cols_to_genes: dict[str, set[str]] = {}
+    for gene, (col, mapping) in _AUTHOR_CLASS_MAPS.items():
+        cols_to_genes.setdefault(col, set()).add(gene)
+        if col not in data.columns:
+            continue
+        vals = np.asarray(data[col].to_list(), dtype=object)
+        for i in np.where(gene_arr == gene)[0]:
+            v = vals[i]
+            if v is None:
+                continue
+            assert v in mapping, f"{gene}: unmapped author class {v!r} in {col}"
+            harm[i] = mapping[v]
+    # Defensive: a gene NOT mapped to a known class column must not carry a non-null
+    # value there (else a real author class would silently stay unharmonized).
+    for col, genes_for_col in cols_to_genes.items():
+        if col not in data.columns:
+            continue
+        stray = (
+            data.filter(
+                pl.col(col).is_not_null() & ~pl.col("gene").is_in(list(genes_for_col))
+            )["gene"]
+            .unique()
+            .to_list()
+        )
+        assert not stray, f"unmapped gene(s) carry non-null {col}: {sorted(stray)}"
+    return data.with_columns(
+        pl.Series("author_class_harmonized", harm.tolist(), dtype=pl.Utf8)
+    )
+
+
+def _numeric_class_rows(scheme: pl.DataFrame, go: str) -> pl.DataFrame:
+    """Rows of ``scheme`` with the given ``go_classification`` and >=1 finite range
+    bound (so they can threshold ``function_score``). Categorical schemes carry
+    ``[null, null]`` ranges and contribute nothing here."""
+    return scheme.filter(
+        (pl.col("go_classification") == go)
+        & (pl.col("range_lower").is_not_null() | pl.col("range_upper").is_not_null())
+    )
+
+
+def _select_numeric_calibration(
+    gcal: pl.DataFrame,
+) -> tuple[str, pl.DataFrame, pl.DataFrame] | None:
+    """Pick a gene's numeric-threshold calibration scheme by the #297 policy; return
+    ``(title, normal_rows, abnormal_rows)`` or None if the gene has no numeric scheme.
+
+    A qualifying scheme needs >=1 finite-range normal AND abnormal class. Among those,
+    rank by (is the primary ``ExCALIBR calibration``, is NOT a dated snapshot,
+    finite-row count, title) so the live ExCALIBR wins over its dated ClinVar snapshot
+    and over investigator-provided classes; a gene whose ExCALIBR lacks a normal class
+    (CTCF) falls back to the next qualifying numeric scheme (its investigator classes).
+    """
+    cands: list[tuple[str, pl.DataFrame, pl.DataFrame]] = []
+    for key, scheme in gcal.group_by("calibration_title", maintain_order=True):
+        title = key[0]
+        norm = _numeric_class_rows(scheme, "normal")
+        abn = _numeric_class_rows(scheme, "abnormal")
+        if norm.height and abn.height:
+            cands.append((title, norm, abn))
+    if not cands:
+        return None
+    cands.sort(
+        key=lambda c: (
+            c[0] == _PRIMARY_CALIBRATION,
+            not bool(_DATED_SNAPSHOT_RE.search(c[0] or "")),
+            c[1].height + c[2].height,
+            c[0],
+        ),
+        reverse=True,
+    )
+    return cands[0]
+
+
+def _in_range(
+    x: float, lo: float | None, hi: float | None, inc_lo: bool, inc_hi: bool
+) -> bool:
+    """Is score ``x`` within the (possibly half-open) range ``[lo, hi]``? A null bound
+    is unbounded on that side; ``inc_*`` toggle open/closed bounds (mirrors the eval's
+    range-membership test in ``calibrated_binary_label``)."""
+    if lo is not None and (x < lo or (x == lo and not inc_lo)):
+        return False
+    if hi is not None and (x > hi or (x == hi and not inc_hi)):
+        return False
+    return True
+
+
+def attach_calibrated_class(
+    data: pl.DataFrame, calibrations: pl.DataFrame
+) -> pl.DataFrame:
+    """Materialize a per-variant calibrated functional class (#297 item C).
+
+    Adds three columns, decided once at build with an explicit policy (replacing the
+    eval's most-rows heuristic):
+
+    - ``calibrated_class`` ∈ {abnormal, intermediate, normal} or null,
+    - ``calibration_scheme``: the chosen scheme title, ``"author_class"`` (categorical
+      genes), or null (no calibration),
+    - ``acmg_strength``: the matched range's ACMG evidence strength (SUPPORTING …
+      VERY_STRONG); null for categorical / intermediate / uncalibrated.
+
+    Per gene: prefer the numeric scheme from :func:`_select_numeric_calibration`
+    (ExCALIBR-first) and label by range membership (abnormal / normal / else
+    intermediate). A gene with no numeric scheme but a harmonized author class (DDX3X)
+    inherits its class from ``author_class_harmonized``; a gene with neither (BRCA2)
+    gets nulls. Requires :func:`attach_author_class_harmonized` first.
+    """
+    assert "author_class_harmonized" in data.columns, (
+        "attach_calibrated_class: call attach_author_class_harmonized first"
+    )
+    n = data.height
+    fs = np.asarray(data["function_score"].to_list(), dtype=float)
+    gene_arr = np.asarray(data["gene"].to_list(), dtype=object)
+    ach = np.asarray(data["author_class_harmonized"].to_list(), dtype=object)
+    cls = np.array([None] * n, dtype=object)
+    scheme_col = np.array([None] * n, dtype=object)
+    strength = np.array([None] * n, dtype=object)
+    for gene in sorted(set(gene_arr)):
+        idx = np.where(gene_arr == gene)[0]
+        gcal = calibrations.filter(pl.col("gene") == gene)
+        sel = _select_numeric_calibration(gcal) if gcal.height else None
+        if sel is not None:
+            title, norm, abn = sel
+            norm_rows = list(norm.iter_rows(named=True))
+            abn_rows = list(abn.iter_rows(named=True))
+            for i in idx:
+                x = fs[i]
+                abn_hit = next(
+                    (
+                        r
+                        for r in abn_rows
+                        if _in_range(
+                            x,
+                            r["range_lower"],
+                            r["range_upper"],
+                            r["inclusive_lower"],
+                            r["inclusive_upper"],
+                        )
+                    ),
+                    None,
+                )
+                norm_hit = next(
+                    (
+                        r
+                        for r in norm_rows
+                        if _in_range(
+                            x,
+                            r["range_lower"],
+                            r["range_upper"],
+                            r["inclusive_lower"],
+                            r["inclusive_upper"],
+                        )
+                    ),
+                    None,
+                )
+                if abn_hit and not norm_hit:
+                    cls[i], strength[i] = "abnormal", abn_hit["acmg_evidence_strength"]
+                elif norm_hit and not abn_hit:
+                    cls[i], strength[i] = "normal", norm_hit["acmg_evidence_strength"]
+                else:
+                    cls[i] = "intermediate"
+                scheme_col[i] = title
+        elif any(ach[i] is not None for i in idx):
+            # Categorical-only gene (DDX3X): no numeric thresholds, but a harmonized
+            # author class exists -> use it directly.
+            for i in idx:
+                if ach[i] is not None:
+                    cls[i], scheme_col[i] = ach[i], "author_class"
+        # else: no calibration and no author class (BRCA2) -> all null.
+    return data.with_columns(
+        pl.Series("calibrated_class", cls.tolist(), dtype=pl.Utf8),
+        pl.Series("calibration_scheme", scheme_col.tolist(), dtype=pl.Utf8),
+        pl.Series("acmg_strength", strength.tolist(), dtype=pl.Utf8),
+    )
+
+
+def _scheme_direction(norm: pl.DataFrame, abn: pl.DataFrame) -> int:
+    """+1 if the abnormal calibration range sits BELOW the normal range (low score =
+    abnormal = less functional, so "higher = more functional"), else -1. Range center =
+    mean of finite midpoints (a single-bound range uses that bound)."""
+
+    def center(rows: pl.DataFrame) -> float:
+        vals: list[float] = []
+        for r in rows.iter_rows(named=True):
+            lo, hi = r["range_lower"], r["range_upper"]
+            if lo is not None and hi is not None:
+                vals.append((lo + hi) / 2)
+            elif lo is not None:
+                vals.append(lo)
+            elif hi is not None:
+                vals.append(hi)
+        assert vals, "empty numeric range set"
+        return float(np.mean(vals))
+
+    return 1 if center(abn) < center(norm) else -1
+
+
+def attach_function_direction(
+    data: pl.DataFrame, calibrations: pl.DataFrame
+) -> pl.DataFrame:
+    """Harmonize the per-study ``function_score`` direction (#297 item B).
+
+    Adds ``function_direction`` (+1 / -1 / null) and ``function_score_aligned`` =
+    ``function_direction * function_score``, so "higher = more functional" holds across
+    genes (the raw per-study ``function_score`` is kept verbatim). Direction is sourced
+    from the **assay, not the model**: numeric-scheme genes from whether the abnormal
+    calibration range sits below or above the normal range
+    (:func:`_scheme_direction`); the categorical-only gene (DDX3X) from the sign of
+    mean(function_score | abnormal) vs (| normal) over its ``author_class_harmonized``
+    labels; a gene with neither (BRCA2) stays null. Requires
+    :func:`attach_author_class_harmonized` first.
+
+    Note: this corrects only the *sign*; per-study *scales* still differ (issue #297
+    §3), so a pooled rank/Spearman view is valid but a pooled raw-Pearson is not.
+    """
+    assert "author_class_harmonized" in data.columns, (
+        "attach_function_direction: call attach_author_class_harmonized first"
+    )
+    n = data.height
+    fs = np.asarray(data["function_score"].to_list(), dtype=float)
+    gene_arr = np.asarray(data["gene"].to_list(), dtype=object)
+    ach = np.asarray(data["author_class_harmonized"].to_list(), dtype=object)
+    direction = np.array([None] * n, dtype=object)
+    for gene in sorted(set(gene_arr)):
+        idx = np.where(gene_arr == gene)[0]
+        gcal = calibrations.filter(pl.col("gene") == gene)
+        sel = _select_numeric_calibration(gcal) if gcal.height else None
+        d: int | None = None
+        if sel is not None:
+            _, norm, abn = sel
+            d = _scheme_direction(norm, abn)
+        else:
+            abn_fs = [fs[i] for i in idx if ach[i] == "abnormal"]
+            norm_fs = [fs[i] for i in idx if ach[i] == "normal"]
+            if abn_fs and norm_fs:
+                d = 1 if float(np.mean(norm_fs)) >= float(np.mean(abn_fs)) else -1
+        if d is not None:
+            for i in idx:
+                direction[i] = d
+    return data.with_columns(
+        pl.Series("function_direction", direction.tolist(), dtype=pl.Int8)
+    ).with_columns(
+        (pl.col("function_direction") * pl.col("function_score")).alias(
+            "function_score_aligned"
+        )
     )
 
 
@@ -597,11 +910,14 @@ def annotate_sge_variants(
     exon_proximal_dist: int,
     tss_proximal_dist: int,
     exclude_consequences: list[str],
+    consequence_groups: dict[str, list[str]],
+    consequence_group_allowlist: list[str] | None = None,
     lift: bool,
     name: str = "",
 ) -> pl.DataFrame:
     """Liftover (optional) + ref/alt validation + consequence/distance annotation +
-    HIGH-impact ``exclude_consequences`` drop, with **no** matching or subsampling.
+    HIGH-impact ``exclude_consequences`` drop + coarse ``consequence_group`` /
+    ``subset`` grouping + optional group allowlist, with **no** matching or subsampling.
 
     Mirrors :func:`marin_dna.pipelines.evals.dart_eval.annotate_variants` but (a)
     drops ``exclude_consequences`` (the QTL path keeps them; SGE drops them), (b)
@@ -610,6 +926,12 @@ def annotate_sge_variants(
     tied to the ref->alt substitution as the author defined it, so a swap (author
     ref != genome) signals a coordinate/strand/build problem, not a benign
     re-orientation.
+
+    Adds (#297) the coarse ``consequence_group`` (and its ``subset`` alias) so SGE
+    stratifies identically to the matched-pair datasets, then optionally filters to a
+    ``consequence_group_allowlist`` (default keeps everything; the build passes
+    ``[missense_variant, splicing]`` — the groups where the SGE assay actually measures
+    function).
 
     Args:
         V: normalized SGE frame (``chrom, pos, ref, alt`` + author columns); ``pos``
@@ -622,6 +944,12 @@ def annotate_sge_variants(
         exon_proximal_dist / tss_proximal_dist: proximity thresholds for the
             ``consequence_final`` recategorization.
         exclude_consequences: VEP consequences to drop (canonical-LOF HIGH-impact).
+        consequence_groups: ``{group: [consequence_final values]}`` map (the pipeline's
+            shared ``consequence_groups`` config) collapsing fine consequences to the
+            coarse ``consequence_group``; unmapped values keep their own value (same
+            ``.replace`` semantics as :func:`trait_intervals.build_dataset`).
+        consequence_group_allowlist: if not None, keep only variants whose
+            ``consequence_group`` is in this list (a build-time row filter).
         lift: if True, lift hg19->GRCh38 first.
         name: label for log/assert messages.
     """
@@ -689,13 +1017,53 @@ def annotate_sge_variants(
         f"{n_pre_excl - V.height} HIGH-impact variants ({V.height} kept)"
     )
     assert V.height > 0, f"{name}: all variants dropped by exclude_consequences"
-    V = (
-        V.pipe(add_exon, exon_pc, exon_nc, exon_proximal_dist)
-        .pipe(add_tss, tss_pc, tss_nc, tss_proximal_dist)
-        .sort(COORDINATES)
+    V = V.pipe(add_exon, exon_pc, exon_nc, exon_proximal_dist).pipe(
+        add_tss, tss_pc, tss_nc, tss_proximal_dist
     )
-    assert (V["pos"] > 0).all(), f"{name}: non-positive positions after annotation"
     assert V["consequence_final"].null_count() == 0, (
         f"{name}: null consequence_final after annotation"
     )
+    # Coarse consequence grouping (#297 item A): collapse consequence_final to the same
+    # `consequence_group` the matched-pair datasets carry, with the SAME `.replace(...)`
+    # semantics as trait_intervals.build_dataset — a consequence_final absent from the
+    # map keeps its own value (missense_variant, synonymous_variant, tss_proximal,
+    # 5_prime_UTR_variant, …). Then alias it to `subset` so SGE stratifies identically
+    # to mendelian/complex (whose metric groups on `subset`).
+    consequence_to_group = {
+        c: group
+        for group, consequences in consequence_groups.items()
+        for c in consequences
+    }
+    V = V.with_columns(
+        pl.col("consequence_final")
+        .replace(consequence_to_group)
+        .alias("consequence_group")
+    )
+    assert V["consequence_group"].null_count() == 0, (
+        f"{name}: null consequence_group after grouping"
+    )
+    V = V.with_columns(pl.col("consequence_group").alias("subset"))
+    # Build-time allowlist (#297 item E): keep only the consequence groups where the SGE
+    # assay actually measures function (the build passes [missense_variant, splicing]);
+    # the rest (synonymous, UTRs, ncRNA, distal, tss_proximal, …) are near-uninformative
+    # for an SGE benchmark and are dropped for inference speed + focus. None keeps all.
+    if consequence_group_allowlist is not None:
+        n_pre = V.height
+        by_group = dict(V.group_by("consequence_group").len().iter_rows())
+        V = V.filter(pl.col("consequence_group").is_in(consequence_group_allowlist))
+        dropped = {
+            g: n
+            for g, n in sorted(by_group.items())
+            if g not in set(consequence_group_allowlist)
+        }
+        print(
+            f"[sge annotate {name}] consequence_group allowlist "
+            f"{consequence_group_allowlist} kept {V.height}/{n_pre} "
+            f"(dropped {n_pre - V.height}: {dropped})"
+        )
+        assert V.height > 0, (
+            f"{name}: all variants dropped by consequence_group_allowlist"
+        )
+    V = V.sort(COORDINATES)
+    assert (V["pos"] > 0).all(), f"{name}: non-positive positions after annotation"
     return V

--- a/src/marin_dna/pipelines/evals/sge.py
+++ b/src/marin_dna/pipelines/evals/sge.py
@@ -415,6 +415,26 @@ def _in_range(
     return True
 
 
+def _matching_range(rows: list[dict], x: float) -> dict | None:
+    """First calibration-class row (from :meth:`iter_rows(named=True)`) whose score
+    range contains ``x``, else None. For ExCALIBR's disjoint graded ranges at most one
+    matches; first-in-order is deterministic by the calibration table's row order."""
+    return next(
+        (
+            r
+            for r in rows
+            if _in_range(
+                x,
+                r["range_lower"],
+                r["range_upper"],
+                r["inclusive_lower"],
+                r["inclusive_upper"],
+            )
+        ),
+        None,
+    )
+
+
 def attach_calibrated_class(
     data: pl.DataFrame, calibrations: pl.DataFrame
 ) -> pl.DataFrame:
@@ -438,6 +458,12 @@ def attach_calibrated_class(
     assert "author_class_harmonized" in data.columns, (
         "attach_calibrated_class: call attach_author_class_harmonized first"
     )
+    # function_score is a non-null loader invariant; guard it here because a null would
+    # become NaN below (np.asarray(..., dtype=float)) and silently match EVERY range in
+    # _in_range (all comparisons against NaN are False), mislabeling the variant.
+    assert data["function_score"].null_count() == 0, (
+        "attach_calibrated_class: null function_score (would corrupt range membership)"
+    )
     n = data.height
     fs = np.asarray(data["function_score"].to_list(), dtype=float)
     gene_arr = np.asarray(data["gene"].to_list(), dtype=object)
@@ -455,34 +481,8 @@ def attach_calibrated_class(
             abn_rows = list(abn.iter_rows(named=True))
             for i in idx:
                 x = fs[i]
-                abn_hit = next(
-                    (
-                        r
-                        for r in abn_rows
-                        if _in_range(
-                            x,
-                            r["range_lower"],
-                            r["range_upper"],
-                            r["inclusive_lower"],
-                            r["inclusive_upper"],
-                        )
-                    ),
-                    None,
-                )
-                norm_hit = next(
-                    (
-                        r
-                        for r in norm_rows
-                        if _in_range(
-                            x,
-                            r["range_lower"],
-                            r["range_upper"],
-                            r["inclusive_lower"],
-                            r["inclusive_upper"],
-                        )
-                    ),
-                    None,
-                )
+                abn_hit = _matching_range(abn_rows, x)
+                norm_hit = _matching_range(norm_rows, x)
                 if abn_hit and not norm_hit:
                     cls[i], strength[i] = "abnormal", abn_hit["acmg_evidence_strength"]
                 elif norm_hit and not abn_hit:
@@ -545,6 +545,12 @@ def attach_function_direction(
     """
     assert "author_class_harmonized" in data.columns, (
         "attach_function_direction: call attach_author_class_harmonized first"
+    )
+    # function_score is a non-null loader invariant; a null would become NaN below and
+    # poison the categorical-gene mean comparison (np.mean of a NaN-containing list is
+    # NaN, and NaN >= NaN is False -> a spurious -1 direction).
+    assert data["function_score"].null_count() == 0, (
+        "attach_function_direction: null function_score (would corrupt direction)"
     )
     n = data.height
     fs = np.asarray(data["function_score"].to_list(), dtype=float)

--- a/tests/pipelines/evals/test_sge.py
+++ b/tests/pipelines/evals/test_sge.py
@@ -8,8 +8,12 @@ import pytest
 from marin_dna.data.utils import load_annotation
 from marin_dna.pipelines.evals.sge import (
     _CALIBRATION_SCHEMA,
+    _select_numeric_calibration,
     annotate_sge_variants,
     attach_assay_facts,
+    attach_author_class_harmonized,
+    attach_calibrated_class,
+    attach_function_direction,
     build_mavedb_metadata,
     extract_assay_facts,
     extract_score_calibrations,
@@ -363,7 +367,17 @@ def _cons_rows(V: pl.DataFrame, consequences: list[str]) -> list[dict]:
     ]
 
 
-def _annotate(tmp_path, intervals, V, consequences, exclude, *, lift=False):
+def _annotate(
+    tmp_path,
+    intervals,
+    V,
+    consequences,
+    exclude,
+    *,
+    lift=False,
+    consequence_groups=None,
+    consequence_group_allowlist=None,
+):
     genome = FakeGenome(
         {("1", p): r for p, r in zip(V["pos"].to_list(), V["ref"].to_list())}
     )
@@ -380,6 +394,8 @@ def _annotate(tmp_path, intervals, V, consequences, exclude, *, lift=False):
         exon_proximal_dist=30,
         tss_proximal_dist=1000,
         exclude_consequences=exclude,
+        consequence_groups=consequence_groups or {},
+        consequence_group_allowlist=consequence_group_allowlist,
         lift=lift,
         name="test",
     )
@@ -485,6 +501,7 @@ class TestAnnotateSgeVariants:
                 exon_proximal_dist=30,
                 tss_proximal_dist=1000,
                 exclude_consequences=[],
+                consequence_groups={},
                 lift=False,
                 name="test",
             )
@@ -511,6 +528,7 @@ class TestAnnotateSgeVariants:
                 exon_proximal_dist=30,
                 tss_proximal_dist=1000,
                 exclude_consequences=[],
+                consequence_groups={},
                 lift=False,
                 name="test",
             )
@@ -716,3 +734,353 @@ class TestAttachAssayFacts:
         data = self._data().with_columns(pl.lit("urn:missing").alias("mavedb_urn"))
         with pytest.raises(AssertionError, match="absent from assay_facts"):
             attach_assay_facts(data, self._facts())
+
+
+# --------------------------------------------------------------------------- #
+# consequence_group / subset + the build-time allowlist (#297 A + E)
+# --------------------------------------------------------------------------- #
+class TestConsequenceGroupAndAllowlist:
+    # A small grouping map; consequence_final values absent from it keep their own
+    # value (same `.replace(...)` semantics as trait_intervals.build_dataset).
+    GROUPS = {
+        "splicing": ["splice_region_variant", "exon_proximal"],
+        "distal": ["intron_variant"],
+    }
+
+    def test_consequence_group_and_subset_invariant(self, tmp_path, intervals) -> None:
+        out = _annotate(
+            tmp_path,
+            intervals,
+            _sge_frame(),
+            ["missense_variant", "intron_variant", "splice_region_variant"],
+            exclude=[],
+            consequence_groups=self.GROUPS,
+        )
+        assert {"consequence_group", "subset"}.issubset(out.columns)
+        # subset is a verbatim copy of consequence_group.
+        assert out["subset"].to_list() == out["consequence_group"].to_list()
+        # group = map.get(consequence_final, consequence_final), robust to whatever
+        # consequence_final the distance recategorization produced.
+        cmap = {c: g for g, cs in self.GROUPS.items() for c in cs}
+        for cf, cg in zip(
+            out["consequence_final"].to_list(), out["consequence_group"].to_list()
+        ):
+            assert cg == cmap.get(cf, cf)
+
+    def test_allowlist_keeps_only_listed_groups(self, tmp_path, intervals) -> None:
+        args = (
+            tmp_path,
+            intervals,
+            _sge_frame(),
+            ["missense_variant", "intron_variant", "splice_region_variant"],
+        )
+        out_all = _annotate(*args, exclude=[], consequence_groups=self.GROUPS)
+        keep = [out_all["consequence_group"].to_list()[0]]
+        out_keep = _annotate(
+            *args,
+            exclude=[],
+            consequence_groups=self.GROUPS,
+            consequence_group_allowlist=keep,
+        )
+        assert set(out_keep["consequence_group"].to_list()) == set(keep)
+        assert (
+            out_keep.height
+            == out_all.filter(pl.col("consequence_group").is_in(keep)).height
+        )
+        assert out_keep.height < out_all.height  # at least one group was dropped
+
+    def test_allowlist_none_keeps_all(self, tmp_path, intervals) -> None:
+        args = (
+            tmp_path,
+            intervals,
+            _sge_frame(),
+            ["missense_variant", "intron_variant", "splice_region_variant"],
+        )
+        a = _annotate(*args, exclude=[], consequence_groups=self.GROUPS)
+        b = _annotate(
+            *args,
+            exclude=[],
+            consequence_groups=self.GROUPS,
+            consequence_group_allowlist=None,
+        )
+        assert a.height == b.height == 3
+
+
+# --------------------------------------------------------------------------- #
+# Calibration / author-class / direction attach helpers (#297 B + C + D)
+# --------------------------------------------------------------------------- #
+def _cal_frame(rows: list[dict]) -> pl.DataFrame:
+    """Build a calibrations frame with the columns the selection / labeling helpers
+    read (a slice of `_CALIBRATION_SCHEMA`)."""
+    return pl.DataFrame(
+        rows,
+        schema={
+            "gene": pl.Utf8,
+            "calibration_title": pl.Utf8,
+            "go_classification": pl.Utf8,
+            "range_lower": pl.Float64,
+            "range_upper": pl.Float64,
+            "inclusive_lower": pl.Boolean,
+            "inclusive_upper": pl.Boolean,
+            "acmg_evidence_strength": pl.Utf8,
+        },
+    )
+
+
+def _cls_row(gene, title, go, lo, hi, strength=None, *, inc_lo=True, inc_hi=True):
+    return dict(
+        gene=gene,
+        calibration_title=title,
+        go_classification=go,
+        range_lower=lo,
+        range_upper=hi,
+        inclusive_lower=inc_lo,
+        inclusive_upper=inc_hi,
+        acmg_evidence_strength=strength,
+    )
+
+
+# A numeric ExCALIBR scheme for "GENEN": normal = fs >= 0, abnormal = fs <= -1,
+# the (-1, 0) gap = intermediate. abnormal range below normal -> direction +1.
+_GENEN_CAL = _cal_frame(
+    [
+        _cls_row("GENEN", "ExCALIBR calibration", "normal", 0.0, None, "BS3_STRONG"),
+        _cls_row("GENEN", "ExCALIBR calibration", "abnormal", None, -1.0, "STRONG"),
+    ]
+)
+
+
+class TestSelectNumericCalibration:
+    def test_prefers_primary_over_dated_snapshot(self) -> None:
+        # The dated snapshot has MORE rows, but the live ExCALIBR must still win.
+        rows = []
+        for title in ("ExCALIBR calibration", "ExCALIBR calibration (ClinVar 2018)"):
+            rows.append(_cls_row("VHL", title, "normal", 0.0, None, "BS3_STRONG"))
+            rows.append(_cls_row("VHL", title, "abnormal", None, -1.0, "STRONG"))
+        rows.append(
+            _cls_row(
+                "VHL",
+                "ExCALIBR calibration (ClinVar 2018)",
+                "abnormal",
+                None,
+                -2.0,
+                "VERY_STRONG",
+            )
+        )
+        sel = _select_numeric_calibration(_cal_frame(rows))
+        assert sel is not None and sel[0] == "ExCALIBR calibration"
+
+    def test_falls_back_when_excalibr_lacks_normal_class(self) -> None:
+        # CTCF-like: ExCALIBR has only abnormal classes -> not qualifying -> investigator.
+        rows = [
+            _cls_row("CTCF", "ExCALIBR calibration", "abnormal", None, 0.0, "STRONG"),
+            _cls_row(
+                "CTCF", "Investigator-provided functional classes", "normal", 0.0, None
+            ),
+            _cls_row(
+                "CTCF",
+                "Investigator-provided functional classes",
+                "abnormal",
+                None,
+                -0.5,
+            ),
+        ]
+        sel = _select_numeric_calibration(_cal_frame(rows))
+        assert sel is not None
+        assert sel[0] == "Investigator-provided functional classes"
+
+    def test_none_when_only_categorical(self) -> None:
+        # DDX3X-like: classes exist but ranges are null (categorical) -> no numeric scheme.
+        rows = [
+            _cls_row(
+                "DDX3X",
+                "Investigator-provided functional classes",
+                "normal",
+                None,
+                None,
+            ),
+            _cls_row(
+                "DDX3X",
+                "Investigator-provided functional classes",
+                "abnormal",
+                None,
+                None,
+            ),
+        ]
+        assert _select_numeric_calibration(_cal_frame(rows)) is None
+
+
+class TestAttachAuthorClassHarmonized:
+    def test_maps_each_vocabulary(self) -> None:
+        data = pl.DataFrame(
+            {
+                "gene": ["BRCA1", "RAD51C", "DDX3X", "BARD1", "BAP1"],
+                "author_func_class": ["LOF", None, None, None, None],
+                "author_functional_classification": [
+                    None,
+                    "fast depleted",
+                    None,
+                    None,
+                    None,
+                ],
+                "author_sge_prediction_of_variant_function_in_ndd_context": [
+                    None,
+                    None,
+                    "abnormal",
+                    None,
+                    None,
+                ],
+                "author_functional_consequence": [
+                    None,
+                    None,
+                    None,
+                    "functionally_normal",
+                    None,
+                ],
+            }
+        )
+        out = attach_author_class_harmonized(data)
+        # BRCA1 LOF, RAD51C fast-depleted, DDX3X abnormal -> abnormal; BARD1
+        # functionally_normal -> normal; BAP1 (no class) -> null.
+        assert out["author_class_harmonized"].to_list() == [
+            "abnormal",
+            "abnormal",
+            "abnormal",
+            "normal",
+            None,
+        ]
+
+    def test_raises_on_unmapped_value(self) -> None:
+        data = pl.DataFrame({"gene": ["BRCA1"], "author_func_class": ["WEIRD"]})
+        with pytest.raises(AssertionError, match="unmapped author class"):
+            attach_author_class_harmonized(data)
+
+    def test_raises_on_stray_unmapped_gene(self) -> None:
+        # An unmapped gene must not carry a non-null value in a known class column.
+        data = pl.DataFrame(
+            {
+                "gene": ["BAP1"],
+                "author_functional_consequence": ["functionally_abnormal"],
+            }
+        )
+        with pytest.raises(
+            AssertionError, match="non-null author_functional_consequence"
+        ):
+            attach_author_class_harmonized(data)
+
+
+class TestAttachCalibratedClass:
+    def test_numeric_ranges_label_and_strength(self) -> None:
+        data = pl.DataFrame(
+            {
+                "gene": ["GENEN", "GENEN", "GENEN"],
+                "function_score": [0.5, -2.0, -0.5],  # normal / abnormal / gap
+                "author_class_harmonized": [None, None, None],
+            }
+        )
+        out = attach_calibrated_class(data, _GENEN_CAL)
+        assert out["calibrated_class"].to_list() == [
+            "normal",
+            "abnormal",
+            "intermediate",
+        ]
+        assert out["acmg_strength"].to_list() == ["BS3_STRONG", "STRONG", None]
+        assert out["calibration_scheme"].to_list() == ["ExCALIBR calibration"] * 3
+
+    def test_categorical_gene_uses_author_class(self) -> None:
+        # DDX3X-like: no numeric scheme for this gene -> inherit author class.
+        data = pl.DataFrame(
+            {
+                "gene": ["DDX", "DDX"],
+                "function_score": [0.1, 0.9],
+                "author_class_harmonized": ["normal", "abnormal"],
+            }
+        )
+        out = attach_calibrated_class(data, _GENEN_CAL)  # no DDX rows in the cal
+        assert out["calibrated_class"].to_list() == ["normal", "abnormal"]
+        assert out["calibration_scheme"].to_list() == ["author_class", "author_class"]
+        assert out["acmg_strength"].to_list() == [None, None]
+
+    def test_no_calibration_no_class_is_null(self) -> None:
+        data = pl.DataFrame(
+            {
+                "gene": ["BRCA2"],
+                "function_score": [0.3],
+                "author_class_harmonized": [None],
+            }
+        )
+        out = attach_calibrated_class(data, _GENEN_CAL)
+        assert out["calibrated_class"].to_list() == [None]
+        assert out["calibration_scheme"].to_list() == [None]
+        assert out["acmg_strength"].to_list() == [None]
+
+    def test_requires_author_class_first(self) -> None:
+        data = pl.DataFrame({"gene": ["GENEN"], "function_score": [0.5]})
+        with pytest.raises(
+            AssertionError, match="attach_author_class_harmonized first"
+        ):
+            attach_calibrated_class(data, _GENEN_CAL)
+
+
+class TestAttachFunctionDirection:
+    def test_numeric_positive_direction(self) -> None:
+        # abnormal range below normal -> +1; aligned == raw score.
+        data = pl.DataFrame(
+            {
+                "gene": ["GENEN", "GENEN"],
+                "function_score": [0.5, -2.0],
+                "author_class_harmonized": [None, None],
+            }
+        )
+        out = attach_function_direction(data, _GENEN_CAL)
+        assert out["function_direction"].to_list() == [1, 1]
+        assert out["function_score_aligned"].to_list() == [0.5, -2.0]
+
+    def test_numeric_negative_direction(self) -> None:
+        # abnormal range ABOVE normal -> -1; aligned flips sign.
+        cal = _cal_frame(
+            [
+                _cls_row(
+                    "GENEP", "ExCALIBR calibration", "normal", None, 0.0, "BS3_STRONG"
+                ),
+                _cls_row(
+                    "GENEP", "ExCALIBR calibration", "abnormal", 1.0, None, "STRONG"
+                ),
+            ]
+        )
+        data = pl.DataFrame(
+            {
+                "gene": ["GENEP", "GENEP"],
+                "function_score": [0.2, 3.0],
+                "author_class_harmonized": [None, None],
+            }
+        )
+        out = attach_function_direction(data, cal)
+        assert out["function_direction"].to_list() == [-1, -1]
+        assert out["function_score_aligned"].to_list() == [-0.2, -3.0]
+
+    def test_categorical_direction_from_author_class(self) -> None:
+        # DDX3X-like: abnormal author class has the HIGHER function_score -> -1.
+        data = pl.DataFrame(
+            {
+                "gene": ["DDX", "DDX"],
+                "function_score": [0.1, 0.9],
+                "author_class_harmonized": ["normal", "abnormal"],
+            }
+        )
+        out = attach_function_direction(data, _GENEN_CAL)  # no DDX rows in the cal
+        assert out["function_direction"].to_list() == [-1, -1]
+        assert out["function_score_aligned"].to_list() == [-0.1, -0.9]
+
+    def test_null_when_no_signal(self) -> None:
+        # BRCA2-like: no numeric scheme, no author class -> null direction + aligned.
+        data = pl.DataFrame(
+            {
+                "gene": ["BRCA2"],
+                "function_score": [0.3],
+                "author_class_harmonized": [None],
+            }
+        )
+        out = attach_function_direction(data, _GENEN_CAL)
+        assert out["function_direction"].to_list() == [None]
+        assert out["function_score_aligned"].to_list() == [None]


### PR DESCRIPTION
## What

v2 build changes to [`bolinas-dna/evals_sge`](https://huggingface.co/datasets/bolinas-dna/evals_sge) (the saturation-genome-editing VEP dataset) so it ships clean, cross-gene-comparable columns and the #292 eval can drop its workarounds. **Additive columns + one build-time row filter — not a schema rewrite.** Addresses #297 (items A–E; F, gene-corpus expansion, stays open).

The problems (logged in #297) and the fixes: `function_score` direction wasn't harmonized (DDX3X is inverted, so cross-gene pooling cancels) → **B**; no `consequence_group`/`subset` so SGE couldn't be subset like the matched-pair datasets → **A**; most consequence groups are near-uninformative → **E**; no materialized calibrated label, and the eval's "most-rows" scheme heuristic wrongly grabbed VHL's dated `ClinVar 2018` snapshot → **C** (+ **D**).

## Changes

| Item | New column(s) / change |
|---|---|
| A | `consequence_group` + `subset` (= `consequence_group`), via the shared `consequence_groups` map + the same `.replace(...)` pattern as `trait_intervals.build_dataset` |
| B | `function_direction` (+1/−1/null) + `function_score_aligned` — direction sourced from the **assay** (calibration ranges; the categorical-only gene DDX3X from its author class), never the model |
| C | `calibrated_class` (abnormal/intermediate/normal) + `calibration_scheme` + `acmg_strength` — **ExCALIBR-first policy**: prefer the live `ExCALIBR calibration`, never a dated ClinVar snapshot, require finite normal+abnormal ranges, else a numeric investigator scheme, else the author class (DDX3X), else null (BRCA2) |
| D | `author_class_harmonized` — each study's discrete vocab → common abnormal/intermediate/normal axis |
| E | build-time allowlist keeping only the `missense_variant` + `splicing` groups (config `sge.consequence_group_allowlist`; ~28% fewer variants) |

New helpers live in [`sge.py`](https://github.com/Open-Athena/marin-dna/blob/b50e6543a789a6a8a0dbe131b0109418377001ea/src/marin_dna/pipelines/evals/sge.py) (`attach_author_class_harmonized`, `attach_calibrated_class`, `attach_function_direction`, `_select_numeric_calibration`), unit-tested; [`sge.smk`](https://github.com/Open-Athena/marin-dna/blob/b50e6543a789a6a8a0dbe131b0109418377001ea/snakemake/evals/workflow/rules/sge.smk) wires them in after `attach_assay_facts`. Raw `function_score` and every `author_` column stay verbatim.

## Rebuilt + re-uploaded

`bolinas-dna/evals_sge` rebuilt and re-uploaded (README + splits + `calibrations.parquet`, one atomic commit, provenance commit-pinned): **45,582 rows** (was 63,012; **−28%**) — train 30,109 / test 15,473.

<details>
<summary>Per-gene verification (direction · chosen scheme · calibrated/harmonized counts)</summary>

| gene | function_direction | calibration_scheme | n calibrated | n author_class | n |
|---|---|---|--:|--:|--:|
| BAP1 | +1 | ExCALIBR calibration | 5,848 | 0 | 5,848 |
| BARD1 | +1 | ExCALIBR calibration | 6,234 | 6,234 | 6,234 |
| BRCA1 | +1 | ExCALIBR calibration | 2,857 | 2,857 | 2,857 |
| BRCA2 | *(null)* | *(none)* | 0 | 0 | 5,181 |
| CTCF | +1 | Investigator-provided functional classes | 3,234 | 3,234 | 3,234 |
| DDX3X | **−1** | author_class | 5,556 | 5,556 | 5,556 |
| PALB2 | +1 | ExCALIBR calibration | 6,005 | 6,005 | 6,005 |
| RAD51C | +1 | ExCALIBR calibration | 3,015 | 3,015 | 3,015 |
| RAD51D | +1 | ExCALIBR calibration | 2,743 | 2,743 | 2,743 |
| SFPQ | +1 | Investigator-provided functional classes | 1,459 | 1,459 | 1,459 |
| VHL | +1 | **ExCALIBR calibration** *(not the 2018 snapshot)* | 1,569 | 0 | 1,569 |
| XRCC2 | +1 | ExCALIBR calibration | 1,881 | 1,881 | 1,881 |

`calibrated_class` distribution: normal 33,756 · abnormal 4,985 · intermediate 1,660 · null 5,181 (= BRCA2). `consequence_group`: missense_variant 37,326 · splicing 8,256.

</details>

## Verification

- `uv run pytest tests/pipelines/evals/` — **408 passed, 4 skipped** (44 in `test_sge.py`, incl. the new A–E cases).
- Post-build sanity on the **live HF splits**: `subset == consequence_group`; `consequence_group` ∈ {missense_variant, splicing}; `function_direction` = −1 for DDX3X / +1 for numeric genes / null for BRCA2; `function_score_aligned == function_direction × function_score`; VHL `calibration_scheme == "ExCALIBR calibration"`; BRCA2 `calibrated_class` all null.
- README re-renders cleanly (Columns table + Score-calibration section), commit-pinned to this branch.

## Follow-ups

- The eval side (#292, separate branch) will rebase to consume these columns and drop its per-gene sign-align, scheme-pick heuristic, and grouping re-derivation.
- **F** (gene-corpus expansion) stays open in #297 — the single biggest robustness lever, ongoing as MaveDB grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

