### PR TITLE
evals_v2: score scaling-v0.5 ladder on SGE + complex traits; add 4B to dashboard

### DIFF
--- a/dashboard/models.yaml
+++ b/dashboard/models.yaml
@@ -325,6 +325,25 @@
     gcs: gs://marin-us-east5/checkpoints/dna-bolinas-exp166-v0.1-p4B-74e146/hf/step-27329
   datasets: [mendelian_traits, complex_traits]
 
+# Parameter-scaling ladder v0.5 — 4B, the largest converged rung (issues
+# #274 / #306; 84.8B tokens, genomes-v5, 255 bp + BOS). Added to the dashboard
+# for the cross-benchmark scaling comparison (mendelian / complex / SGE).
+- id: scaling-v0.5-h2944-p4B-step-215573
+  display: scaling-v0.5 4B
+  family: marin_dna
+  description: param-scaling ladder, 4B, genomes-v5, 84.8B tokens
+  training:
+    data: genomes_v5
+    params: 4.0e9
+    window_size: 255
+    objective: CLM
+  experiment: 274
+  issue: https://github.com/Open-Athena/marin-dna/issues/274
+  wandb: https://wandb.ai/eric-czech/marin/runs/dna-bolinas-scaling-v0.5-h2944-p4B-fa02c3
+  checkpoint:
+    gcs: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h2944-p4B-fa02c3/hf/step-215573
+  datasets: [mendelian_traits, complex_traits, sge]
+
 # Eric Czech's mix-v0.9 1B runs (Slack #marin_dna, 2026-05-18). Headline
 # uniform-mixture run + continued-training upstream-weighted variant.
 - id: mix-v0.9-p1B-i0-uniform-step-25004

--- a/plots/scaling_sge_vs_mendelian.py
+++ b/plots/scaling_sge_vs_mendelian.py
@@ -1,0 +1,228 @@
+"""Issue #306 figure: AUPRC vs model size on SGE vs Mendelian, for missense & splicing.
+
+Two panels over the 8 `dna-bolinas-scaling-v0.5` sizes (46M→4B, step-215573):
+  Panel A — missense_variant
+  Panel B — splicing
+
+Within each panel, two lines on **two independent y-axes** (shared log-x = params):
+  left  (blue)  — Mendelian AUPRC: official evals_v2, pooled within-consequence,
+                  matched 1:9 cluster bootstrap (reused from #274, not recomputed).
+  right (red)   — SGE AUPRC: macro-averaged across genes (`accession == _macro_avg_`).
+
+The two AUPRCs are constructed differently (Mendelian = pooled/matched; SGE =
+unmatched per-gene macro) and are **not level-comparable** — the dual axes make
+explicit that we compare the *shapes / trends with scale*, never the vertical gap
+between the lines. Both use `minus_llr_avg` (signed −LLR, FWD+RC mean).
+
+Self-contained: reads the two evals_v2 metric parquets per model from S3. Params
+are the published final-checkpoint counts (issue #274 table), hardcoded so the
+recipe needs no W&B. Emits SVG + PNG to `plots/output/scaling_sge_vs_mendelian/`.
+
+Usage:
+    uv run python plots/scaling_sge_vs_mendelian.py \
+        --metrics-prefix s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import polars as pl
+
+OUT_DIR = Path(__file__).resolve().parent / "output" / "scaling_sge_vs_mendelian"
+
+# 8-model scaling ladder (issues #274 / #306), all at step-215573 (~84.8B tokens).
+SIZES = [
+    "h640-p46M",
+    "h768-p76M",
+    "h896-p128M",
+    "h1152-p255M",
+    "h1408-p476M",
+    "h1920-p1B",
+    "h2432-p2B",
+    "h2944-p4B",
+]
+# Total parameter count per size (issue #274 table) — x-axis position.
+PARAMS = {
+    "h640-p46M": 45.9e6,
+    "h768-p76M": 75.5e6,
+    "h896-p128M": 128.5e6,
+    "h1152-p255M": 254.8e6,
+    "h1408-p476M": 475.9e6,
+    "h1920-p1B": 1.12e9,
+    "h2432-p2B": 2.27e9,
+    "h2944-p4B": 4.02e9,
+}
+SIZE_LABEL = {
+    "h640-p46M": "46M",
+    "h768-p76M": "76M",
+    "h896-p128M": "128M",
+    "h1152-p255M": "255M",
+    "h1408-p476M": "476M",
+    "h1920-p1B": "1B",
+    "h2432-p2B": "2B",
+    "h2944-p4B": "4B",
+}
+CONSEQUENCES = ["missense_variant", "splicing"]
+
+MEN_COLOR, SGE_COLOR = "tab:blue", "tab:red"
+
+
+def _model(size: str) -> str:
+    return f"scaling-v0.5-{size}-step-215573"
+
+
+def _read(path: str, what: str) -> pl.DataFrame:
+    try:
+        return pl.read_parquet(path)
+    except Exception as e:  # fail loud, name the missing cell
+        raise RuntimeError(
+            f"{what}: could not read {path} — has its sky cell finished? ({e})"
+        )
+
+
+def load_mendelian(prefix: str, score_type: str) -> dict[tuple[str, str], dict]:
+    """(size, consequence) -> {value, se}. Pooled within-consequence AUPRC (#274)."""
+    out: dict[tuple[str, str], dict] = {}
+    for s in SIZES:
+        m = _read(f"{prefix}/{_model(s)}/mendelian_traits.parquet", f"mendelian {s}")
+        m = m.filter(pl.col("score_type") == score_type)
+        for c in CONSEQUENCES:
+            hit = m.filter(pl.col("subset") == c)
+            assert hit.height == 1, (
+                f"{_model(s)} mendelian {c}: expected 1 row, got {hit.height}"
+            )
+            out[(s, c)] = {"value": hit["value"][0], "se": hit["se"][0]}
+    return out
+
+
+def load_sge(prefix: str, score_type: str) -> dict[tuple[str, str], dict]:
+    """(size, consequence) -> {value, se, n_genes}. Macro across genes (_macro_avg_)."""
+    out: dict[tuple[str, str], dict] = {}
+    for s in SIZES:
+        m = _read(f"{prefix}/{_model(s)}/sge.parquet", f"sge {s}")
+        m = m.filter(
+            (pl.col("accession") == "_macro_avg_")
+            & (pl.col("score_type") == score_type)
+        )
+        for c in CONSEQUENCES:
+            hit = m.filter(pl.col("subset") == c)
+            assert hit.height == 1, (
+                f"{_model(s)} sge {c}: expected 1 macro row, got {hit.height}"
+            )
+            out[(s, c)] = {
+                "value": hit["value"][0],
+                "se": hit["se"][0],
+                "n_genes": int(hit["n"][0]),
+            }
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--metrics-prefix",
+        default="s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics",
+    )
+    ap.add_argument("--score-type", default="minus_llr_avg")
+    args = ap.parse_args()
+
+    men = load_mendelian(args.metrics_prefix, args.score_type)
+    sge = load_sge(args.metrics_prefix, args.score_type)
+
+    # Console table (for the issue comment).
+    print(
+        f"score_type={args.score_type}  (Mendelian pooled-within-consequence | SGE macro-across-genes)"
+    )
+    print(
+        f"{'size':>6} {'params':>8} | {'men_miss':>9} {'sge_miss':>9} ({'g':>2}) | {'men_splice':>10} {'sge_splice':>10} ({'g':>2})"
+    )
+    for s in SIZES:
+        mm, sm = men[(s, "missense_variant")], sge[(s, "missense_variant")]
+        mp, sp = men[(s, "splicing")], sge[(s, "splicing")]
+        print(
+            f"{SIZE_LABEL[s]:>6} {PARAMS[s] / 1e6:>7.0f}M | {mm['value']:>9.3f} {sm['value']:>9.3f} ({sm['n_genes']:>2}) "
+            f"| {mp['value']:>10.3f} {sp['value']:>10.3f} ({sp['n_genes']:>2})"
+        )
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    matplotlib.rcParams["svg.fonttype"] = "none"
+    import matplotlib.pyplot as plt
+
+    x = [PARAMS[s] for s in SIZES]
+    xt_labels = [SIZE_LABEL[s] for s in SIZES]
+
+    fig, axes = plt.subplots(1, 2, figsize=(11, 5))
+    gene_note = {}
+    for ax, c in zip(axes, CONSEQUENCES):
+        # Mendelian — left axis (blue)
+        h_men = ax.errorbar(
+            x,
+            [men[(s, c)]["value"] for s in SIZES],
+            yerr=[men[(s, c)]["se"] for s in SIZES],
+            marker="o",
+            ms=5,
+            lw=1.5,
+            color=MEN_COLOR,
+            capsize=3,
+            label="Mendelian (left)",
+        )
+        ax.set_xscale("log")
+        ax.set_xticks(x)
+        ax.set_xticklabels(xt_labels, rotation=45, fontsize=7)
+        ax.tick_params(axis="x", which="minor", bottom=False)
+        ax.set_xlabel("model size (params)")
+        ax.set_ylabel("Mendelian AUPRC", color=MEN_COLOR)
+        ax.tick_params(axis="y", labelcolor=MEN_COLOR)
+        ax.grid(True, alpha=0.3)
+
+        # SGE — right axis (red)
+        ax2 = ax.twinx()
+        h_sge = ax2.errorbar(
+            x,
+            [sge[(s, c)]["value"] for s in SIZES],
+            yerr=[sge[(s, c)]["se"] for s in SIZES],
+            marker="s",
+            ms=5,
+            lw=1.5,
+            color=SGE_COLOR,
+            capsize=3,
+            label="SGE (right)",
+        )
+        ax2.set_ylabel("SGE AUPRC (macro across genes)", color=SGE_COLOR)
+        ax2.tick_params(axis="y", labelcolor=SGE_COLOR)
+
+        ng = sorted({sge[(s, c)]["n_genes"] for s in SIZES})
+        gene_note[c] = f"{ng[0]}" if len(ng) == 1 else f"{ng[0]}–{ng[-1]}"
+        ax.set_title(c.replace("_variant", ""))
+        ax.legend(handles=[h_men, h_sge], fontsize=8, loc="best")
+
+    fig.suptitle(
+        f"Scaling ladder (46M→4B, n=8): Mendelian vs SGE AUPRC by model size — "
+        f"{args.score_type}, FWD+RC (#306)"
+    )
+    fig.text(
+        0.5,
+        -0.04,
+        f"Independent y-axes — compare shapes vs scale, not levels.  "
+        f"SGE = macro across genes (missense: {gene_note['missense_variant']}; "
+        f"splicing: {gene_note['splicing']}), unmatched.  "
+        f"Mendelian = pooled within-consequence, matched 1:9.",
+        ha="center",
+        fontsize=7.5,
+        color="dimgray",
+    )
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    svg = OUT_DIR / "figure.svg"
+    fig.savefig(svg, bbox_inches="tight", dpi=200)
+    fig.savefig(svg.with_suffix(".png"), bbox_inches="tight", dpi=200)
+    plt.close(fig)
+    print(f"\nwrote {svg} (+ .png)")
+
+
+if __name__ == "__main__":
+    main()

--- a/plots/scaling_sge_vs_mendelian.py
+++ b/plots/scaling_sge_vs_mendelian.py
@@ -1,20 +1,25 @@
-"""Issue #306 figure: AUPRC vs model size on Mendelian / complex traits / SGE.
+"""Issue #306 figures: scaling-ladder AUPRC vs model size on Mendelian / complex / SGE.
 
-Two panels over the 8 `dna-bolinas-scaling-v0.5` sizes (46M→4B, step-215573):
-  Panel A — missense_variant
-  Panel B — splicing
+Two figures over the 8 `dna-bolinas-scaling-v0.5` sizes (46M→4B, step-215573),
+each split by consequence (missense, splicing) — no cross-consequence mixing:
 
-Lines (shared log-x = params; two independent y-axes per panel):
-  left  — matched 1:9 AUPRC (baseline 0.10; same construction, comparable):
-            • Mendelian (blue, −LLR), and
-            • Complex traits (green, |LLR|) on both panels. NOTE complex
-              *splicing* rests on only ~19 match-groups (vs ~250 for missense),
-              so it carries a wide CI and is read with caution (caveat on figure).
-  right — SGE AUPRC (red): macro-averaged across genes (`accession == _macro_avg_`, −LLR).
+  figure_relative — ALL 3 datasets on one shared axis. The three benchmarks live
+      on different scales (matched 1:9 Mendelian/complex ~0.1–0.6 baseline 0.10;
+      per-gene-macro SGE), so each series is **min-max normalized over the 8
+      sizes** → a proportion in [0, 1] (0 = that series' smallest, 1 = largest).
+      This compares only the *shape / trend with scale*. 2 panels (missense,
+      splicing) × 3 lines (Mendelian, Complex, SGE).
 
-The matched-pair (left) and per-gene-macro SGE (right) AUPRCs are constructed
-differently and are **not level-comparable** — the dual axes make explicit that
-we compare *shapes / trends with scale*, never the vertical gap. All scores FWD+RC.
+  figure_native — one panel per dataset on its **native AUPRC scale**, each with
+      missense + splicing. 3 panels (Mendelian, Complex, SGE).
+
+Scores (FWD+RC): Mendelian & SGE use −LLR (`minus_llr_avg`); complex uses |LLR|
+(`abs_llr_avg`, its score_protocol). SGE is macro-averaged across genes.
+**Error bars are ±1 SE (bootstrap)** — std of the per-metric bootstrap, not a CI;
+in figure_relative they are the native SE divided by each series' min–max range.
+
+Caveat: complex *splicing* rests on only ~19 match-groups (vs ~250 missense) → its
+AUPRC has a very wide SE and is read with caution.
 
 Self-contained: reads the evals_v2 metric parquets per model from S3. Params are
 the published final-checkpoint counts (issue #274), hardcoded so the recipe needs
@@ -68,7 +73,18 @@ SIZE_LABEL = {
 }
 CONSEQUENCES = ["missense_variant", "splicing"]
 
-MEN_COLOR, COMPLEX_COLOR, SGE_COLOR = "tab:blue", "tab:green", "tab:red"
+# Figure 1 (relative): colour = dataset.
+DATASET_COLOR = {"Mendelian": "tab:blue", "Complex": "tab:green", "SGE": "tab:red"}
+DATASET_MARKER = {"Mendelian": "o", "Complex": "^", "SGE": "s"}
+DATASET_SCORE = {
+    "Mendelian": "−LLR",
+    "Complex": "|LLR|",
+    "SGE": "−LLR, macro across genes",
+}
+# Figure 2 (native): colour = consequence.
+CONSEQ_COLOR = {"missense_variant": "tab:purple", "splicing": "tab:orange"}
+CONSEQ_MARKER = {"missense_variant": "o", "splicing": "s"}
+
 # complex_traits scores with the abs_llr protocol (magnitude); mendelian & sge use minus_llr.
 COMPLEX_SCORE_TYPE = "abs_llr_avg"
 
@@ -86,35 +102,21 @@ def _read(path: str, what: str) -> pl.DataFrame:
         )
 
 
-def load_mendelian(prefix: str, score_type: str) -> dict[tuple[str, str], dict]:
-    """(size, consequence) -> {value, se}. Pooled within-consequence AUPRC (#274)."""
-    out: dict[tuple[str, str], dict] = {}
-    for s in SIZES:
-        m = _read(f"{prefix}/{_model(s)}/mendelian_traits.parquet", f"mendelian {s}")
-        m = m.filter(pl.col("score_type") == score_type)
-        for c in CONSEQUENCES:
-            hit = m.filter(pl.col("subset") == c)
-            assert hit.height == 1, (
-                f"{_model(s)} mendelian {c}: expected 1 row, got {hit.height}"
-            )
-            out[(s, c)] = {"value": hit["value"][0], "se": hit["se"][0]}
-    return out
+def load_matched(
+    prefix: str, dataset: str, score_type: str
+) -> dict[tuple[str, str], dict]:
+    """Matched-pair (mendelian/complex) AUPRC: (size, consequence) -> {value, se, n_groups}.
 
-
-def load_complex(prefix: str, score_type: str) -> dict[tuple[str, str], dict]:
-    """(size, consequence) -> {value, se, n_groups}. Matched 1:9 AUPRC, abs_llr.
-
-    Complex *splicing* has very few match-groups (~19 vs ~250 for missense), so
-    its AUPRC carries a wide CI — plotted on both panels but caveated.
+    Pooled within-consequence AUPRC, matched 1:9, cluster bootstrap over match_groups.
     """
     out: dict[tuple[str, str], dict] = {}
     for s in SIZES:
-        m = _read(f"{prefix}/{_model(s)}/complex_traits.parquet", f"complex {s}")
+        m = _read(f"{prefix}/{_model(s)}/{dataset}.parquet", f"{dataset} {s}")
         m = m.filter(pl.col("score_type") == score_type)
         for c in CONSEQUENCES:
             hit = m.filter(pl.col("subset") == c)
             assert hit.height == 1, (
-                f"{_model(s)} complex {c}: expected 1 row, got {hit.height}"
+                f"{_model(s)} {dataset} {c}: expected 1 row, got {hit.height}"
             )
             out[(s, c)] = {
                 "value": hit["value"][0],
@@ -125,7 +127,7 @@ def load_complex(prefix: str, score_type: str) -> dict[tuple[str, str], dict]:
 
 
 def load_sge(prefix: str, score_type: str) -> dict[tuple[str, str], dict]:
-    """(size, consequence) -> {value, se, n_genes}. Macro across genes (_macro_avg_)."""
+    """SGE macro across genes: (size, consequence) -> {value, se, n_genes} (_macro_avg_)."""
     out: dict[tuple[str, str], dict] = {}
     for s in SIZES:
         m = _read(f"{prefix}/{_model(s)}/sge.parquet", f"sge {s}")
@@ -146,6 +148,21 @@ def load_sge(prefix: str, score_type: str) -> dict[tuple[str, str], dict]:
     return out
 
 
+def _series(d: dict, c: str) -> tuple[list[float], list[float]]:
+    """(values, ses) over SIZES for consequence c."""
+    return ([d[(s, c)]["value"] for s in SIZES], [d[(s, c)]["se"] for s in SIZES])
+
+
+def _minmax(
+    vals: list[float], ses: list[float]
+) -> tuple[list[float], list[float], float]:
+    """Min-max normalize a series to [0,1]; scale SE by the same range. Returns
+    (norm_vals, norm_ses, range)."""
+    lo, hi = min(vals), max(vals)
+    rng = (hi - lo) or 1.0
+    return [(v - lo) / rng for v in vals], [e / rng for e in ses], hi - lo
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -155,27 +172,32 @@ def main() -> None:
     ap.add_argument("--score-type", default="minus_llr_avg", help="for mendelian & sge")
     args = ap.parse_args()
 
-    men = load_mendelian(args.metrics_prefix, args.score_type)
-    cpx = load_complex(args.metrics_prefix, COMPLEX_SCORE_TYPE)
+    men = load_matched(args.metrics_prefix, "mendelian_traits", args.score_type)
+    cpx = load_matched(args.metrics_prefix, "complex_traits", COMPLEX_SCORE_TYPE)
     sge = load_sge(args.metrics_prefix, args.score_type)
+    data = {"Mendelian": men, "Complex": cpx, "SGE": sge}
 
-    # Console table (for the issue comment).
+    # Console table — native AUPRC (M=missense, S=splicing).
     print(
-        f"mendelian/sge={args.score_type} | complex={COMPLEX_SCORE_TYPE} "
-        "(left=matched 1:9 AUPRC | SGE=macro across genes)"
+        f"mendelian/sge={args.score_type} | complex={COMPLEX_SCORE_TYPE}   (native AUPRC ± SE)"
     )
-    hdr = ("size", "params", "men_M", "cpx_M", "sge_M", "men_S", "cpx_S", "sge_S")
     print(
-        f"{hdr[0]:>6} {hdr[1]:>7} | {hdr[2]:>7} {hdr[3]:>7} {hdr[4]:>7} | "
-        f"{hdr[5]:>7} {hdr[6]:>7} {hdr[7]:>7}"
+        f"{'size':>6} {'params':>7} | {'men_M':>7} {'cpx_M':>7} {'sge_M':>7} "
+        f"| {'men_S':>7} {'cpx_S':>7} {'sge_S':>7}"
     )
     for s in SIZES:
-        v = lambda d, c: d[(s, c)]["value"]  # noqa: E731
+        row = [SIZE_LABEL[s], f"{PARAMS[s] / 1e6:.0f}M"]
+        for c in CONSEQUENCES:
+            row += [
+                f"{data[d][(s, c)]['value']:.3f}"
+                for d in ("Mendelian", "Complex", "SGE")
+            ]
         print(
-            f"{SIZE_LABEL[s]:>6} {PARAMS[s] / 1e6:>6.0f}M | "
-            f"{v(men, 'missense_variant'):>7.3f} {v(cpx, 'missense_variant'):>7.3f} {v(sge, 'missense_variant'):>7.3f} | "
-            f"{v(men, 'splicing'):>7.3f} {v(cpx, 'splicing'):>7.3f} {v(sge, 'splicing'):>7.3f}"
+            f"{row[0]:>6} {row[1]:>7} | {row[2]:>7} {row[3]:>7} {row[4]:>7} "
+            f"| {row[5]:>7} {row[6]:>7} {row[7]:>7}"
         )
+    cpx_spl_n = cpx[(SIZES[0], "splicing")]["n_groups"]
+    sge_g = {c: sge[(SIZES[0], c)]["n_genes"] for c in CONSEQUENCES}
 
     import matplotlib
 
@@ -185,99 +207,112 @@ def main() -> None:
 
     x = [PARAMS[s] for s in SIZES]
     xt_labels = [SIZE_LABEL[s] for s in SIZES]
-    cpx_spl_n = cpx[(SIZES[0], "splicing")]["n_groups"]  # constant across models
 
-    # constrained layout auto-spaces the twin-axis labels/ticks between the two
-    # panels (the inner labels would otherwise collide in the centre); the legend
-    # goes *outside* the panels so it can't overlap the data.
-    fig, axes = plt.subplots(1, 2, figsize=(13, 5.5), layout="constrained")
-    h_men_ref = h_cpx_ref = h_sge_ref = None
-    gene_note = {}
-    for ax, c in zip(axes, CONSEQUENCES):
-        # Left axis — matched 1:9 AUPRC (neutral/black: hosts Mendelian + Complex).
-        h_men = ax.errorbar(
-            x,
-            [men[(s, c)]["value"] for s in SIZES],
-            yerr=[men[(s, c)]["se"] for s in SIZES],
-            marker="o",
-            ms=5,
-            lw=1.5,
-            color=MEN_COLOR,
-            capsize=3,
-        )
-        h_cpx = ax.errorbar(
-            x,
-            [cpx[(s, c)]["value"] for s in SIZES],
-            yerr=[cpx[(s, c)]["se"] for s in SIZES],
-            marker="^",
-            ms=5,
-            lw=1.5,
-            color=COMPLEX_COLOR,
-            capsize=3,
-        )
+    def _style_x(ax) -> None:
         ax.set_xscale("log")
         ax.set_xticks(x)
         ax.set_xticklabels(xt_labels, fontsize=8)
         ax.tick_params(axis="x", which="minor", bottom=False)
         ax.set_xlabel("model size (params)")
-        ax.set_ylabel("AUPRC — matched 1:9")
         ax.grid(True, alpha=0.3)
 
-        # Right axis — SGE macro across genes (red).
-        ax2 = ax.twinx()
-        h_sge = ax2.errorbar(
-            x,
-            [sge[(s, c)]["value"] for s in SIZES],
-            yerr=[sge[(s, c)]["se"] for s in SIZES],
-            marker="s",
-            ms=5,
-            lw=1.5,
-            color=SGE_COLOR,
-            capsize=3,
-        )
-        ax2.set_ylabel("SGE AUPRC (macro)", color=SGE_COLOR)
-        ax2.tick_params(axis="y", labelcolor=SGE_COLOR)
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
 
-        ng = sorted({sge[(s, c)]["n_genes"] for s in SIZES})
-        gene_note[c] = f"{ng[0]}" if len(ng) == 1 else f"{ng[0]}–{ng[-1]}"
+    # ===== Figure 1: relative (min-max normalized per series), all 3 datasets =====
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5.5), layout="constrained")
+    handles = {}
+    for ax, c in zip(axes, CONSEQUENCES):
+        for dsname, d in data.items():
+            vals, ses = _series(d, c)
+            nv, nse, _ = _minmax(vals, ses)
+            h = ax.errorbar(
+                x,
+                nv,
+                yerr=nse,
+                marker=DATASET_MARKER[dsname],
+                ms=5,
+                lw=1.5,
+                color=DATASET_COLOR[dsname],
+                capsize=3,
+                elinewidth=1,
+                alpha=0.9,
+            )
+            handles[dsname] = h
+        _style_x(ax)
+        ax.set_ylabel("relative AUPRC (0 = series min, 1 = max)")
         ax.set_title(c.replace("_variant", ""))
-        h_men_ref, h_cpx_ref, h_sge_ref = h_men, h_cpx, h_sge
-
     fig.suptitle(
-        "Scaling ladder (46M→4B, n=8): AUPRC by model size — "
-        "Mendelian / complex / SGE, FWD+RC (#306)"
+        "Scaling ladder (46M→4B, n=8): relative AUPRC vs model size — "
+        "Mendelian / complex / SGE (#306)"
     )
-    # One legend outside the axes at the bottom, caveat as its title — exactly one
-    # element on top (suptitle) and one at the bottom (legend), so nothing overlaps
-    # the lines, the suptitle, the inner axis labels, or each other.
     leg = fig.legend(
-        [h_men_ref, h_cpx_ref, h_sge_ref],
+        [handles[d] for d in ("Mendelian", "Complex", "SGE")],
         [
-            "Mendelian (left, −LLR)",
-            "Complex traits (left, |LLR|)",
-            "SGE (right, macro across genes)",
+            "Mendelian (−LLR)",
+            "Complex traits (|LLR|)",
+            "SGE (macro across genes, −LLR)",
         ],
         loc="outside lower center",
         ncol=3,
         frameon=True,
         title=(
-            "Independent y-axes — compare shapes/trends with scale, not the vertical gap.   "
-            "Left = matched 1:9 AUPRC (baseline 0.10); "
-            f"right = SGE macro across genes ({gene_note['missense_variant']} missense / "
-            f"{gene_note['splicing']} splicing), unmatched.\n"
-            f"Caveat: complex splicing rests on only ~{cpx_spl_n} match-groups → wide CI; "
-            "read its trend cautiously."
+            "Each series min-max normalized over the 8 sizes → proportion in [0,1] "
+            "(absolute scales differ; compare shape/trend only).\n"
+            "Error bars = ±1 SE (bootstrap), scaled by each series' min–max range.   "
+            f"Caveat: complex splicing rests on only ~{cpx_spl_n} match-groups → very wide SE."
         ),
     )
     leg.get_title().set_fontsize(8)
     leg.get_title().set_color("dimgray")
-
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
-    svg = OUT_DIR / "figure.svg"
-    fig.savefig(svg, dpi=200)
-    fig.savefig(svg.with_suffix(".png"), dpi=200)
+    fig.savefig(OUT_DIR / "figure_relative.svg", dpi=200)
+    fig.savefig(OUT_DIR / "figure_relative.png", dpi=200)
     plt.close(fig)
-    print(f"\nwrote {svg} (+ .png)")
+
+    # ===== Figure 2: native AUPRC, one panel per dataset =====
+    fig, axes = plt.subplots(1, 3, figsize=(15.5, 5), layout="constrained")
+    handles = {}
+    for ax, dsname in zip(axes, ("Mendelian", "Complex", "SGE")):
+        d = data[dsname]
+        for c in CONSEQUENCES:
+            vals, ses = _series(d, c)
+            h = ax.errorbar(
+                x,
+                vals,
+                yerr=ses,
+                marker=CONSEQ_MARKER[c],
+                ms=5,
+                lw=1.5,
+                color=CONSEQ_COLOR[c],
+                capsize=3,
+            )
+            handles[c] = h
+        _style_x(ax)
+        ax.set_ylabel("AUPRC")
+        ax.set_title(f"{dsname}  ({DATASET_SCORE[dsname]})")
+    fig.suptitle(
+        "Scaling ladder (46M→4B, n=8): native AUPRC by model size, per dataset — FWD+RC (#306)"
+    )
+    leg = fig.legend(
+        [handles[c] for c in CONSEQUENCES],
+        ["missense", "splicing"],
+        loc="outside lower center",
+        ncol=2,
+        frameon=True,
+        title=(
+            "Error bars = ±1 SE (bootstrap).   Mendelian/complex = matched 1:9 (baseline 0.10); "
+            f"SGE = macro across genes ({sge_g['missense_variant']} missense / {sge_g['splicing']} splicing).\n"
+            f"Caveat: complex splicing rests on only ~{cpx_spl_n} match-groups → very wide SE; read its trend cautiously."
+        ),
+    )
+    leg.get_title().set_fontsize(8)
+    leg.get_title().set_color("dimgray")
+    fig.savefig(OUT_DIR / "figure_native.svg", dpi=200)
+    fig.savefig(OUT_DIR / "figure_native.png", dpi=200)
+    plt.close(fig)
+
+    print(
+        f"\nwrote {OUT_DIR}/figure_relative.{{svg,png}} and figure_native.{{svg,png}}"
+    )
 
 
 if __name__ == "__main__":

--- a/plots/scaling_sge_vs_mendelian.py
+++ b/plots/scaling_sge_vs_mendelian.py
@@ -1,23 +1,15 @@
-"""Issue #306 figures: scaling-ladder AUPRC vs model size on Mendelian / complex / SGE.
+"""Issue #306 figure: scaling-ladder native AUPRC vs model size, per dataset × subset.
 
-Two figures over the 8 `dna-bolinas-scaling-v0.5` sizes (46M→4B, step-215573),
-always keeping missense and splicing on separate axes (no cross-consequence mixing):
-
-  figure_relative — ALL 3 datasets on one shared axis. The three benchmarks live
-      on different scales (matched 1:9 Mendelian/complex ~0.1–0.6 baseline 0.10;
-      per-gene-macro SGE), so each series is **min-max normalized over the 8
-      sizes** → a proportion in [0, 1] (0 = that series' smallest, 1 = largest).
-      Compares only the *shape / trend with scale*. 2 panels (missense, splicing)
-      × 3 lines (Mendelian, Complex, SGE).
-
-  figure_native — native AUPRC, a **dataset × consequence grid** (2 rows =
-      consequence, 3 cols = dataset = 6 panels), each on its OWN scale so missense
-      and splicing never share an axis.
+One figure over the 8 `dna-bolinas-scaling-v0.5` sizes (46M→4B, step-215573): a
+**dataset × subset grid** — 3 rows (Mendelian, complex traits, SGE) × 2 cols
+(missense, splicing) = 6 panels, each on its **own native AUPRC scale** (missense
+and splicing never share an axis; no cross-consequence mixing).
 
 Scores (FWD+RC): Mendelian & SGE use −LLR (`minus_llr_avg`); complex uses |LLR|
-(`abs_llr_avg`, its score_protocol). SGE is macro-averaged across genes.
-**Error bars are ±1 SE (bootstrap)** — drawn capless (a dispersion indicator, not
-a bounded interval); in figure_relative they are the native SE / each series' range.
+(`abs_llr_avg`, its score_protocol). SGE is macro-averaged across genes; Mendelian
+and complex are pooled within-consequence, matched 1:9 (baseline 0.10).
+**Error bars are ±1 SE (bootstrap)** — drawn capless (a dispersion indicator, not a
+bounded interval).
 
 Caveat: complex *splicing* rests on only ~19 match-groups (vs ~250 missense) → its
 AUPRC has a very wide SE and is read with caution.
@@ -72,16 +64,10 @@ SIZE_LABEL = {
     "h2432-p2B": "2B",
     "h2944-p4B": "4B",
 }
-CONSEQUENCES = ["missense_variant", "splicing"]
-DATASETS = ["Mendelian", "Complex", "SGE"]
+CONSEQUENCES = ["missense_variant", "splicing"]  # columns
+DATASETS = ["Mendelian", "Complex", "SGE"]  # rows
 
 DATASET_COLOR = {"Mendelian": "tab:blue", "Complex": "tab:green", "SGE": "tab:red"}
-DATASET_MARKER = {"Mendelian": "o", "Complex": "^", "SGE": "s"}
-DATASET_SCORE = {
-    "Mendelian": "−LLR",
-    "Complex": "|LLR|",
-    "SGE": "−LLR, macro across genes",
-}
 CONSEQ_MARKER = {"missense_variant": "o", "splicing": "s"}
 
 # complex_traits scores with the abs_llr protocol (magnitude); mendelian & sge use minus_llr.
@@ -152,13 +138,6 @@ def _series(d: dict, c: str) -> tuple[list[float], list[float]]:
     return ([d[(s, c)]["value"] for s in SIZES], [d[(s, c)]["se"] for s in SIZES])
 
 
-def _minmax(vals: list[float], ses: list[float]) -> tuple[list[float], list[float]]:
-    """Min-max normalize a series to [0,1]; scale SE by the same range."""
-    lo, hi = min(vals), max(vals)
-    rng = (hi - lo) or 1.0
-    return [(v - lo) / rng for v in vals], [e / rng for e in ses]
-
-
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -197,81 +176,21 @@ def main() -> None:
     matplotlib.use("Agg")
     matplotlib.rcParams["svg.fonttype"] = "none"
     import matplotlib.pyplot as plt
-    from matplotlib.lines import Line2D
 
     x = [PARAMS[s] for s in SIZES]
     xt_labels = [SIZE_LABEL[s] for s in SIZES]
 
-    def _style_x(ax) -> None:
-        ax.set_xscale("log")
-        ax.set_xticks(x)
-        ax.set_xticklabels(xt_labels, fontsize=8)
-        ax.tick_params(axis="x", which="minor", bottom=False)
-        ax.set_xlabel("model size (params)")
-
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
-
-    # ===== Figure 1: relative (min-max normalized per series), all 3 datasets =====
-    # Error bars capless: ±1 SE is a dispersion indicator, not a bounded interval.
-    fig, axes = plt.subplots(1, 2, figsize=(13, 5.5), layout="constrained")
-    handles = {}
-    for ax, c in zip(axes, CONSEQUENCES):
-        for dsname, d in data.items():
-            vals, ses = _series(d, c)
-            nv, nse = _minmax(vals, ses)
-            handles[dsname] = ax.errorbar(
-                x,
-                nv,
-                yerr=nse,
-                marker=DATASET_MARKER[dsname],
-                ms=5,
-                lw=1.5,
-                color=DATASET_COLOR[dsname],
-                elinewidth=1,
-                alpha=0.9,
-            )
-        _style_x(ax)
-        ax.grid(True, alpha=0.3)
-        ax.set_ylabel("relative AUPRC (0 = series min, 1 = max)")
-        ax.set_title(c.replace("_variant", ""))
-    fig.suptitle(
-        "Scaling ladder (46M→4B, n=8): relative AUPRC vs model size — "
-        "Mendelian / complex / SGE (#306)"
-    )
-    leg = fig.legend(
-        [handles[d] for d in DATASETS],
-        [
-            "Mendelian (−LLR)",
-            "Complex traits (|LLR|)",
-            "SGE (macro across genes, −LLR)",
-        ],
-        loc="outside lower center",
-        ncol=3,
-        frameon=True,
-        title=(
-            "Each series min-max normalized over the 8 sizes → proportion in [0,1] "
-            "(absolute scales differ; compare shape/trend only).\n"
-            "Error bars = ±1 SE (bootstrap), scaled by each series' min–max range.   "
-            f"Caveat: complex splicing rests on only ~{cpx_spl_n} match-groups → very wide SE."
-        ),
-    )
-    leg.get_title().set_fontsize(8)
-    leg.get_title().set_color("dimgray")
-    fig.savefig(OUT_DIR / "figure_relative.svg", dpi=200)
-    fig.savefig(OUT_DIR / "figure_relative.png", dpi=200)
-    plt.close(fig)
-
-    # ===== Figure 2: native AUPRC — dataset (cols) × consequence (rows) grid =====
-    # Each panel its own native scale: missense and splicing never share an axis.
+    # Native AUPRC grid: rows = dataset, cols = consequence. Each panel its own
+    # scale (missense / splicing never share an axis). Error bars capless ±1 SE.
     fig, axes = plt.subplots(
-        len(CONSEQUENCES),
         len(DATASETS),
-        figsize=(14, 8.5),
+        len(CONSEQUENCES),
+        figsize=(9.5, 11),
         sharex=True,
         layout="constrained",
     )
-    for ri, c in enumerate(CONSEQUENCES):
-        for ci, dsname in enumerate(DATASETS):
+    for ri, dsname in enumerate(DATASETS):
+        for ci, c in enumerate(CONSEQUENCES):
             ax = axes[ri, ci]
             vals, ses = _series(data[dsname], c)
             ax.errorbar(
@@ -287,40 +206,35 @@ def main() -> None:
             ax.set_xscale("log")
             ax.grid(True, alpha=0.3)
             ax.tick_params(axis="x", which="minor", bottom=False)
-            if ri == 0:
-                ax.set_title(f"{dsname}  ({DATASET_SCORE[dsname]})")
-            ax.set_ylabel(f"{c.replace('_variant', '')} AUPRC" if ci == 0 else "AUPRC")
-    for ax in axes[-1]:  # x labels on the bottom row (sharex hides the top row's)
-        _style_x(ax)
-    fig.suptitle(
-        "Scaling ladder (46M→4B, n=8): native AUPRC by dataset × consequence — FWD+RC (#306)"
-    )
-    proxies = [
-        Line2D([0], [0], color=DATASET_COLOR[d], marker=DATASET_MARKER[d], lw=1.5)
-        for d in DATASETS
-    ]
-    leg = fig.legend(
-        proxies,
-        [f"{d} ({DATASET_SCORE[d]})" for d in DATASETS],
-        loc="outside lower center",
-        ncol=3,
-        frameon=True,
-        title=(
-            "Each panel native scale (missense / splicing not shared).   "
-            "Error bars = ±1 SE (bootstrap).   Mendelian/complex = matched 1:9 (baseline 0.10); "
-            f"SGE = macro across genes ({sge_g['missense_variant']} missense / {sge_g['splicing']} splicing).\n"
-            f"Caveat: complex splicing rests on only ~{cpx_spl_n} match-groups → very wide SE; read its trend cautiously."
-        ),
-    )
-    leg.get_title().set_fontsize(8)
-    leg.get_title().set_color("dimgray")
-    fig.savefig(OUT_DIR / "figure_native.svg", dpi=200)
-    fig.savefig(OUT_DIR / "figure_native.png", dpi=200)
-    plt.close(fig)
+            if ri == 0:  # column header = consequence
+                ax.set_title(c.replace("_variant", ""), fontsize=12)
+            if ci == 0:  # row label = dataset
+                ax.set_ylabel(f"{dsname}\nAUPRC", fontsize=11)
+            else:
+                ax.set_ylabel("AUPRC")
+    for ax in axes[-1]:  # x labels on the bottom row (sharex hides the upper rows')
+        ax.set_xticks(x)
+        ax.set_xticklabels(xt_labels, fontsize=8)
+        ax.set_xlabel("model size (params)")
 
-    print(
-        f"\nwrote {OUT_DIR}/figure_relative.{{svg,png}} and figure_native.{{svg,png}}"
+    fig.suptitle(
+        "Scaling ladder (46M→4B, n=8): native AUPRC by dataset × subset — FWD+RC (#306)"
     )
+    fig.supxlabel(
+        "Error bars = ±1 SE (bootstrap).   Scores: Mendelian & SGE = −LLR, complex = |LLR|.   "
+        "Mendelian/complex = pooled within-consequence, matched 1:9 (baseline 0.10); "
+        f"SGE = macro across genes ({sge_g['missense_variant']} missense / {sge_g['splicing']} splicing).\n"
+        f"Caveat: complex splicing rests on only ~{cpx_spl_n} match-groups → very wide SE; read its trend cautiously.",
+        fontsize=8,
+        color="dimgray",
+    )
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    svg = OUT_DIR / "figure.svg"
+    fig.savefig(svg, dpi=200)
+    fig.savefig(svg.with_suffix(".png"), dpi=200)
+    plt.close(fig)
+    print(f"\nwrote {svg} (+ .png)")
 
 
 if __name__ == "__main__":

--- a/plots/scaling_sge_vs_mendelian.py
+++ b/plots/scaling_sge_vs_mendelian.py
@@ -1,22 +1,23 @@
 """Issue #306 figures: scaling-ladder AUPRC vs model size on Mendelian / complex / SGE.
 
 Two figures over the 8 `dna-bolinas-scaling-v0.5` sizes (46M→4B, step-215573),
-each split by consequence (missense, splicing) — no cross-consequence mixing:
+always keeping missense and splicing on separate axes (no cross-consequence mixing):
 
   figure_relative — ALL 3 datasets on one shared axis. The three benchmarks live
       on different scales (matched 1:9 Mendelian/complex ~0.1–0.6 baseline 0.10;
       per-gene-macro SGE), so each series is **min-max normalized over the 8
       sizes** → a proportion in [0, 1] (0 = that series' smallest, 1 = largest).
-      This compares only the *shape / trend with scale*. 2 panels (missense,
-      splicing) × 3 lines (Mendelian, Complex, SGE).
+      Compares only the *shape / trend with scale*. 2 panels (missense, splicing)
+      × 3 lines (Mendelian, Complex, SGE).
 
-  figure_native — one panel per dataset on its **native AUPRC scale**, each with
-      missense + splicing. 3 panels (Mendelian, Complex, SGE).
+  figure_native — native AUPRC, a **dataset × consequence grid** (2 rows =
+      consequence, 3 cols = dataset = 6 panels), each on its OWN scale so missense
+      and splicing never share an axis.
 
 Scores (FWD+RC): Mendelian & SGE use −LLR (`minus_llr_avg`); complex uses |LLR|
 (`abs_llr_avg`, its score_protocol). SGE is macro-averaged across genes.
-**Error bars are ±1 SE (bootstrap)** — std of the per-metric bootstrap, not a CI;
-in figure_relative they are the native SE divided by each series' min–max range.
+**Error bars are ±1 SE (bootstrap)** — drawn capless (a dispersion indicator, not
+a bounded interval); in figure_relative they are the native SE / each series' range.
 
 Caveat: complex *splicing* rests on only ~19 match-groups (vs ~250 missense) → its
 AUPRC has a very wide SE and is read with caution.
@@ -72,8 +73,8 @@ SIZE_LABEL = {
     "h2944-p4B": "4B",
 }
 CONSEQUENCES = ["missense_variant", "splicing"]
+DATASETS = ["Mendelian", "Complex", "SGE"]
 
-# Figure 1 (relative): colour = dataset.
 DATASET_COLOR = {"Mendelian": "tab:blue", "Complex": "tab:green", "SGE": "tab:red"}
 DATASET_MARKER = {"Mendelian": "o", "Complex": "^", "SGE": "s"}
 DATASET_SCORE = {
@@ -81,8 +82,6 @@ DATASET_SCORE = {
     "Complex": "|LLR|",
     "SGE": "−LLR, macro across genes",
 }
-# Figure 2 (native): colour = consequence.
-CONSEQ_COLOR = {"missense_variant": "tab:purple", "splicing": "tab:orange"}
 CONSEQ_MARKER = {"missense_variant": "o", "splicing": "s"}
 
 # complex_traits scores with the abs_llr protocol (magnitude); mendelian & sge use minus_llr.
@@ -153,14 +152,11 @@ def _series(d: dict, c: str) -> tuple[list[float], list[float]]:
     return ([d[(s, c)]["value"] for s in SIZES], [d[(s, c)]["se"] for s in SIZES])
 
 
-def _minmax(
-    vals: list[float], ses: list[float]
-) -> tuple[list[float], list[float], float]:
-    """Min-max normalize a series to [0,1]; scale SE by the same range. Returns
-    (norm_vals, norm_ses, range)."""
+def _minmax(vals: list[float], ses: list[float]) -> tuple[list[float], list[float]]:
+    """Min-max normalize a series to [0,1]; scale SE by the same range."""
     lo, hi = min(vals), max(vals)
     rng = (hi - lo) or 1.0
-    return [(v - lo) / rng for v in vals], [e / rng for e in ses], hi - lo
+    return [(v - lo) / rng for v in vals], [e / rng for e in ses]
 
 
 def main() -> None:
@@ -188,10 +184,7 @@ def main() -> None:
     for s in SIZES:
         row = [SIZE_LABEL[s], f"{PARAMS[s] / 1e6:.0f}M"]
         for c in CONSEQUENCES:
-            row += [
-                f"{data[d][(s, c)]['value']:.3f}"
-                for d in ("Mendelian", "Complex", "SGE")
-            ]
+            row += [f"{data[d][(s, c)]['value']:.3f}" for d in DATASETS]
         print(
             f"{row[0]:>6} {row[1]:>7} | {row[2]:>7} {row[3]:>7} {row[4]:>7} "
             f"| {row[5]:>7} {row[6]:>7} {row[7]:>7}"
@@ -204,6 +197,7 @@ def main() -> None:
     matplotlib.use("Agg")
     matplotlib.rcParams["svg.fonttype"] = "none"
     import matplotlib.pyplot as plt
+    from matplotlib.lines import Line2D
 
     x = [PARAMS[s] for s in SIZES]
     xt_labels = [SIZE_LABEL[s] for s in SIZES]
@@ -214,18 +208,18 @@ def main() -> None:
         ax.set_xticklabels(xt_labels, fontsize=8)
         ax.tick_params(axis="x", which="minor", bottom=False)
         ax.set_xlabel("model size (params)")
-        ax.grid(True, alpha=0.3)
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
 
     # ===== Figure 1: relative (min-max normalized per series), all 3 datasets =====
+    # Error bars capless: ±1 SE is a dispersion indicator, not a bounded interval.
     fig, axes = plt.subplots(1, 2, figsize=(13, 5.5), layout="constrained")
     handles = {}
     for ax, c in zip(axes, CONSEQUENCES):
         for dsname, d in data.items():
             vals, ses = _series(d, c)
-            nv, nse, _ = _minmax(vals, ses)
-            h = ax.errorbar(
+            nv, nse = _minmax(vals, ses)
+            handles[dsname] = ax.errorbar(
                 x,
                 nv,
                 yerr=nse,
@@ -233,12 +227,11 @@ def main() -> None:
                 ms=5,
                 lw=1.5,
                 color=DATASET_COLOR[dsname],
-                capsize=3,
                 elinewidth=1,
                 alpha=0.9,
             )
-            handles[dsname] = h
         _style_x(ax)
+        ax.grid(True, alpha=0.3)
         ax.set_ylabel("relative AUPRC (0 = series min, 1 = max)")
         ax.set_title(c.replace("_variant", ""))
     fig.suptitle(
@@ -246,7 +239,7 @@ def main() -> None:
         "Mendelian / complex / SGE (#306)"
     )
     leg = fig.legend(
-        [handles[d] for d in ("Mendelian", "Complex", "SGE")],
+        [handles[d] for d in DATASETS],
         [
             "Mendelian (−LLR)",
             "Complex traits (|LLR|)",
@@ -268,37 +261,52 @@ def main() -> None:
     fig.savefig(OUT_DIR / "figure_relative.png", dpi=200)
     plt.close(fig)
 
-    # ===== Figure 2: native AUPRC, one panel per dataset =====
-    fig, axes = plt.subplots(1, 3, figsize=(15.5, 5), layout="constrained")
-    handles = {}
-    for ax, dsname in zip(axes, ("Mendelian", "Complex", "SGE")):
-        d = data[dsname]
-        for c in CONSEQUENCES:
-            vals, ses = _series(d, c)
-            h = ax.errorbar(
+    # ===== Figure 2: native AUPRC — dataset (cols) × consequence (rows) grid =====
+    # Each panel its own native scale: missense and splicing never share an axis.
+    fig, axes = plt.subplots(
+        len(CONSEQUENCES),
+        len(DATASETS),
+        figsize=(14, 8.5),
+        sharex=True,
+        layout="constrained",
+    )
+    for ri, c in enumerate(CONSEQUENCES):
+        for ci, dsname in enumerate(DATASETS):
+            ax = axes[ri, ci]
+            vals, ses = _series(data[dsname], c)
+            ax.errorbar(
                 x,
                 vals,
                 yerr=ses,
                 marker=CONSEQ_MARKER[c],
                 ms=5,
                 lw=1.5,
-                color=CONSEQ_COLOR[c],
-                capsize=3,
+                color=DATASET_COLOR[dsname],
+                elinewidth=1,
             )
-            handles[c] = h
+            ax.set_xscale("log")
+            ax.grid(True, alpha=0.3)
+            ax.tick_params(axis="x", which="minor", bottom=False)
+            if ri == 0:
+                ax.set_title(f"{dsname}  ({DATASET_SCORE[dsname]})")
+            ax.set_ylabel(f"{c.replace('_variant', '')} AUPRC" if ci == 0 else "AUPRC")
+    for ax in axes[-1]:  # x labels on the bottom row (sharex hides the top row's)
         _style_x(ax)
-        ax.set_ylabel("AUPRC")
-        ax.set_title(f"{dsname}  ({DATASET_SCORE[dsname]})")
     fig.suptitle(
-        "Scaling ladder (46M→4B, n=8): native AUPRC by model size, per dataset — FWD+RC (#306)"
+        "Scaling ladder (46M→4B, n=8): native AUPRC by dataset × consequence — FWD+RC (#306)"
     )
+    proxies = [
+        Line2D([0], [0], color=DATASET_COLOR[d], marker=DATASET_MARKER[d], lw=1.5)
+        for d in DATASETS
+    ]
     leg = fig.legend(
-        [handles[c] for c in CONSEQUENCES],
-        ["missense", "splicing"],
+        proxies,
+        [f"{d} ({DATASET_SCORE[d]})" for d in DATASETS],
         loc="outside lower center",
-        ncol=2,
+        ncol=3,
         frameon=True,
         title=(
+            "Each panel native scale (missense / splicing not shared).   "
             "Error bars = ±1 SE (bootstrap).   Mendelian/complex = matched 1:9 (baseline 0.10); "
             f"SGE = macro across genes ({sge_g['missense_variant']} missense / {sge_g['splicing']} splicing).\n"
             f"Caveat: complex splicing rests on only ~{cpx_spl_n} match-groups → very wide SE; read its trend cautiously."

--- a/plots/scaling_sge_vs_mendelian.py
+++ b/plots/scaling_sge_vs_mendelian.py
@@ -1,22 +1,24 @@
-"""Issue #306 figure: AUPRC vs model size on SGE vs Mendelian, for missense & splicing.
+"""Issue #306 figure: AUPRC vs model size on Mendelian / complex traits / SGE.
 
 Two panels over the 8 `dna-bolinas-scaling-v0.5` sizes (46M→4B, step-215573):
   Panel A — missense_variant
   Panel B — splicing
 
-Within each panel, two lines on **two independent y-axes** (shared log-x = params):
-  left  (blue)  — Mendelian AUPRC: official evals_v2, pooled within-consequence,
-                  matched 1:9 cluster bootstrap (reused from #274, not recomputed).
-  right (red)   — SGE AUPRC: macro-averaged across genes (`accession == _macro_avg_`).
+Lines (shared log-x = params; two independent y-axes per panel):
+  left  — matched 1:9 AUPRC (baseline 0.10; same construction, comparable):
+            • Mendelian (blue, −LLR), and
+            • Complex traits (green, |LLR|) on both panels. NOTE complex
+              *splicing* rests on only ~19 match-groups (vs ~250 for missense),
+              so it carries a wide CI and is read with caution (caveat on figure).
+  right — SGE AUPRC (red): macro-averaged across genes (`accession == _macro_avg_`, −LLR).
 
-The two AUPRCs are constructed differently (Mendelian = pooled/matched; SGE =
-unmatched per-gene macro) and are **not level-comparable** — the dual axes make
-explicit that we compare the *shapes / trends with scale*, never the vertical gap
-between the lines. Both use `minus_llr_avg` (signed −LLR, FWD+RC mean).
+The matched-pair (left) and per-gene-macro SGE (right) AUPRCs are constructed
+differently and are **not level-comparable** — the dual axes make explicit that
+we compare *shapes / trends with scale*, never the vertical gap. All scores FWD+RC.
 
-Self-contained: reads the two evals_v2 metric parquets per model from S3. Params
-are the published final-checkpoint counts (issue #274 table), hardcoded so the
-recipe needs no W&B. Emits SVG + PNG to `plots/output/scaling_sge_vs_mendelian/`.
+Self-contained: reads the evals_v2 metric parquets per model from S3. Params are
+the published final-checkpoint counts (issue #274), hardcoded so the recipe needs
+no W&B. Emits SVG + PNG to `plots/output/scaling_sge_vs_mendelian/`.
 
 Usage:
     uv run python plots/scaling_sge_vs_mendelian.py \
@@ -66,7 +68,9 @@ SIZE_LABEL = {
 }
 CONSEQUENCES = ["missense_variant", "splicing"]
 
-MEN_COLOR, SGE_COLOR = "tab:blue", "tab:red"
+MEN_COLOR, COMPLEX_COLOR, SGE_COLOR = "tab:blue", "tab:green", "tab:red"
+# complex_traits scores with the abs_llr protocol (magnitude); mendelian & sge use minus_llr.
+COMPLEX_SCORE_TYPE = "abs_llr_avg"
 
 
 def _model(size: str) -> str:
@@ -94,6 +98,29 @@ def load_mendelian(prefix: str, score_type: str) -> dict[tuple[str, str], dict]:
                 f"{_model(s)} mendelian {c}: expected 1 row, got {hit.height}"
             )
             out[(s, c)] = {"value": hit["value"][0], "se": hit["se"][0]}
+    return out
+
+
+def load_complex(prefix: str, score_type: str) -> dict[tuple[str, str], dict]:
+    """(size, consequence) -> {value, se, n_groups}. Matched 1:9 AUPRC, abs_llr.
+
+    Complex *splicing* has very few match-groups (~19 vs ~250 for missense), so
+    its AUPRC carries a wide CI — plotted on both panels but caveated.
+    """
+    out: dict[tuple[str, str], dict] = {}
+    for s in SIZES:
+        m = _read(f"{prefix}/{_model(s)}/complex_traits.parquet", f"complex {s}")
+        m = m.filter(pl.col("score_type") == score_type)
+        for c in CONSEQUENCES:
+            hit = m.filter(pl.col("subset") == c)
+            assert hit.height == 1, (
+                f"{_model(s)} complex {c}: expected 1 row, got {hit.height}"
+            )
+            out[(s, c)] = {
+                "value": hit["value"][0],
+                "se": hit["se"][0],
+                "n_groups": int(hit["n_groups"][0]),
+            }
     return out
 
 
@@ -125,25 +152,29 @@ def main() -> None:
         "--metrics-prefix",
         default="s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics",
     )
-    ap.add_argument("--score-type", default="minus_llr_avg")
+    ap.add_argument("--score-type", default="minus_llr_avg", help="for mendelian & sge")
     args = ap.parse_args()
 
     men = load_mendelian(args.metrics_prefix, args.score_type)
+    cpx = load_complex(args.metrics_prefix, COMPLEX_SCORE_TYPE)
     sge = load_sge(args.metrics_prefix, args.score_type)
 
     # Console table (for the issue comment).
     print(
-        f"score_type={args.score_type}  (Mendelian pooled-within-consequence | SGE macro-across-genes)"
+        f"mendelian/sge={args.score_type} | complex={COMPLEX_SCORE_TYPE} "
+        "(left=matched 1:9 AUPRC | SGE=macro across genes)"
     )
+    hdr = ("size", "params", "men_M", "cpx_M", "sge_M", "men_S", "cpx_S", "sge_S")
     print(
-        f"{'size':>6} {'params':>8} | {'men_miss':>9} {'sge_miss':>9} ({'g':>2}) | {'men_splice':>10} {'sge_splice':>10} ({'g':>2})"
+        f"{hdr[0]:>6} {hdr[1]:>7} | {hdr[2]:>7} {hdr[3]:>7} {hdr[4]:>7} | "
+        f"{hdr[5]:>7} {hdr[6]:>7} {hdr[7]:>7}"
     )
     for s in SIZES:
-        mm, sm = men[(s, "missense_variant")], sge[(s, "missense_variant")]
-        mp, sp = men[(s, "splicing")], sge[(s, "splicing")]
+        v = lambda d, c: d[(s, c)]["value"]  # noqa: E731
         print(
-            f"{SIZE_LABEL[s]:>6} {PARAMS[s] / 1e6:>7.0f}M | {mm['value']:>9.3f} {sm['value']:>9.3f} ({sm['n_genes']:>2}) "
-            f"| {mp['value']:>10.3f} {sp['value']:>10.3f} ({sp['n_genes']:>2})"
+            f"{SIZE_LABEL[s]:>6} {PARAMS[s] / 1e6:>6.0f}M | "
+            f"{v(men, 'missense_variant'):>7.3f} {v(cpx, 'missense_variant'):>7.3f} {v(sge, 'missense_variant'):>7.3f} | "
+            f"{v(men, 'splicing'):>7.3f} {v(cpx, 'splicing'):>7.3f} {v(sge, 'splicing'):>7.3f}"
         )
 
     import matplotlib
@@ -154,15 +185,16 @@ def main() -> None:
 
     x = [PARAMS[s] for s in SIZES]
     xt_labels = [SIZE_LABEL[s] for s in SIZES]
+    cpx_spl_n = cpx[(SIZES[0], "splicing")]["n_groups"]  # constant across models
 
     # constrained layout auto-spaces the twin-axis labels/ticks between the two
-    # panels (the inner SGE/Mendelian labels would otherwise collide in the
-    # centre); the legend goes *outside* the panels so it can't overlap the data.
+    # panels (the inner labels would otherwise collide in the centre); the legend
+    # goes *outside* the panels so it can't overlap the data.
     fig, axes = plt.subplots(1, 2, figsize=(13, 5.5), layout="constrained")
-    handles = None
+    h_men_ref = h_cpx_ref = h_sge_ref = None
     gene_note = {}
     for ax, c in zip(axes, CONSEQUENCES):
-        # Mendelian — left axis (blue)
+        # Left axis — matched 1:9 AUPRC (neutral/black: hosts Mendelian + Complex).
         h_men = ax.errorbar(
             x,
             [men[(s, c)]["value"] for s in SIZES],
@@ -173,16 +205,25 @@ def main() -> None:
             color=MEN_COLOR,
             capsize=3,
         )
+        h_cpx = ax.errorbar(
+            x,
+            [cpx[(s, c)]["value"] for s in SIZES],
+            yerr=[cpx[(s, c)]["se"] for s in SIZES],
+            marker="^",
+            ms=5,
+            lw=1.5,
+            color=COMPLEX_COLOR,
+            capsize=3,
+        )
         ax.set_xscale("log")
         ax.set_xticks(x)
         ax.set_xticklabels(xt_labels, fontsize=8)
         ax.tick_params(axis="x", which="minor", bottom=False)
         ax.set_xlabel("model size (params)")
-        ax.set_ylabel("Mendelian AUPRC", color=MEN_COLOR)
-        ax.tick_params(axis="y", labelcolor=MEN_COLOR)
+        ax.set_ylabel("AUPRC — matched 1:9")
         ax.grid(True, alpha=0.3)
 
-        # SGE — right axis (red)
+        # Right axis — SGE macro across genes (red).
         ax2 = ax.twinx()
         h_sge = ax2.errorbar(
             x,
@@ -200,28 +241,32 @@ def main() -> None:
         ng = sorted({sge[(s, c)]["n_genes"] for s in SIZES})
         gene_note[c] = f"{ng[0]}" if len(ng) == 1 else f"{ng[0]}–{ng[-1]}"
         ax.set_title(c.replace("_variant", ""))
-        if handles is None:
-            handles = [h_men, h_sge]
+        h_men_ref, h_cpx_ref, h_sge_ref = h_men, h_cpx, h_sge
 
     fig.suptitle(
-        f"Scaling ladder (46M→4B, n=8): Mendelian vs SGE AUPRC by model size — "
-        f"{args.score_type}, FWD+RC (#306)"
+        "Scaling ladder (46M→4B, n=8): AUPRC by model size — "
+        "Mendelian / complex / SGE, FWD+RC (#306)"
     )
-    # Single legend outside the axes at the bottom, with the caveat as its title —
-    # exactly one element on top (suptitle) and one at the bottom (legend), so
-    # nothing can overlap the lines, the suptitle, the inner axis labels, or each
-    # other (constrained_layout reserves room for all of it).
+    # One legend outside the axes at the bottom, caveat as its title — exactly one
+    # element on top (suptitle) and one at the bottom (legend), so nothing overlaps
+    # the lines, the suptitle, the inner axis labels, or each other.
     leg = fig.legend(
-        handles,
-        ["Mendelian (left axis)", "SGE (right axis)"],
+        [h_men_ref, h_cpx_ref, h_sge_ref],
+        [
+            "Mendelian (left, −LLR)",
+            "Complex traits (left, |LLR|)",
+            "SGE (right, macro across genes)",
+        ],
         loc="outside lower center",
-        ncol=2,
+        ncol=3,
         frameon=True,
         title=(
-            "Independent y-axes — compare shapes/trends with scale, not the vertical gap.\n"
-            f"SGE = macro across genes ({gene_note['missense_variant']} missense / "
-            f"{gene_note['splicing']} splicing), unmatched   ·   "
-            "Mendelian = pooled within-consequence, matched 1:9"
+            "Independent y-axes — compare shapes/trends with scale, not the vertical gap.   "
+            "Left = matched 1:9 AUPRC (baseline 0.10); "
+            f"right = SGE macro across genes ({gene_note['missense_variant']} missense / "
+            f"{gene_note['splicing']} splicing), unmatched.\n"
+            f"Caveat: complex splicing rests on only ~{cpx_spl_n} match-groups → wide CI; "
+            "read its trend cautiously."
         ),
     )
     leg.get_title().set_fontsize(8)

--- a/plots/scaling_sge_vs_mendelian.py
+++ b/plots/scaling_sge_vs_mendelian.py
@@ -155,7 +155,11 @@ def main() -> None:
     x = [PARAMS[s] for s in SIZES]
     xt_labels = [SIZE_LABEL[s] for s in SIZES]
 
-    fig, axes = plt.subplots(1, 2, figsize=(11, 5))
+    # constrained layout auto-spaces the twin-axis labels/ticks between the two
+    # panels (the inner SGE/Mendelian labels would otherwise collide in the
+    # centre); the legend goes *outside* the panels so it can't overlap the data.
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5.5), layout="constrained")
+    handles = None
     gene_note = {}
     for ax, c in zip(axes, CONSEQUENCES):
         # Mendelian — left axis (blue)
@@ -168,11 +172,10 @@ def main() -> None:
             lw=1.5,
             color=MEN_COLOR,
             capsize=3,
-            label="Mendelian (left)",
         )
         ax.set_xscale("log")
         ax.set_xticks(x)
-        ax.set_xticklabels(xt_labels, rotation=45, fontsize=7)
+        ax.set_xticklabels(xt_labels, fontsize=8)
         ax.tick_params(axis="x", which="minor", bottom=False)
         ax.set_xlabel("model size (params)")
         ax.set_ylabel("Mendelian AUPRC", color=MEN_COLOR)
@@ -190,36 +193,44 @@ def main() -> None:
             lw=1.5,
             color=SGE_COLOR,
             capsize=3,
-            label="SGE (right)",
         )
-        ax2.set_ylabel("SGE AUPRC (macro across genes)", color=SGE_COLOR)
+        ax2.set_ylabel("SGE AUPRC (macro)", color=SGE_COLOR)
         ax2.tick_params(axis="y", labelcolor=SGE_COLOR)
 
         ng = sorted({sge[(s, c)]["n_genes"] for s in SIZES})
         gene_note[c] = f"{ng[0]}" if len(ng) == 1 else f"{ng[0]}–{ng[-1]}"
         ax.set_title(c.replace("_variant", ""))
-        ax.legend(handles=[h_men, h_sge], fontsize=8, loc="best")
+        if handles is None:
+            handles = [h_men, h_sge]
 
     fig.suptitle(
         f"Scaling ladder (46M→4B, n=8): Mendelian vs SGE AUPRC by model size — "
         f"{args.score_type}, FWD+RC (#306)"
     )
-    fig.text(
-        0.5,
-        -0.04,
-        f"Independent y-axes — compare shapes vs scale, not levels.  "
-        f"SGE = macro across genes (missense: {gene_note['missense_variant']}; "
-        f"splicing: {gene_note['splicing']}), unmatched.  "
-        f"Mendelian = pooled within-consequence, matched 1:9.",
-        ha="center",
-        fontsize=7.5,
-        color="dimgray",
+    # Single legend outside the axes at the bottom, with the caveat as its title —
+    # exactly one element on top (suptitle) and one at the bottom (legend), so
+    # nothing can overlap the lines, the suptitle, the inner axis labels, or each
+    # other (constrained_layout reserves room for all of it).
+    leg = fig.legend(
+        handles,
+        ["Mendelian (left axis)", "SGE (right axis)"],
+        loc="outside lower center",
+        ncol=2,
+        frameon=True,
+        title=(
+            "Independent y-axes — compare shapes/trends with scale, not the vertical gap.\n"
+            f"SGE = macro across genes ({gene_note['missense_variant']} missense / "
+            f"{gene_note['splicing']} splicing), unmatched   ·   "
+            "Mendelian = pooled within-consequence, matched 1:9"
+        ),
     )
+    leg.get_title().set_fontsize(8)
+    leg.get_title().set_color("dimgray")
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     svg = OUT_DIR / "figure.svg"
-    fig.savefig(svg, bbox_inches="tight", dpi=200)
-    fig.savefig(svg.with_suffix(".png"), bbox_inches="tight", dpi=200)
+    fig.savefig(svg, dpi=200)
+    fig.savefig(svg.with_suffix(".png"), dpi=200)
     plt.close(fig)
     print(f"\nwrote {svg} (+ .png)")
 

--- a/plots/scaling_sge_vs_mendelian.py
+++ b/plots/scaling_sge_vs_mendelian.py
@@ -1,18 +1,20 @@
-"""Issue #306 figure: scaling-ladder native AUPRC vs model size, per dataset × subset.
+"""Issue #306 figures: scaling-ladder native AUPRC vs model size, per dataset × subset.
 
-One figure over the 8 `dna-bolinas-scaling-v0.5` sizes (46M→4B, step-215573): a
-**dataset × subset grid** — 3 rows (Mendelian, complex traits, SGE) × 2 cols
-(missense, splicing) = 6 panels, each on its **own native AUPRC scale** (missense
-and splicing never share an axis; no cross-consequence mixing).
+Two figures (one per scoring), each a **dataset × subset grid** over the 8
+`dna-bolinas-scaling-v0.5` sizes (46M→4B, step-215573) — 3 rows (Mendelian,
+complex traits, SGE) × 2 cols (missense, splicing) = 6 panels, each on its **own
+native AUPRC scale** (missense and splicing never share an axis):
 
-Scores (FWD+RC): Mendelian & SGE use −LLR (`minus_llr_avg`); complex uses |LLR|
-(`abs_llr_avg`, its score_protocol). SGE is macro-averaged across genes; Mendelian
-and complex are pooled within-consequence, matched 1:9 (baseline 0.10).
+  figure      — per-dataset **LLR** score (each dataset's score_protocol):
+                Mendelian & SGE = −LLR (`minus_llr_avg`), complex = |LLR| (`abs_llr_avg`).
+  figure_jsd  — **JSD** (`jsd_avg`) for all three datasets — a magnitude /
+                direction-agnostic score, probing whether trends are LLR-specific.
+
+All scores FWD+RC. SGE is macro-averaged across genes; Mendelian and complex are
+pooled within-consequence, matched 1:9 (baseline 0.10).
 **Error bars are ±1 SE (bootstrap)** — drawn capless (a dispersion indicator, not a
-bounded interval).
-
-Caveat: complex *splicing* rests on only ~19 match-groups (vs ~250 missense) → its
-AUPRC has a very wide SE and is read with caution.
+bounded interval). Caveat: complex *splicing* rests on only ~19 match-groups → very
+wide SE, read with caution.
 
 Self-contained: reads the evals_v2 metric parquets per model from S3. Params are
 the published final-checkpoint counts (issue #274), hardcoded so the recipe needs
@@ -70,8 +72,26 @@ DATASETS = ["Mendelian", "Complex", "SGE"]  # rows
 DATASET_COLOR = {"Mendelian": "tab:blue", "Complex": "tab:green", "SGE": "tab:red"}
 CONSEQ_MARKER = {"missense_variant": "o", "splicing": "s"}
 
-# complex_traits scores with the abs_llr protocol (magnitude); mendelian & sge use minus_llr.
-COMPLEX_SCORE_TYPE = "abs_llr_avg"
+# Two scorings. LLR uses each dataset's score_protocol (complex is magnitude |LLR|);
+# JSD uses jsd_avg for all (magnitude / direction-agnostic).
+SCORE_MODES = [
+    {
+        "st": {
+            "Mendelian": "minus_llr_avg",
+            "Complex": "abs_llr_avg",
+            "SGE": "minus_llr_avg",
+        },
+        "suptitle": "−LLR (Mendelian/SGE) · |LLR| (complex)",
+        "caption": "Scores: Mendelian & SGE = −LLR, complex = |LLR| (each dataset's score_protocol).",
+        "out": "figure",
+    },
+    {
+        "st": {"Mendelian": "jsd_avg", "Complex": "jsd_avg", "SGE": "jsd_avg"},
+        "suptitle": "JSD (Jensen–Shannon divergence)",
+        "caption": "Scores: all datasets = JSD (jsd_avg) — magnitude / direction-agnostic.",
+        "out": "figure_jsd",
+    },
+]
 
 
 def _model(size: str) -> str:
@@ -101,7 +121,7 @@ def load_matched(
         for c in CONSEQUENCES:
             hit = m.filter(pl.col("subset") == c)
             assert hit.height == 1, (
-                f"{_model(s)} {dataset} {c}: expected 1 row, got {hit.height}"
+                f"{_model(s)} {dataset} {c} [{score_type}]: expected 1 row, got {hit.height}"
             )
             out[(s, c)] = {
                 "value": hit["value"][0],
@@ -123,7 +143,7 @@ def load_sge(prefix: str, score_type: str) -> dict[tuple[str, str], dict]:
         for c in CONSEQUENCES:
             hit = m.filter(pl.col("subset") == c)
             assert hit.height == 1, (
-                f"{_model(s)} sge {c}: expected 1 macro row, got {hit.height}"
+                f"{_model(s)} sge {c} [{score_type}]: expected 1 macro row, got {hit.height}"
             )
             out[(s, c)] = {
                 "value": hit["value"][0],
@@ -133,29 +153,22 @@ def load_sge(prefix: str, score_type: str) -> dict[tuple[str, str], dict]:
     return out
 
 
+def load_all(prefix: str, st: dict[str, str]) -> dict[str, dict]:
+    """All 3 datasets for one score mode (st = per-dataset score_type)."""
+    return {
+        "Mendelian": load_matched(prefix, "mendelian_traits", st["Mendelian"]),
+        "Complex": load_matched(prefix, "complex_traits", st["Complex"]),
+        "SGE": load_sge(prefix, st["SGE"]),
+    }
+
+
 def _series(d: dict, c: str) -> tuple[list[float], list[float]]:
     """(values, ses) over SIZES for consequence c."""
     return ([d[(s, c)]["value"] for s in SIZES], [d[(s, c)]["se"] for s in SIZES])
 
 
-def main() -> None:
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument(
-        "--metrics-prefix",
-        default="s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics",
-    )
-    ap.add_argument("--score-type", default="minus_llr_avg", help="for mendelian & sge")
-    args = ap.parse_args()
-
-    men = load_matched(args.metrics_prefix, "mendelian_traits", args.score_type)
-    cpx = load_matched(args.metrics_prefix, "complex_traits", COMPLEX_SCORE_TYPE)
-    sge = load_sge(args.metrics_prefix, args.score_type)
-    data = {"Mendelian": men, "Complex": cpx, "SGE": sge}
-
-    # Console table — native AUPRC (M=missense, S=splicing).
-    print(
-        f"mendelian/sge={args.score_type} | complex={COMPLEX_SCORE_TYPE}   (native AUPRC ± SE)"
-    )
+def print_table(data: dict[str, dict], label: str) -> None:
+    print(f"\n=== {label} — native AUPRC (M=missense, S=splicing) ===")
     print(
         f"{'size':>6} {'params':>7} | {'men_M':>7} {'cpx_M':>7} {'sge_M':>7} "
         f"| {'men_S':>7} {'cpx_S':>7} {'sge_S':>7}"
@@ -168,20 +181,14 @@ def main() -> None:
             f"{row[0]:>6} {row[1]:>7} | {row[2]:>7} {row[3]:>7} {row[4]:>7} "
             f"| {row[5]:>7} {row[6]:>7} {row[7]:>7}"
         )
-    cpx_spl_n = cpx[(SIZES[0], "splicing")]["n_groups"]
-    sge_g = {c: sge[(SIZES[0], c)]["n_genes"] for c in CONSEQUENCES}
 
-    import matplotlib
 
-    matplotlib.use("Agg")
-    matplotlib.rcParams["svg.fonttype"] = "none"
-    import matplotlib.pyplot as plt
-
-    x = [PARAMS[s] for s in SIZES]
+def build_figure(plt, data: dict[str, dict], mode: dict, x: list[float]) -> None:
+    """3×2 native-AUPRC grid (rows = dataset, cols = consequence) for one score mode."""
+    cpx_spl_n = data["Complex"][(SIZES[0], "splicing")]["n_groups"]
+    sge_g = {c: data["SGE"][(SIZES[0], c)]["n_genes"] for c in CONSEQUENCES}
     xt_labels = [SIZE_LABEL[s] for s in SIZES]
 
-    # Native AUPRC grid: rows = dataset, cols = consequence. Each panel its own
-    # scale (missense / splicing never share an axis). Error bars capless ±1 SE.
     fig, axes = plt.subplots(
         len(DATASETS),
         len(CONSEQUENCES),
@@ -208,20 +215,21 @@ def main() -> None:
             ax.tick_params(axis="x", which="minor", bottom=False)
             if ri == 0:  # column header = consequence
                 ax.set_title(c.replace("_variant", ""), fontsize=12)
-            if ci == 0:  # row label = dataset
-                ax.set_ylabel(f"{dsname}\nAUPRC", fontsize=11)
-            else:
-                ax.set_ylabel("AUPRC")
+            ax.set_ylabel(
+                f"{dsname}\nAUPRC" if ci == 0 else "AUPRC",
+                fontsize=11 if ci == 0 else 10,
+            )
     for ax in axes[-1]:  # x labels on the bottom row (sharex hides the upper rows')
         ax.set_xticks(x)
         ax.set_xticklabels(xt_labels, fontsize=8)
         ax.set_xlabel("model size (params)")
 
     fig.suptitle(
-        "Scaling ladder (46M→4B, n=8): native AUPRC by dataset × subset — FWD+RC (#306)"
+        f"Scaling ladder (46M→4B, n=8): native AUPRC by dataset × subset — "
+        f"{mode['suptitle']}, FWD+RC (#306)"
     )
     fig.supxlabel(
-        "Error bars = ±1 SE (bootstrap).   Scores: Mendelian & SGE = −LLR, complex = |LLR|.   "
+        f"Error bars = ±1 SE (bootstrap).   {mode['caption']}   "
         "Mendelian/complex = pooled within-consequence, matched 1:9 (baseline 0.10); "
         f"SGE = macro across genes ({sge_g['missense_variant']} missense / {sge_g['splicing']} splicing).\n"
         f"Caveat: complex splicing rests on only ~{cpx_spl_n} match-groups → very wide SE; read its trend cautiously.",
@@ -230,11 +238,32 @@ def main() -> None:
     )
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
-    svg = OUT_DIR / "figure.svg"
+    svg = OUT_DIR / f"{mode['out']}.svg"
     fig.savefig(svg, dpi=200)
     fig.savefig(svg.with_suffix(".png"), dpi=200)
     plt.close(fig)
-    print(f"\nwrote {svg} (+ .png)")
+    print(f"wrote {svg} (+ .png)")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--metrics-prefix",
+        default="s3://oa-bolinas/snakemake/analysis/evals_v2/results/metrics",
+    )
+    args = ap.parse_args()
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    matplotlib.rcParams["svg.fonttype"] = "none"
+    import matplotlib.pyplot as plt
+
+    x = [PARAMS[s] for s in SIZES]
+    for mode in SCORE_MODES:
+        data = load_all(args.metrics_prefix, mode["st"])
+        print_table(data, mode["suptitle"])
+        build_figure(plt, data, mode, x)
 
 
 if __name__ == "__main__":

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -566,8 +566,8 @@ models:
   # 4B is `h2944` (NOT the separate short/crashed `dna-bolinas-4b-v0.*` search).
   # 255 bp DNA + BOS.
   # `datasets` widened to include `sge` + `complex_traits` (#306) — score the
-  # ladder on SGE (missense/splicing) and complex traits (missense in the
-  # analysis) to compare AUPRC vs model size against Mendelian.
+  # ladder on SGE and complex traits (missense + splicing) to compare AUPRC vs
+  # model size against Mendelian.
   - name: scaling-v0.5-h640-p46M-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h640-p46M-353f3d/hf/step-215573
     window_size: 255

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -565,40 +565,41 @@ models:
   # LL gap itself rides the same registry via the `ll_gap:` section below. The
   # 4B is `h2944` (NOT the separate short/crashed `dna-bolinas-4b-v0.*` search).
   # 255 bp DNA + BOS.
-  # `datasets` widened to include `sge` (#306) — score the ladder on the SGE
-  # benchmark to compare missense/splicing AUPRC vs model size against Mendelian.
+  # `datasets` widened to include `sge` + `complex_traits` (#306) — score the
+  # ladder on SGE (missense/splicing) and complex traits (missense in the
+  # analysis) to compare AUPRC vs model size against Mendelian.
   - name: scaling-v0.5-h640-p46M-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h640-p46M-353f3d/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits, sge]
+    datasets: [mendelian_traits, complex_traits, sge]
   - name: scaling-v0.5-h768-p76M-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h768-p76M-8dbaca/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits, sge]
+    datasets: [mendelian_traits, complex_traits, sge]
   - name: scaling-v0.5-h896-p128M-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h896-p128M-43ec40/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits, sge]
+    datasets: [mendelian_traits, complex_traits, sge]
   - name: scaling-v0.5-h1152-p255M-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h1152-p255M-c72f29/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits, sge]
+    datasets: [mendelian_traits, complex_traits, sge]
   - name: scaling-v0.5-h1408-p476M-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h1408-p476M-85cce6/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits, sge]
+    datasets: [mendelian_traits, complex_traits, sge]
   - name: scaling-v0.5-h1920-p1B-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h1920-p1B-0dc6f4/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits, sge]
+    datasets: [mendelian_traits, complex_traits, sge]
   - name: scaling-v0.5-h2432-p2B-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h2432-p2B-f5f484/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits, sge]
+    datasets: [mendelian_traits, complex_traits, sge]
   - name: scaling-v0.5-h2944-p4B-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h2944-p4B-fa02c3/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits, sge]
+    datasets: [mendelian_traits, complex_traits, sge]
 
   # exp21 — animal-promoters-yolo (issue #21, wandb animal-promoters-yolo-r01-213a8e).
   # 512 bp context, no BOS. Scoped to mendelian_traits only: complex signal

--- a/snakemake/analysis/evals_v2/config/config.yaml
+++ b/snakemake/analysis/evals_v2/config/config.yaml
@@ -565,38 +565,40 @@ models:
   # LL gap itself rides the same registry via the `ll_gap:` section below. The
   # 4B is `h2944` (NOT the separate short/crashed `dna-bolinas-4b-v0.*` search).
   # 255 bp DNA + BOS.
+  # `datasets` widened to include `sge` (#306) — score the ladder on the SGE
+  # benchmark to compare missense/splicing AUPRC vs model size against Mendelian.
   - name: scaling-v0.5-h640-p46M-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h640-p46M-353f3d/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits]
+    datasets: [mendelian_traits, sge]
   - name: scaling-v0.5-h768-p76M-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h768-p76M-8dbaca/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits]
+    datasets: [mendelian_traits, sge]
   - name: scaling-v0.5-h896-p128M-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h896-p128M-43ec40/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits]
+    datasets: [mendelian_traits, sge]
   - name: scaling-v0.5-h1152-p255M-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h1152-p255M-c72f29/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits]
+    datasets: [mendelian_traits, sge]
   - name: scaling-v0.5-h1408-p476M-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h1408-p476M-85cce6/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits]
+    datasets: [mendelian_traits, sge]
   - name: scaling-v0.5-h1920-p1B-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h1920-p1B-0dc6f4/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits]
+    datasets: [mendelian_traits, sge]
   - name: scaling-v0.5-h2432-p2B-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h2432-p2B-f5f484/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits]
+    datasets: [mendelian_traits, sge]
   - name: scaling-v0.5-h2944-p4B-step-215573
     gcs_path: gs://marin-us-east5/checkpoints/dna-bolinas-scaling-v0.5-h2944-p4B-fa02c3/hf/step-215573
     window_size: 255
-    datasets: [mendelian_traits]
+    datasets: [mendelian_traits, sge]
 
   # exp21 — animal-promoters-yolo (issue #21, wandb animal-promoters-yolo-r01-213a8e).
   # 512 bp context, no BOS. Scoped to mendelian_traits only: complex signal


### PR DESCRIPTION
## Summary

Scores the 8-model `dna-bolinas-scaling-v0.5` parameter-scaling ladder (46M→4B, step-215573) on **SGE** and **complex traits** — previously it was scored only on Mendelian — and adds the **4B** rung to the dashboard. Backs the cross-benchmark scaling analysis in #306.

## Changes

- **`snakemake/analysis/evals_v2/config/config.yaml`** — widen `datasets:` for the 8 `scaling-v0.5-*` entries from `[mendelian_traits]` to `[mendelian_traits, complex_traits, sge]`. No other pipeline change — the `sge` and `matched_pair` protocols already handle these models; this just emits the extra metric parquets.
- **`dashboard/models.yaml`** — add `scaling-v0.5-h2944-p4B-step-215573` (family `marin_dna`; datasets mendelian/complex/SGE; genomes-v5, 84.8B tokens). This is what makes the 4B appear on the live dashboard once merged + rebuilt.
- **`plots/scaling_sge_vs_mendelian.py`** — new self-contained recipe: native AUPRC by dataset × subset (rows = dataset, cols = missense/splicing), with both −LLR/|LLR| and JSD scorings; reads the metric parquets from S3.

## Notes

- Part of the #306 investigation (the research issue stays open; figures + findings live there).
- Metrics for all 8 × {mendelian_traits, complex_traits, sge} are already on S3 from the eval runs, so the dashboard row + the recipe resolve immediately.
- Headline (details in #306): on missense, only the Mendelian (clinical) benchmark degrades with scale; SGE (functional) and complex (GWAS, matched 1:9 like Mendelian) both improve — robust across −LLR and JSD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
