### PR TITLE
evals: SGE benchmark — per-accession AUPRC across 3 gLMs + 5 conservation baselines + dashboard

### DIFF
--- a/dashboard/models.yaml
+++ b/dashboard/models.yaml
@@ -41,31 +41,31 @@
   display: phastCons (100v)
   family: conservation
   description: phastCons across 100 vertebrates
-  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl, sge]
 
 - id: phastCons_43p
   display: phastCons (43p)
   family: conservation
   description: phastCons across 43 primates
-  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl, sge]
 
 - id: phastCons_470m
   display: phastCons (470m)
   family: conservation
   description: phastCons across 470 mammals
-  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl, sge]
 
 - id: phyloP_100v
   display: phyloP (100v)
   family: conservation
   description: phyloP across 100 vertebrates
-  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl, sge]
 
 - id: phyloP_447m
   display: phyloP (447m)
   family: conservation
   description: phyloP across 447 mammals
-  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl]
+  datasets: [mendelian_traits, complex_traits, caqtl, dsqtl, sge]
 
 # ---------------------------------------------------------------------------
 # marin_dna gLMs — evals_v2 pipeline. Registry order matches the legacy
@@ -197,7 +197,7 @@
   wandb: https://wandb.ai/gonzalobenegas/marin/runs/promoter-cds-mixture-proportional-r01-6705f1
   checkpoint:
     gcs: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-proportional-r01-6705f1/hf/step-26000
-  datasets: [mendelian_traits]
+  datasets: [mendelian_traits, sge]
 
 - id: exp27-cds-yolo-step-34000
   display: exp27-cds-yolo
@@ -306,7 +306,7 @@
   wandb: https://wandb.ai/gonzalobenegas/marin/runs/dna-bolinas-exp166-v0.1-p1B-c127da
   checkpoint:
     gcs: gs://marin-us-east5/checkpoints/dna-bolinas-exp166-v0.1-p1B-c127da/hf/step-27329
-  datasets: [mendelian_traits, complex_traits]
+  datasets: [mendelian_traits, complex_traits, sge]
 
 # Canonical 4B zoonomia generalist (v0.1), companion to the 1B above.
 - id: exp166-v0.1-p4B-step-27329
@@ -371,7 +371,7 @@
   wandb: https://wandb.ai/eric-czech/marin/runs/dna-bolinas-mix-v0.9-p1B-i24-exp135-zoonomia-m5.1-bef41e
   checkpoint:
     gcs: gs://marin-us-east5/checkpoints/dna-bolinas-mix-v0.9-p1B-i24-exp135-zoonomia-m5.1-bef41e/hf/step-59158
-  datasets: [mendelian_traits]
+  datasets: [mendelian_traits, sge]
 
 # ---------------------------------------------------------------------------
 # External baselines (AlphaGenome, GPN-Star).

--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -37,7 +37,7 @@ export default {
         {name: "Complex traits", path: "/leaderboards/complex"},
         {name: "caQTL", path: "/leaderboards/caqtl"},
         {name: "dsQTL", path: "/leaderboards/dsqtl"},
-        {name: "SGE", path: "/leaderboards/sge"},
+        {name: "Saturation genome editing", path: "/leaderboards/sge"},
         {name: "Protocol: MarinDNA", path: "/protocols/marin_dna"},
         {name: "Protocol: Evo 2", path: "/protocols/evo2"},
         {name: "Protocol: GPN-Star", path: "/protocols/gpn-star"},

--- a/dashboard/observablehq.config.js
+++ b/dashboard/observablehq.config.js
@@ -37,6 +37,7 @@ export default {
         {name: "Complex traits", path: "/leaderboards/complex"},
         {name: "caQTL", path: "/leaderboards/caqtl"},
         {name: "dsQTL", path: "/leaderboards/dsqtl"},
+        {name: "SGE", path: "/leaderboards/sge"},
         {name: "Protocol: MarinDNA", path: "/protocols/marin_dna"},
         {name: "Protocol: Evo 2", path: "/protocols/evo2"},
         {name: "Protocol: GPN-Star", path: "/protocols/gpn-star"},

--- a/dashboard/src/data/datasets.json.py
+++ b/dashboard/src/data/datasets.json.py
@@ -32,6 +32,17 @@ _QTL_METRIC = (
     "selected metric."
 )
 
+_SGE_METRIC = (
+    "Two **rank-based** metrics, both computed **per accession** (MaveDB study) "
+    "then macro-averaged over consequence subsets and accessions. **Spearman ρ** "
+    "± bootstrap SE — rank correlation of the deleteriousness score vs "
+    "`−function_score_aligned` (so a good predictor scores positive). **AUPRC** ± "
+    "bootstrap SE — predicting the ClinGen/ExCALIBR `calibrated_class` "
+    "abnormal-vs-normal call. Both are scale-free, so conservation tracks and "
+    "gLMs compare on the same footing (Pearson is intentionally omitted — it's "
+    "scale-sensitive and not comparable across families)."
+)
+
 DATASETS = {
     "mendelian_traits": {
         "name": "Mendelian Traits",
@@ -101,6 +112,23 @@ DATASETS = {
             "DART-Eval Task-5 dsQTL benchmark (`eval_protocol: qtl_global`). Single selected-metric column (+ forest plot); no subsets, no matched negatives.",
             "Random-baseline AUPRC is the positive rate ≈ 0.021 (309 / 15,018). AUPRC is over all variants; Pearson/Spearman over the 309 positives only — the small positive count makes the correlation SEs wide (~0.06).",
             "MarinDNA defaults to NucDep (Jensen-Shannon divergence, `jsd_avg`) here — a symmetric distributional distance suited to unsigned QTL effects; the LLR magnitude protocol (`abs_llr_avg`) is one click away via the protocol toggle.",
+        ],
+    },
+    "sge": {
+        "name": "Saturation Genome Editing (SGE)",
+        "hf_repo": "bolinas-dna/evals_sge",
+        "hf_commit": "39f47f09",
+        "score_type": "minus_llr_avg",
+        "issue": "https://github.com/Open-Athena/marin-dna/issues/301",
+        "split": "train",
+        "positives": "Variants whose endogenous-locus function is abnormal (ClinGen/ExCALIBR-calibrated) — the AUPRC positives",
+        "negatives": "Variants calibrated normal (intermediate / uncalibrated dropped)",
+        "matching": "none — metrics are computed per accession (MaveDB study), since function scores are non-comparable across studies, then macro-averaged over subsets and accessions",
+        "metric": _SGE_METRIC,
+        "notes": [
+            "Saturation-genome-editing VEP (12 genes, missense + splicing only; v2 rebuild #300). `function_score_aligned` is the direction-harmonized continuous score; `calibrated_class` is the uniform ClinGen/ExCALIBR abnormal/normal call.",
+            "Use the gene selector to view a single accession or the macro across accessions; a board per consequence subset (missense / splicing / both / subset-macro), each method × {Spearman, AUPRC}.",
+            "MarinDNA defaults to LLR (`minus_llr_avg`, signed — the assayed ALT's direction is informative, so not `abs`); NucDep (`jsd_avg`) is one click away. Conservation tracks use their single per-position score.",
         ],
     },
 }

--- a/dashboard/src/data/datasets.json.py
+++ b/dashboard/src/data/datasets.json.py
@@ -33,14 +33,14 @@ _QTL_METRIC = (
 )
 
 _SGE_METRIC = (
-    "Two **rank-based** metrics, both computed **per accession** (MaveDB study) "
-    "then macro-averaged over consequence subsets and accessions. **Spearman ρ** "
-    "± bootstrap SE — rank correlation of the deleteriousness score vs "
-    "`−function_score_aligned` (so a good predictor scores positive). **AUPRC** ± "
-    "bootstrap SE — predicting the ClinGen/ExCALIBR `calibrated_class` "
-    "abnormal-vs-normal call. Both are scale-free, so conservation tracks and "
-    "gLMs compare on the same footing (Pearson is intentionally omitted — it's "
-    "scale-sensitive and not comparable across families)."
+    "**AUPRC** ± bootstrap SE for the ClinGen/ExCALIBR `calibrated_class` "
+    "abnormal-vs-normal call, computed **per accession** (MaveDB study) then "
+    "macro-averaged over consequence subsets and accessions (scores are "
+    "non-comparable across studies). Rank-based, so conservation tracks and gLMs "
+    "compare on the same footing. The abnormal base rate varies per gene/subset "
+    "(~5–16%), so the random-baseline AUPRC is not a single number. AUPRC-only, "
+    "matching the classification framing of the other benchmarks; the continuous "
+    "function-score columns remain in the dataset (v3) for provenance."
 )
 
 DATASETS = {
@@ -117,7 +117,7 @@ DATASETS = {
     "sge": {
         "name": "Saturation Genome Editing (SGE)",
         "hf_repo": "bolinas-dna/evals_sge",
-        "hf_commit": "39f47f09",
+        "hf_commit": "225d3d1e",
         "score_type": "minus_llr_avg",
         "issue": "https://github.com/Open-Athena/marin-dna/issues/301",
         "split": "train",
@@ -127,7 +127,7 @@ DATASETS = {
         "metric": _SGE_METRIC,
         "notes": [
             "Saturation-genome-editing VEP (12 genes, missense + splicing only; v2 rebuild #300). `function_score_aligned` is the direction-harmonized continuous score; `calibrated_class` is the uniform ClinGen/ExCALIBR abnormal/normal call.",
-            "Use the gene selector to view a single accession or the macro across accessions; a board per consequence subset (missense / splicing / both / subset-macro), each method × {Spearman, AUPRC}.",
+            "Use the gene selector to view the macro across accessions or a single accession; an AUPRC heatmap (methods × consequence subsets — Macro / Missense / Splicing / Both), colored on a SGE-tuned scale (anchored at 0, since the abnormal base rate is well below the matched-pair 0.10).",
             "MarinDNA defaults to LLR (`minus_llr_avg`, signed — the assayed ALT's direction is informative, so not `abs`); NucDep (`jsd_avg`) is one click away. Conservation tracks use their single per-position score.",
         ],
     },

--- a/dashboard/src/data/datasets.json.py
+++ b/dashboard/src/data/datasets.json.py
@@ -127,7 +127,7 @@ DATASETS = {
         "metric": _SGE_METRIC,
         "notes": [
             "Saturation-genome-editing VEP (12 genes, missense + splicing only; v2 rebuild #300). `function_score_aligned` is the direction-harmonized continuous score; `calibrated_class` is the uniform ClinGen/ExCALIBR abnormal/normal call.",
-            "Use the gene selector to view the macro across accessions or a single accession; an AUPRC heatmap (methods × consequence subsets — Macro / Missense / Splicing / Both), colored on a SGE-tuned scale (anchored at 0, since the abnormal base rate is well below the matched-pair 0.10).",
+            "Use the gene selector to view the macro across accessions or a single accession; an AUPRC heatmap (methods × consequence subsets — Macro / Missense / Splicing / Both), colored on a 0→1 scale (anchored at 0, the metric's full range — the abnormal base rate is well below the matched-pair 0.10; upper end matches the matched-pair heatmap).",
             "MarinDNA defaults to LLR (`minus_llr_avg`, signed — the assayed ALT's direction is informative, so not `abs`); NucDep (`jsd_avg`) is one click away. Conservation tracks use their single per-position score.",
         ],
     },

--- a/dashboard/src/data/sge.parquet.py
+++ b/dashboard/src/data/sge.parquet.py
@@ -1,0 +1,24 @@
+"""Observable Framework data loader: SGE metrics → one tidy parquet.
+
+Pulls the per-(method, score_type, metric, subset, accession) SGE metric rows
+from S3 via ``marin_dna.pipelines.evals.leaderboard.sge_normalized_rows`` and
+writes the DataFrame as a parquet blob on stdout for the dashboard to read.
+
+SGE's grid is richer than the other leaderboards' (metric × consequence-subset ×
+accession), so it gets its own loader + page (``src/leaderboards/sge.md``)
+instead of riding the shared ``leaderboard.parquet`` / ``normalized_rows`` path.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from marin_dna.pipelines.evals.leaderboard import sge_normalized_rows
+
+
+def main() -> None:
+    sge_normalized_rows("sge").write_parquet(sys.stdout.buffer)
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboard/src/leaderboards/sge.md
+++ b/dashboard/src/leaderboards/sge.md
@@ -168,9 +168,14 @@ function sgeHeatmap({rows, geneScope}) {
 
   let sortKey = "_macro_avg_";
   const root = html`<div></div>`;
+  // Gated cells carry a NaN value (blank, but with class counts) — sort them to
+  // the bottom rather than letting NaN poison the comparator.
+  const sortVal = (m) => {
+    const v = m.cells.get(sortKey)?.value;
+    return Number.isFinite(v) ? v : -Infinity;
+  };
   const cmp = () => (a, b) => {
-    const va = a.cells.get(sortKey)?.value ?? -Infinity;
-    const vb = b.cells.get(sortKey)?.value ?? -Infinity;
+    const va = sortVal(a), vb = sortVal(b);
     return vb !== va ? vb - va : a.method_display.localeCompare(b.method_display);
   };
   function render() {

--- a/dashboard/src/leaderboards/sge.md
+++ b/dashboard/src/leaderboards/sge.md
@@ -19,7 +19,6 @@ import {
   PROTOCOL_OPTIONS,
   PROTOCOL_DEFAULTS,
   FamilyProtocolToggle,
-  PillSelect,
 } from "../components/controls.js";
 ```
 
@@ -58,14 +57,16 @@ const SUBSET_COLS = [
   {key: "splicing", label: "Splicing"},
   {key: "both", label: "Both"},
 ];
-// AUPRC color domain tuned for SGE: the abnormal base rate is low (~5–16%, well
-// below the matched-pair 0.10), so anchor at 0 and cap near the observed ceiling
-// for contrast. YlGn (same family as the other leaderboards).
-const AUPRC_DOMAIN = [0, 0.6];
+// AUPRC color domain: anchor at 0 (SGE's abnormal base rate is low, ~5–16%, well
+// below the matched-pair 0.10) and run to the metric ceiling 1.0, so the color
+// encodes absolute AUPRC. This matches the matched-pair heatmap's upper end
+// (components/heatmap.js maps [0.10, 1.0]); same YlGn ramp and `0.1 + 0.85·t`
+// mapping, so a given green reads as the same AUPRC across leaderboards.
+const AUPRC_DOMAIN = [0, 1.0];
 const auprcColor = (v) => {
   if (v == null || !Number.isFinite(v)) return "#ffffff";
   const t = Math.max(0, Math.min(1, (v - AUPRC_DOMAIN[0]) / (AUPRC_DOMAIN[1] - AUPRC_DOMAIN[0])));
-  return d3.interpolateYlGn(0.12 + 0.88 * t);
+  return d3.interpolateYlGn(0.1 + 0.85 * t);
 };
 const auprcText = (v) => (v == null || !Number.isFinite(v) ? "#666" : d3.lab(auprcColor(v)).l > 60 ? "#000" : "#fff");
 ```
@@ -106,7 +107,30 @@ const geneLabel = new Map([
   ["_macro_avg_", "All genes"],
   ...accPairs.map(([urn, gene]) => [urn, gene]),
 ]);
-const geneScope = view(PillSelect(geneOptions, "_macro_avg_", (o) => geneLabel.get(o) ?? o));
+
+// Modern segmented control: a single grey track of pills, active = white pill
+// with a soft lift (the iOS look). "All genes" (the overview) is set apart in
+// green. All options visible at a glance; no dropdown.
+function GenePills(options, initial, labelFor) {
+  let value = initial;
+  const node = html`<span class="sge-genebar" role="radiogroup" aria-label="Gene scope"></span>`;
+  Object.defineProperty(node, "value", {get: () => value});
+  const fire = () => node.dispatchEvent(new Event("input", {bubbles: true}));
+  function render() {
+    node.replaceChildren(
+      ...options.map((o) => {
+        const isAll = o === "_macro_avg_";
+        return html`<button type="button" role="radio" aria-checked=${value === o}
+          class=${`sge-gene-btn${value === o ? " active" : ""}${isAll ? " sge-gene-all" : ""}`}
+          onclick=${() => { if (value !== o) { value = o; render(); fire(); } }}
+        >${labelFor(o)}</button>`;
+      }),
+    );
+  }
+  render();
+  return node;
+}
+const geneScope = view(GenePills(geneOptions, "_macro_avg_", (o) => geneLabel.get(o) ?? o));
 ```
 
 ```js
@@ -151,17 +175,20 @@ function sgeHeatmap({rows, geneScope}) {
   };
   function render() {
     const ordered = [...byMethod.values()].sort(cmp());
-    // Per-column sample-size sub-label. For a specific gene: n = labeled
-    // variants (AUPRC) on the subset columns, K subsets on Macro. For the
-    // All-genes macro: K accessions averaged (also surfaces coverage — fewer
-    // genes qualify on splicing). Same across methods (identical scored rows).
+    // Per-column sub-label (same across methods — identical scored rows).
+    //  • All-genes macro: K accessions averaged → show coverage (fewer genes
+    //    qualify on splicing, where small genes miss the 30-per-class gate).
+    //  • Specific gene, Macro column: mean of the qualifying subsets → K subsets.
+    //  • Specific gene, a real subset (leaf cell): the AUPRC class balance,
+    //    positives vs negatives (n_neg = n − n_pos, since every scored row is
+    //    one or the other).
     const colSub = (key) => {
-      let n = null;
-      for (const m of ordered) { const c = m.cells.get(key); if (c != null) { n = c.n; break; } }
-      if (n == null) return "";
-      if (geneScope === "_macro_avg_") return `${n} ${n === 1 ? "gene" : "genes"}`;
-      if (key === "_macro_avg_") return `${n} ${n === 1 ? "subset" : "subsets"}`;
-      return `n=${n}`;
+      let c = null;
+      for (const m of ordered) { const cc = m.cells.get(key); if (cc != null) { c = cc; break; } }
+      if (c == null) return "";
+      if (geneScope === "_macro_avg_") return `${c.n} ${c.n === 1 ? "gene" : "genes"}`;
+      if (key === "_macro_avg_") return `${c.n} ${c.n === 1 ? "subset" : "subsets"}`;
+      return `n=${c.n_pos} vs. ${c.n - c.n_pos}`;
     };
     const table = html`<table class="sge-heatmap">
       <colgroup><col style="width:220px"></col>${SUBSET_COLS.map(() => html`<col style="width:108px"></col>`)}</colgroup>
@@ -205,7 +232,7 @@ function sgeHeatmap({rows, geneScope}) {
 
 // AUPRC color legend (YlGn on the SGE domain).
 function auprcLegend({width = 240, height = 14} = {}) {
-  const ticks = [0, 0.15, 0.3, 0.45, 0.6];
+  const ticks = [0, 0.2, 0.4, 0.6, 0.8, 1.0];
   const stops = d3.range(0, 1.001, 1 / 40).map((t) => ({
     offset: `${t * 100}%`,
     color: auprcColor(AUPRC_DOMAIN[0] + t * (AUPRC_DOMAIN[1] - AUPRC_DOMAIN[0])),
@@ -239,7 +266,7 @@ const filtered = rows.filter(
 ```
 
 <div class="legend-row">
-  <span><b>AUPRC</b> ×100, colored on the scale below (anchored at 0; abnormal base rate ~5–16% varies per gene). <b>Macro</b> = mean of the missense + splicing subsets; <b>Both</b> = the two pooled. Click a column header to sort. Hover a model for details; hover a cell for ± SE.</span>
+  <span><b>AUPRC</b> ×100, colored on the 0→100 scale below (anchored at 0, the metric's full range — abnormal base rate ~5–16% varies per gene). <b>Macro</b> = mean of the missense + splicing subsets; <b>Both</b> = the two pooled. Column sub-labels: <b>positives vs. negatives</b> for a selected gene, or genes-averaged for the all-genes macro. Click a column header to sort. Hover a model for its card; hover a cell for ± SE.</span>
   ${auprcLegend()}
 </div>
 
@@ -282,4 +309,72 @@ main > h1, main > h2, main > p { max-width: 1100px; }
 .dataset-notes { margin-top: 0.5em; color: #666; font-size: 0.9em; }
 .dataset-notes div { margin: 2px 0; }
 .legend-row { display: flex; align-items: center; gap: 16px; margin: 0.5em 0 1em; font-size: 0.85em; color: #444; max-width: 1100px; flex-wrap: wrap; }
+
+/* Gene-scope segmented control */
+.sge-genebar {
+  display: inline-flex; flex-wrap: wrap; gap: 4px;
+  padding: 4px; background: #f1f3f5; border: 1px solid #e6e9ec; border-radius: 11px;
+  max-width: 100%;
+}
+.sge-gene-btn {
+  appearance: none; border: none; background: transparent; color: #495057;
+  font-size: 0.86em; font-weight: 500; padding: 5px 13px; border-radius: 8px;
+  cursor: pointer; transition: background .12s, color .12s, box-shadow .12s;
+}
+.sge-gene-btn:hover:not(.active) { background: rgba(0, 0, 0, 0.05); color: #212529; }
+.sge-gene-btn.active {
+  background: #fff; color: #111; font-weight: 600;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.14), 0 0 0 1px rgba(0, 0, 0, 0.04);
+}
+.sge-gene-btn.sge-gene-all { color: #2f6f3e; font-weight: 600; }
+.sge-gene-btn.sge-gene-all.active {
+  background: #2f6f3e; color: #fff; box-shadow: 0 1px 3px rgba(47, 111, 62, 0.35);
+}
+
+/* Model popover on method-name hover (the element is appended to <body> by
+   attachModelPopover, so this CSS must live on every page that uses it — the
+   matched-pair/QTL leaderboards carry an identical block). */
+.lb-method-popover {
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+  font-size: 0.85em;
+  line-height: 1.4;
+  padding: 10px 12px;
+  min-width: 280px;
+  max-width: 360px;
+}
+.lb-pop-header { display: flex; flex-direction: column; gap: 3px; margin-bottom: 4px; }
+.lb-pop-family {
+  display: inline-block;
+  font-size: 0.7em;
+  font-weight: 500;
+  padding: 1px 7px;
+  border-radius: 9999px;
+  color: #fff;
+  width: fit-content;
+}
+.lb-pop-display { font-size: 0.98em; font-weight: 600; }
+.lb-pop-desc { color: #555; margin: 4px 0 6px; font-size: 0.92em; }
+.lb-pop-specs { margin: 6px 0; }
+.lb-pop-row {
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  gap: 10px;
+  align-items: baseline;
+  margin: 2px 0;
+}
+.lb-pop-key {
+  color: #888; text-transform: uppercase; font-size: 0.72em;
+  letter-spacing: 0.04em;
+}
+.lb-pop-val { font-size: 0.92em; }
+.lb-pop-links { margin: 6px 0 2px; font-size: 0.9em; }
+.lb-pop-more {
+  display: inline-block;
+  margin-top: 6px;
+  font-size: 0.82em;
+  color: #3a7bd5;
+}
 </style>

--- a/dashboard/src/leaderboards/sge.md
+++ b/dashboard/src/leaderboards/sge.md
@@ -59,9 +59,10 @@ const SUBSET_COLS = [
 ];
 // AUPRC color domain: anchor at 0 (SGE's abnormal base rate is low, ~5–16%, well
 // below the matched-pair 0.10) and run to the metric ceiling 1.0, so the color
-// encodes absolute AUPRC. This matches the matched-pair heatmap's upper end
-// (components/heatmap.js maps [0.10, 1.0]); same YlGn ramp and `0.1 + 0.85·t`
-// mapping, so a given green reads as the same AUPRC across leaderboards.
+// encodes absolute AUPRC. Same YlGn ramp and `0.1 + 0.85·t` mapping as the
+// matched-pair heatmap (components/heatmap.js) and the same upper end (1.0) — but
+// the lower anchor differs (0 here vs the matched-pair 0.10), so a given green is
+// NOT directly comparable across the two pages; read the number / legend.
 const AUPRC_DOMAIN = [0, 1.0];
 const auprcColor = (v) => {
   if (v == null || !Number.isFinite(v)) return "#ffffff";

--- a/dashboard/src/leaderboards/sge.md
+++ b/dashboard/src/leaderboards/sge.md
@@ -1,54 +1,73 @@
 ---
-title: SGE Leaderboard
+title: Saturation Genome Editing
 toc: false
 wide: true
 ---
 
-# SGE Leaderboard
+# Saturation Genome Editing
 
-Saturation genome editing: per-variant endogenous-locus function scores. Both metrics are **rank-based** (so conservation tracks and gLMs compare on the same footing): **Spearman** of the deleteriousness score vs `−function_score_aligned`, and **AUPRC** for the ClinGen/ExCALIBR `calibrated_class` abnormal-vs-normal call. Scores are non-comparable across studies, so everything is computed **per accession** (MaveDB study) then macro-averaged.
+Per-variant endogenous-locus function scores (MaveDB SGE studies). The leaderboard metric is **AUPRC** for the ClinGen/ExCALIBR `calibrated_class` abnormal-vs-normal call — computed **per accession** (study) then macro-averaged over consequence subsets and accessions (scores are non-comparable across studies). Higher = better; the abnormal base rate varies per gene/subset (~5–16%).
 
 ```js
+import * as d3 from "npm:d3";
 const sgeTable = await FileAttachment("../data/sge.parquet").parquet();
 const methods = await FileAttachment("../data/models.json").json();
 const datasets = await FileAttachment("../data/datasets.json").json();
+import {modelHref, attachModelPopover} from "../components/model-cards.js";
 import {
   FAMILY_LABEL,
   PROTOCOL_OPTIONS,
   PROTOCOL_DEFAULTS,
   FamilyProtocolToggle,
+  PillSelect,
 } from "../components/controls.js";
 ```
 
 ```js
-// Arrow → plain JS rows (sge.parquet schema; see leaderboard.sge_normalized_rows).
-const rows = sgeTable.toArray().map((r) => ({
-  method_id: String(r.method_id),
-  method_display: String(r.method_display),
-  family: String(r.family),
-  score_type: String(r.score_type),
-  metric: String(r.metric),
-  subset: String(r.subset),
-  accession: String(r.accession),
-  gene: String(r.gene),
-  value: Number(r.value),
-  se: Number(r.se),
-  n: Number(r.n),
-  n_pos: Number(r.n_pos),
-}));
+// SGE v3 computes AUPRC only; the metric filter below is defensive.
+const rows = sgeTable
+  .toArray()
+  .map((r) => ({
+    method_id: String(r.method_id),
+    method_display: String(r.method_display),
+    family: String(r.family),
+    score_type: String(r.score_type),
+    metric: String(r.metric),
+    subset: String(r.subset),
+    accession: String(r.accession),
+    gene: String(r.gene),
+    value: Number(r.value),
+    se: Number(r.se),
+    n: Number(r.n),
+    n_pos: Number(r.n_pos),
+  }))
+  .filter((r) => r.metric === "AUPRC");
+const modelById = new Map(methods.map((m) => [m.id, m]));
 const meta = datasets.sge;
-// MarinDNA protocol → the score_type column it selects (signed LLR default; the
-// assayed ALT's direction is informative, so not abs). Conservation has one score.
+
+// MarinDNA protocol → score_type column (signed LLR default; ALT direction is
+// informative, so not abs). Conservation has its single per-position score.
 const SGE_SCORE_TYPE = {
   marin_dna: {LLR: "minus_llr_avg", JSD: "jsd_avg"},
   conservation: {score: "score"},
 };
-const SUBSETS = [
+// Columns: subset-macro leftmost (the headline), then the per-subset scopes.
+const SUBSET_COLS = [
+  {key: "_macro_avg_", label: "Macro"},
   {key: "missense_variant", label: "Missense"},
   {key: "splicing", label: "Splicing"},
-  {key: "both", label: "Both (pooled)"},
-  {key: "_macro_avg_", label: "Subset macro"},
+  {key: "both", label: "Both"},
 ];
+// AUPRC color domain tuned for SGE: the abnormal base rate is low (~5–16%, well
+// below the matched-pair 0.10), so anchor at 0 and cap near the observed ceiling
+// for contrast. YlGn (same family as the other leaderboards).
+const AUPRC_DOMAIN = [0, 0.6];
+const auprcColor = (v) => {
+  if (v == null || !Number.isFinite(v)) return "#ffffff";
+  const t = Math.max(0, Math.min(1, (v - AUPRC_DOMAIN[0]) / (AUPRC_DOMAIN[1] - AUPRC_DOMAIN[0])));
+  return d3.interpolateYlGn(0.12 + 0.88 * t);
+};
+const auprcText = (v) => (v == null || !Number.isFinite(v) ? "#666" : d3.lab(auprcColor(v)).l > 60 ? "#000" : "#fff");
 ```
 
 ## Dataset
@@ -75,28 +94,22 @@ display(html`<div class="card">
 ## Leaderboard
 
 ```js
-// Gene-scope: macro across accessions, or one accession (labeled by gene).
+// Gene scope — all options visible at a glance (macro across accessions, or one
+// accession labeled by gene).
 const accPairs = Array.from(
   new Map(
     rows.filter((r) => r.accession !== "_macro_avg_").map((r) => [r.accession, r.gene]),
   ).entries(),
 ).sort((a, b) => a[1].localeCompare(b[1]));
-const geneScopeLabel = new Map([
-  ["_macro_avg_", "All genes (macro)"],
+const geneOptions = ["_macro_avg_", ...accPairs.map(([urn]) => urn)];
+const geneLabel = new Map([
+  ["_macro_avg_", "All genes"],
   ...accPairs.map(([urn, gene]) => [urn, gene]),
 ]);
-const geneScopeOptions = ["_macro_avg_", ...accPairs.map(([urn]) => urn)];
-const geneScope = view(
-  Inputs.select(geneScopeOptions, {
-    label: "Gene",
-    value: "_macro_avg_",
-    format: (o) => geneScopeLabel.get(o) ?? o,
-  }),
-);
+const geneScope = view(PillSelect(geneOptions, "_macro_avg_", (o) => geneLabel.get(o) ?? o));
 ```
 
 ```js
-// Only families with SGE data appear; order follows FAMILY_LABEL.
 const present = new Set(rows.map((r) => r.family));
 const families = Object.keys(FAMILY_LABEL).filter((f) => present.has(f));
 const sel = view(FamilyProtocolToggle(families, PROTOCOL_OPTIONS, PROTOCOL_DEFAULTS));
@@ -104,133 +117,169 @@ const sel = view(FamilyProtocolToggle(families, PROTOCOL_OPTIONS, PROTOCOL_DEFAU
 
 ```js
 const search = view(
-  Inputs.text({
-    label: "Model name",
-    placeholder: "filter by method (e.g. exp135, phyloP)",
-  }),
+  Inputs.text({label: "Model name", placeholder: "filter by method (e.g. exp135, phyloP)"}),
 );
 ```
 
 ```js
-function activeScoreType(family, protocol) {
-  const m = SGE_SCORE_TYPE[family];
-  if (!m) return null;
-  return m[protocol] ?? Object.values(m)[0];
-}
-
-// One row per method for a subset board: {method, family, spearman, AUPRC}.
-function boardRows(subsetKey) {
+// Dedicated SGE heatmap: methods × {Macro, Missense, Splicing, Both}, colored by
+// AUPRC. Self-managing sort (click a header). Mirrors the matched-pair heatmap's
+// look (YlGn cells, family swatch, model popover) but on SGE's columns + domain.
+function sgeHeatmap({rows, geneScope}) {
   const byMethod = new Map();
   for (const r of rows) {
-    if (r.accession !== geneScope) continue;
-    if (r.subset !== subsetKey) continue;
-    if (!sel.families.includes(r.family)) continue;
-    const wantProto = sel.protocols[r.family] ?? PROTOCOL_DEFAULTS[r.family];
-    if (r.score_type !== activeScoreType(r.family, wantProto)) continue;
-    if (search && !r.method_display.toLowerCase().includes(search.toLowerCase())) continue;
     if (!byMethod.has(r.method_id)) {
       byMethod.set(r.method_id, {
         method_id: r.method_id,
         method_display: r.method_display,
         family: r.family,
+        cells: new Map(),
       });
     }
-    byMethod.get(r.method_id)[r.metric] = {value: r.value, se: r.se, n: r.n};
+    byMethod.get(r.method_id).cells.set(r.subset, {value: r.value, se: r.se, n: r.n, n_pos: r.n_pos});
   }
-  // Sort by Spearman desc (methods missing it sink to the bottom).
-  return [...byMethod.values()].sort(
-    (a, b) => (b.spearman?.value ?? -Infinity) - (a.spearman?.value ?? -Infinity),
-  );
+  if (byMethod.size === 0) {
+    return html`<div class="sge-empty">No methods for this selection.</div>`;
+  }
+
+  let sortKey = "_macro_avg_";
+  const root = html`<div></div>`;
+  const cmp = () => (a, b) => {
+    const va = a.cells.get(sortKey)?.value ?? -Infinity;
+    const vb = b.cells.get(sortKey)?.value ?? -Infinity;
+    return vb !== va ? vb - va : a.method_display.localeCompare(b.method_display);
+  };
+  function render() {
+    const ordered = [...byMethod.values()].sort(cmp());
+    // Per-column sample-size sub-label. For a specific gene: n = labeled
+    // variants (AUPRC) on the subset columns, K subsets on Macro. For the
+    // All-genes macro: K accessions averaged (also surfaces coverage — fewer
+    // genes qualify on splicing). Same across methods (identical scored rows).
+    const colSub = (key) => {
+      let n = null;
+      for (const m of ordered) { const c = m.cells.get(key); if (c != null) { n = c.n; break; } }
+      if (n == null) return "";
+      if (geneScope === "_macro_avg_") return `${n} ${n === 1 ? "gene" : "genes"}`;
+      if (key === "_macro_avg_") return `${n} ${n === 1 ? "subset" : "subsets"}`;
+      return `n=${n}`;
+    };
+    const table = html`<table class="sge-heatmap">
+      <colgroup><col style="width:220px"></col>${SUBSET_COLS.map(() => html`<col style="width:108px"></col>`)}</colgroup>
+      <thead><tr>
+        <th class="sge-method-header">Model</th>
+        ${SUBSET_COLS.map(
+          (c) => html`<th class=${`sge-col${c.key === sortKey ? " sge-col-sorted" : ""}`}
+            title="Click to sort by this column"
+            onclick=${() => { sortKey = c.key; root.replaceChildren(render()); }}>
+            <span class="sge-col-label">${c.label}</span><br><small>${colSub(c.key)}</small>
+          </th>`,
+        )}
+      </tr></thead>
+      <tbody>
+        ${ordered.map((m) => {
+          const meta = modelById.get(m.method_id);
+          const anchor = html`<a href=${modelHref(m.method_id)}><code>${m.method_display}</code></a>`;
+          if (meta) attachModelPopover(anchor, meta);
+          return html`<tr>
+            <td class="sge-method"><span class=${`lb-family lb-family-${m.family}`} title=${m.family}></span>${anchor}</td>
+            ${SUBSET_COLS.map((c) => {
+              const cell = m.cells.get(c.key);
+              const sortedCls = c.key === sortKey ? " sge-col-sorted" : "";
+              if (cell == null || !Number.isFinite(cell.value))
+                return html`<td class=${`sge-na${sortedCls}`}>—</td>`;
+              return html`<td class=${`sge-cell${sortedCls}`}
+                style=${`background-color:${auprcColor(cell.value)};color:${auprcText(cell.value)}`}
+                title=${`AUPRC ${cell.value.toFixed(3)} ± ${Number.isFinite(cell.se) ? cell.se.toFixed(3) : "—"}`}>
+                ${(cell.value * 100).toFixed(1)}
+              </td>`;
+            })}
+          </tr>`;
+        })}
+      </tbody>
+    </table>`;
+    return table;
+  }
+  root.replaceChildren(render());
+  return root;
 }
 
-function fmtCell(cell) {
-  if (cell == null || !Number.isFinite(cell.value)) return html`<span class="lb-na">—</span>`;
-  return html`${cell.value.toFixed(3)} <span class="muted">± ${Number.isFinite(cell.se) ? cell.se.toFixed(3) : "—"}</span>`;
+// AUPRC color legend (YlGn on the SGE domain).
+function auprcLegend({width = 240, height = 14} = {}) {
+  const ticks = [0, 0.15, 0.3, 0.45, 0.6];
+  const stops = d3.range(0, 1.001, 1 / 40).map((t) => ({
+    offset: `${t * 100}%`,
+    color: auprcColor(AUPRC_DOMAIN[0] + t * (AUPRC_DOMAIN[1] - AUPRC_DOMAIN[0])),
+  }));
+  return svg`<svg viewBox=${`0 0 ${width} ${height + 18}`} width=${width} style="overflow:visible">
+    <defs><linearGradient id="sge-grad" x1="0" x2="1">
+      ${stops.map((s) => svg`<stop offset=${s.offset} stop-color=${s.color}></stop>`)}
+    </linearGradient></defs>
+    <rect x="0" y="0" width=${width} height=${height} fill="url(#sge-grad)" stroke="#888"></rect>
+    ${ticks.map((v) => {
+      const x = ((v - AUPRC_DOMAIN[0]) / (AUPRC_DOMAIN[1] - AUPRC_DOMAIN[0])) * width;
+      return svg`<g transform=${`translate(${x},0)`}><line y1=${height} y2=${height + 4} stroke="#666"></line>
+        <text y=${height + 16} text-anchor="middle" font-size="10" fill="#555">${(v * 100).toFixed(0)}</text></g>`;
+    })}
+  </svg>`;
 }
+```
 
-function renderBoard(subset) {
-  const data = boardRows(subset.key);
-  return html`<div class="card sge-board">
-    <h3>${subset.label}</h3>
-    ${
-      data.length === 0
-        ? html`<div class="lb-forest-empty">No methods for this selection.</div>`
-        : html`<table class="sge-heatmap">
-            <thead><tr>
-              <th class="sge-method-header">Model</th>
-              <th>Spearman</th>
-              <th>AUPRC</th>
-            </tr></thead>
-            <tbody>${data.map(
-              (d) => html`<tr>
-                <td class="sge-method" title=${d.method_display}>
-                  <span class=${`lb-family lb-family-${d.family}`}></span>${d.method_display}
-                </td>
-                <td class="sge-cell">${fmtCell(d.spearman)}</td>
-                <td class="sge-cell">${fmtCell(d.AUPRC)}</td>
-              </tr>`,
-            )}</tbody>
-          </table>`
-    }
-  </div>`;
+```js
+function scoreTypeFor(family, protocol) {
+  const m = SGE_SCORE_TYPE[family];
+  return m ? m[protocol] ?? Object.values(m)[0] : null;
 }
+const filtered = rows.filter(
+  (r) =>
+    r.accession === geneScope &&
+    sel.families.includes(r.family) &&
+    r.score_type === scoreTypeFor(r.family, sel.protocols[r.family] ?? PROTOCOL_DEFAULTS[r.family]) &&
+    (!search || r.method_display.toLowerCase().includes(search.toLowerCase())),
+);
 ```
 
 <div class="legend-row">
-  <span>Per the selected gene scope, one board per consequence subset; rows are methods, sorted by Spearman. <b>±</b> = bootstrap SE. Spearman is oriented so a good deleteriousness predictor scores positive; AUPRC random-baseline is the per-cell abnormal rate.</span>
+  <span><b>AUPRC</b> ×100, colored on the scale below (anchored at 0; abnormal base rate ~5–16% varies per gene). <b>Macro</b> = mean of the missense + splicing subsets; <b>Both</b> = the two pooled. Click a column header to sort. Hover a model for details; hover a cell for ± SE.</span>
+  ${auprcLegend()}
 </div>
 
 ```js
-display(html`<div class="sge-board-grid">${SUBSETS.map(renderBoard)}</div>`);
+display(sgeHeatmap({rows: filtered, geneScope}));
 ```
 
 <style>
-:root { --observablehq-max-width: 2200px; }
-main > p, main > h1, main > h2, main > h3, main > .card { max-width: none; }
-main > h1, main > h2, main > p { max-width: 1200px; }
-.card.sge-board { max-width: 560px; margin: 0; }
-
-.sge-board-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 14px;
-  align-items: flex-start;
-}
-.sge-board h3 { margin: 0 0 0.5em; font-size: 1em; }
+:root { --observablehq-max-width: 2000px; }
+main > p, main > h1, main > h2, main > .card { max-width: none; }
+main > h1, main > h2, main > p { max-width: 1100px; }
+.card { max-width: 1100px; }
 
 .sge-heatmap {
   border-collapse: collapse;
   font-variant-numeric: tabular-nums;
   font-size: 0.85em;
+  margin: 0.5em 0;
   table-layout: fixed;
-  width: 420px;
 }
-.sge-heatmap thead th { width: 110px; }
-.sge-heatmap th.sge-method-header { width: 200px; text-align: left; }
 .sge-heatmap th, .sge-heatmap td { padding: 6px 4px; border: 1px solid #ddd; }
-.sge-heatmap thead th { background: #f7f7f7; text-align: center; user-select: none; }
+.sge-heatmap thead th { background: #f7f7f7; text-align: center; user-select: none; cursor: pointer; }
+.sge-heatmap thead tr { height: 40px; }
+.sge-heatmap tbody tr { height: 28px; }
+.sge-method-header { text-align: left !important; }
+.sge-col-label { white-space: nowrap; }
+.sge-heatmap thead th.sge-col-sorted { background: #d6e8d6; font-weight: 600; border: 2px solid #5c8a5c; }
+.sge-heatmap td.sge-col-sorted { border-left: 2px solid #5c8a5c; border-right: 2px solid #5c8a5c; }
 .sge-cell { text-align: center; font-feature-settings: "tnum"; }
+.sge-na { text-align: center; color: #aaa; }
 .sge-method { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.lb-family {
-  display: inline-block;
-  width: 10px; height: 10px;
-  border-radius: 2px;
-  margin-right: 6px;
-  vertical-align: middle;
-}
-.lb-na { text-align: center; color: #aaa; }
-.lb-forest-empty { color: #888; margin: 0.5em 0; font-size: 0.9em; }
-.muted { color: #aaa; }
+.sge-method a { text-decoration: none; }
+.sge-method a:hover { text-decoration: underline; }
+.lb-family { display: inline-block; width: 10px; height: 10px; border-radius: 2px; margin-right: 6px; vertical-align: middle; }
+.sge-empty { color: #888; margin: 1em 0; font-size: 0.9em; }
 .dataset-meta td { padding: 2px 8px; }
 .dataset-meta td:first-child { white-space: nowrap; }
 .dataset-bullets { margin: 0.5em 0 0.25em; }
 .dataset-bullets div { margin: 2px 0; }
 .dataset-notes { margin-top: 0.5em; color: #666; font-size: 0.9em; }
 .dataset-notes div { margin: 2px 0; }
-.legend-row {
-  display: flex; align-items: center; gap: 12px;
-  margin: 0.5em 0 1em;
-  font-size: 0.85em; color: #444;
-  max-width: 1200px;
-}
+.legend-row { display: flex; align-items: center; gap: 16px; margin: 0.5em 0 1em; font-size: 0.85em; color: #444; max-width: 1100px; flex-wrap: wrap; }
 </style>

--- a/dashboard/src/leaderboards/sge.md
+++ b/dashboard/src/leaderboards/sge.md
@@ -1,0 +1,236 @@
+---
+title: SGE Leaderboard
+toc: false
+wide: true
+---
+
+# SGE Leaderboard
+
+Saturation genome editing: per-variant endogenous-locus function scores. Both metrics are **rank-based** (so conservation tracks and gLMs compare on the same footing): **Spearman** of the deleteriousness score vs `−function_score_aligned`, and **AUPRC** for the ClinGen/ExCALIBR `calibrated_class` abnormal-vs-normal call. Scores are non-comparable across studies, so everything is computed **per accession** (MaveDB study) then macro-averaged.
+
+```js
+const sgeTable = await FileAttachment("../data/sge.parquet").parquet();
+const methods = await FileAttachment("../data/models.json").json();
+const datasets = await FileAttachment("../data/datasets.json").json();
+import {
+  FAMILY_LABEL,
+  PROTOCOL_OPTIONS,
+  PROTOCOL_DEFAULTS,
+  FamilyProtocolToggle,
+} from "../components/controls.js";
+```
+
+```js
+// Arrow → plain JS rows (sge.parquet schema; see leaderboard.sge_normalized_rows).
+const rows = sgeTable.toArray().map((r) => ({
+  method_id: String(r.method_id),
+  method_display: String(r.method_display),
+  family: String(r.family),
+  score_type: String(r.score_type),
+  metric: String(r.metric),
+  subset: String(r.subset),
+  accession: String(r.accession),
+  gene: String(r.gene),
+  value: Number(r.value),
+  se: Number(r.se),
+  n: Number(r.n),
+  n_pos: Number(r.n_pos),
+}));
+const meta = datasets.sge;
+// MarinDNA protocol → the score_type column it selects (signed LLR default; the
+// assayed ALT's direction is informative, so not abs). Conservation has one score.
+const SGE_SCORE_TYPE = {
+  marin_dna: {LLR: "minus_llr_avg", JSD: "jsd_avg"},
+  conservation: {score: "score"},
+};
+const SUBSETS = [
+  {key: "missense_variant", label: "Missense"},
+  {key: "splicing", label: "Splicing"},
+  {key: "both", label: "Both (pooled)"},
+  {key: "_macro_avg_", label: "Subset macro"},
+];
+```
+
+## Dataset
+
+```js
+const hfUrl = `https://huggingface.co/datasets/${meta.hf_repo}/tree/${meta.hf_commit}`;
+display(html`<div class="card">
+  <table class="dataset-meta">
+    <tr><td><b>HF dataset</b></td><td><a href=${hfUrl}><code>${meta.hf_repo} @ ${meta.hf_commit}</code></a></td></tr>
+    <tr><td><b>Split</b></td><td><code>${meta.split}</code> (development split; test held out for final-eval)</td></tr>
+  </table>
+  <div class="dataset-bullets">
+    <div><b>AUPRC positives:</b> ${meta.positives}</div>
+    <div><b>AUPRC negatives:</b> ${meta.negatives}</div>
+    <div><b>Aggregation:</b> ${meta.matching}</div>
+    <div><b>Metric:</b> ${meta.metric}</div>
+  </div>
+  <div class="dataset-notes">
+    ${meta.notes.map((n) => html`<div>${n}</div>`)}
+  </div>
+</div>`);
+```
+
+## Leaderboard
+
+```js
+// Gene-scope: macro across accessions, or one accession (labeled by gene).
+const accPairs = Array.from(
+  new Map(
+    rows.filter((r) => r.accession !== "_macro_avg_").map((r) => [r.accession, r.gene]),
+  ).entries(),
+).sort((a, b) => a[1].localeCompare(b[1]));
+const geneScopeLabel = new Map([
+  ["_macro_avg_", "All genes (macro)"],
+  ...accPairs.map(([urn, gene]) => [urn, gene]),
+]);
+const geneScopeOptions = ["_macro_avg_", ...accPairs.map(([urn]) => urn)];
+const geneScope = view(
+  Inputs.select(geneScopeOptions, {
+    label: "Gene",
+    value: "_macro_avg_",
+    format: (o) => geneScopeLabel.get(o) ?? o,
+  }),
+);
+```
+
+```js
+// Only families with SGE data appear; order follows FAMILY_LABEL.
+const present = new Set(rows.map((r) => r.family));
+const families = Object.keys(FAMILY_LABEL).filter((f) => present.has(f));
+const sel = view(FamilyProtocolToggle(families, PROTOCOL_OPTIONS, PROTOCOL_DEFAULTS));
+```
+
+```js
+const search = view(
+  Inputs.text({
+    label: "Model name",
+    placeholder: "filter by method (e.g. exp135, phyloP)",
+  }),
+);
+```
+
+```js
+function activeScoreType(family, protocol) {
+  const m = SGE_SCORE_TYPE[family];
+  if (!m) return null;
+  return m[protocol] ?? Object.values(m)[0];
+}
+
+// One row per method for a subset board: {method, family, spearman, AUPRC}.
+function boardRows(subsetKey) {
+  const byMethod = new Map();
+  for (const r of rows) {
+    if (r.accession !== geneScope) continue;
+    if (r.subset !== subsetKey) continue;
+    if (!sel.families.includes(r.family)) continue;
+    const wantProto = sel.protocols[r.family] ?? PROTOCOL_DEFAULTS[r.family];
+    if (r.score_type !== activeScoreType(r.family, wantProto)) continue;
+    if (search && !r.method_display.toLowerCase().includes(search.toLowerCase())) continue;
+    if (!byMethod.has(r.method_id)) {
+      byMethod.set(r.method_id, {
+        method_id: r.method_id,
+        method_display: r.method_display,
+        family: r.family,
+      });
+    }
+    byMethod.get(r.method_id)[r.metric] = {value: r.value, se: r.se, n: r.n};
+  }
+  // Sort by Spearman desc (methods missing it sink to the bottom).
+  return [...byMethod.values()].sort(
+    (a, b) => (b.spearman?.value ?? -Infinity) - (a.spearman?.value ?? -Infinity),
+  );
+}
+
+function fmtCell(cell) {
+  if (cell == null || !Number.isFinite(cell.value)) return html`<span class="lb-na">—</span>`;
+  return html`${cell.value.toFixed(3)} <span class="muted">± ${Number.isFinite(cell.se) ? cell.se.toFixed(3) : "—"}</span>`;
+}
+
+function renderBoard(subset) {
+  const data = boardRows(subset.key);
+  return html`<div class="card sge-board">
+    <h3>${subset.label}</h3>
+    ${
+      data.length === 0
+        ? html`<div class="lb-forest-empty">No methods for this selection.</div>`
+        : html`<table class="sge-heatmap">
+            <thead><tr>
+              <th class="sge-method-header">Model</th>
+              <th>Spearman</th>
+              <th>AUPRC</th>
+            </tr></thead>
+            <tbody>${data.map(
+              (d) => html`<tr>
+                <td class="sge-method" title=${d.method_display}>
+                  <span class=${`lb-family lb-family-${d.family}`}></span>${d.method_display}
+                </td>
+                <td class="sge-cell">${fmtCell(d.spearman)}</td>
+                <td class="sge-cell">${fmtCell(d.AUPRC)}</td>
+              </tr>`,
+            )}</tbody>
+          </table>`
+    }
+  </div>`;
+}
+```
+
+<div class="legend-row">
+  <span>Per the selected gene scope, one board per consequence subset; rows are methods, sorted by Spearman. <b>±</b> = bootstrap SE. Spearman is oriented so a good deleteriousness predictor scores positive; AUPRC random-baseline is the per-cell abnormal rate.</span>
+</div>
+
+```js
+display(html`<div class="sge-board-grid">${SUBSETS.map(renderBoard)}</div>`);
+```
+
+<style>
+:root { --observablehq-max-width: 2200px; }
+main > p, main > h1, main > h2, main > h3, main > .card { max-width: none; }
+main > h1, main > h2, main > p { max-width: 1200px; }
+.card.sge-board { max-width: 560px; margin: 0; }
+
+.sge-board-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: flex-start;
+}
+.sge-board h3 { margin: 0 0 0.5em; font-size: 1em; }
+
+.sge-heatmap {
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.85em;
+  table-layout: fixed;
+  width: 420px;
+}
+.sge-heatmap thead th { width: 110px; }
+.sge-heatmap th.sge-method-header { width: 200px; text-align: left; }
+.sge-heatmap th, .sge-heatmap td { padding: 6px 4px; border: 1px solid #ddd; }
+.sge-heatmap thead th { background: #f7f7f7; text-align: center; user-select: none; }
+.sge-cell { text-align: center; font-feature-settings: "tnum"; }
+.sge-method { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.lb-family {
+  display: inline-block;
+  width: 10px; height: 10px;
+  border-radius: 2px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.lb-na { text-align: center; color: #aaa; }
+.lb-forest-empty { color: #888; margin: 0.5em 0; font-size: 0.9em; }
+.muted { color: #aaa; }
+.dataset-meta td { padding: 2px 8px; }
+.dataset-meta td:first-child { white-space: nowrap; }
+.dataset-bullets { margin: 0.5em 0 0.25em; }
+.dataset-bullets div { margin: 2px 0; }
+.dataset-notes { margin-top: 0.5em; color: #666; font-size: 0.9em; }
+.dataset-notes div { margin: 2px 0; }
+.legend-row {
+  display: flex; align-items: center; gap: 12px;
+  margin: 0.5em 0 1em;
+  font-size: 0.85em; color: #444;
+  max-width: 1200px;
+}
+</style>

--- a/scripts/issue301_build_sge_v3.py
+++ b/scripts/issue301_build_sge_v3.py
@@ -81,7 +81,9 @@ def main() -> None:
         "sge", sha, paths["train"], paths["test"], calibration_path=calib
     )
     (OUT / "README.md").write_text(card)
-    print(f"\nwrote {OUT}/ (train/test/calibrations parquet + README.md); sha={sha[:7]}")
+    print(
+        f"\nwrote {OUT}/ (train/test/calibrations parquet + README.md); sha={sha[:7]}"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/issue301_build_sge_v3.py
+++ b/scripts/issue301_build_sge_v3.py
@@ -1,0 +1,88 @@
+"""Build evals_sge v3 (AUPRC-only) from the existing v2 unsplit parquet (#301).
+
+v3 = v2 + a boolean ``label`` (True = impactful / calibrated abnormal, False =
+normal) + a row filter to label-non-null variants (drops intermediate +
+uncalibrated/null incl. BRCA2). This is a *targeted* build: it applies the
+committed ``attach_label`` and the same chrom-parity split the
+``split_dataset_by_chrom`` rule uses, directly to the v2 unsplit parquet — so it
+re-derives nothing (no genome re-stage, no cdot re-recode) and is guaranteed to
+equal "v2 labeled-subset", keeping the AUPRC numbers identical. The pipeline's
+``sge.smk`` carries the same label+filter, so a future full run reproduces this.
+
+Outputs (gitignored scratch): v3 train/test parquets + the rendered dataset card,
+for review before the HF upload (a separate, gated step).
+
+Run: ``uv run python scripts/issue301_build_sge_v3.py``
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import polars as pl
+
+from marin_dna.pipelines.evals import hf_readme
+from marin_dna.pipelines.evals.sge import attach_label
+
+S3 = "s3://oa-bolinas/snakemake/evals/results"
+SO = {"aws_region": "us-east-2"}
+OUT = Path(__file__).resolve().parents[1] / "scratch" / "sge_v3"
+
+# Mirror snakemake/evals common.smk: CHROMS[::2] → train (odd + X), [1::2] → test.
+CHROMS = [str(i) for i in range(1, 23)] + ["X", "Y"]
+SPLIT_CHROMS = {"train": CHROMS[::2], "test": CHROMS[1::2]}
+# PRIMARY_COLS = COORDS + [label, subset, match_group]; SGE has no match_group.
+PRIMARY_COLS = ["chrom", "pos", "ref", "alt", "label", "subset", "match_group"]
+
+
+def _reorder(df: pl.DataFrame) -> pl.DataFrame:
+    primary = [c for c in PRIMARY_COLS if c in df.columns]
+    return df.select(primary + [c for c in df.columns if c not in primary])
+
+
+def main() -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+
+    unsplit = pl.read_parquet(f"{S3}/dataset_unsplit/sge.parquet", storage_options=SO)
+    print(f"v2 unsplit: {unsplit.height} rows")
+
+    labeled = attach_label(unsplit).filter(pl.col("label").is_not_null())
+    n_abn = labeled.filter(pl.col("label")).height
+    n_norm = labeled.filter(~pl.col("label")).height
+    print(f"v3 labeled: {labeled.height} rows ({n_abn} abnormal / {n_norm} normal)")
+    assert labeled.height == n_abn + n_norm
+    # Every shipped row carries a clean bool (the filter guarantees it).
+    assert labeled["label"].null_count() == 0
+
+    labeled = _reorder(labeled)
+    paths = {}
+    for split, chroms in SPLIT_CHROMS.items():
+        part = labeled.filter(pl.col("chrom").is_in(chroms))
+        path = OUT / f"{split}.parquet"
+        part.write_parquet(path)
+        paths[split] = path
+        print(
+            f"  {split}: {part.height} rows "
+            f"({part.filter(pl.col('label')).height} abnormal / "
+            f"{part.filter(~pl.col('label')).height} normal) "
+            f"chroms={sorted(part['chrom'].unique().to_list())}"
+        )
+    assert sum(pl.read_parquet(p).height for p in paths.values()) == labeled.height
+
+    # Calibration companion (for the card's Score-calibration section).
+    calib = OUT / "calibrations.parquet"
+    pl.read_parquet(f"{S3}/sge/calibrations.parquet", storage_options=SO).write_parquet(
+        calib
+    )
+
+    card = hf_readme.render(
+        "sge", sha, paths["train"], paths["test"], calibration_path=calib
+    )
+    (OUT / "README.md").write_text(card)
+    print(f"\nwrote {OUT}/ (train/test/calibrations parquet + README.md); sha={sha[:7]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue301_launch_sge_v3_glms.sh
+++ b/scripts/issue301_launch_sge_v3_glms.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Re-score the 3 #292 gLMs on evals_sge v3 (AUPRC-only, #301), one A10G cluster
+# per model. Mirrors snakemake/analysis/evals_v2/sky/parallel_sweep.sh but injects
+# `--forcerun results/scores/{model}/sge.parquet` — a fresh cluster has no local
+# snakemake metadata and the v2 sge.parquet already exists on S3, so without the
+# force snakemake would report "nothing to do" and never re-score on v3.
+#
+# Usage (from the repo/worktree root):
+#   scripts/issue301_launch_sge_v3_glms.sh [<model> ...]
+# With no args, launches all 3. Pass model names to re-launch just those (e.g.
+# after an AZ-saturation ResourcesUnavailableError on a subset).
+#
+# Cluster names sanitize the dotted model names (sky cluster names are
+# hostname-like). Logs: $SKY_LOG_DIR/<cluster>.log (default /tmp/sky_sge_v3).
+set -uo pipefail
+
+DEFAULT_MODELS=(
+    mix-v0.9-p1B-i24-exp135-m5.1-step-59158
+    exp166-v0.1-p1B-step-27329
+    exp13-mixture-proportional-step-26000
+)
+models=("$@")
+[[ ${#models[@]} -eq 0 ]] && models=("${DEFAULT_MODELS[@]}")
+
+here=$(cd "$(dirname "$0")" && pwd)
+repo_root=$(cd "$here/.." && pwd)
+[[ -f "$repo_root/pyproject.toml" ]] || { echo "no pyproject.toml at $repo_root" >&2; exit 1; }
+cd "$repo_root"
+
+run_yaml="snakemake/analysis/evals_v2/sky/run.yaml"
+[[ -f "$run_yaml" ]] || { echo "missing $run_yaml" >&2; exit 1; }
+
+stagger=${SKY_STAGGER:-5}
+autostop=${SKY_AUTOSTOP_MIN:-5}
+log_dir=${SKY_LOG_DIR:-/tmp/sky_sge_v3}
+mkdir -p "$log_dir"
+echo "[launch] log_dir=$log_dir models=${#models[@]}" >&2
+
+# Short, dot-free cluster aliases keyed by model.
+cluster_for() {
+    case "$1" in
+        mix-v0.9-p1B-i24-exp135-m5.1-step-59158) echo "evals-sge-exp135" ;;
+        exp166-v0.1-p1B-step-27329)              echo "evals-sge-exp166" ;;
+        exp13-mixture-proportional-step-26000)   echo "evals-sge-exp13mp" ;;
+        *) echo "evals-sge-$(echo "$1" | tr '.' '-' | cut -c1-40)" ;;
+    esac
+}
+
+pids=()
+for model in "${models[@]}"; do
+    cluster=$(cluster_for "$model")
+    args="--forcerun results/scores/$model/sge.parquet -- results/metrics/$model/sge.parquet"
+    echo "[launch] $cluster  <-  $model" >&2
+    sky launch -c "$cluster" \
+        --env SNAKEMAKE_ARGS="$args" \
+        --idle-minutes-to-autostop="$autostop" \
+        --down \
+        --yes \
+        "$run_yaml" \
+        > "$log_dir/$cluster.log" 2>&1 &
+    pids+=($!)
+    sleep "$stagger"
+done
+
+echo "[launch] dispatched ${#pids[@]} sky launches; waiting…" >&2
+wait
+echo "[launch] all sky clusters reached terminal state" >&2

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -66,6 +66,35 @@ These metrics parquets have columns
 `[metric, score_type, value, se, n_rows, n_pos, model, dataset, split]` — note
 the `metric` column and the absence of subset rows.
 
+### SGE dataset (`sge`, `eval_protocol: sge`)
+
+The saturation-genome-editing benchmark (`bolinas-dna/evals_sge`, issue #301; v2
+rebuild #300) is **unmatched** and carries a per-study, direction-harmonized
+`function_score_aligned` plus a uniform ClinGen/ExCALIBR `calibrated_class`,
+instead of `label` / `subset` / `match_group` / `effect_size`. `eval_protocol:
+sge` selects `marin_dna.pipelines.evals.metrics.compute_sge_metrics`. Scoring
+uses `score_protocol: minus_llr` (signed — the assayed ALT is the
+deleterious-*candidate*, so its sign is informative; not `abs`), giving score
+columns `minus_llr_{fwd,rc,avg}` + `jsd_{fwd,rc,avg}`.
+
+Scores are **non-comparable across studies**, so everything is computed **per
+accession** (`mavedb_urn`) then macro-averaged. Two **rank-based** metrics — so
+they compare fairly with the conservation tracks (Pearson is intentionally
+omitted: scale-sensitive, not cross-family comparable):
+
+- **Spearman** of the deleteriousness score vs `−function_score_aligned` (a good
+  predictor scores positive), over rows with a finite target.
+- **AUPRC** for the `calibrated_class` abnormal-vs-normal call (intermediate /
+  uncalibrated dropped).
+
+Both run on a 2-axis grid: `subset` ∈ {`missense_variant`, `splicing`, `both`
+(pooled), `_macro_avg_` (mean of the two subsets)} × `accession` ∈ {each
+`mavedb_urn`, `_macro_avg_` (mean over accessions)}. Parquet columns:
+`[metric, subset, accession, gene, score_type, value, se, n, n_pos, model,
+dataset, split]`. The **same** `compute_sge_metrics` is reused by the
+conservation pipeline (`snakemake/conservation_eval/`). Scoped to the three
+#292 gLMs via their per-model `datasets:` lists.
+
 ## Conventions
 
 - **Train split only.** Test is held out for the final-eval pass; train is
@@ -226,7 +255,7 @@ Two unavoidable AWS-side failure modes worth knowing about:
 | `input_hf_prefix` | HF prefix for `f"{prefix}_{dataset.name}"`. |
 | `genome_path` | Canonical GRCh38 FASTA. fsspec URI (e.g. `s3://...`) or local path. The S3 path requires `--group genome-s3` at install time. |
 | `split` | `train` (or `test` once held-out eval is unlocked). |
-| `datasets` | List of `{name, hf_revision, score_protocol, [eval_protocol]}`. `hf_revision` is the pinned HF dataset commit SHA — bumping it triggers re-execution. `score_protocol` ∈ `{minus_llr, abs_llr}`. Optional `eval_protocol` ∈ `{matched_pair (default), qtl_global}` — `qtl_global` selects the global AUPRC + positives-only `effect_size` correlation path for the unmatched caqtl/dsqtl datasets. |
+| `datasets` | List of `{name, hf_revision, score_protocol, [eval_protocol]}`. `hf_revision` is the pinned HF dataset commit SHA — bumping it triggers re-execution. `score_protocol` ∈ `{minus_llr, abs_llr}`. Optional `eval_protocol` ∈ `{matched_pair (default), qtl_global, sge}` — `qtl_global` selects the global AUPRC + positives-only `effect_size` correlation path for the unmatched caqtl/dsqtl datasets; `sge` selects the per-accession × consequence-subset Spearman + AUPRC path for `evals_sge` (see the SGE section above). |
 | `models` | List of `{name, window_size, ...}`. Each entry has exactly one of `gcs_path` (full GCS URI incl. `/hf/step-{N}`) or `hf_repo` (HuggingFace Hub repo ID), plus two optional fields: `datasets: [...]` to restrict which `datasets` this checkpoint evaluates on (defaults to all), and `batch_size: N` to override the global `inference.batch_size` for this checkpoint (useful when context size differs from the global default's tuning). |
 | `inference.*` | Batch size, workers, `data_transform_on_the_fly`, `torch_compile`; `rc` (also score the reverse-complement strand — doubles inference time); `n_bootstrap` (AUPRC bootstrap iterations per subset × score_type); `bootstrap_seed` (reproducibility seed; bumping triggers metrics re-execution). |
 | `nuc_dep` | Optional; nucleotide-dependency maps (#237, off `rule all`). `{combines, ord, batch_size, dpi, models: [...], loci: {...}}`. See `rules/interpretation.smk`. |

--- a/snakemake/analysis/evals_v2/README.md
+++ b/snakemake/analysis/evals_v2/README.md
@@ -68,32 +68,34 @@ the `metric` column and the absence of subset rows.
 
 ### SGE dataset (`sge`, `eval_protocol: sge`)
 
-The saturation-genome-editing benchmark (`bolinas-dna/evals_sge`, issue #301; v2
-rebuild #300) is **unmatched** and carries a per-study, direction-harmonized
-`function_score_aligned` plus a uniform ClinGen/ExCALIBR `calibrated_class`,
-instead of `label` / `subset` / `match_group` / `effect_size`. `eval_protocol:
-sge` selects `marin_dna.pipelines.evals.metrics.compute_sge_metrics`. Scoring
-uses `score_protocol: minus_llr` (signed — the assayed ALT is the
+The saturation-genome-editing benchmark (`bolinas-dna/evals_sge`, issue #301; v3
+label build) is **unmatched** and frames the task as a binary VEP: each variant
+carries a boolean `label` (True = impactful = ClinGen/ExCALIBR-calibrated
+abnormal) and a consequence-group `subset` ∈ {`missense_variant`, `splicing`}.
+The v3 build keeps only labeled variants (abnormal/normal); the continuous
+`function_score_aligned` + `calibrated_class` columns stay for provenance.
+`eval_protocol: sge` selects
+`marin_dna.pipelines.evals.metrics.compute_sge_metrics`. Scoring uses
+`score_protocol: minus_llr` (signed — the assayed ALT is the
 deleterious-*candidate*, so its sign is informative; not `abs`), giving score
 columns `minus_llr_{fwd,rc,avg}` + `jsd_{fwd,rc,avg}`.
 
-Scores are **non-comparable across studies**, so everything is computed **per
-accession** (`mavedb_urn`) then macro-averaged. Two **rank-based** metrics — so
-they compare fairly with the conservation tracks (Pearson is intentionally
-omitted: scale-sensitive, not cross-family comparable):
+Scores are **non-comparable across studies**, so AUPRC is computed **per
+accession** (`mavedb_urn`) then macro-averaged. AUPRC is rank-based, so it
+compares fairly with the conservation tracks (Spearman vs the continuous
+function score was dropped in #301 to keep one classification metric and let the
+dataset shed unlabeled variants for faster inference).
 
-- **Spearman** of the deleteriousness score vs `−function_score_aligned` (a good
-  predictor scores positive), over rows with a finite target.
-- **AUPRC** for the `calibrated_class` abnormal-vs-normal call (intermediate /
-  uncalibrated dropped).
+- **AUPRC** predicting `label` (impactful vs not) from the deleteriousness score;
+  requires ≥ 30 rows per label class per cell.
 
-Both run on a 2-axis grid: `subset` ∈ {`missense_variant`, `splicing`, `both`
+It runs on a 2-axis grid: `subset` ∈ {`missense_variant`, `splicing`, `both`
 (pooled), `_macro_avg_` (mean of the two subsets)} × `accession` ∈ {each
 `mavedb_urn`, `_macro_avg_` (mean over accessions)}. Parquet columns:
 `[metric, subset, accession, gene, score_type, value, se, n, n_pos, model,
-dataset, split]`. The **same** `compute_sge_metrics` is reused by the
-conservation pipeline (`snakemake/conservation_eval/`). Scoped to the three
-#292 gLMs via their per-model `datasets:` lists.
+dataset, split]` (`metric` is always `AUPRC`). The **same** `compute_sge_metrics`
+is reused by the conservation pipeline (`snakemake/conservation_eval/`). Scoped
+to the three #292 gLMs via their per-model `datasets:` lists.
 
 ## Conventions
 
@@ -255,7 +257,7 @@ Two unavoidable AWS-side failure modes worth knowing about:
 | `input_hf_prefix` | HF prefix for `f"{prefix}_{dataset.name}"`. |
 | `genome_path` | Canonical GRCh38 FASTA. fsspec URI (e.g. `s3://...`) or local path. The S3 path requires `--group genome-s3` at install time. |
 | `split` | `train` (or `test` once held-out eval is unlocked). |
-| `datasets` | List of `{name, hf_revision, score_protocol, [eval_protocol]}`. `hf_revision` is the pinned HF dataset commit SHA — bumping it triggers re-execution. `score_protocol` ∈ `{minus_llr, abs_llr}`. Optional `eval_protocol` ∈ `{matched_pair (default), qtl_global, sge}` — `qtl_global` selects the global AUPRC + positives-only `effect_size` correlation path for the unmatched caqtl/dsqtl datasets; `sge` selects the per-accession × consequence-subset Spearman + AUPRC path for `evals_sge` (see the SGE section above). |
+| `datasets` | List of `{name, hf_revision, score_protocol, [eval_protocol]}`. `hf_revision` is the pinned HF dataset commit SHA — bumping it triggers re-execution. `score_protocol` ∈ `{minus_llr, abs_llr}`. Optional `eval_protocol` ∈ `{matched_pair (default), qtl_global, sge}` — `qtl_global` selects the global AUPRC + positives-only `effect_size` correlation path for the unmatched caqtl/dsqtl datasets; `sge` selects the per-accession × consequence-subset AUPRC-on-`label` path for `evals_sge` (see the SGE section above). |
 | `models` | List of `{name, window_size, ...}`. Each entry has exactly one of `gcs_path` (full GCS URI incl. `/hf/step-{N}`) or `hf_repo` (HuggingFace Hub repo ID), plus two optional fields: `datasets: [...]` to restrict which `datasets` this checkpoint evaluates on (defaults to all), and `batch_size: N` to override the global `inference.batch_size` for this checkpoint (useful when context size differs from the global default's tuning). |
 | `inference.*` | Batch size, workers, `data_transform_on_the_fly`, `torch_compile`; `rc` (also score the reverse-complement strand — doubles inference time); `n_bootstrap` (AUPRC bootstrap iterations per subset × score_type); `bootstrap_seed` (reproducibility seed; bumping triggers metrics re-execution). |
 | `nuc_dep` | Optional; nucleotide-dependency maps (#237, off `rule all`). `{combines, ord, batch_size, dpi, models: [...], loci: {...}}`. See `rules/interpretation.smk`. |

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -38,6 +38,20 @@ datasets:
     score_protocol: abs_llr
     eval_protocol: qtl_global
 
+  # Saturation-genome-editing dataset (bolinas-dna/evals_sge, issue #301;
+  # builder #289, v2 rebuild #300). Unmatched — no label/subset(=consequence)/
+  # match_group; instead a harmonized per-study `function_score_aligned` + a
+  # uniform `calibrated_class`. `eval_protocol: sge` selects the
+  # SGE_VARIANT_COLUMNS assert set and the `compute_sge_metrics` path
+  # (per-accession × consequence-subset Spearman + AUPRC, macro-averaged).
+  # `score_protocol: minus_llr` orients the gLM score toward deleteriousness
+  # (the assayed ALT's sign is informative — not abs), matching mendelian_traits;
+  # the raw llr_*/jsd_* atoms are stored regardless, so JSD stays available.
+  - name: sge
+    hf_revision: 39f47f0909a8130f8f8b6cbea6b09eb376fed70b  # evals_sge v2 (#300)
+    score_protocol: minus_llr
+    eval_protocol: sge
+
 # Model checkpoints. Each entry must have exactly one of:
 #   - `gcs_path`: full GCS URI to the checkpoint directory (includes /hf/step-{N});
 #                  pulled with `gcloud storage cp -r`.
@@ -120,7 +134,7 @@ models:
   - name: exp166-v0.1-p1B-step-27329
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-exp166-v0.1-p1B-c127da/hf/step-27329
     window_size: 255
-    datasets: [mendelian_traits, complex_traits]
+    datasets: [mendelian_traits, complex_traits, sge]
 
   # exp166 v0.1 — generalist 4B run (74e146). Same 3 HF-exported
   # checkpoints as 1B: 10000, 20000, 27329 (final). Intermediates scoped
@@ -543,7 +557,7 @@ models:
   - name: mix-v0.9-p1B-i24-exp135-m5.1-step-59158
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-mix-v0.9-p1B-i24-exp135-zoonomia-m5.1-bef41e/hf/step-59158
     window_size: 255
-    datasets: [mendelian_traits]
+    datasets: [mendelian_traits, sge]
 
   # Parameter-scaling ladder v0.5 (issue #274) — 8 sizes, all at step-215573
   # (~84.77B tokens; batch 1536 x seq 256; identical optimizer hparams). The
@@ -756,7 +770,7 @@ models:
   - name: exp13-mixture-proportional-step-26000
     gcs_path: gs://marin-dna-us-central1/checkpoints/promoter-cds-mixture-proportional-r01-6705f1/hf/step-26000
     window_size: 512
-    datasets: [mendelian_traits]
+    datasets: [mendelian_traits, sge]
     batch_size: 64
 
   # exp55/exp58/exp59 — promoters/CDS/downstream across evolutionary timescales

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -39,16 +39,16 @@ datasets:
     eval_protocol: qtl_global
 
   # Saturation-genome-editing dataset (bolinas-dna/evals_sge, issue #301;
-  # builder #289, v2 rebuild #300). Unmatched — no label/subset(=consequence)/
-  # match_group; instead a harmonized per-study `function_score_aligned` + a
-  # uniform `calibrated_class`. `eval_protocol: sge` selects the
+  # builder #289, v2 rebuild #300, v3 label/AUPRC-only #301). Unmatched — no
+  # match_group; instead a boolean `label` (impactful = calibrated abnormal) +
+  # the consequence-group `subset`. `eval_protocol: sge` selects the
   # SGE_VARIANT_COLUMNS assert set and the `compute_sge_metrics` path
-  # (per-accession × consequence-subset Spearman + AUPRC, macro-averaged).
+  # (per-accession × consequence-subset AUPRC on `label`, macro-averaged).
   # `score_protocol: minus_llr` orients the gLM score toward deleteriousness
   # (the assayed ALT's sign is informative — not abs), matching mendelian_traits;
   # the raw llr_*/jsd_* atoms are stored regardless, so JSD stays available.
   - name: sge
-    hf_revision: 39f47f0909a8130f8f8b6cbea6b09eb376fed70b  # evals_sge v2 (#300)
+    hf_revision: 225d3d1ea32a4af547891b13c33b5e92a5aae849  # evals_sge v3 (#301, AUPRC-only)
     score_protocol: minus_llr
     eval_protocol: sge
 

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -25,9 +25,9 @@ from marin_dna.pipelines.evals.metrics import (
 # global AUPRC + positives-only effect_size correlation on the unmatched
 # DART-Eval QTL datasets (caqtl/dsqtl), which carry no subset/match_group.
 # `sge` (issue #301) → the saturation-genome-editing dataset (evals_sge):
-# per-accession (mavedb_urn) × consequence-subset Spearman (score vs
-# −function_score_aligned) + AUPRC (calibrated_class abnormal-vs-normal),
-# macro-averaged over subsets and accessions (compute_sge_metrics).
+# per-accession (mavedb_urn) × consequence-subset AUPRC on the binary `label`
+# (impactful = calibrated abnormal), macro-averaged over subsets and accessions
+# (compute_sge_metrics).
 EVAL_PROTOCOLS = ("matched_pair", "qtl_global", "sge")
 
 

--- a/snakemake/analysis/evals_v2/workflow/rules/common.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/common.smk
@@ -10,19 +10,25 @@ from marin_dna.pipelines.evals.calibration import compute_llr_neutral_mean
 from marin_dna.pipelines.evals.conservation import (
     QTL_VARIANT_COLUMNS,
     REQUIRED_VARIANT_COLUMNS,
+    SGE_VARIANT_COLUMNS,
 )
 from marin_dna.pipelines.evals.inference import compute_variant_scores
 from marin_dna.pipelines.evals.metrics import (
     SCORE_PROTOCOLS,
     compute_auprc_metrics,
     compute_qtl_metrics,
+    compute_sge_metrics,
 )
 
 # Per-dataset eval protocol. `matched_pair` (default) → per-subset AUPRC +
 # cluster bootstrap over `match_group` (mendelian/complex). `qtl_global` →
 # global AUPRC + positives-only effect_size correlation on the unmatched
 # DART-Eval QTL datasets (caqtl/dsqtl), which carry no subset/match_group.
-EVAL_PROTOCOLS = ("matched_pair", "qtl_global")
+# `sge` (issue #301) → the saturation-genome-editing dataset (evals_sge):
+# per-accession (mavedb_urn) × consequence-subset Spearman (score vs
+# −function_score_aligned) + AUPRC (calibrated_class abnormal-vs-normal),
+# macro-averaged over subsets and accessions (compute_sge_metrics).
+EVAL_PROTOCOLS = ("matched_pair", "qtl_global", "sge")
 
 
 def get_dataset_config(name):
@@ -39,11 +45,12 @@ def get_dataset_protocol(name):
 
 def get_dataset_variant_columns(name):
     """Required variant columns for a dataset, keyed by eval protocol."""
-    return (
-        QTL_VARIANT_COLUMNS
-        if get_dataset_protocol(name) == "qtl_global"
-        else REQUIRED_VARIANT_COLUMNS
-    )
+    protocol = get_dataset_protocol(name)
+    if protocol == "qtl_global":
+        return QTL_VARIANT_COLUMNS
+    if protocol == "sge":
+        return SGE_VARIANT_COLUMNS
+    return REQUIRED_VARIANT_COLUMNS
 
 
 def get_model_config(name):

--- a/snakemake/analysis/evals_v2/workflow/rules/metrics.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/metrics.smk
@@ -74,6 +74,18 @@ rule compute_metrics:
                 n_bootstrap=params.n_bootstrap,
                 rng=params.bootstrap_seed,
             )
+        elif eval_protocol == "sge":
+            # Per-accession (mavedb_urn) × consequence-subset Spearman (score vs
+            # −function_score_aligned) + AUPRC (calibrated_class abnormal-vs-
+            # normal), macro-averaged over subsets and accessions. Frame carries
+            # `metric` / `subset` / `accession` columns.
+            metrics = compute_sge_metrics(
+                dataset=df[list(SGE_VARIANT_COLUMNS)],
+                scores=df[score_cols],
+                score_columns=score_cols,
+                n_bootstrap=params.n_bootstrap,
+                rng=params.bootstrap_seed,
+            )
         else:
             metrics = compute_auprc_metrics(
                 dataset=df[list(REQUIRED_VARIANT_COLUMNS)],

--- a/snakemake/analysis/evals_v2/workflow/rules/metrics.smk
+++ b/snakemake/analysis/evals_v2/workflow/rules/metrics.smk
@@ -75,10 +75,10 @@ rule compute_metrics:
                 rng=params.bootstrap_seed,
             )
         elif eval_protocol == "sge":
-            # Per-accession (mavedb_urn) × consequence-subset Spearman (score vs
-            # −function_score_aligned) + AUPRC (calibrated_class abnormal-vs-
-            # normal), macro-averaged over subsets and accessions. Frame carries
-            # `metric` / `subset` / `accession` columns.
+            # Per-accession (mavedb_urn) × consequence-subset AUPRC on the binary
+            # `label` (impactful = calibrated abnormal), macro-averaged over
+            # subsets and accessions. Frame carries `metric` / `subset` /
+            # `accession` columns.
             metrics = compute_sge_metrics(
                 dataset=df[list(SGE_VARIANT_COLUMNS)],
                 scores=df[score_cols],

--- a/snakemake/conservation_eval/README.md
+++ b/snakemake/conservation_eval/README.md
@@ -64,14 +64,14 @@ rows (correlations). The markdown is a single `metric × track` table.
 
 ### SGE dataset (`sge`, `eval_protocol: sge`)
 
-The saturation-genome-editing benchmark (`bolinas-dna/evals_sge`, issue #301) is
-also unmatched, carrying a per-study `function_score_aligned` + a uniform
-`calibrated_class` instead of `effect_size`. A dataset entry with `eval_protocol:
-sge` runs the **same shared** `compute_sge_metrics` as `evals_v2` (no metric logic
-duplicated): per-accession (`mavedb_urn`) × consequence-subset **Spearman** of the
-track score vs `−function_score_aligned`, and **AUPRC** for the abnormal-vs-normal
-`calibrated_class` call, macro-averaged over subsets then accessions. Aggregation
-is `aggregate_conservation_sge_metrics` — a thin wrapper (per-track loop +
+The saturation-genome-editing benchmark (`bolinas-dna/evals_sge` v3, issue #301)
+is also unmatched, framed as a binary VEP: each variant carries a boolean `label`
+(True = impactful = calibrated abnormal) and a consequence-group `subset`. A
+dataset entry with `eval_protocol: sge` runs the **same shared**
+`compute_sge_metrics` as `evals_v2` (no metric logic duplicated): per-accession
+(`mavedb_urn`) × consequence-subset **AUPRC** predicting `label` from the track
+score, macro-averaged over subsets then accessions. Aggregation is
+`aggregate_conservation_sge_metrics` — a thin wrapper (per-track loop + NaN-fill +
 `score_name` stamping + markdown). All five configured tracks run on it; the
 headline markdown is a `metric × track` table.
 

--- a/snakemake/conservation_eval/README.md
+++ b/snakemake/conservation_eval/README.md
@@ -62,6 +62,19 @@ dataset's `effect_size` (unsigned `|effect|`) over **positive variants only**
 and bootstrap-seed conventions; the bootstrap resamples rows (AUPRC) / positive
 rows (correlations). The markdown is a single `metric × track` table.
 
+### SGE dataset (`sge`, `eval_protocol: sge`)
+
+The saturation-genome-editing benchmark (`bolinas-dna/evals_sge`, issue #301) is
+also unmatched, carrying a per-study `function_score_aligned` + a uniform
+`calibrated_class` instead of `effect_size`. A dataset entry with `eval_protocol:
+sge` runs the **same shared** `compute_sge_metrics` as `evals_v2` (no metric logic
+duplicated): per-accession (`mavedb_urn`) × consequence-subset **Spearman** of the
+track score vs `−function_score_aligned`, and **AUPRC** for the abnormal-vs-normal
+`calibrated_class` call, macro-averaged over subsets then accessions. Aggregation
+is `aggregate_conservation_sge_metrics` — a thin wrapper (per-track loop +
+`score_name` stamping + markdown). All five configured tracks run on it; the
+headline markdown is a `metric × track` table.
+
 ## Tracks
 
 | Name | Source URL | Notes |
@@ -80,14 +93,16 @@ URLs are owned by `marin_dna.evals.conservation.CONSERVATION_TRACKS` (single sou
 
 NaN values arise when the bigWig has no alignment at a given locus (e.g.
 patches, alt contigs, or genuinely unalignable bases). Before computing AUPRC
-we **`fillna(0)`**:
+we **`fillna(0)`** — via the single shared `conservation.fill_score_nan`, used by
+**every** eval protocol (matched_pair / qtl_global / sge) so the convention can't
+drift between benchmarks:
 
 - For phyloP, **0 is semantically meaningful**: neither conserved nor accelerated.
 - For phastCons, **0 is also semantically meaningful**: non-conserved.
 
 This matches the choice in TraitGym's own `eval/workflow/rules/conservation.smk`.
-`auprc_with_bootstrap_se` also asserts no NaN scores, so the fill is required
-upstream of the metric call.
+`auprc_with_bootstrap_se` (and the SGE path) assert/expect no NaN scores, so the
+fill is required upstream of the metric call.
 
 The per-variant parquets (`{score}_{split}.parquet`) preserve raw NaNs so you
 can apply a different policy without re-running scoring. Filling happens only

--- a/snakemake/conservation_eval/config/config.yaml
+++ b/snakemake/conservation_eval/config/config.yaml
@@ -18,12 +18,12 @@ datasets:
   - name: dsqtl
     hf_revision: b7e02a07beb831c7047286aacd3ddfd299d6f88f
     eval_protocol: qtl_global
-  # Saturation-genome-editing dataset (bolinas-dna/evals_sge, issue #301; v2
-  # rebuild #300). `sge` → per-accession × consequence-subset Spearman (track
-  # score vs −function_score_aligned) + AUPRC (calibrated_class abnormal-vs-
-  # normal), via the shared compute_sge_metrics. All 5 tracks in `scores:` run.
+  # Saturation-genome-editing dataset (bolinas-dna/evals_sge v3, issue #301).
+  # `sge` → per-accession × consequence-subset AUPRC predicting the binary
+  # `label` (impactful = calibrated abnormal) from the track score, via the
+  # shared compute_sge_metrics. All 5 tracks in `scores:` run.
   - name: sge
-    hf_revision: 39f47f0909a8130f8f8b6cbea6b09eb376fed70b  # evals_sge v2 (#300)
+    hf_revision: 225d3d1ea32a4af547891b13c33b5e92a5aae849  # evals_sge v3 (#301, AUPRC-only)
     eval_protocol: sge
 
 # Splits to score. Train-only convention — the test split is held out for

--- a/snakemake/conservation_eval/config/config.yaml
+++ b/snakemake/conservation_eval/config/config.yaml
@@ -18,6 +18,13 @@ datasets:
   - name: dsqtl
     hf_revision: b7e02a07beb831c7047286aacd3ddfd299d6f88f
     eval_protocol: qtl_global
+  # Saturation-genome-editing dataset (bolinas-dna/evals_sge, issue #301; v2
+  # rebuild #300). `sge` → per-accession × consequence-subset Spearman (track
+  # score vs −function_score_aligned) + AUPRC (calibrated_class abnormal-vs-
+  # normal), via the shared compute_sge_metrics. All 5 tracks in `scores:` run.
+  - name: sge
+    hf_revision: 39f47f0909a8130f8f8b6cbea6b09eb376fed70b  # evals_sge v2 (#300)
+    eval_protocol: sge
 
 # Splits to score. Train-only convention — the test split is held out for
 # the final-eval pass; all development / iteration uses train. Mirrors

--- a/snakemake/conservation_eval/workflow/rules/common.smk
+++ b/snakemake/conservation_eval/workflow/rules/common.smk
@@ -8,8 +8,10 @@ from marin_dna.pipelines.evals.conservation import (
     CONSERVATION_TRACKS,
     QTL_VARIANT_COLUMNS,
     REQUIRED_VARIANT_COLUMNS,
+    SGE_VARIANT_COLUMNS,
     aggregate_conservation_metrics,
     aggregate_conservation_qtl_metrics,
+    aggregate_conservation_sge_metrics,
     score_variants_at_positions,
 )
 
@@ -23,7 +25,9 @@ INPUT_HF_PREFIX = config["input_hf_prefix"]
 # `matched_pair` (default) → per-subset AUPRC + cluster bootstrap.
 # `qtl_global` → global AUPRC + positives-only effect_size correlation on the
 # unmatched DART-Eval QTL datasets (caqtl/dsqtl).
-EVAL_PROTOCOLS = ("matched_pair", "qtl_global")
+# `sge` (issue #301) → per-accession × consequence-subset Spearman + AUPRC on
+# evals_sge, via the same shared `compute_sge_metrics` as evals_v2.
+EVAL_PROTOCOLS = ("matched_pair", "qtl_global", "sge")
 
 
 def get_dataset_config(name: str) -> dict:
@@ -42,11 +46,12 @@ def get_dataset_protocol(name: str) -> str:
 
 def get_dataset_variant_columns(name: str) -> tuple[str, ...]:
     """Required variant columns for a dataset, keyed by eval protocol."""
-    return (
-        QTL_VARIANT_COLUMNS
-        if get_dataset_protocol(name) == "qtl_global"
-        else REQUIRED_VARIANT_COLUMNS
-    )
+    protocol = get_dataset_protocol(name)
+    if protocol == "qtl_global":
+        return QTL_VARIANT_COLUMNS
+    if protocol == "sge":
+        return SGE_VARIANT_COLUMNS
+    return REQUIRED_VARIANT_COLUMNS
 
 
 # Fail fast on an unknown eval_protocol (typo) at parse time.

--- a/snakemake/conservation_eval/workflow/rules/common.smk
+++ b/snakemake/conservation_eval/workflow/rules/common.smk
@@ -25,8 +25,8 @@ INPUT_HF_PREFIX = config["input_hf_prefix"]
 # `matched_pair` (default) → per-subset AUPRC + cluster bootstrap.
 # `qtl_global` → global AUPRC + positives-only effect_size correlation on the
 # unmatched DART-Eval QTL datasets (caqtl/dsqtl).
-# `sge` (issue #301) → per-accession × consequence-subset Spearman + AUPRC on
-# evals_sge, via the same shared `compute_sge_metrics` as evals_v2.
+# `sge` (issue #301) → per-accession × consequence-subset AUPRC on the binary
+# `label` of evals_sge, via the same shared `compute_sge_metrics` as evals_v2.
 EVAL_PROTOCOLS = ("matched_pair", "qtl_global", "sge")
 
 

--- a/snakemake/conservation_eval/workflow/rules/score.smk
+++ b/snakemake/conservation_eval/workflow/rules/score.smk
@@ -64,6 +64,12 @@ rule aggregate_metrics:
                 n_bootstrap=params.n_bootstrap,
                 bootstrap_seed=params.bootstrap_seed,
             )
+        elif get_dataset_protocol(wildcards.dataset) == "sge":
+            metrics, md = aggregate_conservation_sge_metrics(
+                parquet_paths,
+                n_bootstrap=params.n_bootstrap,
+                bootstrap_seed=params.bootstrap_seed,
+            )
         else:
             metrics, md = aggregate_conservation_metrics(
                 parquet_paths,

--- a/snakemake/evals/workflow/rules/sge.smk
+++ b/snakemake/evals/workflow/rules/sge.smk
@@ -7,6 +7,7 @@ from marin_dna.pipelines.evals.sge import (
     attach_author_class_harmonized,
     attach_calibrated_class,
     attach_function_direction,
+    attach_label,
     build_mavedb_metadata,
     load_mavedb_genomic_scoreset,
     load_mavedb_transcript_scoreset,
@@ -197,4 +198,17 @@ HIGH-impact, diagonal-concat."""
         data = attach_author_class_harmonized(data)
         data = attach_calibrated_class(data, calibrations)
         data = attach_function_direction(data, calibrations)
+        # #301: AUPRC-only benchmark. Add the boolean `label` (True = impactful =
+        # calibrated abnormal, False = normal) and keep only binary-labeled variants —
+        # drop intermediate + uncalibrated/null (incl. all of BRCA2) so no model scores
+        # a variant the classification metric never uses. The continuous
+        # function_score* columns stay for provenance.
+        data = attach_label(data)
+        n_before = data.height
+        data = data.filter(pl.col("label").is_not_null())
+        print(
+            f"[sge] label filter: kept {data.height}/{n_before} binary-labeled variants "
+            f"({data.filter(pl.col('label')).height} abnormal / "
+            f"{data.filter(~pl.col('label')).height} normal)"
+        )
         data.write_parquet(output[0])

--- a/src/marin_dna/pipelines/evals/conservation.py
+++ b/src/marin_dna/pipelines/evals/conservation.py
@@ -20,10 +20,10 @@ training_dataset/dataset_creation) but each pipeline manages its own
 download to avoid coupling.
 
 NaN policy: this module preserves NaNs from the bigWig (no alignment at that
-locus). Callers decide how to handle them — the ``conservation_eval`` pipeline
-``fillna(0)``s at the matched-pair / QTL metrics-aggregation step; the SGE path
-(``aggregate_conservation_sge_metrics``) instead drops non-finite scores per
-cell, since its metrics are rank-based (a 0 fill would inject a fake rank).
+locus). Callers decide how to fill them — the ``conservation_eval`` pipeline
+applies ``fillna(0)`` at the metrics-aggregation step (every eval protocol,
+SGE included; 0 is meaningful — neither conserved nor accelerated for phyloP,
+non-conserved for phastCons).
 """
 
 from pathlib import Path
@@ -164,6 +164,19 @@ def score_variants_at_positions(
     return scores
 
 
+def fill_score_nan(scores: pd.DataFrame) -> pd.DataFrame:
+    """The conservation NaN policy — the single shared home, used by **every**
+    eval-protocol aggregate (matched_pair / qtl_global / sge).
+
+    Unaligned bigWig loci have no value (NaN from ``score_variants_at_positions``).
+    Every conservation metric fills the score with 0 before scoring, because 0 is
+    semantically meaningful for both track types: neither conserved nor
+    accelerated (phyloP), non-conserved (phastCons). Callers that report an
+    ``n_nan`` diagnostic must count NaNs **before** calling this.
+    """
+    return scores.fillna(0)
+
+
 def aggregate_conservation_metrics(
     parquet_paths: dict[str, str | Path],
     n_min: int = 30,
@@ -223,7 +236,7 @@ def aggregate_conservation_metrics(
 
         m = compute_auprc_metrics(
             dataset=df[list(REQUIRED_VARIANT_COLUMNS)],
-            scores=df[["score"]].fillna(0),
+            scores=fill_score_nan(df[["score"]]),
             score_columns=["score"],
             n_min=n_min,
             n_bootstrap=n_bootstrap,
@@ -403,7 +416,7 @@ def aggregate_conservation_qtl_metrics(
 
         m = compute_qtl_metrics(
             dataset=df[["label", "effect_size"]],
-            scores=df[["score"]].fillna(0),
+            scores=fill_score_nan(df[["score"]]),
             score_columns=["score"],
             n_bootstrap=n_bootstrap,
             rng=bootstrap_seed,
@@ -479,14 +492,13 @@ def aggregate_conservation_sge_metrics(
     The conservation counterpart to the evals_v2 ``sge`` path. Each input parquet
     is ``score_variants_at_positions`` output plus SGE_VARIANT_COLUMNS
     (``[mavedb_urn, gene, subset, function_score_aligned, calibrated_class,
-    score]``). The per-track ``score`` is fed straight into the **shared**
+    score]``). The per-track ``score`` is fed into the **shared**
     ``compute_sge_metrics`` (``score_columns=["score"]``) — no metric logic is
     duplicated here; only the per-track loop + ``score_name`` stamping + markdown
-    are conservation-specific. Unlike the matched-pair / QTL conservation paths,
-    ``score`` is **not** ``.fillna(0)``: both SGE metrics are rank-based and
-    ``compute_sge_metrics`` drops non-finite scores per cell (a 0 fill would
-    inject a fake "neutral" rank at unaligned loci), so the NaN count is just
-    reported.
+    are conservation-specific. ``score`` is ``.fillna(0)`` before scoring, the
+    same convention as the matched-pair / QTL conservation paths (0 is
+    semantically meaningful: neither conserved nor accelerated for phyloP,
+    non-conserved for phastCons). The pre-fill NaN count is reported per track.
 
     Args:
         parquet_paths: mapping ``score_name -> parquet path``; order preserved.
@@ -522,7 +534,7 @@ def aggregate_conservation_sge_metrics(
 
         m = compute_sge_metrics(
             dataset=df[metric_cols],
-            scores=df[["score"]],
+            scores=fill_score_nan(df[["score"]]),
             score_columns=["score"],
             n_bootstrap=n_bootstrap,
             rng=bootstrap_seed,
@@ -548,8 +560,8 @@ def _build_sge_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
         "Per-accession (MaveDB study) Spearman of the conservation score vs "
         "`−function_score_aligned`, and AUPRC for `calibrated_class` "
         "abnormal-vs-normal, macro-averaged over consequence subsets "
-        "(missense/splicing) then over accessions. Both rank-based, so NaN "
-        "(unaligned) scores are dropped per cell, not filled."
+        "(missense/splicing) then over accessions. Unaligned (NaN) scores are "
+        "filled with 0 before scoring (the conservation-pipeline convention)."
     )
     lines.append("")
     headline = metrics[

--- a/src/marin_dna/pipelines/evals/conservation.py
+++ b/src/marin_dna/pipelines/evals/conservation.py
@@ -87,6 +87,30 @@ QTL_VARIANT_COLUMNS: tuple[str, ...] = (
     "effect_size",
 )
 
+# Columns the saturation-genome-editing dataset (``evals_sge``, issue #301; v2
+# rebuild #300) carries instead: no ``label`` / ``match_group`` / ``effect_size``.
+# Instead a per-study experimental score harmonized into ``function_score_aligned``
+# (higher = more functional/tolerated), a uniform ClinGen/ExCALIBR
+# ``calibrated_class`` ∈ {abnormal, intermediate, normal, null}, the MaveDB
+# ``mavedb_urn`` (the per-study grouping key — scores are non-comparable across
+# studies, so metrics are computed per accession), the ``gene`` (display), and the
+# consequence-group ``subset`` ∈ {missense_variant, splicing}. Asserted by the
+# ``eval_protocol: sge`` branch of each pipeline's score/metric rules.
+# ``compute_variant_scores`` itself only reads chrom/pos/ref/alt; asserting the
+# metric columns early fails fast on schema drift, since ``compute_sge_metrics``
+# depends on them surviving into the scores parquet.
+SGE_VARIANT_COLUMNS: tuple[str, ...] = (
+    "chrom",
+    "pos",
+    "ref",
+    "alt",
+    "mavedb_urn",
+    "gene",
+    "subset",
+    "function_score_aligned",
+    "calibrated_class",
+)
+
 
 def score_variants_at_positions(
     df: pd.DataFrame,

--- a/src/marin_dna/pipelines/evals/conservation.py
+++ b/src/marin_dna/pipelines/evals/conservation.py
@@ -90,18 +90,16 @@ QTL_VARIANT_COLUMNS: tuple[str, ...] = (
     "effect_size",
 )
 
-# Columns the saturation-genome-editing dataset (``evals_sge``, issue #301; v2
-# rebuild #300) carries instead: no ``label`` / ``match_group`` / ``effect_size``.
-# Instead a per-study experimental score harmonized into ``function_score_aligned``
-# (higher = more functional/tolerated), a uniform ClinGen/ExCALIBR
-# ``calibrated_class`` ∈ {abnormal, intermediate, normal, null}, the MaveDB
-# ``mavedb_urn`` (the per-study grouping key — scores are non-comparable across
-# studies, so metrics are computed per accession), the ``gene`` (display), and the
-# consequence-group ``subset`` ∈ {missense_variant, splicing}. Asserted by the
-# ``eval_protocol: sge`` branch of each pipeline's score/metric rules.
-# ``compute_variant_scores`` itself only reads chrom/pos/ref/alt; asserting the
-# metric columns early fails fast on schema drift, since ``compute_sge_metrics``
-# depends on them surviving into the scores parquet.
+# Columns the saturation-genome-editing dataset (``evals_sge`` v3, issue #301)
+# carries instead of ``match_group`` / ``effect_size``: a boolean ``label`` (True =
+# impactful = calibrated abnormal — the AUPRC target), the MaveDB ``mavedb_urn``
+# (the per-study grouping key — scores are non-comparable across studies, so AUPRC
+# is computed per accession), the ``gene`` (display), and the consequence-group
+# ``subset`` ∈ {missense_variant, splicing}. Asserted by the ``eval_protocol: sge``
+# branch of each pipeline's score/metric rules. ``compute_variant_scores`` itself
+# only reads chrom/pos/ref/alt; asserting the metric columns early fails fast on
+# schema drift, since ``compute_sge_metrics`` depends on them surviving into the
+# scores parquet.
 SGE_VARIANT_COLUMNS: tuple[str, ...] = (
     "chrom",
     "pos",
@@ -110,8 +108,7 @@ SGE_VARIANT_COLUMNS: tuple[str, ...] = (
     "mavedb_urn",
     "gene",
     "subset",
-    "function_score_aligned",
-    "calibrated_class",
+    "label",
 )
 
 
@@ -491,8 +488,8 @@ def aggregate_conservation_sge_metrics(
 
     The conservation counterpart to the evals_v2 ``sge`` path. Each input parquet
     is ``score_variants_at_positions`` output plus SGE_VARIANT_COLUMNS
-    (``[mavedb_urn, gene, subset, function_score_aligned, calibrated_class,
-    score]``). The per-track ``score`` is fed into the **shared**
+    (``[mavedb_urn, gene, subset, label, score]``). The per-track ``score`` is fed
+    into the **shared**
     ``compute_sge_metrics`` (``score_columns=["score"]``) — no metric logic is
     duplicated here; only the per-track loop + ``score_name`` stamping + markdown
     are conservation-specific. ``score`` is ``.fillna(0)`` before scoring, the
@@ -515,13 +512,7 @@ def aggregate_conservation_sge_metrics(
     assert parquet_paths, "parquet_paths must be non-empty"
 
     score_names = list(parquet_paths)
-    metric_cols = [
-        "mavedb_urn",
-        "gene",
-        "subset",
-        "function_score_aligned",
-        "calibrated_class",
-    ]
+    metric_cols = ["mavedb_urn", "gene", "subset", "label"]
     required = (*metric_cols, "score")
     all_metrics: list[pd.DataFrame] = []
 
@@ -557,11 +548,11 @@ def _build_sge_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
     lines.append("### SGE — headline macro (value ± bootstrap SE)")
     lines.append("")
     lines.append(
-        "Per-accession (MaveDB study) Spearman of the conservation score vs "
-        "`−function_score_aligned`, and AUPRC for `calibrated_class` "
-        "abnormal-vs-normal, macro-averaged over consequence subsets "
-        "(missense/splicing) then over accessions. Unaligned (NaN) scores are "
-        "filled with 0 before scoring (the conservation-pipeline convention)."
+        "Per-accession (MaveDB study) AUPRC predicting the binary `label` "
+        "(impactful vs not) from the conservation score, macro-averaged over "
+        "consequence subsets (missense/splicing) then over accessions. Unaligned "
+        "(NaN) scores are filled with 0 before scoring (the conservation-pipeline "
+        "convention)."
     )
     lines.append("")
     headline = metrics[
@@ -577,7 +568,7 @@ def _build_sge_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
     header = ["metric", *score_names]
     lines.append("| " + " | ".join(header) + " |")
     lines.append("| " + " | ".join(["---"] * len(header)) + " |")
-    for metric in ("spearman", "AUPRC"):
+    for metric in ("AUPRC",):
         if metric not in val.index:
             continue
         cells = []

--- a/src/marin_dna/pipelines/evals/conservation.py
+++ b/src/marin_dna/pipelines/evals/conservation.py
@@ -20,8 +20,10 @@ training_dataset/dataset_creation) but each pipeline manages its own
 download to avoid coupling.
 
 NaN policy: this module preserves NaNs from the bigWig (no alignment at that
-locus). Callers decide how to fill them — the ``conservation_eval`` pipeline
-applies ``fillna(0)`` only at the metrics-aggregation step.
+locus). Callers decide how to handle them — the ``conservation_eval`` pipeline
+``fillna(0)``s at the matched-pair / QTL metrics-aggregation step; the SGE path
+(``aggregate_conservation_sge_metrics``) instead drops non-finite scores per
+cell, since its metrics are rank-based (a 0 fill would inject a fake rank).
 """
 
 from pathlib import Path
@@ -35,6 +37,7 @@ from marin_dna.pipelines.evals.metrics import (
     MACRO_AVG_SUBSET,
     compute_auprc_metrics,
     compute_qtl_metrics,
+    compute_sge_metrics,
 )
 
 
@@ -462,4 +465,123 @@ def _build_qtl_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
         + ", ".join(f"{s}={int(nan_map.get(s, 0))}" for s in score_names)
     )
 
+    return "\n".join(lines) + "\n"
+
+
+def aggregate_conservation_sge_metrics(
+    parquet_paths: dict[str, str | Path],
+    *,
+    n_bootstrap: int = 1000,
+    bootstrap_seed: int | None = 0,
+) -> tuple[pd.DataFrame, str]:
+    """SGE metrics across per-track scored parquets (``eval_protocol: sge``).
+
+    The conservation counterpart to the evals_v2 ``sge`` path. Each input parquet
+    is ``score_variants_at_positions`` output plus SGE_VARIANT_COLUMNS
+    (``[mavedb_urn, gene, subset, function_score_aligned, calibrated_class,
+    score]``). The per-track ``score`` is fed straight into the **shared**
+    ``compute_sge_metrics`` (``score_columns=["score"]``) — no metric logic is
+    duplicated here; only the per-track loop + ``score_name`` stamping + markdown
+    are conservation-specific. Unlike the matched-pair / QTL conservation paths,
+    ``score`` is **not** ``.fillna(0)``: both SGE metrics are rank-based and
+    ``compute_sge_metrics`` drops non-finite scores per cell (a 0 fill would
+    inject a fake "neutral" rank at unaligned loci), so the NaN count is just
+    reported.
+
+    Args:
+        parquet_paths: mapping ``score_name -> parquet path``; order preserved.
+        n_bootstrap: bootstrap iterations per cell.
+        bootstrap_seed: seed; ``None`` for fresh randomness. Default ``0`` keeps
+            outputs bit-stable across re-runs.
+
+    Returns:
+        ``(metrics_df, markdown)`` where ``metrics_df`` is ``compute_sge_metrics``
+        output (``[metric, subset, accession, gene, score_type, value, se, n,
+        n_pos]``, ``score_type == "score"``) plus ``[score_name, n_nan, n_total]``
+        per track.
+    """
+    assert parquet_paths, "parquet_paths must be non-empty"
+
+    score_names = list(parquet_paths)
+    metric_cols = [
+        "mavedb_urn",
+        "gene",
+        "subset",
+        "function_score_aligned",
+        "calibrated_class",
+    ]
+    required = (*metric_cols, "score")
+    all_metrics: list[pd.DataFrame] = []
+
+    for score_name in score_names:
+        df = pd.read_parquet(parquet_paths[score_name])
+        for col in required:
+            assert col in df.columns, (
+                f"{parquet_paths[score_name]}: missing column {col!r}"
+            )
+
+        m = compute_sge_metrics(
+            dataset=df[metric_cols],
+            scores=df[["score"]],
+            score_columns=["score"],
+            n_bootstrap=n_bootstrap,
+            rng=bootstrap_seed,
+        )
+        m["score_name"] = score_name
+        m["n_nan"] = int(df["score"].isna().sum())
+        m["n_total"] = int(len(df))
+        all_metrics.append(m)
+
+    metrics = pd.concat(all_metrics, ignore_index=True)
+    md = _build_sge_markdown(metrics, score_names)
+    return metrics, md
+
+
+def _build_sge_markdown(metrics: pd.DataFrame, score_names: list[str]) -> str:
+    """Render the SGE headline (across-accession × across-subset macro) as a
+    markdown table (metric × track). The full per-accession × per-subset grid
+    lives in the metrics parquet; this is the at-a-glance summary."""
+    lines: list[str] = []
+    lines.append("### SGE — headline macro (value ± bootstrap SE)")
+    lines.append("")
+    lines.append(
+        "Per-accession (MaveDB study) Spearman of the conservation score vs "
+        "`−function_score_aligned`, and AUPRC for `calibrated_class` "
+        "abnormal-vs-normal, macro-averaged over consequence subsets "
+        "(missense/splicing) then over accessions. Both rank-based, so NaN "
+        "(unaligned) scores are dropped per cell, not filled."
+    )
+    lines.append("")
+    headline = metrics[
+        (metrics["accession"] == MACRO_AVG_SUBSET)
+        & (metrics["subset"] == MACRO_AVG_SUBSET)
+    ]
+    val = headline.pivot_table(
+        index="metric", columns="score_name", values="value", aggfunc="first"
+    )
+    se = headline.pivot_table(
+        index="metric", columns="score_name", values="se", aggfunc="first"
+    )
+    header = ["metric", *score_names]
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("| " + " | ".join(["---"] * len(header)) + " |")
+    for metric in ("spearman", "AUPRC"):
+        if metric not in val.index:
+            continue
+        cells = []
+        for s in score_names:
+            v = val.loc[metric, s] if s in val.columns else float("nan")
+            e = se.loc[metric, s] if s in se.columns else float("nan")
+            cells.append(f"{v:.3f} ± {e:.3f}" if pd.notna(v) and pd.notna(e) else "—")
+        lines.append("| " + " | ".join([metric, *cells]) + " |")
+
+    nan_map = (
+        metrics.drop_duplicates("score_name").set_index("score_name")["n_nan"].to_dict()
+    )
+    n_total = int(metrics["n_total"].iloc[0])
+    lines.append("")
+    lines.append(
+        f"n_total = {n_total}. NaN (unaligned) scores per track: "
+        + ", ".join(f"{s}={int(nan_map.get(s, 0))}" for s in score_names)
+    )
     return "\n".join(lines) + "\n"

--- a/src/marin_dna/pipelines/evals/hf_readme.py
+++ b/src/marin_dna/pipelines/evals/hf_readme.py
@@ -835,9 +835,11 @@ def render_sge(
 ) -> str:
     """Dataset card for the SGE (saturation genome editing) dataset.
 
-    Each row is one assayed SNV with an experimental function score. There is no
-    matching/subsampling and no binary `label` (so no pos/neg counts); the
-    HIGH-impact `exclude_consequences` are dropped; every original author column is
+    Each row is one assayed SNV with an experimental function score and (v3, #301) a
+    binary `label` (True = impactful / calibrated abnormal, False = normal). No
+    matching/subsampling; the HIGH-impact `exclude_consequences` are dropped, the
+    missense+splicing groups kept, and v3 keeps only label-non-null variants (drops
+    intermediate + uncalibrated, incl. BRCA2). Every original author column is
     preserved under an `author_` prefix. Provenance is per-variant `(gene,
     mavedb_urn)`; per-study citation comes from `_SGE_STUDY_META`.
     """
@@ -893,13 +895,16 @@ in genomic coordinates — an axis orthogonal to the clinical/population/statist
 labels of the other `evals_*` datasets, and one that covers near-exon noncoding
 (splice-region, proximal-intronic) SNVs, not just missense.
 
-**No matching, no subsampling, no binary label.** The trivially-deleterious **HIGH-impact
-consequences** (canonical splice, nonsense, frameshift, …) are dropped
-(`exclude_consequences`), and v2
+**No matching, no subsampling.** The trivially-deleterious **HIGH-impact consequences**
+(canonical splice, nonsense, frameshift, …) are dropped (`exclude_consequences`), and v2
 ([#297](https://github.com/Open-Athena/marin-dna/issues/297)) further keeps only the
 **missense + splicing** consequence groups — the two where the SGE assay actually
-measures function. **Every original author column is preserved** under an `author_`
-prefix ({n_author} columns), so no source metadata is lost.
+measures function. **v3 ([#301](https://github.com/Open-Athena/marin-dna/issues/301))**
+adds a binary **`label`** (`True` = impactful = calibrated `abnormal`, `False` =
+`normal`) and keeps only label-non-null variants — dropping `intermediate` and
+uncalibrated rows (all of BRCA2) — so this is a clean classification benchmark scored by
+AUPRC. **Every original author column is preserved** under an `author_` prefix
+({n_author} columns), so no source metadata is lost.
 
 ## Studies
 
@@ -918,11 +923,11 @@ Chromosome-parity split (same convention as the other `evals_*` datasets): odd
 chromosomes + X → `train`, even + Y → `test`. SGE loci sit on whole chromosomes, so
 this is a **gene-level holdout** (e.g. BRCA1·chr17 → train).
 
-| Split | Variants | Chromosomes |
-|---|---:|---|
-| `train` | {train.height:,} | odd: 1, 3, …, X |
-| `test` | {test.height:,} | even: 2, 4, …, Y |
-| **total** | **{total:,}** | |
+| Split | Variants | Abnormal | Normal | Chromosomes |
+|---|---:|---:|---:|---|
+| `train` | {train.height:,} | {train.filter(pl.col("label")).height:,} | {train.filter(~pl.col("label")).height:,} | odd: 1, 3, …, X |
+| `test` | {test.height:,} | {test.filter(pl.col("label")).height:,} | {test.filter(~pl.col("label")).height:,} | even: 2, 4, …, Y |
+| **total** | **{total:,}** | **{allv.filter(pl.col("label")).height:,}** | **{allv.filter(~pl.col("label")).height:,}** | |
 
 ## Columns
 
@@ -932,6 +937,7 @@ this is a **gene-level holdout** (e.g. BRCA1·chr17 → train).
 | `gene` | str | Gene symbol. |
 | `assay` | str | `sge`. |
 | `mavedb_urn` | str | Canonical MaveDB accession for the source study (see the table above). |
+| `label` | bool | **The AUPRC target (v3, [#301](https://github.com/Open-Athena/marin-dna/issues/301)):** `True` = impactful (calibrated `abnormal`), `False` = `normal`. The build keeps only label-non-null rows, so this is always a clean bool. |
 | `function_score` | float | Each study's headline continuous functional score (raw, **per-study scale** — pool by rank, not raw value). |
 | `function_direction`, `function_score_aligned` | int / float | Per-gene assay direction (`+1` / `−1`, null if unresolved — BRCA2) and the direction-corrected score (`function_direction × function_score`) so "higher = more functional" holds across genes. Sourced from the assay (calibration ranges / author class), **not** the model. |
 | `calibrated_class` | str | ClinGen/ExCALIBR-calibrated `abnormal` / `intermediate` / `normal` (or null), decided at build with an **ExCALIBR-first policy** (prefers the live calibration; never a dated ClinVar snapshot). |
@@ -943,12 +949,14 @@ this is a **gene-level holdout** (e.g. BRCA1·chr17 → train).
 | `consequence`, `consequence_cre`, `consequence_final` | str | Ensembl VEP consequence (raw, with-CRE-class, and after TSS/exon-proximity recategorization); reference annotations. |
 | `distance_tss_*`, `distance_exon_*`, `*_closest_gene_id` | int / str | Distances to nearest TSS / exon and the Ensembl gene IDs there; reference annotations. |
 
-There is still no binary `label`, but v2 ([#297](https://github.com/Open-Athena/marin-dna/issues/297))
-ships harmonized, cross-gene-comparable columns so the eval needn't re-derive them: a
-per-gene `function_direction` / `function_score_aligned`, a calibrated `calibrated_class`
-(ExCALIBR-first policy) with its `calibration_scheme` + `acmg_strength`, and an
-`author_class_harmonized`. The authors' raw `function_score` and every `author_` column
-are preserved verbatim; **per-study scales still differ**, so pool by rank, not raw value.
+v3 ([#301](https://github.com/Open-Athena/marin-dna/issues/301)) derives the binary
+`label` from `calibrated_class` (abnormal → `True`, normal → `False`) and filters to
+label-non-null rows. The harmonized continuous columns v2 added —
+`function_direction` / `function_score_aligned`, `calibrated_class` with its
+`calibration_scheme` + `acmg_strength`, and `author_class_harmonized` — are kept for
+provenance (the AUPRC eval reads only `label`). The authors' raw `function_score` and
+every `author_` column are preserved verbatim; **per-study scales still differ**, so any
+continuous re-analysis should pool by rank, not raw value.
 
 ## Provenance
 

--- a/src/marin_dna/pipelines/evals/leaderboard.py
+++ b/src/marin_dna/pipelines/evals/leaderboard.py
@@ -351,3 +351,76 @@ def normalized_rows(dataset: str) -> pl.DataFrame:
                     }
                 )
     return pl.DataFrame(rows)
+
+
+# Columns kept from each method's SGE metrics parquet, in output order.
+_SGE_ROW_COLUMNS = (
+    "metric",
+    "subset",
+    "accession",
+    "gene",
+    "score_type",
+    "value",
+    "se",
+    "n",
+    "n_pos",
+)
+
+
+def sge_normalized_rows(dataset: str = "sge") -> pl.DataFrame:
+    """Long-form SGE metrics across all registered methods (the dedicated SGE
+    leaderboard loader; ``dashboard/src/data/sge.parquet.py`` writes its output).
+
+    SGE keeps the full per-accession × per-subset × per-metric grid from
+    ``compute_sge_metrics`` — too rich for ``normalized_rows``' single
+    ``[subset, value, se, …]`` row shape — so this emits one row per
+    ``(method, score_type, metric, subset, accession)`` and lets the dashboard
+    page do the gene-scope / subset / metric / protocol selection.
+
+    Reuses ``_parquet_path``: marin_dna methods have a per-method parquet (every
+    ``score_type`` — ``minus_llr_*`` / ``jsd_*`` — kept, so the page's LLR/JSD
+    toggle works); conservation methods share one per-dataset parquet, filtered
+    to the track by ``score_name == method.id`` (``score_type`` is always
+    ``"score"`` there). Methods whose parquet isn't on S3 yet are skipped with a
+    warning (same soft-fail posture as ``normalized_rows``).
+
+    Columns: ``[method_id, method_display, family, score_type, metric, subset,
+    accession, gene, value, se, n, n_pos]``. ``n_pos`` is the abnormal count for
+    AUPRC rows and NaN for Spearman rows.
+    """
+    soft_fail = (LookupError, pl.exceptions.ComputeError, FileNotFoundError)
+    rows: list[dict] = []
+    for method in models_for_dataset(dataset):
+        path = _parquet_path(method, dataset)
+        try:
+            df = _read_parquet(path)
+        except soft_fail as exc:
+            print(f"  ! sge skip for {method.id} ({path}): {exc}", file=sys.stderr)
+            continue
+        if method.family == "conservation":
+            df = df.filter(pl.col("score_name") == method.id)
+        missing = [c for c in _SGE_ROW_COLUMNS if c not in df.columns]
+        assert not missing, (
+            f"SGE parquet for {method.id!r} missing columns {missing}; got {df.columns}"
+        )
+        if df.height == 0:
+            print(f"  ! sge no rows for {method.id} in {path}", file=sys.stderr)
+            continue
+        for row in df.iter_rows(named=True):
+            rows.append(
+                {
+                    "method_id": method.id,
+                    "method_display": method.display,
+                    "family": method.family,
+                    "score_type": row["score_type"],
+                    "metric": row["metric"],
+                    "subset": row["subset"],
+                    "accession": row["accession"],
+                    "gene": row["gene"],
+                    "value": float(row["value"]),
+                    "se": float(row["se"]),
+                    "n": int(row["n"]),
+                    "n_pos": float(row["n_pos"]),
+                }
+            )
+    return pl.DataFrame(rows)

--- a/src/marin_dna/pipelines/evals/leaderboard.py
+++ b/src/marin_dna/pipelines/evals/leaderboard.py
@@ -410,7 +410,14 @@ def sge_normalized_rows(dataset: str = "sge") -> pl.DataFrame:
             print(f"  ! sge skip for {method.id} ({path}): {exc}", file=sys.stderr)
             continue
         if method.family == "conservation":
+            # conservation's parquet path is split-specific (…/metrics_{SPLIT}.parquet),
+            # so it only needs the per-track score_name select, no split filter.
             df = df.filter(pl.col("score_name") == method.id)
+        elif method.family == "marin_dna":
+            # The per-model parquet path is NOT split-specific and carries a
+            # `split` column for whichever split was scored — guard it like
+            # fetch_method_metrics so a future test-split run can't leak in.
+            df = df.filter(pl.col("split") == SPLIT)
         missing = [c for c in _SGE_ROW_COLUMNS if c not in df.columns]
         assert not missing, (
             f"SGE parquet for {method.id!r} missing columns {missing}; got {df.columns}"

--- a/src/marin_dna/pipelines/evals/leaderboard.py
+++ b/src/marin_dna/pipelines/evals/leaderboard.py
@@ -367,6 +367,14 @@ _SGE_ROW_COLUMNS = (
 )
 
 
+def _nan_float(x: object) -> float:
+    """Map a polars null back to NaN. A pandas float-NaN written to parquet
+    round-trips as a *null*, so Spearman rows (``n_pos`` = NaN, by design) and
+    any degenerate-bootstrap ``se`` come back as ``None``; keep them as NaN
+    rather than crashing on ``float(None)``."""
+    return float("nan") if x is None else float(x)
+
+
 def sge_normalized_rows(dataset: str = "sge") -> pl.DataFrame:
     """Long-form SGE metrics across all registered methods (the dedicated SGE
     leaderboard loader; ``dashboard/src/data/sge.parquet.py`` writes its output).
@@ -388,7 +396,11 @@ def sge_normalized_rows(dataset: str = "sge") -> pl.DataFrame:
     accession, gene, value, se, n, n_pos]``. ``n_pos`` is the abnormal count for
     AUPRC rows and NaN for Spearman rows.
     """
-    soft_fail = (LookupError, pl.exceptions.ComputeError, FileNotFoundError)
+    # A method registered for SGE may not have its metrics parquet on S3 yet
+    # (e.g. the gLMs before their scoring run is done) — polars surfaces an S3
+    # 404 as OSError (FileNotFoundError covers the local-path case). Skip + warn
+    # rather than fail the whole loader; the parquet appears once the run lands.
+    soft_fail = (LookupError, pl.exceptions.ComputeError, FileNotFoundError, OSError)
     rows: list[dict] = []
     for method in models_for_dataset(dataset):
         path = _parquet_path(method, dataset)
@@ -417,10 +429,10 @@ def sge_normalized_rows(dataset: str = "sge") -> pl.DataFrame:
                     "subset": row["subset"],
                     "accession": row["accession"],
                     "gene": row["gene"],
-                    "value": float(row["value"]),
-                    "se": float(row["se"]),
+                    "value": _nan_float(row["value"]),
+                    "se": _nan_float(row["se"]),
                     "n": int(row["n"]),
-                    "n_pos": float(row["n_pos"]),
+                    "n_pos": _nan_float(row["n_pos"]),
                 }
             )
     return pl.DataFrame(rows)

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -108,6 +108,13 @@ def pairwise_accuracy(
 GLOBAL_SUBSET = "_global_"
 MACRO_AVG_SUBSET = "_macro_avg_"
 
+# Derived SGE subset scope. The dataset's real ``subset`` values are
+# ``missense_variant`` / ``splicing``; ``SGE_POOLED_SUBSET`` is the two pooled
+# within an accession ("both"), while ``MACRO_AVG_SUBSET`` (reused) is the
+# equal-weight mean of the base-subset values. Both the ``subset`` and the
+# ``accession`` axes use ``MACRO_AVG_SUBSET`` for their macro rows.
+SGE_POOLED_SUBSET = "both"
+
 # Per-strand LLR → score-protocol transforms. Keyed by the
 # ``score_protocol`` field in `snakemake/analysis/evals_v2/config/config.yaml`
 # and consumed by `metrics.smk` to materialize `{protocol}_{fwd,rc,avg}`
@@ -623,6 +630,261 @@ def compute_qtl_metrics(
                     "n_pos": n_pos,
                 }
             )
+
+    return pd.DataFrame(rows)
+
+
+def _macro(children: list[dict]) -> dict | None:
+    """Equal-weight macro over leaf/child metric dicts.
+
+    ``value`` = unweighted mean; ``se`` = SE-of-mean ``sqrt(Σ SE²)/K`` (same form
+    as ``compute_auprc_metrics``); ``n`` = K (children averaged); ``n_pos`` =
+    summed abnormal count, or NaN if any child's ``n_pos`` is NaN (Spearman
+    children carry no positive count). Returns ``None`` if there are no children.
+    """
+    if not children:
+        return None
+    k = len(children)
+    value = sum(c["value"] for c in children) / k
+    se = math.sqrt(sum(c["se"] ** 2 for c in children)) / k
+    n_pos_vals = [c["n_pos"] for c in children]
+    n_pos = (
+        float("nan") if any(np.isnan(v) for v in n_pos_vals) else int(sum(n_pos_vals))
+    )
+    return {"value": float(value), "se": float(se), "n": k, "n_pos": n_pos}
+
+
+def _sge_cell_metrics(
+    cell: pd.DataFrame,
+    score_col: str,
+    *,
+    n_bootstrap: int,
+    rng: np.random.Generator,
+    n_min_corr: int,
+    n_min_auprc: int,
+) -> dict[str, dict]:
+    """Spearman + AUPRC for one (accession, subset-scope) cell and one score column.
+
+    Returns only the metrics that meet their ``n_min`` gate, keyed
+    ``"spearman"`` / ``"AUPRC"`` → ``dict(value, se, n, n_pos)``. NaN scores are
+    dropped (conservation tracks have no value at unaligned loci).
+    """
+    out: dict[str, dict] = {}
+    score = np.asarray(cell[score_col], dtype=float)
+
+    # Spearman: deleteriousness-oriented score vs −function_score_aligned (higher
+    # function_score_aligned = more tolerated, so a good score → positive ρ).
+    aligned = np.asarray(cell["function_score_aligned"], dtype=float)
+    finite = np.isfinite(score) & np.isfinite(aligned)
+    x = score[finite]
+    y = -aligned[finite]
+    if len(x) >= n_min_corr and np.std(x) > 0 and np.std(y) > 0:
+        value, se = _correlation_with_bootstrap_se(
+            x, y, method="spearman", n_bootstrap=n_bootstrap, rng=rng
+        )
+        out["spearman"] = {
+            "value": value,
+            "se": se,
+            "n": int(len(x)),
+            "n_pos": float("nan"),
+        }
+
+    # AUPRC: abnormal (1) vs normal (0); intermediate / null / NaN-score dropped.
+    cc = cell["calibrated_class"].to_numpy()
+    binary = np.isin(cc, ("abnormal", "normal")) & np.isfinite(score)
+    label = (cc[binary] == "abnormal").astype(int)
+    bscore = score[binary]
+    n_pos = int(label.sum())
+    n_neg = int((label == 0).sum())
+    if n_pos >= n_min_auprc and n_neg >= n_min_auprc:
+        res = auprc_with_bootstrap_se(
+            label=label,
+            score=bscore,
+            match_group=np.arange(len(label)),
+            n_bootstrap=n_bootstrap,
+            rng=rng,
+        )
+        out["AUPRC"] = {
+            "value": res["value"],
+            "se": res["se"],
+            "n": res["n_rows"],
+            "n_pos": n_pos,
+        }
+    return out
+
+
+def compute_sge_metrics(
+    dataset: pd.DataFrame,
+    scores: pd.DataFrame,
+    score_columns: list[str] | None = None,
+    *,
+    n_bootstrap: int = 1000,
+    rng: np.random.Generator | int | None = 0,
+    n_min_corr: int = 100,
+    n_min_auprc: int = 30,
+) -> pd.DataFrame:
+    """Per-accession × per-subset Spearman + AUPRC for the SGE benchmark.
+
+    Saturation-genome-editing (``evals_sge``) is an orthogonal label axis: each
+    variant carries a continuous, per-study function score (harmonized across
+    studies into ``function_score_aligned``) and, where ClinGen/ExCALIBR
+    calibration exists, a uniform ``calibrated_class`` ∈ {abnormal, intermediate,
+    normal}. Scores are per-study (non-comparable scales), so everything is
+    computed **per accession** (``mavedb_urn``) and then macro-averaged — raw
+    scores are never pooled across accessions.
+
+    Both metrics are **rank-based**, so a conservation track's single scalar and
+    a gLM's ``minus_llr`` compare on the same footing despite very different
+    score scales (this is also why Pearson is intentionally omitted):
+
+    - **spearman**: rank correlation of the (deleteriousness-oriented) model
+      score vs **``−function_score_aligned``**. Over rows with finite score and
+      finite aligned target; requires ``n >= n_min_corr``.
+    - **AUPRC**: predict ``calibrated_class == "abnormal"`` vs ``== "normal"``
+      (``intermediate`` / null dropped). Plain row bootstrap via singleton
+      ``match_group`` (as in ``compute_qtl_metrics``); requires
+      ``>= n_min_auprc`` per label.
+
+    Two macro axes, each using the ``_macro_avg_`` sentinel:
+
+    - ``subset`` ∈ {each base subset (e.g. ``missense_variant`` / ``splicing``),
+      ``SGE_POOLED_SUBSET`` (``"both"``, pooled within the accession),
+      ``MACRO_AVG_SUBSET`` (equal-weight mean of the base-subset values)}.
+    - ``accession`` ∈ {each ``mavedb_urn``, ``MACRO_AVG_SUBSET`` (equal-weight
+      mean over qualifying accessions)} — taken of **every** subset scope above,
+      including the per-accession subset-macro.
+
+    The same single ``rng`` ``Generator`` is threaded through every bootstrap
+    (as in ``compute_qtl_metrics``) so outputs are bit-stable across re-runs.
+
+    Args:
+        dataset: columns ``[mavedb_urn, gene, subset, function_score_aligned,
+            calibrated_class]``, row-aligned with ``scores``.
+        scores: model-score columns; row-aligned with ``dataset``. gLM passes
+            ``minus_llr_*`` + ``jsd_*``; conservation passes ``["score"]``.
+        score_columns: which score columns to evaluate (default: all of
+            ``scores``).
+        n_bootstrap: bootstrap iterations per cell.
+        rng: ``Generator`` / seed / ``None`` (default ``0`` → reproducible).
+        n_min_corr: min finite rows per cell for a Spearman.
+        n_min_auprc: min count **per label** per cell for an AUPRC.
+
+    Returns:
+        DataFrame ``[metric, subset, accession, gene, score_type, value, se, n,
+        n_pos]``. ``metric`` ∈ {``spearman``, ``AUPRC``}. For leaf cells ``n`` is
+        the rows used and ``n_pos`` the abnormal count (NaN for Spearman); for
+        macro rows ``n`` is K (children averaged) and ``n_pos`` the summed
+        abnormal count (NaN for Spearman).
+    """
+    for col in (
+        "mavedb_urn",
+        "gene",
+        "subset",
+        "function_score_aligned",
+        "calibrated_class",
+    ):
+        assert col in dataset.columns, f"dataset missing required column {col!r}"
+    assert len(dataset) == len(scores), (
+        f"length mismatch: dataset={len(dataset)} scores={len(scores)}"
+    )
+    if score_columns is None:
+        score_columns = list(scores.columns)
+
+    merged = pd.concat(
+        [dataset.reset_index(drop=True), scores.reset_index(drop=True)], axis=1
+    )
+
+    base_subsets = sorted(merged["subset"].dropna().unique().tolist())
+    assert base_subsets, "no subset values in dataset"
+    for sentinel in (SGE_POOLED_SUBSET, MACRO_AVG_SUBSET):
+        assert sentinel not in base_subsets, (
+            f"reserved subset name {sentinel!r} collides with a real subset"
+        )
+
+    # Each MaveDB study (mavedb_urn) identifies exactly one gene — fail loud on
+    # drift, then carry `gene` for display alongside the accession key.
+    urn_gene = merged.groupby("mavedb_urn")["gene"].nunique()
+    assert (urn_gene == 1).all(), (
+        f"mavedb_urn maps to >1 gene: {urn_gene[urn_gene > 1].to_dict()}"
+    )
+    urn_to_gene = merged.groupby("mavedb_urn")["gene"].first().to_dict()
+
+    rng = np.random.default_rng(rng)
+
+    rows: list[dict] = []
+    for score_col in score_columns:
+        # (accession, subset_scope, metric) -> dict(value, se, n, n_pos)
+        cells: dict[tuple[str, str, str], dict] = {}
+
+        for urn, urn_df in merged.groupby("mavedb_urn", sort=False):
+            scopes: dict[str, pd.DataFrame] = {
+                s: urn_df[urn_df["subset"] == s] for s in base_subsets
+            }
+            scopes[SGE_POOLED_SUBSET] = urn_df
+            for scope, cell_df in scopes.items():
+                got = _sge_cell_metrics(
+                    cell_df,
+                    score_col,
+                    n_bootstrap=n_bootstrap,
+                    rng=rng,
+                    n_min_corr=n_min_corr,
+                    n_min_auprc=n_min_auprc,
+                )
+                for metric, res in got.items():
+                    cells[(str(urn), scope, metric)] = res
+
+            # Per-accession subset-macro: mean over base subsets that qualified.
+            for metric in ("spearman", "AUPRC"):
+                kids = [
+                    cells[(str(urn), s, metric)]
+                    for s in base_subsets
+                    if (str(urn), s, metric) in cells
+                ]
+                macro = _macro(kids)
+                if macro is not None:
+                    cells[(str(urn), MACRO_AVG_SUBSET, metric)] = macro
+
+        # Per-accession rows.
+        for (urn, scope, metric), res in cells.items():
+            rows.append(
+                {
+                    "metric": metric,
+                    "subset": scope,
+                    "accession": urn,
+                    "gene": urn_to_gene[urn],
+                    "score_type": score_col,
+                    "value": res["value"],
+                    "se": res["se"],
+                    "n": res["n"],
+                    "n_pos": res["n_pos"],
+                }
+            )
+
+        # Accession-macro: mean over accessions of every subset scope.
+        all_scopes = base_subsets + [SGE_POOLED_SUBSET, MACRO_AVG_SUBSET]
+        accessions = [str(u) for u in merged["mavedb_urn"].unique()]
+        for scope in all_scopes:
+            for metric in ("spearman", "AUPRC"):
+                kids = [
+                    cells[(urn, scope, metric)]
+                    for urn in accessions
+                    if (urn, scope, metric) in cells
+                ]
+                macro = _macro(kids)
+                if macro is not None:
+                    rows.append(
+                        {
+                            "metric": metric,
+                            "subset": scope,
+                            "accession": MACRO_AVG_SUBSET,
+                            "gene": MACRO_AVG_SUBSET,
+                            "score_type": score_col,
+                            "value": macro["value"],
+                            "se": macro["se"],
+                            "n": macro["n"],
+                            "n_pos": macro["n_pos"],
+                        }
+                    )
 
     return pd.DataFrame(rows)
 

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -661,14 +661,17 @@ def _sge_cell_metrics(
     n_bootstrap: int,
     rng: np.random.Generator,
     n_min_auprc: int,
-) -> dict[str, dict]:
+) -> tuple[dict[str, dict], int, int]:
     """AUPRC for one (accession, subset-scope) cell and one score column.
 
-    Returns ``{"AUPRC": dict(value, se, n, n_pos)}`` when both classes of the
-    binary ``label`` (True = impactful) have ``>= n_min_auprc`` rows, else ``{}``.
-    Plain row bootstrap via singleton ``match_group`` (as in
-    ``compute_qtl_metrics``). NaN-score rows are dropped (conservation fills
-    unaligned loci with 0 upstream, so this is a defensive guard).
+    Returns ``(out, n_pos, n_neg)``. ``out`` is ``{"AUPRC": dict(value, se, n,
+    n_pos)}`` when both classes of the binary ``label`` (True = impactful) have
+    ``>= n_min_auprc`` rows, else ``{}`` (the cell is gated — too few of one
+    class for a stable AUPRC). ``n_pos`` / ``n_neg`` are the (finite-score) class
+    counts, returned **regardless** of the gate so the caller can still report a
+    blanked cell's sample size. Plain row bootstrap via singleton ``match_group``
+    (as in ``compute_qtl_metrics``). NaN-score rows are dropped (conservation
+    fills unaligned loci with 0 upstream, so this is a defensive guard).
     """
     out: dict[str, dict] = {}
     score = np.asarray(cell[score_col], dtype=float)
@@ -691,7 +694,7 @@ def _sge_cell_metrics(
             "n": res["n_rows"],
             "n_pos": n_pos,
         }
-    return out
+    return out, n_pos, n_neg
 
 
 def compute_sge_metrics(
@@ -745,6 +748,10 @@ def compute_sge_metrics(
         n_pos]``. ``metric`` is always ``"AUPRC"``. For leaf cells ``n`` is the
         rows used and ``n_pos`` the impactful (label-True) count; for macro rows
         ``n`` is K (children averaged) and ``n_pos`` the summed impactful count.
+        Leaf cells that fail the ``n_min_auprc`` gate are still emitted, with
+        ``value``/``se`` = NaN but a real ``n`` / ``n_pos`` (so a blanked cell's
+        class balance is still reported); these gated rows are excluded from
+        every macro.
     """
     for col in ("mavedb_urn", "gene", "subset", "label"):
         assert col in dataset.columns, f"dataset missing required column {col!r}"
@@ -779,6 +786,10 @@ def compute_sge_metrics(
     for score_col in score_columns:
         # (accession, subset_scope, metric) -> dict(value, se, n, n_pos)
         cells: dict[tuple[str, str, str], dict] = {}
+        # Leaf cells that failed the AUPRC gate: (accession, scope, n_pos, n_neg).
+        # Emitted as value=NaN rows so the grid still reports the blanked cell's
+        # class balance, but kept OUT of `cells` so they never enter a macro.
+        gated: list[tuple[str, str, int, int]] = []
 
         for urn, urn_df in merged.groupby("mavedb_urn", sort=False):
             scopes: dict[str, pd.DataFrame] = {
@@ -786,7 +797,7 @@ def compute_sge_metrics(
             }
             scopes[SGE_POOLED_SUBSET] = urn_df
             for scope, cell_df in scopes.items():
-                got = _sge_cell_metrics(
+                got, n_pos, n_neg = _sge_cell_metrics(
                     cell_df,
                     score_col,
                     n_bootstrap=n_bootstrap,
@@ -795,6 +806,8 @@ def compute_sge_metrics(
                 )
                 for metric, res in got.items():
                     cells[(str(urn), scope, metric)] = res
+                if "AUPRC" not in got and (n_pos + n_neg) > 0:
+                    gated.append((str(urn), scope, n_pos, n_neg))
 
             # Per-accession subset-macro: mean over base subsets that qualified.
             for metric in ("AUPRC",):
@@ -820,6 +833,23 @@ def compute_sge_metrics(
                     "se": res["se"],
                     "n": res["n"],
                     "n_pos": res["n_pos"],
+                }
+            )
+
+        # Gated leaf cells: value=NaN, but carry the class counts so the grid
+        # reports the sample size of each blanked cell (n_pos / n=n_pos+n_neg).
+        for urn, scope, n_pos, n_neg in gated:
+            rows.append(
+                {
+                    "metric": "AUPRC",
+                    "subset": scope,
+                    "accession": urn,
+                    "gene": urn_to_gene[urn],
+                    "score_type": score_col,
+                    "value": float("nan"),
+                    "se": float("nan"),
+                    "n": n_pos + n_neg,
+                    "n_pos": n_pos,
                 }
             )
 

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -660,50 +660,27 @@ def _sge_cell_metrics(
     *,
     n_bootstrap: int,
     rng: np.random.Generator,
-    n_min_corr: int,
     n_min_auprc: int,
 ) -> dict[str, dict]:
-    """Spearman + AUPRC for one (accession, subset-scope) cell and one score column.
+    """AUPRC for one (accession, subset-scope) cell and one score column.
 
-    Returns only the metrics that meet their ``n_min`` gate, keyed
-    ``"spearman"`` / ``"AUPRC"`` → ``dict(value, se, n, n_pos)``. Rows with a
-    non-finite ``function_score_aligned`` (the correlation target — e.g. BRCA2,
-    which has no harmonized direction) or a non-{abnormal,normal}
-    ``calibrated_class`` (AUPRC) are excluded; scores are expected finite
-    (conservation fills unaligned loci with 0 upstream), with a defensive
-    ``isfinite`` guard.
+    Returns ``{"AUPRC": dict(value, se, n, n_pos)}`` when both classes of the
+    binary ``label`` (True = impactful) have ``>= n_min_auprc`` rows, else ``{}``.
+    Plain row bootstrap via singleton ``match_group`` (as in
+    ``compute_qtl_metrics``). NaN-score rows are dropped (conservation fills
+    unaligned loci with 0 upstream, so this is a defensive guard).
     """
     out: dict[str, dict] = {}
     score = np.asarray(cell[score_col], dtype=float)
-
-    # Spearman: deleteriousness-oriented score vs −function_score_aligned (higher
-    # function_score_aligned = more tolerated, so a good score → positive ρ).
-    aligned = np.asarray(cell["function_score_aligned"], dtype=float)
-    finite = np.isfinite(score) & np.isfinite(aligned)
-    x = score[finite]
-    y = -aligned[finite]
-    if len(x) >= n_min_corr and np.std(x) > 0 and np.std(y) > 0:
-        value, se = _correlation_with_bootstrap_se(
-            x, y, method="spearman", n_bootstrap=n_bootstrap, rng=rng
-        )
-        out["spearman"] = {
-            "value": value,
-            "se": se,
-            "n": int(len(x)),
-            "n_pos": float("nan"),
-        }
-
-    # AUPRC: abnormal (1) vs normal (0); intermediate / null / NaN-score dropped.
-    cc = cell["calibrated_class"].to_numpy()
-    binary = np.isin(cc, ("abnormal", "normal")) & np.isfinite(score)
-    label = (cc[binary] == "abnormal").astype(int)
-    bscore = score[binary]
+    label = np.asarray(cell["label"]).astype(bool)
+    keep = np.isfinite(score)
+    label, score = label[keep], score[keep]
     n_pos = int(label.sum())
-    n_neg = int((label == 0).sum())
+    n_neg = int((~label).sum())
     if n_pos >= n_min_auprc and n_neg >= n_min_auprc:
         res = auprc_with_bootstrap_se(
-            label=label,
-            score=bscore,
+            label=label.astype(int),
+            score=score,
             match_group=np.arange(len(label)),
             n_bootstrap=n_bootstrap,
             rng=rng,
@@ -724,30 +701,21 @@ def compute_sge_metrics(
     *,
     n_bootstrap: int = 1000,
     rng: np.random.Generator | int | None = 0,
-    n_min_corr: int = 100,
     n_min_auprc: int = 30,
 ) -> pd.DataFrame:
-    """Per-accession × per-subset Spearman + AUPRC for the SGE benchmark.
+    """Per-accession × per-subset **AUPRC** for the SGE benchmark (#301).
 
-    Saturation-genome-editing (``evals_sge``) is an orthogonal label axis: each
-    variant carries a continuous, per-study function score (harmonized across
-    studies into ``function_score_aligned``) and, where ClinGen/ExCALIBR
-    calibration exists, a uniform ``calibrated_class`` ∈ {abnormal, intermediate,
-    normal}. Scores are per-study (non-comparable scales), so everything is
-    computed **per accession** (``mavedb_urn``) and then macro-averaged — raw
-    scores are never pooled across accessions.
+    Saturation-genome-editing (``evals_sge`` v3) is a binary VEP task: each
+    variant has a boolean ``label`` (True = impactful = calibrated abnormal). The
+    deleteriousness-oriented model score (gLM ``minus_llr`` / ``jsd``,
+    conservation ``score``) predicts ``label``; **AUPRC** (rank-based, so it
+    compares fairly across model families) is computed **per accession**
+    (``mavedb_urn``) — scores are per-study, non-comparable — then macro-averaged.
+    (Spearman vs the continuous function score was dropped in #301; the
+    continuous columns stay in the dataset for provenance.)
 
-    Both metrics are **rank-based**, so a conservation track's single scalar and
-    a gLM's ``minus_llr`` compare on the same footing despite very different
-    score scales (this is also why Pearson is intentionally omitted):
-
-    - **spearman**: rank correlation of the (deleteriousness-oriented) model
-      score vs **``−function_score_aligned``**. Over rows with finite score and
-      finite aligned target; requires ``n >= n_min_corr``.
-    - **AUPRC**: predict ``calibrated_class == "abnormal"`` vs ``== "normal"``
-      (``intermediate`` / null dropped). Plain row bootstrap via singleton
-      ``match_group`` (as in ``compute_qtl_metrics``); requires
-      ``>= n_min_auprc`` per label.
+    Per cell: AUPRC via a plain row bootstrap (singleton ``match_group``, as in
+    ``compute_qtl_metrics``); requires ``>= n_min_auprc`` per label class.
 
     Two macro axes, each using the ``_macro_avg_`` sentinel:
 
@@ -758,35 +726,27 @@ def compute_sge_metrics(
       mean over qualifying accessions)} — taken of **every** subset scope above,
       including the per-accession subset-macro.
 
-    The same single ``rng`` ``Generator`` is threaded through every bootstrap
-    (as in ``compute_qtl_metrics``) so outputs are bit-stable across re-runs.
+    The same single ``rng`` ``Generator`` is threaded through every bootstrap (as
+    in ``compute_qtl_metrics``) so outputs are bit-stable across re-runs.
 
     Args:
-        dataset: columns ``[mavedb_urn, gene, subset, function_score_aligned,
-            calibrated_class]``, row-aligned with ``scores``.
+        dataset: columns ``[mavedb_urn, gene, subset, label]``, row-aligned with
+            ``scores``.
         scores: model-score columns; row-aligned with ``dataset``. gLM passes
             ``minus_llr_*`` + ``jsd_*``; conservation passes ``["score"]``.
         score_columns: which score columns to evaluate (default: all of
             ``scores``).
         n_bootstrap: bootstrap iterations per cell.
         rng: ``Generator`` / seed / ``None`` (default ``0`` → reproducible).
-        n_min_corr: min finite rows per cell for a Spearman.
-        n_min_auprc: min count **per label** per cell for an AUPRC.
+        n_min_auprc: min count **per label class** per cell.
 
     Returns:
         DataFrame ``[metric, subset, accession, gene, score_type, value, se, n,
-        n_pos]``. ``metric`` ∈ {``spearman``, ``AUPRC``}. For leaf cells ``n`` is
-        the rows used and ``n_pos`` the abnormal count (NaN for Spearman); for
-        macro rows ``n`` is K (children averaged) and ``n_pos`` the summed
-        abnormal count (NaN for Spearman).
+        n_pos]``. ``metric`` is always ``"AUPRC"``. For leaf cells ``n`` is the
+        rows used and ``n_pos`` the impactful (label-True) count; for macro rows
+        ``n`` is K (children averaged) and ``n_pos`` the summed impactful count.
     """
-    for col in (
-        "mavedb_urn",
-        "gene",
-        "subset",
-        "function_score_aligned",
-        "calibrated_class",
-    ):
+    for col in ("mavedb_urn", "gene", "subset", "label"):
         assert col in dataset.columns, f"dataset missing required column {col!r}"
     assert len(dataset) == len(scores), (
         f"length mismatch: dataset={len(dataset)} scores={len(scores)}"
@@ -831,14 +791,13 @@ def compute_sge_metrics(
                     score_col,
                     n_bootstrap=n_bootstrap,
                     rng=rng,
-                    n_min_corr=n_min_corr,
                     n_min_auprc=n_min_auprc,
                 )
                 for metric, res in got.items():
                     cells[(str(urn), scope, metric)] = res
 
             # Per-accession subset-macro: mean over base subsets that qualified.
-            for metric in ("spearman", "AUPRC"):
+            for metric in ("AUPRC",):
                 kids = [
                     cells[(str(urn), s, metric)]
                     for s in base_subsets
@@ -868,7 +827,7 @@ def compute_sge_metrics(
         all_scopes = base_subsets + [SGE_POOLED_SUBSET, MACRO_AVG_SUBSET]
         accessions = [str(u) for u in merged["mavedb_urn"].unique()]
         for scope in all_scopes:
-            for metric in ("spearman", "AUPRC"):
+            for metric in ("AUPRC",):
                 kids = [
                     cells[(urn, scope, metric)]
                     for urn in accessions

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -755,6 +755,15 @@ def compute_sge_metrics(
     """
     for col in ("mavedb_urn", "gene", "subset", "label"):
         assert col in dataset.columns, f"dataset missing required column {col!r}"
+    # Fail fast on the silent-corruption risks rather than coercing them: a null
+    # `label` would be turned into a wrong class by `.astype(bool)` (NaN→True,
+    # None→False) in `_sge_cell_metrics`; a null `subset` would be dropped from
+    # `base_subsets` yet still pooled into the SGE_POOLED_SUBSET ('both') scope,
+    # making 'both' a superset of the named subsets.
+    assert dataset["label"].notna().all(), (
+        "SGE dataset `label` has nulls (expected boolean)"
+    )
+    assert dataset["subset"].notna().all(), "SGE dataset `subset` has nulls"
     assert len(dataset) == len(scores), (
         f"length mismatch: dataset={len(dataset)} scores={len(scores)}"
     )

--- a/src/marin_dna/pipelines/evals/metrics.py
+++ b/src/marin_dna/pipelines/evals/metrics.py
@@ -666,8 +666,12 @@ def _sge_cell_metrics(
     """Spearman + AUPRC for one (accession, subset-scope) cell and one score column.
 
     Returns only the metrics that meet their ``n_min`` gate, keyed
-    ``"spearman"`` / ``"AUPRC"`` → ``dict(value, se, n, n_pos)``. NaN scores are
-    dropped (conservation tracks have no value at unaligned loci).
+    ``"spearman"`` / ``"AUPRC"`` → ``dict(value, se, n, n_pos)``. Rows with a
+    non-finite ``function_score_aligned`` (the correlation target — e.g. BRCA2,
+    which has no harmonized direction) or a non-{abnormal,normal}
+    ``calibrated_class`` (AUPRC) are excluded; scores are expected finite
+    (conservation fills unaligned loci with 0 upstream), with a defensive
+    ``isfinite`` guard.
     """
     out: dict[str, dict] = {}
     score = np.asarray(cell[score_col], dtype=float)

--- a/src/marin_dna/pipelines/evals/models.py
+++ b/src/marin_dna/pipelines/evals/models.py
@@ -28,6 +28,7 @@ ALL_DATASETS: tuple[str, ...] = (
     "complex_traits",
     "caqtl",
     "dsqtl",
+    "sge",
 )
 
 

--- a/src/marin_dna/pipelines/evals/sge.py
+++ b/src/marin_dna/pipelines/evals/sge.py
@@ -504,6 +504,28 @@ def attach_calibrated_class(
     )
 
 
+def attach_label(data: pl.DataFrame) -> pl.DataFrame:
+    """Add the boolean ``label`` — the AUPRC target (#301).
+
+    ``True`` = impactful (calibrated **abnormal**), ``False`` = **normal**, null for
+    ``intermediate`` / uncalibrated (BRCA2). The build keeps only ``label``-non-null
+    rows (the AUPRC-only benchmark drops the variants no classification metric uses),
+    so in the shipped dataset ``label`` is always a clean bool. Requires
+    :func:`attach_calibrated_class` first.
+    """
+    assert "calibrated_class" in data.columns, (
+        "attach_label: call attach_calibrated_class first"
+    )
+    return data.with_columns(
+        pl.when(pl.col("calibrated_class") == "abnormal")
+        .then(pl.lit(True))
+        .when(pl.col("calibrated_class") == "normal")
+        .then(pl.lit(False))
+        .otherwise(None)
+        .alias("label")
+    )
+
+
 def _scheme_direction(norm: pl.DataFrame, abn: pl.DataFrame) -> int:
     """+1 if the abnormal calibration range sits BELOW the normal range (low score =
     abnormal = less functional, so "higher = more functional"), else -1. Range center =

--- a/tests/pipelines/evals/test_conservation.py
+++ b/tests/pipelines/evals/test_conservation.py
@@ -209,26 +209,20 @@ def test_aggregate_conservation_qtl_metrics(tmp_path):
 
 
 def _sge_scored_parquet(
-    tmp_path, name, *, seed=0, n_per_cell=150, perfect=True, inject_nan=0
+    tmp_path, name, *, seed=0, n_per_cell=150, perfect=False, inject_nan=0
 ):
-    """Write a fake SGE scored-variant parquet (SGE_VARIANT_COLUMNS + score).
+    """Write a fake SGE v3 scored-variant parquet (SGE_VARIANT_COLUMNS + score).
 
-    Two accessions × {missense_variant, splicing}. With ``perfect=True`` the
-    track ``score`` equals ``−function_score_aligned`` → every per-cell Spearman
-    (score vs −aligned) is +1. ``inject_nan`` NaNs the first rows' score."""
+    Two accessions × {missense_variant, splicing}, each with a boolean ``label``
+    (~40% True). With ``perfect=True`` the track ``score`` separates the classes
+    (impactful scores high) → AUPRC = 1. ``inject_nan`` NaNs the first rows' score."""
     rng = np.random.default_rng(seed)
     rows = []
     score_blocks = []
     for urn, gene in (("urn:1", "GENEA"), ("urn:2", "GENEB")):
         for subset in ("missense_variant", "splicing"):
-            aligned = rng.normal(size=n_per_cell)
-            lo, hi = np.quantile(aligned, [0.4, 0.6])
-            cc = np.where(
-                aligned <= lo,
-                "abnormal",
-                np.where(aligned >= hi, "normal", "intermediate"),
-            )
-            for a, c in zip(aligned, cc):
+            label = rng.random(n_per_cell) < 0.4
+            for lab in label:
                 rows.append(
                     {
                         "chrom": "chr1",
@@ -238,11 +232,14 @@ def _sge_scored_parquet(
                         "mavedb_urn": urn,
                         "gene": gene,
                         "subset": subset,
-                        "function_score_aligned": a,
-                        "calibrated_class": c,
+                        "label": bool(lab),
                     }
                 )
-            score_blocks.append(-aligned if perfect else rng.normal(size=n_per_cell))
+            score_blocks.append(
+                np.where(label, 1.0, 0.0) + rng.normal(0, 1e-6, n_per_cell)
+                if perfect
+                else rng.normal(size=n_per_cell)
+            )
     df = pd.DataFrame(rows)
     sc = np.concatenate(score_blocks)
     if inject_nan:
@@ -254,8 +251,8 @@ def _sge_scored_parquet(
 
 
 def test_aggregate_conservation_sge_metrics(tmp_path):
-    """SGE aggregation: per-track Spearman + AUPRC via the shared
-    compute_sge_metrics, with score_name/n_nan stamping and an SGE markdown."""
+    """SGE aggregation: per-track AUPRC via the shared compute_sge_metrics, with
+    score_name/n_nan stamping and an SGE markdown."""
     p1 = _sge_scored_parquet(tmp_path, "phyloP_241m", seed=0, perfect=True)
     p2 = _sge_scored_parquet(
         tmp_path, "phastCons_43p", seed=1, perfect=False, inject_nan=3
@@ -279,23 +276,22 @@ def test_aggregate_conservation_sge_metrics(tmp_path):
         "n_nan",
         "n_total",
     } <= set(metrics.columns)
-    assert set(metrics["metric"]) <= {"spearman", "AUPRC"}
+    assert set(metrics["metric"]) == {"AUPRC"}
     assert (metrics["score_type"] == "score").all()
     assert set(metrics["score_name"]) == {"phyloP_241m", "phastCons_43p"}
 
-    # Perfect track → headline (across-accession × across-subset) Spearman ≈ +1.
+    # Perfect track → headline (across-accession × across-subset) AUPRC ≈ 1.
     head = metrics[
         (metrics["score_name"] == "phyloP_241m")
         & (metrics["accession"] == MACRO_AVG_SUBSET)
         & (metrics["subset"] == MACRO_AVG_SUBSET)
-        & (metrics["metric"] == "spearman")
     ]
     assert head["value"].iloc[0] == pytest.approx(1.0, abs=1e-9)
     # NaN scores are counted, then filled with 0 (the shared conservation policy).
     assert int(metrics[metrics["score_name"] == "phastCons_43p"]["n_nan"].iloc[0]) == 3
 
     assert "SGE" in md
-    for tok in ("phyloP_241m", "phastCons_43p", "spearman", "AUPRC"):
+    for tok in ("phyloP_241m", "phastCons_43p", "AUPRC"):
         assert tok in md
 
 

--- a/tests/pipelines/evals/test_conservation.py
+++ b/tests/pipelines/evals/test_conservation.py
@@ -256,10 +256,10 @@ def _sge_scored_parquet(
 def test_aggregate_conservation_sge_metrics(tmp_path):
     """SGE aggregation: per-track Spearman + AUPRC via the shared
     compute_sge_metrics, with score_name/n_nan stamping and an SGE markdown."""
-    p1 = _sge_scored_parquet(
-        tmp_path, "phyloP_241m", seed=0, perfect=True, inject_nan=3
+    p1 = _sge_scored_parquet(tmp_path, "phyloP_241m", seed=0, perfect=True)
+    p2 = _sge_scored_parquet(
+        tmp_path, "phastCons_43p", seed=1, perfect=False, inject_nan=3
     )
-    p2 = _sge_scored_parquet(tmp_path, "phastCons_43p", seed=1, perfect=False)
 
     metrics, md = aggregate_conservation_sge_metrics(
         {"phyloP_241m": p1, "phastCons_43p": p2}, n_bootstrap=20
@@ -291,8 +291,8 @@ def test_aggregate_conservation_sge_metrics(tmp_path):
         & (metrics["metric"] == "spearman")
     ]
     assert head["value"].iloc[0] == pytest.approx(1.0, abs=1e-9)
-    # NaN scores are counted (and dropped, not filled).
-    assert int(metrics[metrics["score_name"] == "phyloP_241m"]["n_nan"].iloc[0]) == 3
+    # NaN scores are counted, then filled with 0 (the shared conservation policy).
+    assert int(metrics[metrics["score_name"] == "phastCons_43p"]["n_nan"].iloc[0]) == 3
 
     assert "SGE" in md
     for tok in ("phyloP_241m", "phastCons_43p", "spearman", "AUPRC"):

--- a/tests/pipelines/evals/test_conservation.py
+++ b/tests/pipelines/evals/test_conservation.py
@@ -9,6 +9,7 @@ from marin_dna.pipelines.evals.conservation import (
     CONSERVATION_TRACKS,
     aggregate_conservation_metrics,
     aggregate_conservation_qtl_metrics,
+    aggregate_conservation_sge_metrics,
     score_variants_at_positions,
 )
 from marin_dna.pipelines.evals.metrics import GLOBAL_SUBSET, MACRO_AVG_SUBSET
@@ -204,6 +205,97 @@ def test_aggregate_conservation_qtl_metrics(tmp_path):
 
     assert "caQTL/dsQTL" in md
     for tok in ("phyloP_241m", "phastCons_43p", "AUPRC", "pearson", "spearman"):
+        assert tok in md
+
+
+def _sge_scored_parquet(
+    tmp_path, name, *, seed=0, n_per_cell=150, perfect=True, inject_nan=0
+):
+    """Write a fake SGE scored-variant parquet (SGE_VARIANT_COLUMNS + score).
+
+    Two accessions × {missense_variant, splicing}. With ``perfect=True`` the
+    track ``score`` equals ``−function_score_aligned`` → every per-cell Spearman
+    (score vs −aligned) is +1. ``inject_nan`` NaNs the first rows' score."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    score_blocks = []
+    for urn, gene in (("urn:1", "GENEA"), ("urn:2", "GENEB")):
+        for subset in ("missense_variant", "splicing"):
+            aligned = rng.normal(size=n_per_cell)
+            lo, hi = np.quantile(aligned, [0.4, 0.6])
+            cc = np.where(
+                aligned <= lo,
+                "abnormal",
+                np.where(aligned >= hi, "normal", "intermediate"),
+            )
+            for a, c in zip(aligned, cc):
+                rows.append(
+                    {
+                        "chrom": "chr1",
+                        "pos": len(rows) + 1,
+                        "ref": "A",
+                        "alt": "T",
+                        "mavedb_urn": urn,
+                        "gene": gene,
+                        "subset": subset,
+                        "function_score_aligned": a,
+                        "calibrated_class": c,
+                    }
+                )
+            score_blocks.append(-aligned if perfect else rng.normal(size=n_per_cell))
+    df = pd.DataFrame(rows)
+    sc = np.concatenate(score_blocks)
+    if inject_nan:
+        sc[:inject_nan] = np.nan
+    df["score"] = sc
+    path = tmp_path / f"{name}.parquet"
+    df.to_parquet(path, index=False)
+    return path
+
+
+def test_aggregate_conservation_sge_metrics(tmp_path):
+    """SGE aggregation: per-track Spearman + AUPRC via the shared
+    compute_sge_metrics, with score_name/n_nan stamping and an SGE markdown."""
+    p1 = _sge_scored_parquet(
+        tmp_path, "phyloP_241m", seed=0, perfect=True, inject_nan=3
+    )
+    p2 = _sge_scored_parquet(tmp_path, "phastCons_43p", seed=1, perfect=False)
+
+    metrics, md = aggregate_conservation_sge_metrics(
+        {"phyloP_241m": p1, "phastCons_43p": p2}, n_bootstrap=20
+    )
+
+    assert {
+        "metric",
+        "subset",
+        "accession",
+        "gene",
+        "score_type",
+        "value",
+        "se",
+        "n",
+        "n_pos",
+        "score_name",
+        "n_nan",
+        "n_total",
+    } <= set(metrics.columns)
+    assert set(metrics["metric"]) <= {"spearman", "AUPRC"}
+    assert (metrics["score_type"] == "score").all()
+    assert set(metrics["score_name"]) == {"phyloP_241m", "phastCons_43p"}
+
+    # Perfect track → headline (across-accession × across-subset) Spearman ≈ +1.
+    head = metrics[
+        (metrics["score_name"] == "phyloP_241m")
+        & (metrics["accession"] == MACRO_AVG_SUBSET)
+        & (metrics["subset"] == MACRO_AVG_SUBSET)
+        & (metrics["metric"] == "spearman")
+    ]
+    assert head["value"].iloc[0] == pytest.approx(1.0, abs=1e-9)
+    # NaN scores are counted (and dropped, not filled).
+    assert int(metrics[metrics["score_name"] == "phyloP_241m"]["n_nan"].iloc[0]) == 3
+
+    assert "SGE" in md
+    for tok in ("phyloP_241m", "phastCons_43p", "spearman", "AUPRC"):
         assert tok in md
 
 

--- a/tests/pipelines/evals/test_hf_readme.py
+++ b/tests/pipelines/evals/test_hf_readme.py
@@ -69,9 +69,10 @@ def _qc(tmp_path: Path, *, with_maf: bool = False) -> Path:
 
 
 def _sge_train_test(tmp_path: Path) -> tuple[Path, Path]:
-    # SGE schema: no `label`; provenance via (gene, mavedb_urn); author_-prefixed
-    # source columns + constant-per-gene assay_ keyword columns. BRCA1 is chr17
-    # (odd) -> all in train, empty test.
+    # SGE v3 schema: binary `label` (True = impactful/abnormal, False = normal);
+    # provenance via (gene, mavedb_urn); author_-prefixed source columns +
+    # constant-per-gene assay_ keyword columns. BRCA1 is chr17 (odd) -> all in
+    # train, empty test.
     train = pl.DataFrame(
         {
             "chrom": ["17", "17", "17"],
@@ -81,6 +82,7 @@ def _sge_train_test(tmp_path: Path) -> tuple[Path, Path]:
             "gene": ["BRCA1", "BRCA1", "BRCA1"],
             "assay": ["sge", "sge", "sge"],
             "mavedb_urn": ["urn:mavedb:00000097-0-2"] * 3,
+            "label": [True, False, True],
             "author_function_score_mean": [-1.0, 0.1, -2.0],
             "author_func_class": ["LOF", "FUNC", "LOF"],
             "assay_phenotypic_assay_method": ["Cell fitness"] * 3,
@@ -266,8 +268,9 @@ class TestRender:
         # Per-(gene, study) provenance + the canonical accession.
         assert "BRCA1" in md and "Findlay" in md
         assert "urn:mavedb:00000097-0-2" in md
-        # Distinctive SGE framing.
-        assert "No matching, no subsampling, no binary label" in md
+        # Distinctive SGE framing + the v3 binary label.
+        assert "No matching, no subsampling" in md
+        assert "AUPRC target" in md  # the `label` column row
         assert "exclude_consequences" in md
         assert "author_" in md
         # Assay facts: the loss-of-function readout + model system surface in the card.

--- a/tests/pipelines/evals/test_leaderboard.py
+++ b/tests/pipelines/evals/test_leaderboard.py
@@ -722,3 +722,25 @@ def test_sge_normalized_rows_marin_and_conservation(monkeypatch: pytest.MonkeyPa
     # n_pos is NaN for spearman rows, finite for AUPRC rows.
     sp = df.filter(pl.col("metric") == "spearman")
     assert sp["n_pos"].is_nan().all()
+
+
+def test_sge_normalized_rows_skips_missing_parquet(monkeypatch: pytest.MonkeyPatch):
+    """A method whose metrics parquet isn't on S3 yet (polars surfaces an S3 404
+    as OSError) is skipped, not fatal — e.g. the gLMs before their scoring run."""
+    glm = _mk_method(id="glm_pending", family="marin_dna", datasets=("sge",))
+    cons = _mk_method(id="phyloP_100v", family="conservation", datasets=("sge",))
+    _patch_methods(monkeypatch, (glm, cons))
+    glm_path = leaderboard._parquet_path(glm, "sge")
+    cons_path = leaderboard._parquet_path(cons, "sge")
+    leaderboard._read_parquet.cache_clear()
+
+    def fake(path: str) -> pl.DataFrame:
+        if path == glm_path:
+            raise OSError("object-store error: 404 Not Found")
+        if path == cons_path:
+            return _sge_metrics_parquet(["score"], score_name="phyloP_100v")
+        raise FileNotFoundError(path)
+
+    monkeypatch.setattr(leaderboard, "_read_parquet", fake)
+    df = leaderboard.sge_normalized_rows("sge")
+    assert set(df["method_id"].to_list()) == {"phyloP_100v"}

--- a/tests/pipelines/evals/test_leaderboard.py
+++ b/tests/pipelines/evals/test_leaderboard.py
@@ -649,24 +649,22 @@ def test_storage_options_ignores_other_values(monkeypatch: pytest.MonkeyPatch):
 
 
 def _sge_metrics_parquet(score_types, *, score_name=None) -> pl.DataFrame:
-    """Tiny SGE metrics parquet: one (spearman, AUPRC) pair per score_type at the
-    headline (across-accession × across-subset macro) cell."""
-    rows = []
-    for st in score_types:
-        for metric in ("spearman", "AUPRC"):
-            rows.append(
-                {
-                    "metric": metric,
-                    "subset": MACRO_AVG_SUBSET,
-                    "accession": MACRO_AVG_SUBSET,
-                    "gene": MACRO_AVG_SUBSET,
-                    "score_type": st,
-                    "value": 0.3,
-                    "se": 0.01,
-                    "n": 5,
-                    "n_pos": float("nan") if metric == "spearman" else 100.0,
-                }
-            )
+    """Tiny SGE metrics parquet: one AUPRC row per score_type at the headline
+    (across-accession × across-subset macro) cell."""
+    rows = [
+        {
+            "metric": "AUPRC",
+            "subset": MACRO_AVG_SUBSET,
+            "accession": MACRO_AVG_SUBSET,
+            "gene": MACRO_AVG_SUBSET,
+            "score_type": st,
+            "value": 0.3,
+            "se": 0.01,
+            "n": 5,
+            "n_pos": 100.0,
+        }
+        for st in score_types
+    ]
     df = pl.DataFrame(rows)
     if score_name is not None:
         df = df.with_columns(pl.lit(score_name).alias("score_name"))
@@ -717,11 +715,11 @@ def test_sge_normalized_rows_marin_and_conservation(monkeypatch: pytest.MonkeyPa
     assert set(g["score_type"].to_list()) == {"minus_llr_avg", "jsd_avg"}
     # conservation: each method filtered to its own track, no cross-leak.
     c = df.filter(pl.col("method_id") == "phyloP_100v")
-    assert c.height == 2 and (c["score_type"] == "score").all()
-    assert df.filter(pl.col("method_id") == "phastCons_43p").height == 2
-    # n_pos is NaN for spearman rows, finite for AUPRC rows.
-    sp = df.filter(pl.col("metric") == "spearman")
-    assert sp["n_pos"].is_nan().all()
+    assert c.height == 1 and (c["score_type"] == "score").all()
+    assert df.filter(pl.col("method_id") == "phastCons_43p").height == 1
+    # SGE v3 is AUPRC-only; every metric row is AUPRC with a finite n_pos.
+    assert set(df["metric"].to_list()) == {"AUPRC"}
+    assert df["n_pos"].is_finite().all()
 
 
 def test_sge_normalized_rows_skips_missing_parquet(monkeypatch: pytest.MonkeyPatch):

--- a/tests/pipelines/evals/test_leaderboard.py
+++ b/tests/pipelines/evals/test_leaderboard.py
@@ -643,3 +643,82 @@ def test_storage_options_ignores_other_values(monkeypatch: pytest.MonkeyPatch):
     from marin_dna.pipelines.evals.leaderboard import _storage_options
 
     assert _storage_options() is None
+
+
+# ---- sge_normalized_rows ----------------------------------------------------
+
+
+def _sge_metrics_parquet(score_types, *, score_name=None) -> pl.DataFrame:
+    """Tiny SGE metrics parquet: one (spearman, AUPRC) pair per score_type at the
+    headline (across-accession × across-subset macro) cell."""
+    rows = []
+    for st in score_types:
+        for metric in ("spearman", "AUPRC"):
+            rows.append(
+                {
+                    "metric": metric,
+                    "subset": MACRO_AVG_SUBSET,
+                    "accession": MACRO_AVG_SUBSET,
+                    "gene": MACRO_AVG_SUBSET,
+                    "score_type": st,
+                    "value": 0.3,
+                    "se": 0.01,
+                    "n": 5,
+                    "n_pos": float("nan") if metric == "spearman" else 100.0,
+                }
+            )
+    df = pl.DataFrame(rows)
+    if score_name is not None:
+        df = df.with_columns(pl.lit(score_name).alias("score_name"))
+    return df
+
+
+def test_sge_normalized_rows_marin_and_conservation(monkeypatch: pytest.MonkeyPatch):
+    """marin_dna keeps every score_type (LLR/JSD toggle); conservation methods
+    share one parquet, each filtered to its own track by score_name."""
+    glm = _mk_method(id="glm1", family="marin_dna", datasets=("sge",))
+    cons = _mk_method(id="phyloP_100v", family="conservation", datasets=("sge",))
+    cons2 = _mk_method(id="phastCons_43p", family="conservation", datasets=("sge",))
+    _patch_methods(monkeypatch, (glm, cons, cons2))
+
+    glm_path = leaderboard._parquet_path(glm, "sge")
+    cons_path = leaderboard._parquet_path(cons, "sge")  # shared by both tracks
+    cons_df = pl.concat(
+        [
+            _sge_metrics_parquet(["score"], score_name="phyloP_100v"),
+            _sge_metrics_parquet(["score"], score_name="phastCons_43p"),
+        ]
+    )
+    _patch_read_parquet(
+        monkeypatch,
+        {
+            glm_path: _sge_metrics_parquet(["minus_llr_avg", "jsd_avg"]),
+            cons_path: cons_df,
+        },
+    )
+
+    df = leaderboard.sge_normalized_rows("sge")
+    assert set(df.columns) == {
+        "method_id",
+        "method_display",
+        "family",
+        "score_type",
+        "metric",
+        "subset",
+        "accession",
+        "gene",
+        "value",
+        "se",
+        "n",
+        "n_pos",
+    }
+    # marin_dna: both score_types survive (drives the dashboard LLR/JSD toggle).
+    g = df.filter(pl.col("method_id") == "glm1")
+    assert set(g["score_type"].to_list()) == {"minus_llr_avg", "jsd_avg"}
+    # conservation: each method filtered to its own track, no cross-leak.
+    c = df.filter(pl.col("method_id") == "phyloP_100v")
+    assert c.height == 2 and (c["score_type"] == "score").all()
+    assert df.filter(pl.col("method_id") == "phastCons_43p").height == 2
+    # n_pos is NaN for spearman rows, finite for AUPRC rows.
+    sp = df.filter(pl.col("metric") == "spearman")
+    assert sp["n_pos"].is_nan().all()

--- a/tests/pipelines/evals/test_leaderboard.py
+++ b/tests/pipelines/evals/test_leaderboard.py
@@ -648,7 +648,9 @@ def test_storage_options_ignores_other_values(monkeypatch: pytest.MonkeyPatch):
 # ---- sge_normalized_rows ----------------------------------------------------
 
 
-def _sge_metrics_parquet(score_types, *, score_name=None) -> pl.DataFrame:
+def _sge_metrics_parquet(
+    score_types, *, score_name=None, split="train"
+) -> pl.DataFrame:
     """Tiny SGE metrics parquet: one AUPRC row per score_type at the headline
     (across-accession × across-subset macro) cell."""
     rows = [
@@ -662,6 +664,9 @@ def _sge_metrics_parquet(score_types, *, score_name=None) -> pl.DataFrame:
             "se": 0.01,
             "n": 5,
             "n_pos": 100.0,
+            # The real evals_v2/conservation metrics parquets carry a `split`
+            # column; sge_normalized_rows filters marin_dna rows by it.
+            "split": split,
         }
         for st in score_types
     ]
@@ -687,10 +692,18 @@ def test_sge_normalized_rows_marin_and_conservation(monkeypatch: pytest.MonkeyPa
             _sge_metrics_parquet(["score"], score_name="phastCons_43p"),
         ]
     )
+    # The marin_dna parquet path is not split-specific, so it can carry both
+    # splits; only the train rows should survive.
+    glm_df = pl.concat(
+        [
+            _sge_metrics_parquet(["minus_llr_avg", "jsd_avg"], split="train"),
+            _sge_metrics_parquet(["minus_llr_avg", "jsd_avg"], split="test"),
+        ]
+    )
     _patch_read_parquet(
         monkeypatch,
         {
-            glm_path: _sge_metrics_parquet(["minus_llr_avg", "jsd_avg"]),
+            glm_path: glm_df,
             cons_path: cons_df,
         },
     )
@@ -710,8 +723,10 @@ def test_sge_normalized_rows_marin_and_conservation(monkeypatch: pytest.MonkeyPa
         "n",
         "n_pos",
     }
-    # marin_dna: both score_types survive (drives the dashboard LLR/JSD toggle).
+    # marin_dna: both score_types survive (drives the dashboard LLR/JSD toggle),
+    # but only the train split — the 2 test-split rows are filtered out (height 2).
     g = df.filter(pl.col("method_id") == "glm1")
+    assert g.height == 2
     assert set(g["score_type"].to_list()) == {"minus_llr_avg", "jsd_avg"}
     # conservation: each method filtered to its own track, no cross-leak.
     c = df.filter(pl.col("method_id") == "phyloP_100v")

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
-from scipy.stats import spearmanr
 from sklearn.metrics import average_precision_score
 
 from marin_dna.pipelines.evals.metrics import (
@@ -663,38 +662,32 @@ def _sge_data(
     seed: int = 0,
     perfect: bool = False,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Synthesize an SGE frame: accessions × {missense_variant, splicing} cells.
-
-    ``calibrated_class`` is abnormal in the bottom 40% of
-    ``function_score_aligned`` (most damaging = least functional), normal in the
-    top 40%, intermediate in the middle 20%. With ``perfect=True`` the model
-    score equals ``−function_score_aligned`` → Spearman(score, −aligned) = +1 and
-    abnormal (low aligned) scores highest → AUPRC = 1.
+    """Synthesize an SGE v3 frame: accessions × {missense_variant, splicing} cells,
+    each with a boolean ``label`` (~40% True = impactful) and a score. With
+    ``perfect=True`` the score separates the classes (impactful scores high) →
+    AUPRC = 1.
     """
     rng = np.random.default_rng(seed)
     frames = []
     score_blocks = []
     for urn, gene in accessions:
         for subset in ("missense_variant", "splicing"):
-            aligned = rng.normal(size=n_per_cell)
-            lo, hi = np.quantile(aligned, [0.4, 0.6])
-            cc = np.where(
-                aligned <= lo,
-                "abnormal",
-                np.where(aligned >= hi, "normal", "intermediate"),
-            )
+            label = rng.random(n_per_cell) < 0.4  # ~40% impactful
             frames.append(
                 pd.DataFrame(
                     {
                         "mavedb_urn": urn,
                         "gene": gene,
                         "subset": subset,
-                        "function_score_aligned": aligned,
-                        "calibrated_class": cc,
+                        "label": label,
                     }
                 )
             )
-            score_blocks.append(-aligned if perfect else rng.normal(size=n_per_cell))
+            score_blocks.append(
+                np.where(label, 1.0, 0.0) + rng.normal(0, 1e-6, n_per_cell)
+                if perfect
+                else rng.normal(size=n_per_cell)
+            )
     dataset = pd.concat(frames, ignore_index=True)
     scores = pd.DataFrame({"score": np.concatenate(score_blocks)})
     return dataset, scores
@@ -710,8 +703,8 @@ def _val(df: pd.DataFrame, **filters: object) -> pd.Series:
 
 
 def test_sge_shape_and_grid():
-    """Columns fixed; per accession each metric spans all four subset scopes;
-    the across-accession macro row exists; gene carried for display."""
+    """Columns fixed; AUPRC spans all four subset scopes per accession; the
+    across-accession macro row exists; gene carried for display."""
     dataset, scores = _sge_data(seed=0)
     out = compute_sge_metrics(dataset, scores, n_bootstrap=20, rng=0)
     assert set(out.columns) == {
@@ -725,7 +718,7 @@ def test_sge_shape_and_grid():
         "n",
         "n_pos",
     }
-    assert set(out["metric"]) <= {"spearman", "AUPRC"}
+    assert set(out["metric"]) == {"AUPRC"}
     assert set(out["subset"]) <= {
         "missense_variant",
         "splicing",
@@ -734,100 +727,68 @@ def test_sge_shape_and_grid():
     }
     assert {"urn:1", "urn:2", MACRO_AVG_SUBSET} <= set(out["accession"])
     for urn in ("urn:1", "urn:2"):
-        for metric in ("spearman", "AUPRC"):
-            scopes = set(
-                out[(out["accession"] == urn) & (out["metric"] == metric)]["subset"]
-            )
-            assert scopes == {
-                "missense_variant",
-                "splicing",
-                SGE_POOLED_SUBSET,
-                MACRO_AVG_SUBSET,
-            }, (urn, metric, scopes)
+        scopes = set(out[out["accession"] == urn]["subset"])
+        assert scopes == {
+            "missense_variant",
+            "splicing",
+            SGE_POOLED_SUBSET,
+            MACRO_AVG_SUBSET,
+        }, (urn, scopes)
     assert (
-        _val(out, metric="spearman", subset=SGE_POOLED_SUBSET, accession="urn:1")[
-            "gene"
-        ]
+        _val(out, metric="AUPRC", subset=SGE_POOLED_SUBSET, accession="urn:1")["gene"]
         == "GENEA"
     )
     assert (
-        _val(
-            out, metric="spearman", subset=SGE_POOLED_SUBSET, accession=MACRO_AVG_SUBSET
-        )["gene"]
+        _val(out, metric="AUPRC", subset=SGE_POOLED_SUBSET, accession=MACRO_AVG_SUBSET)[
+            "gene"
+        ]
         == MACRO_AVG_SUBSET
     )
     assert out["value"].notna().all()
     assert out["se"].notna().all()
 
 
-def test_sge_perfect_orientation_spearman_and_auprc():
-    """score = −function_score_aligned → every Spearman ≈ +1 and every AUPRC ≈ 1
-    (confirms the −aligned orientation: a deleteriousness score scores positive)."""
+def test_sge_perfect_auprc():
+    """A score that separates the label (impactful scores high) → every AUPRC ≈ 1."""
     dataset, scores = _sge_data(seed=0, perfect=True)
     out = compute_sge_metrics(dataset, scores, n_bootstrap=30, rng=0)
-    assert (out[out["metric"] == "spearman"]["value"] > 0.999).all()
-    assert (out[out["metric"] == "AUPRC"]["value"] > 0.999).all()
+    assert (out["value"] > 0.999).all()
 
 
-def test_sge_spearman_matches_scipy():
-    """A leaf Spearman equals scipy's spearmanr(score, −function_score_aligned)."""
-    dataset, scores = _sge_data(seed=7)
-    out = compute_sge_metrics(dataset, scores, n_bootstrap=5, rng=0)
-    mask = (dataset["mavedb_urn"] == "urn:1") & (
-        dataset["subset"] == "missense_variant"
-    )
-    expected = spearmanr(
-        scores.loc[mask, "score"].to_numpy(),
-        -dataset.loc[mask, "function_score_aligned"].to_numpy(),
-    )[0]
-    got = _val(out, metric="spearman", subset="missense_variant", accession="urn:1")
-    assert got["value"] == pytest.approx(expected)
-
-
-def test_sge_auprc_matches_sklearn_and_excludes_intermediate_null():
-    """A leaf AUPRC equals sklearn over the abnormal/normal rows only;
-    intermediate + null are dropped (so n = abnormal+normal, n_pos = abnormal)."""
+def test_sge_auprc_matches_sklearn():
+    """A leaf AUPRC equals sklearn's average_precision_score over the cell, with
+    n = rows and n_pos = the impactful (label-True) count."""
     rng = np.random.default_rng(0)
-    n = 200
-    aligned = rng.normal(size=n)
-    cc = np.array(
-        ["abnormal"] * 60 + ["normal"] * 60 + ["intermediate"] * 40 + [None] * 40,
-        dtype=object,
-    )
+    label = np.array([True] * 70 + [False] * 130)
     dataset = pd.DataFrame(
         {
             "mavedb_urn": "urn:1",
             "gene": "G",
             "subset": "missense_variant",
-            "function_score_aligned": aligned,
-            "calibrated_class": cc,
+            "label": label,
         }
     )
-    score = rng.normal(size=n)
+    score = rng.normal(size=len(label))
     scores = pd.DataFrame({"score": score})
     out = compute_sge_metrics(dataset, scores, n_bootstrap=10, rng=0)
     auprc = _val(out, metric="AUPRC", subset="missense_variant", accession="urn:1")
-    binary = np.isin(cc, ("abnormal", "normal"))
-    expected = average_precision_score(
-        (cc[binary] == "abnormal").astype(int), score[binary]
-    )
+    expected = average_precision_score(label.astype(int), score)
     assert auprc["value"] == pytest.approx(expected)
-    assert auprc["n"] == 120
-    assert auprc["n_pos"] == 60
+    assert auprc["n"] == 200
+    assert auprc["n_pos"] == 70
 
 
 def test_sge_subset_macro_is_mean_of_base_subsets():
-    """The per-accession _macro_avg_ subset = unweighted mean of missense &
-    splicing, with SE = sqrt(Σ SE²)/2 over the two."""
+    """The per-accession _macro_avg_ subset = unweighted mean of the missense &
+    splicing AUPRC, with SE = sqrt(Σ SE²)/2 over the two."""
     dataset, scores = _sge_data(seed=3)
     out = compute_sge_metrics(dataset, scores, n_bootstrap=20, rng=0)
-    for metric in ("spearman", "AUPRC"):
-        m = _val(out, metric=metric, subset="missense_variant", accession="urn:1")
-        s = _val(out, metric=metric, subset="splicing", accession="urn:1")
-        macro = _val(out, metric=metric, subset=MACRO_AVG_SUBSET, accession="urn:1")
-        assert macro["value"] == pytest.approx((m["value"] + s["value"]) / 2)
-        assert macro["se"] == pytest.approx(math.sqrt(m["se"] ** 2 + s["se"] ** 2) / 2)
-        assert macro["n"] == 2
+    m = _val(out, metric="AUPRC", subset="missense_variant", accession="urn:1")
+    s = _val(out, metric="AUPRC", subset="splicing", accession="urn:1")
+    macro = _val(out, metric="AUPRC", subset=MACRO_AVG_SUBSET, accession="urn:1")
+    assert macro["value"] == pytest.approx((m["value"] + s["value"]) / 2)
+    assert macro["se"] == pytest.approx(math.sqrt(m["se"] ** 2 + s["se"] ** 2) / 2)
+    assert macro["n"] == 2
 
 
 def test_sge_accession_macro_is_mean_over_accessions():
@@ -835,58 +796,51 @@ def test_sge_accession_macro_is_mean_over_accessions():
     same subset scope; n records the count of accessions averaged."""
     dataset, scores = _sge_data(seed=3)
     out = compute_sge_metrics(dataset, scores, n_bootstrap=20, rng=0)
-    for metric in ("spearman", "AUPRC"):
-        vals = [
-            _val(out, metric=metric, subset=SGE_POOLED_SUBSET, accession=u)["value"]
-            for u in ("urn:1", "urn:2")
-        ]
-        macro = _val(
-            out, metric=metric, subset=SGE_POOLED_SUBSET, accession=MACRO_AVG_SUBSET
-        )
-        assert macro["value"] == pytest.approx(sum(vals) / 2)
-        assert macro["n"] == 2
+    vals = [
+        _val(out, metric="AUPRC", subset=SGE_POOLED_SUBSET, accession=u)["value"]
+        for u in ("urn:1", "urn:2")
+    ]
+    macro = _val(
+        out, metric="AUPRC", subset=SGE_POOLED_SUBSET, accession=MACRO_AVG_SUBSET
+    )
+    assert macro["value"] == pytest.approx(sum(vals) / 2)
+    assert macro["n"] == 2
 
 
-def test_sge_n_min_corr_gates_small_cells():
-    """A subset cell below n_min_corr produces no Spearman; the subset-macro
-    then averages only the qualifying base subset (K=1)."""
+def test_sge_n_min_auprc_gates_small_cells():
+    """A subset cell with <n_min_auprc of either label class produces no AUPRC; the
+    subset-macro then averages only the qualifying base subset (K=1)."""
     rng = np.random.default_rng(0)
 
-    def block(subset: str, n: int) -> tuple[pd.DataFrame, np.ndarray]:
-        aligned = rng.normal(size=n)
+    def block(subset: str, n_pos: int, n_neg: int) -> tuple[pd.DataFrame, np.ndarray]:
+        label = np.array([True] * n_pos + [False] * n_neg)
         df = pd.DataFrame(
-            {
-                "mavedb_urn": "urn:1",
-                "gene": "G",
-                "subset": subset,
-                "function_score_aligned": aligned,
-                "calibrated_class": np.where(aligned < 0, "abnormal", "normal"),
-            }
+            {"mavedb_urn": "urn:1", "gene": "G", "subset": subset, "label": label}
         )
-        return df, rng.normal(size=n)
+        return df, rng.normal(size=n_pos + n_neg)
 
-    dm, sm = block("missense_variant", 150)
-    ds, ss = block("splicing", 50)
+    dm, sm = block("missense_variant", 60, 90)  # ≥30 each → qualifies
+    ds, ss = block("splicing", 10, 90)  # only 10 impactful (<30) → gated
     dataset = pd.concat([dm, ds], ignore_index=True)
     scores = pd.DataFrame({"score": np.concatenate([sm, ss])})
     out = compute_sge_metrics(dataset, scores, n_bootstrap=10, rng=0)
-    sp = out[out["metric"] == "spearman"]
-    assert ((sp["subset"] == "missense_variant") & (sp["accession"] == "urn:1")).any()
-    assert not ((sp["subset"] == "splicing") & (sp["accession"] == "urn:1")).any()
-    macro = _val(out, metric="spearman", subset=MACRO_AVG_SUBSET, accession="urn:1")
-    miss = _val(out, metric="spearman", subset="missense_variant", accession="urn:1")
+    a = out[out["metric"] == "AUPRC"]
+    assert ((a["subset"] == "missense_variant") & (a["accession"] == "urn:1")).any()
+    assert not ((a["subset"] == "splicing") & (a["accession"] == "urn:1")).any()
+    macro = _val(out, metric="AUPRC", subset=MACRO_AVG_SUBSET, accession="urn:1")
+    miss = _val(out, metric="AUPRC", subset="missense_variant", accession="urn:1")
     assert macro["value"] == pytest.approx(miss["value"])
     assert macro["n"] == 1
 
 
 def test_sge_nan_scores_dropped():
     """NaN scores (conservation has no value at unaligned loci) are dropped per
-    cell rather than raising; the metric is computed on the finite remainder."""
+    cell rather than raising; AUPRC is computed on the finite remainder."""
     dataset, scores = _sge_data(seed=2)
     scores = scores.copy()
     scores.loc[:20, "score"] = np.nan
     out = compute_sge_metrics(dataset, scores, n_bootstrap=10, rng=0)
-    assert (out["metric"] == "spearman").any()
+    assert (out["metric"] == "AUPRC").any()
     assert out["value"].notna().all()
 
 
@@ -904,8 +858,7 @@ def test_sge_urn_maps_to_multiple_genes_raises():
             "mavedb_urn": ["urn:1"] * 4,
             "gene": ["A", "A", "B", "B"],
             "subset": ["missense_variant"] * 4,
-            "function_score_aligned": [0.1, 0.2, 0.3, 0.4],
-            "calibrated_class": ["normal"] * 4,
+            "label": [True, False, True, False],
         }
     )
     scores = pd.DataFrame({"score": [1.0, 2.0, 3.0, 4.0]})

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -844,10 +844,19 @@ def test_sge_nan_scores_dropped():
     cell rather than raising; AUPRC is computed on the finite remainder."""
     dataset, scores = _sge_data(seed=2)
     scores = scores.copy()
-    scores.loc[:20, "score"] = np.nan
+    scores.loc[:20, "score"] = (
+        np.nan
+    )  # 21 NaN scores in the first cell (urn:1 missense)
     out = compute_sge_metrics(dataset, scores, n_bootstrap=10, rng=0)
-    assert (out["metric"] == "AUPRC").any()
-    assert out["value"].notna().all()
+    a = out[out["metric"] == "AUPRC"]
+    assert len(a) > 0
+    # The first cell shrinks 150→129 but still clears the gate (≥30/class), so no
+    # cell is gated → every AUPRC value is finite. (A gated cell would carry NaN;
+    # this asserts the fixture stays un-gated, not that gating is impossible.)
+    assert a["value"].notna().all()
+    # The 21 NaN-score rows were dropped, not counted: n reflects the remainder.
+    first = a[(a["accession"] == "urn:1") & (a["subset"] == "missense_variant")]
+    assert int(first["n"].iloc[0]) == 150 - 21
 
 
 def test_sge_multiple_score_columns():

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -3,23 +3,27 @@ aggregation, plus the cluster-bootstrap AUPRC used by ``evals_v2``.
 Per-metric tests for ``pairwise_accuracy`` live in
 ``test_pairwise_accuracy.py``."""
 
+import math
 import tempfile
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.stats import spearmanr
 from sklearn.metrics import average_precision_score
 
 from marin_dna.pipelines.evals.metrics import (
     GLOBAL_SUBSET,
     MACRO_AVG_SUBSET,
     METRIC_FUNCTIONS,
+    SGE_POOLED_SUBSET,
     aggregate_metrics,
     auprc_with_bootstrap_se,
     compute_auprc_metrics,
     compute_metrics,
     compute_qtl_metrics,
+    compute_sge_metrics,
     paired_metric_delta_bootstrap,
 )
 
@@ -645,3 +649,272 @@ def test_compute_qtl_metrics_nan_score_raises():
     scores.loc[5, "score"] = np.nan
     with pytest.raises(AssertionError, match="NaN"):
         compute_qtl_metrics(dataset, scores, n_bootstrap=10, rng=0)
+
+
+# ---------------------------------------------------------------------------
+# compute_sge_metrics (saturation genome editing: evals_sge)
+# ---------------------------------------------------------------------------
+
+
+def _sge_data(
+    *,
+    n_per_cell: int = 150,
+    accessions: tuple[tuple[str, str], ...] = (("urn:1", "GENEA"), ("urn:2", "GENEB")),
+    seed: int = 0,
+    perfect: bool = False,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Synthesize an SGE frame: accessions × {missense_variant, splicing} cells.
+
+    ``calibrated_class`` is abnormal in the bottom 40% of
+    ``function_score_aligned`` (most damaging = least functional), normal in the
+    top 40%, intermediate in the middle 20%. With ``perfect=True`` the model
+    score equals ``−function_score_aligned`` → Spearman(score, −aligned) = +1 and
+    abnormal (low aligned) scores highest → AUPRC = 1.
+    """
+    rng = np.random.default_rng(seed)
+    frames = []
+    score_blocks = []
+    for urn, gene in accessions:
+        for subset in ("missense_variant", "splicing"):
+            aligned = rng.normal(size=n_per_cell)
+            lo, hi = np.quantile(aligned, [0.4, 0.6])
+            cc = np.where(
+                aligned <= lo,
+                "abnormal",
+                np.where(aligned >= hi, "normal", "intermediate"),
+            )
+            frames.append(
+                pd.DataFrame(
+                    {
+                        "mavedb_urn": urn,
+                        "gene": gene,
+                        "subset": subset,
+                        "function_score_aligned": aligned,
+                        "calibrated_class": cc,
+                    }
+                )
+            )
+            score_blocks.append(-aligned if perfect else rng.normal(size=n_per_cell))
+    dataset = pd.concat(frames, ignore_index=True)
+    scores = pd.DataFrame({"score": np.concatenate(score_blocks)})
+    return dataset, scores
+
+
+def _val(df: pd.DataFrame, **filters: object) -> pd.Series:
+    """Fetch the single row matching all column==value filters."""
+    sub = df
+    for col, value in filters.items():
+        sub = sub[sub[col] == value]
+    assert len(sub) == 1, f"expected 1 row for {filters}, got {len(sub)}"
+    return sub.iloc[0]
+
+
+def test_sge_shape_and_grid():
+    """Columns fixed; per accession each metric spans all four subset scopes;
+    the across-accession macro row exists; gene carried for display."""
+    dataset, scores = _sge_data(seed=0)
+    out = compute_sge_metrics(dataset, scores, n_bootstrap=20, rng=0)
+    assert set(out.columns) == {
+        "metric",
+        "subset",
+        "accession",
+        "gene",
+        "score_type",
+        "value",
+        "se",
+        "n",
+        "n_pos",
+    }
+    assert set(out["metric"]) <= {"spearman", "AUPRC"}
+    assert set(out["subset"]) <= {
+        "missense_variant",
+        "splicing",
+        SGE_POOLED_SUBSET,
+        MACRO_AVG_SUBSET,
+    }
+    assert {"urn:1", "urn:2", MACRO_AVG_SUBSET} <= set(out["accession"])
+    for urn in ("urn:1", "urn:2"):
+        for metric in ("spearman", "AUPRC"):
+            scopes = set(
+                out[(out["accession"] == urn) & (out["metric"] == metric)]["subset"]
+            )
+            assert scopes == {
+                "missense_variant",
+                "splicing",
+                SGE_POOLED_SUBSET,
+                MACRO_AVG_SUBSET,
+            }, (urn, metric, scopes)
+    assert (
+        _val(out, metric="spearman", subset=SGE_POOLED_SUBSET, accession="urn:1")[
+            "gene"
+        ]
+        == "GENEA"
+    )
+    assert (
+        _val(
+            out, metric="spearman", subset=SGE_POOLED_SUBSET, accession=MACRO_AVG_SUBSET
+        )["gene"]
+        == MACRO_AVG_SUBSET
+    )
+    assert out["value"].notna().all()
+    assert out["se"].notna().all()
+
+
+def test_sge_perfect_orientation_spearman_and_auprc():
+    """score = −function_score_aligned → every Spearman ≈ +1 and every AUPRC ≈ 1
+    (confirms the −aligned orientation: a deleteriousness score scores positive)."""
+    dataset, scores = _sge_data(seed=0, perfect=True)
+    out = compute_sge_metrics(dataset, scores, n_bootstrap=30, rng=0)
+    assert (out[out["metric"] == "spearman"]["value"] > 0.999).all()
+    assert (out[out["metric"] == "AUPRC"]["value"] > 0.999).all()
+
+
+def test_sge_spearman_matches_scipy():
+    """A leaf Spearman equals scipy's spearmanr(score, −function_score_aligned)."""
+    dataset, scores = _sge_data(seed=7)
+    out = compute_sge_metrics(dataset, scores, n_bootstrap=5, rng=0)
+    mask = (dataset["mavedb_urn"] == "urn:1") & (
+        dataset["subset"] == "missense_variant"
+    )
+    expected = spearmanr(
+        scores.loc[mask, "score"].to_numpy(),
+        -dataset.loc[mask, "function_score_aligned"].to_numpy(),
+    )[0]
+    got = _val(out, metric="spearman", subset="missense_variant", accession="urn:1")
+    assert got["value"] == pytest.approx(expected)
+
+
+def test_sge_auprc_matches_sklearn_and_excludes_intermediate_null():
+    """A leaf AUPRC equals sklearn over the abnormal/normal rows only;
+    intermediate + null are dropped (so n = abnormal+normal, n_pos = abnormal)."""
+    rng = np.random.default_rng(0)
+    n = 200
+    aligned = rng.normal(size=n)
+    cc = np.array(
+        ["abnormal"] * 60 + ["normal"] * 60 + ["intermediate"] * 40 + [None] * 40,
+        dtype=object,
+    )
+    dataset = pd.DataFrame(
+        {
+            "mavedb_urn": "urn:1",
+            "gene": "G",
+            "subset": "missense_variant",
+            "function_score_aligned": aligned,
+            "calibrated_class": cc,
+        }
+    )
+    score = rng.normal(size=n)
+    scores = pd.DataFrame({"score": score})
+    out = compute_sge_metrics(dataset, scores, n_bootstrap=10, rng=0)
+    auprc = _val(out, metric="AUPRC", subset="missense_variant", accession="urn:1")
+    binary = np.isin(cc, ("abnormal", "normal"))
+    expected = average_precision_score(
+        (cc[binary] == "abnormal").astype(int), score[binary]
+    )
+    assert auprc["value"] == pytest.approx(expected)
+    assert auprc["n"] == 120
+    assert auprc["n_pos"] == 60
+
+
+def test_sge_subset_macro_is_mean_of_base_subsets():
+    """The per-accession _macro_avg_ subset = unweighted mean of missense &
+    splicing, with SE = sqrt(Σ SE²)/2 over the two."""
+    dataset, scores = _sge_data(seed=3)
+    out = compute_sge_metrics(dataset, scores, n_bootstrap=20, rng=0)
+    for metric in ("spearman", "AUPRC"):
+        m = _val(out, metric=metric, subset="missense_variant", accession="urn:1")
+        s = _val(out, metric=metric, subset="splicing", accession="urn:1")
+        macro = _val(out, metric=metric, subset=MACRO_AVG_SUBSET, accession="urn:1")
+        assert macro["value"] == pytest.approx((m["value"] + s["value"]) / 2)
+        assert macro["se"] == pytest.approx(math.sqrt(m["se"] ** 2 + s["se"] ** 2) / 2)
+        assert macro["n"] == 2
+
+
+def test_sge_accession_macro_is_mean_over_accessions():
+    """The accession _macro_avg_ row = unweighted mean over accessions of the
+    same subset scope; n records the count of accessions averaged."""
+    dataset, scores = _sge_data(seed=3)
+    out = compute_sge_metrics(dataset, scores, n_bootstrap=20, rng=0)
+    for metric in ("spearman", "AUPRC"):
+        vals = [
+            _val(out, metric=metric, subset=SGE_POOLED_SUBSET, accession=u)["value"]
+            for u in ("urn:1", "urn:2")
+        ]
+        macro = _val(
+            out, metric=metric, subset=SGE_POOLED_SUBSET, accession=MACRO_AVG_SUBSET
+        )
+        assert macro["value"] == pytest.approx(sum(vals) / 2)
+        assert macro["n"] == 2
+
+
+def test_sge_n_min_corr_gates_small_cells():
+    """A subset cell below n_min_corr produces no Spearman; the subset-macro
+    then averages only the qualifying base subset (K=1)."""
+    rng = np.random.default_rng(0)
+
+    def block(subset: str, n: int) -> tuple[pd.DataFrame, np.ndarray]:
+        aligned = rng.normal(size=n)
+        df = pd.DataFrame(
+            {
+                "mavedb_urn": "urn:1",
+                "gene": "G",
+                "subset": subset,
+                "function_score_aligned": aligned,
+                "calibrated_class": np.where(aligned < 0, "abnormal", "normal"),
+            }
+        )
+        return df, rng.normal(size=n)
+
+    dm, sm = block("missense_variant", 150)
+    ds, ss = block("splicing", 50)
+    dataset = pd.concat([dm, ds], ignore_index=True)
+    scores = pd.DataFrame({"score": np.concatenate([sm, ss])})
+    out = compute_sge_metrics(dataset, scores, n_bootstrap=10, rng=0)
+    sp = out[out["metric"] == "spearman"]
+    assert ((sp["subset"] == "missense_variant") & (sp["accession"] == "urn:1")).any()
+    assert not ((sp["subset"] == "splicing") & (sp["accession"] == "urn:1")).any()
+    macro = _val(out, metric="spearman", subset=MACRO_AVG_SUBSET, accession="urn:1")
+    miss = _val(out, metric="spearman", subset="missense_variant", accession="urn:1")
+    assert macro["value"] == pytest.approx(miss["value"])
+    assert macro["n"] == 1
+
+
+def test_sge_nan_scores_dropped():
+    """NaN scores (conservation has no value at unaligned loci) are dropped per
+    cell rather than raising; the metric is computed on the finite remainder."""
+    dataset, scores = _sge_data(seed=2)
+    scores = scores.copy()
+    scores.loc[:20, "score"] = np.nan
+    out = compute_sge_metrics(dataset, scores, n_bootstrap=10, rng=0)
+    assert (out["metric"] == "spearman").any()
+    assert out["value"].notna().all()
+
+
+def test_sge_multiple_score_columns():
+    dataset, scores = _sge_data(seed=0)
+    scores = scores.copy()
+    scores["jsd"] = np.random.default_rng(1).normal(size=len(scores))
+    out = compute_sge_metrics(dataset, scores, n_bootstrap=10, rng=0)
+    assert set(out["score_type"]) == {"score", "jsd"}
+
+
+def test_sge_urn_maps_to_multiple_genes_raises():
+    dataset = pd.DataFrame(
+        {
+            "mavedb_urn": ["urn:1"] * 4,
+            "gene": ["A", "A", "B", "B"],
+            "subset": ["missense_variant"] * 4,
+            "function_score_aligned": [0.1, 0.2, 0.3, 0.4],
+            "calibrated_class": ["normal"] * 4,
+        }
+    )
+    scores = pd.DataFrame({"score": [1.0, 2.0, 3.0, 4.0]})
+    with pytest.raises(AssertionError, match="maps to >1 gene"):
+        compute_sge_metrics(dataset, scores, n_bootstrap=2, rng=0)
+
+
+def test_sge_seed_reproducibility():
+    dataset, scores = _sge_data(seed=1)
+    a = compute_sge_metrics(dataset, scores, n_bootstrap=50, rng=0)
+    b = compute_sge_metrics(dataset, scores, n_bootstrap=50, rng=0)
+    pd.testing.assert_frame_equal(a, b)

--- a/tests/pipelines/evals/test_metrics.py
+++ b/tests/pipelines/evals/test_metrics.py
@@ -808,8 +808,10 @@ def test_sge_accession_macro_is_mean_over_accessions():
 
 
 def test_sge_n_min_auprc_gates_small_cells():
-    """A subset cell with <n_min_auprc of either label class produces no AUPRC; the
-    subset-macro then averages only the qualifying base subset (K=1)."""
+    """A subset cell with <n_min_auprc of either label class is gated: it's still
+    emitted (so a blanked cell reports its class balance) but with value/se = NaN
+    and a real n / n_pos, and it's excluded from the subset-macro (which then
+    averages only the qualifying base subset, K=1)."""
     rng = np.random.default_rng(0)
 
     def block(subset: str, n_pos: int, n_neg: int) -> tuple[pd.DataFrame, np.ndarray]:
@@ -824,11 +826,15 @@ def test_sge_n_min_auprc_gates_small_cells():
     dataset = pd.concat([dm, ds], ignore_index=True)
     scores = pd.DataFrame({"score": np.concatenate([sm, ss])})
     out = compute_sge_metrics(dataset, scores, n_bootstrap=10, rng=0)
-    a = out[out["metric"] == "AUPRC"]
-    assert ((a["subset"] == "missense_variant") & (a["accession"] == "urn:1")).any()
-    assert not ((a["subset"] == "splicing") & (a["accession"] == "urn:1")).any()
-    macro = _val(out, metric="AUPRC", subset=MACRO_AVG_SUBSET, accession="urn:1")
+
     miss = _val(out, metric="AUPRC", subset="missense_variant", accession="urn:1")
+    assert np.isfinite(miss["value"])
+    # Gated splicing cell: emitted, value NaN, but class counts preserved.
+    spl = _val(out, metric="AUPRC", subset="splicing", accession="urn:1")
+    assert np.isnan(spl["value"]) and np.isnan(spl["se"])
+    assert spl["n_pos"] == 10 and spl["n"] == 100  # n_neg = n - n_pos = 90
+    # Subset-macro excludes the gated cell → equals missense alone (K=1).
+    macro = _val(out, metric="AUPRC", subset=MACRO_AVG_SUBSET, accession="urn:1")
     assert macro["value"] == pytest.approx(miss["value"])
     assert macro["n"] == 1
 

--- a/tests/pipelines/evals/test_sge.py
+++ b/tests/pipelines/evals/test_sge.py
@@ -14,6 +14,7 @@ from marin_dna.pipelines.evals.sge import (
     attach_author_class_harmonized,
     attach_calibrated_class,
     attach_function_direction,
+    attach_label,
     build_mavedb_metadata,
     extract_assay_facts,
     extract_score_calibrations,
@@ -1020,6 +1021,21 @@ class TestAttachCalibratedClass:
             AssertionError, match="attach_author_class_harmonized first"
         ):
             attach_calibrated_class(data, _GENEN_CAL)
+
+
+class TestAttachLabel:
+    def test_label_from_calibrated_class(self) -> None:
+        data = pl.DataFrame(
+            {"calibrated_class": ["abnormal", "normal", "intermediate", None]}
+        )
+        out = attach_label(data)
+        # True = impactful (abnormal), False = normal; null for intermediate /
+        # uncalibrated (those rows are dropped from the shipped v3 dataset).
+        assert out["label"].to_list() == [True, False, None, None]
+
+    def test_requires_calibrated_class_first(self) -> None:
+        with pytest.raises(AssertionError, match="attach_calibrated_class first"):
+            attach_label(pl.DataFrame({"gene": ["X"]}))
 
 
 class TestAttachFunctionDirection:


### PR DESCRIPTION
## What

Formalizes the **saturation-genome-editing (SGE)** variant-effect benchmark as a binary VEP task and runs it on **3 marin-dna gLMs + 5 conservation baselines**, with a dedicated dashboard leaderboard. Implements #301 (follow-up to #292's single-model exploration).

The benchmark frames SGE as: predict each variant's boolean `label` (impactful = ClinGen/ExCALIBR-calibrated **abnormal**) from a method's deleteriousness score, scored by **AUPRC** per accession (MaveDB study) then macro-averaged. Scores are non-comparable across studies, so nothing is pooled across accessions; AUPRC is rank-based, so a conservation track's scalar and a gLM's LLR compare on the same footing.

- **`compute_sge_metrics`** — one shared core ([`metrics.py`](https://github.com/Open-Athena/marin-dna/blob/78a9e47bb1b1c67e973f9b1a56811bc8cd2286de/src/marin_dna/pipelines/evals/metrics.py#L700)): AUPRC over a 2-axis grid — `subset` ∈ {missense, splicing, both, subset-macro} × `accession` ∈ {each, macro}. Output parquet `[metric, subset, accession, gene, score_type, value, se, n, n_pos]` (`metric` always `AUPRC`). A cell that fails the `n_min_auprc=30`-per-class gate (only VHL/XRCC2 splicing, at 14/11 positives) is still emitted — `value`/`se` = NaN but a real `n`/`n_pos` — so the dashboard can report its class balance; gated cells are excluded from every macro, so all macro values are byte-identical.
- **Both pipelines call the same core** — `evals_v2` (`eval_protocol: sge`, `score_protocol: minus_llr`) for the gLMs and [`conservation_eval`](https://github.com/Open-Athena/marin-dna/blob/78a9e47bb1b1c67e973f9b1a56811bc8cd2286de/src/marin_dna/pipelines/evals/conservation.py#L481) (`score_columns=["score"]`) for the tracks. No metric logic duplicated.
- **Conservation NaN policy centralized** into one shared `fill_score_nan` (`fillna(0)`, used by all three eval protocols).
- **Dashboard** — new `leaderboards/sge.md`: an AUPRC heatmap (methods × {Macro, Missense, Splicing, Both}) on a YlGn scale over **[0, 1.0]** (anchored at 0; upper end matches the matched-pair heatmap, so colors read as absolute AUPRC across pages), a modern segmented gene-scope selector (all options visible), click-to-sort columns, hover model-cards, and per-column class-balance sub-labels (`n={n_pos} vs. {n_neg}` for a selected gene — shown even on cells the gate blanks, so an empty cell explains itself); LLR/JSD toggle. `npm run build` renders all pages.

## Dataset: v3 (AUPRC-only reconstruction)

Mid-PR the metric set was narrowed to **AUPRC-only** (matching the classification framing of the other benchmarks, e.g. Evo 2's SGE eval), and the dataset was rebuilt to **v3** ([`225d3d1e`](https://huggingface.co/datasets/bolinas-dna/evals_sge/tree/225d3d1ea32a4af547891b13c33b5e92a5aae849)) to add a boolean `label` (abnormal→true / normal→false) and **drop the unlabeled** (intermediate / uncalibrated) variants — fewer forward passes per model, which matters for slow models like Evo 2 down the line. The continuous `function_score_aligned` / `calibrated_class` columns stay in the dataset for provenance. v3 is exactly the labeled subset of v2, so the AUPRC numbers are unchanged from the v2 run; only the metric surface (no Spearman) and the inference cost changed. Built by [`scripts/issue301_build_sge_v3.py`](https://github.com/Open-Athena/marin-dna/blob/78a9e47bb1b1c67e973f9b1a56811bc8cd2286de/scripts/issue301_build_sge_v3.py).

## Orientation

Default gLM score is **signed LLR** (`minus_llr_avg`) — the assayed ALT is the deleterious-*candidate*, so its sign is informative (not `abs`), matching `mendelian_traits`; **JSD** (`jsd_avg`) is a dashboard toggle. Higher score = more damaging, so a good predictor scores high AUPRC uniformly across the gLM/conservation families.

## Results (8 methods, `evals_sge` v3, `train`)

Full table + reads in [#301](https://github.com/Open-Athena/marin-dna/issues/301). Headline (all-genes macro AUPRC, LLR): the CDS-specialist **`exp13-mp`** leads at **0.450** and dominates splicing (0.571); **`phyloP_100v`** (0.365) edges **`exp135`** (0.358) for 2nd; `exp166` 0.310; the phastCons tracks trail (0.21–0.25). The gLM ranking reproduces #292 (`exp13-mp` > `exp135` > `exp166`). Macro `n_pos` = 3,501 across 8 qualifying accessions.

## Test plan

- `uv run pytest tests/pipelines/evals/` → **418 passed, 4 skipped** (incl. `compute_sge_metrics` AUPRC tests + conservation/leaderboard/`attach_label`/`hf_readme` SGE tests).
- Dry-ran both pipelines (only the `sge` targets re-triggered, via the v3 `hf_revision` bump); ran conservation (5 tracks, local) + re-scored the 3 gLMs on v3 (one A10G each, [`scripts/issue301_launch_sge_v3_glms.sh`](https://github.com/Open-Athena/marin-dna/blob/78a9e47bb1b1c67e973f9b1a56811bc8cd2286de/scripts/issue301_launch_sge_v3_glms.sh)); `npm run build` clean.

## Scope

Closes #301. The issue's deferred items (held-out **test split**, **gene-corpus expansion**, prime-editing pooling) are out of scope and tracked as separate follow-ups, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
