### PR TITLE
evals: GPN-Star (V/M/P) on SGE — per-accession AUPRC + dashboard

### DIFF
--- a/dashboard/models.yaml
+++ b/dashboard/models.yaml
@@ -409,7 +409,7 @@
   msa: v100-200m
   training:
     params: 2.0e8       # 200M, from the "-200m" suffix in the MSA tag
-  datasets: [mendelian_traits, complex_traits]
+  datasets: [mendelian_traits, complex_traits, sge]
 
 - id: GPN-Star-M
   display: GPN-Star (M)
@@ -418,7 +418,7 @@
   msa: m447-200m
   training:
     params: 2.0e8
-  datasets: [mendelian_traits, complex_traits]
+  datasets: [mendelian_traits, complex_traits, sge]
 
 - id: GPN-Star-P
   display: GPN-Star (P)
@@ -427,7 +427,7 @@
   msa: p243-200m
   training:
     params: 2.0e8
-  datasets: [mendelian_traits, complex_traits]
+  datasets: [mendelian_traits, complex_traits, sge]
 
 # Evo 2 (issue #131) — AUPRC metrics via gist pinned in
 # `leaderboard.py::EVO2_METRICS_GIST_COMMIT`; mendelian_traits only.

--- a/dashboard/src/leaderboards/sge.md
+++ b/dashboard/src/leaderboards/sge.md
@@ -46,9 +46,15 @@ const meta = datasets.sge;
 
 // MarinDNA protocol → score_type column (signed LLR default; ALT direction is
 // informative, so not abs). Conservation has its single per-position score.
+// GPN-Star mirrors MarinDNA's signed convention: cLLR (calibrated, the default)
+// and LLR pick the `minus_llr*` columns — abnormal = loss of function =
+// deleterious, a directional signal (the `abs_llr*` atoms exist in the parquet
+// but aren't surfaced). The producer already FWD+RC-averages, so no `_avg`/`_fwd`
+// split here — one column per protocol.
 const SGE_SCORE_TYPE = {
   marin_dna: {LLR: "minus_llr_avg", JSD: "jsd_avg"},
   conservation: {score: "score"},
+  gpn_star: {cLLR: "minus_llr_calibrated", LLR: "minus_llr"},
 };
 // Columns: subset-macro leftmost (the headline), then the per-subset scopes.
 const SUBSET_COLS = [

--- a/snakemake/gpn_star_eval/README.md
+++ b/snakemake/gpn_star_eval/README.md
@@ -1,50 +1,64 @@
-# gpn_star_eval — GPN-Star V/M/P baseline on matched-pair eval datasets
+# gpn_star_eval — GPN-Star V/M/P baseline on the eval datasets
 
 AUPRC ± cluster-bootstrap SE for the three GPN-Star variants
 (V = vertebrate-100way, M = mammal-447way, P = primate-243way; all 200M params)
-on the matched-pair eval datasets ([#161 Mendelian](https://github.com/Open-Athena/marin-dna/issues/161),
-[#162 Complex traits](https://github.com/Open-Athena/marin-dna/issues/162)).
+on the eval datasets: the matched-pair benchmarks
+([#161 Mendelian](https://github.com/Open-Athena/marin-dna/issues/161),
+[#162 Complex traits](https://github.com/Open-Athena/marin-dna/issues/162)) and
+saturation genome editing ([#301 SGE](https://github.com/Open-Athena/marin-dna/issues/301)).
 Same metric, dataset revisions, and bootstrap config as
 [`evals_v2`](../analysis/evals_v2), so these rows are directly comparable to our
 own models. **This pipeline's S3 metrics parquet is the dashboard's GPN-Star
-source** (`leaderboard._parquet_path` case `gpn_star`) — the pipeline is the
-single source of truth; the old #145 metrics gist is kept only as a provenance
-record.
+source** (`leaderboard._parquet_path` / `sge_normalized_rows` case `gpn_star`) —
+the pipeline is the single source of truth; the old #145 metrics gist is kept
+only as a provenance record.
 
 GPN-Star scoring runs in [songlab-cal/TraitGym](https://github.com/songlab-cal/TraitGym),
-not this repo. Predictions are pulled from a gist (commit pinned in
-`marin_dna.pipelines.evals.gpn_star.GPN_STAR_GIST_BASE`); see the
-[#145 calibration definition](https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4444680280)
-and the [current-revision upload](https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4489509362).
+not this repo. Predictions are pulled from gists (commits pinned in
+`marin_dna.pipelines.evals.gpn_star`: `GPN_STAR_GIST_BASE` for the matched-pair
+datasets, `GPN_STAR_SGE_GIST_BASE` for SGE — a separate gist); see the
+[#145 calibration definition](https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4444680280),
+the [matched-pair upload](https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4489509362),
+and the [SGE upload](https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4683700490).
 This pipeline is the align + aggregate step: load HF eval dataset, row-align with
-the predictions parquet, compute AUPRC per subset.
+the predictions parquet, compute AUPRC.
 
 eQTL (#172) was retired in the 1:9 / k=9 migration (#194) and has no
 current-revision GPN-Star upload, so it is not evaluated here.
 
 ## What it does
 
-For each `dataset` in `config["datasets"]` (a `{name, hf_revision}` list pinned
-to the k=9 HF commits):
+Each `dataset` in `config["datasets"]` (a `{name, hf_revision, eval_protocol}`
+list pinned to the revisions evals_v2 targets) runs through two steps. The
+`eval_protocol` (`matched_pair` default, or `sge`) selects the metric path —
+mirroring [`conservation_eval`](../conservation_eval):
 
 1. **Score** — for each of the 3 model variants, load the GPN-Star prediction
    parquet (`predictions_url`), align row-by-row with the HF dataset's `train`
    split **at the pinned revision**, derive `minus_llr` and
    `minus_llr_calibrated` for the leaderboard convention. Output: one long
-   parquet per dataset, `model` column distinguishing V / M / P.
+   parquet per dataset, `model` column distinguishing V / M / P. The carried
+   variant columns differ by protocol (`get_dataset_variant_columns`):
+   matched-pair keeps `[…, label, subset, match_group]`; SGE keeps
+   `[…, mavedb_urn, gene, subset, label]`.
 
    Row alignment is asserted element-wise, no key-based merge — TraitGym's
    `bolinas_pack_predictions` rule builds the predictions parquet by
    horizontal-concat with HF row order, so a `split == "train"` filter on the
    matching revision is sufficient (and `score_variants_gpn_star` fails loud if
-   it ever isn't).
+   it ever isn't). The align is protocol-independent.
 
-2. **Compute** AUPRC + cluster-bootstrap SE (cluster = `match_group`) per
-   consequence subset on all 4 score columns (`minus_llr`, `abs_llr`,
-   `minus_llr_calibrated`, `abs_llr_calibrated`). Output: metrics parquet keyed
-   by `(model, score_type, subset)`, plus the `_global_` / `_macro_avg_`
-   sentinel rows from `compute_auprc_metrics` (`n_min` from config). Baseline
-   AUPRC ≈ 0.10 under 1:9.
+2. **Compute** AUPRC + cluster-bootstrap SE on all 4 score columns (`minus_llr`,
+   `abs_llr`, `minus_llr_calibrated`, `abs_llr_calibrated`):
+   - **matched_pair** → `compute_auprc_metrics`: per consequence subset, cluster
+     bootstrap on `match_group`, keyed by `(model, score_type, subset)` + the
+     `_global_` / `_macro_avg_` sentinel rows (`n_min` from config). Baseline
+     AUPRC ≈ 0.10 under 1:9.
+   - **sge** → `compute_sge_metrics`: per accession (MaveDB study) × consequence
+     subset, macro-averaged over subsets then accessions, keyed by
+     `(model, score_type, metric, subset, accession)` (the `_macro_avg_`
+     sentinels; `n_min_auprc` from config `n_min`). Same shared metric as
+     evals_v2 / conservation. The abnormal base rate (~5–16%) varies per gene.
 
 Downstream consumers filter by `score_type` to pick the leaderboard-convention
 column:
@@ -52,6 +66,8 @@ column:
 - **Mendelian:** `minus_llr_calibrated` (pathogenic ⇒ alt depleted under
   purifying selection ⇒ negative LLR ⇒ positive `minus_llr`).
 - **Complex traits:** `abs_llr_calibrated` (direction-agnostic magnitude).
+- **SGE:** `minus_llr_calibrated` (abnormal = loss of function = deleterious, a
+  directional signal like Mendelian).
 
 ## Outputs
 
@@ -60,11 +76,16 @@ S3 bucket `s3://oa-bolinas/snakemake/gpn_star_eval/`:
 ```
 results/
 ├── scores/{dataset}.parquet    # 3 × N rows: variant cols + scores per model
-└── metrics/{dataset}.parquet   # AUPRC per (model, score_type, subset);
-                                 # cols [score_type, subset, value, se,
-                                 #       n_groups, n_rows, model, dataset]
+└── metrics/{dataset}.parquet   # AUPRC, keyed by eval_protocol:
+                                 #  matched_pair → (model, score_type, subset),
+                                 #    cols [score_type, subset, value, se,
+                                 #          n_groups, n_rows, model, dataset]
+                                 #  sge → (model, score_type, metric, subset,
+                                 #    accession), cols [metric, subset, accession,
+                                 #    gene, score_type, value, se, n, n_pos,
+                                 #    model, dataset]
                                  # (no `split` col — train only; the dashboard
-                                 #  reads this parquet, filtering model+score_type)
+                                 #  reads this parquet, filtering on model)
 ```
 
 ## Conventions
@@ -83,9 +104,9 @@ results/
 
 ## Usage
 
-Pure CPU, no GPU. Network: a few MB (downloads 6 prediction parquets from the
-pinned gist). The bootstrap dominates wallclock (~3 min CPU per dataset at
-`n_bootstrap: 1000`).
+Pure CPU, no GPU. Network: a few MB (downloads 9 prediction parquets — 3 models ×
+3 datasets — from the pinned gists). The bootstrap dominates wallclock (~3 min CPU
+per dataset at `n_bootstrap: 1000`).
 
 ```bash
 cd snakemake/gpn_star_eval
@@ -95,6 +116,9 @@ uv run snakemake -n
 
 # Real run — writes outputs to S3 per the default profile.
 uv run snakemake
+
+# Build one dataset only (e.g. just SGE).
+uv run snakemake results/metrics/sge.parquet
 ```
 
 No SkyPilot launch yaml — the workload is too small to be worth it.
@@ -105,9 +129,16 @@ Pipeline rules are thin glue around `marin_dna.pipelines.evals.gpn_star`:
 
 - `score_variants_gpn_star(hf_df, predictions, split)` — load + row-align
   predictions, derive `minus_*` columns. Asserts row-count + key-order match.
-- `predictions_url(dataset, model)` — gist raw URL for one prediction parquet.
+  Protocol-independent (matched-pair + SGE share it).
+- `predictions_url(dataset, model)` — gist raw URL for one prediction parquet
+  (the hosting gist differs by dataset; SGE uses `GPN_STAR_SGE_GIST_BASE`).
 - `GPN_STAR_MODELS`, `GPN_STAR_MODEL_INFO`, `GPN_STAR_SCORE_COLUMN` — metadata.
+
+The metric functions are the same shared ones our models use:
+`compute_auprc_metrics` (matched-pair) / `compute_sge_metrics` (SGE) in
+`marin_dna.pipelines.evals.metrics`; SGE also reuses `SGE_VARIANT_COLUMNS` from
+`marin_dna.pipelines.evals.conservation`.
 
 Tests at [`tests/pipelines/evals/test_gpn_star.py`](../../tests/pipelines/evals/test_gpn_star.py)
 cover alignment, NaN detection, chrom-dtype handling, and the predictions-URL
-helper.
+helper (incl. the SGE gist).

--- a/snakemake/gpn_star_eval/config/config.yaml
+++ b/snakemake/gpn_star_eval/config/config.yaml
@@ -1,17 +1,31 @@
 input_hf_prefix: bolinas-dna/evals
 split: train
 
-# Matched-pair eval datasets, pinned to the k=9 / AUPRC revisions this repo's
-# evals_v2 targets (mirrors snakemake/analysis/evals_v2/config/config.yaml). The
-# GPN-Star prediction parquets (gist in `marin_dna.pipelines.evals.gpn_star`) are
-# row-aligned to exactly these revisions, so the `split == "train"` filter aligns
-# element-wise with `load_dataset(..., revision=...)`. eQTL was retired
-# (#172/#194) and has no current-revision GPN-Star upload, so it is not evaluated.
+# Eval datasets, pinned to the revisions this repo's evals_v2 targets (mirrors
+# snakemake/analysis/evals_v2/config/config.yaml). The GPN-Star prediction
+# parquets (gists in `marin_dna.pipelines.evals.gpn_star`) are row-aligned to
+# exactly these revisions, so the `split == "train"` filter aligns element-wise
+# with `load_dataset(..., revision=...)`. eQTL was retired (#172/#194) and has no
+# current-revision GPN-Star upload, so it is not evaluated.
+#
+# `eval_protocol` (default `matched_pair`) selects the variant-column assert set
+# and the metric path, mirroring conservation_eval. `matched_pair` →
+# `compute_auprc_metrics` (per-subset AUPRC + cluster bootstrap on `match_group`).
+# `sge` → `compute_sge_metrics` (per-accession × consequence-subset AUPRC on the
+# binary `label`, macro-averaged) — the same SGE path evals_v2 / conservation use.
 datasets:
   - name: mendelian_traits
     hf_revision: 4aed58e50c5dea0b878a665007af2ef9e5108e9f  # PR #194 k=9 rebuild
+    eval_protocol: matched_pair
   - name: complex_traits
     hf_revision: 22f86a89c65cb8f3007ac3cc2739f40efefa4340  # PR #194 k=9 rebuild
+    eval_protocol: matched_pair
+  # Saturation-genome-editing dataset (bolinas-dna/evals_sge v3, issue #301). The
+  # SGE prediction parquets live in a separate gist (GPN_STAR_SGE_GIST_BASE),
+  # row-aligned to this revision's train split.
+  - name: sge
+    hf_revision: 225d3d1ea32a4af547891b13c33b5e92a5aae849  # evals_sge v3 (#301, AUPRC-only)
+    eval_protocol: sge
 
 # GPN-Star model variants (3 in current set). Model decoding lives in
 # `marin_dna.pipelines.evals.gpn_star.GPN_STAR_MODEL_INFO`; source URLs are
@@ -21,10 +35,12 @@ models:
   - M
   - P
 
-# Score columns evaluated by `compute_auprc_metrics`. The 4 entries below produce
-# both the leaderboard-convention column (calibrated) and its uncalibrated
-# counterpart per dataset, so the same metrics parquet powers both the live
-# leaderboards and the #145 eval comment's parallel reporting.
+# Score columns evaluated by the metric path (`compute_auprc_metrics` for
+# matched_pair, `compute_sge_metrics` for sge). The 4 entries below produce both
+# the leaderboard-convention column (calibrated) and its uncalibrated counterpart
+# per dataset, so the same metrics parquet powers both the live leaderboards and
+# the #145 eval comment's parallel reporting. (The SGE leaderboard surfaces the
+# signed `minus_llr*`; `abs_llr*` are kept for provenance.)
 score_columns:
   - minus_llr
   - abs_llr

--- a/snakemake/gpn_star_eval/workflow/rules/common.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/common.smk
@@ -3,14 +3,56 @@
 import pandas as pd
 from datasets import load_dataset
 
-from marin_dna.pipelines.evals.conservation import REQUIRED_VARIANT_COLUMNS
+from marin_dna.pipelines.evals.conservation import (
+    REQUIRED_VARIANT_COLUMNS,
+    SGE_VARIANT_COLUMNS,
+)
 from marin_dna.pipelines.evals.gpn_star import predictions_url, score_variants_gpn_star
-from marin_dna.pipelines.evals.metrics import compute_auprc_metrics
+from marin_dna.pipelines.evals.metrics import compute_auprc_metrics, compute_sge_metrics
 
-# `datasets` is a list of {name, hf_revision} (revisions pinned to the k=9 /
-# AUPRC HF commits). Names drive the wildcards; the revision map pins
-# `load_dataset` so the prediction parquets row-align deterministically.
+# `datasets` is a list of {name, hf_revision, eval_protocol?} (revisions pinned to
+# the HF commits evals_v2 targets). Names drive the wildcards; the revision map
+# pins `load_dataset` so the prediction parquets row-align deterministically.
 DATASETS = [d["name"] for d in config["datasets"]]
 HF_REVISION = {d["name"]: d["hf_revision"] for d in config["datasets"]}
 MODELS = config["models"]
 SCORE_COLUMNS = config["score_columns"]
+
+# Per-dataset eval protocol — mirrors snakemake/conservation_eval common.smk.
+# `matched_pair` (default) → per-subset AUPRC + cluster bootstrap on `match_group`
+# (`compute_auprc_metrics`). `sge` (#301) → per-accession × consequence-subset
+# AUPRC on the binary `label` of evals_sge (`compute_sge_metrics`). No `qtl_global`
+# here — GPN-Star has no current-revision QTL prediction upload.
+EVAL_PROTOCOLS = ("matched_pair", "sge")
+
+
+def get_dataset_config(name: str) -> dict:
+    """Per-dataset config entry (name, hf_revision, eval_protocol)."""
+    for d in config["datasets"]:
+        if d["name"] == name:
+            return d
+    raise KeyError(f"unknown dataset {name!r}")
+
+
+def get_dataset_protocol(name: str) -> str:
+    """Eval protocol for a dataset (default `matched_pair`)."""
+    return get_dataset_config(name).get("eval_protocol", "matched_pair")
+
+
+def get_dataset_variant_columns(name: str) -> tuple[str, ...]:
+    """Required variant columns for a dataset, keyed by eval protocol. These are
+    carried verbatim from the HF dataset into the scores parquet so the metric
+    step (`compute_auprc_metrics` / `compute_sge_metrics`) has its grouping +
+    label columns."""
+    if get_dataset_protocol(name) == "sge":
+        return SGE_VARIANT_COLUMNS
+    return REQUIRED_VARIANT_COLUMNS
+
+
+# Fail fast on an unknown eval_protocol (typo) at parse time.
+for _d in config["datasets"]:
+    _ep = _d.get("eval_protocol", "matched_pair")
+    assert _ep in EVAL_PROTOCOLS, (
+        f"dataset {_d['name']!r} `eval_protocol` must be one of "
+        f"{sorted(EVAL_PROTOCOLS)}, got {_ep!r}"
+    )

--- a/snakemake/gpn_star_eval/workflow/rules/metrics.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/metrics.smk
@@ -50,14 +50,17 @@ rule compute_metrics:
             sub = df[df["model"] == model]
             if protocol == "sge":
                 # Per-accession × consequence-subset AUPRC on the binary `label`.
-                # `n_min_auprc` is the per-label-class floor per cell (config `n_min`).
+                # Leave `n_min_auprc` at the compute_sge_metrics default (the SGE
+                # per-label-class cell floor) so this matches evals_v2 +
+                # conservation_eval exactly — they don't pass it either. (config
+                # `n_min` is the matched_pair macro-entry gate, a different
+                # semantic, and is used only in the else branch below.)
                 metrics = compute_sge_metrics(
                     dataset=sub[["mavedb_urn", "gene", "subset", "label"]],
                     scores=sub[SCORE_COLUMNS],
                     score_columns=SCORE_COLUMNS,
                     n_bootstrap=config["n_bootstrap"],
                     rng=config["bootstrap_seed"],
-                    n_min_auprc=config["n_min"],
                 )
             else:
                 metrics = compute_auprc_metrics(

--- a/snakemake/gpn_star_eval/workflow/rules/metrics.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/metrics.smk
@@ -1,15 +1,26 @@
 """Per-dataset AUPRC + cluster-bootstrap SE on the 4 score columns × 3 models.
 
-Output schema (one row per ``(model, score_type, subset)``):
-``[score_type, subset, value, se, n_groups, n_rows, model, dataset]``.
-Includes ``_global_`` and ``_macro_avg_`` sentinel subset rows from
-``compute_auprc_metrics`` (``n_min`` from config). AUPRC + cluster bootstrap on
-``match_group`` matches evals_v2, so these rows are directly comparable to our
-models on the same dataset revisions. The dashboard reads this parquet directly
-(``leaderboard._parquet_path`` case ``gpn_star``), filtering by ``model`` +
-``score_type`` — there is no ``split`` column (all rows are the train split, the
-only split this pipeline emits). (The previous PairwiseAccuracy path asserted
-1 pos + 1 neg per ``match_group`` and would fail on the 1:9 k=9 datasets.)
+The metric path is keyed by `eval_protocol` (`get_dataset_protocol`), matching
+the score columns the dashboard surfaces per dataset:
+
+- **matched_pair** (mendelian_traits / complex_traits) → `compute_auprc_metrics`:
+  per-consequence-subset AUPRC + cluster bootstrap on `match_group`, plus
+  `_global_` / `_macro_avg_` sentinel rows (`n_min` from config). One row per
+  `(model, score_type, subset)`: `[score_type, subset, value, se, n_groups,
+  n_rows, model, dataset]`.
+- **sge** (#301) → `compute_sge_metrics`: per-accession (MaveDB study) ×
+  consequence-subset AUPRC on the binary `label`, macro-averaged over subsets
+  then accessions (`_macro_avg_` sentinels; gated cells emit NaN value with real
+  counts). One row per `(model, score_type, metric, subset, accession)`:
+  `[metric, subset, accession, gene, score_type, value, se, n, n_pos, model,
+  dataset]`. Same shared `compute_sge_metrics` as evals_v2 / conservation, so the
+  rows are directly comparable to our models on the same evals_sge revision.
+
+Both are AUPRC + bootstrap (seed from config) on exactly the variants our models
+are scored on. There is no ``split`` column (all rows are the train split, the
+only split this pipeline emits). The dashboard reads this parquet directly
+(``leaderboard._parquet_path`` / ``sge_normalized_rows`` case ``gpn_star``),
+filtering by ``model`` (+ ``score_type`` for matched_pair).
 """
 
 
@@ -22,9 +33,9 @@ rule compute_metrics:
         dataset="|".join(DATASETS),
     run:
         df = pd.read_parquet(input[0])
-        for col in REQUIRED_VARIANT_COLUMNS:
-            assert col in df.columns, f"input scores parquet missing column {col!r}"
-        for col in SCORE_COLUMNS:
+        protocol = get_dataset_protocol(wildcards.dataset)
+        variant_cols = get_dataset_variant_columns(wildcards.dataset)
+        for col in (*variant_cols, *SCORE_COLUMNS):
             assert col in df.columns, f"input scores parquet missing column {col!r}"
 
         expected_models = {f"GPN-Star-{m}" for m in MODELS}
@@ -37,14 +48,26 @@ rule compute_metrics:
         for m in MODELS:
             model = f"GPN-Star-{m}"
             sub = df[df["model"] == model]
-            metrics = compute_auprc_metrics(
-                dataset=sub[["label", "subset", "match_group"]],
-                scores=sub[SCORE_COLUMNS],
-                score_columns=SCORE_COLUMNS,
-                n_bootstrap=config["n_bootstrap"],
-                rng=config["bootstrap_seed"],
-                n_min=config["n_min"],
-            )
+            if protocol == "sge":
+                # Per-accession × consequence-subset AUPRC on the binary `label`.
+                # `n_min_auprc` is the per-label-class floor per cell (config `n_min`).
+                metrics = compute_sge_metrics(
+                    dataset=sub[["mavedb_urn", "gene", "subset", "label"]],
+                    scores=sub[SCORE_COLUMNS],
+                    score_columns=SCORE_COLUMNS,
+                    n_bootstrap=config["n_bootstrap"],
+                    rng=config["bootstrap_seed"],
+                    n_min_auprc=config["n_min"],
+                )
+            else:
+                metrics = compute_auprc_metrics(
+                    dataset=sub[["label", "subset", "match_group"]],
+                    scores=sub[SCORE_COLUMNS],
+                    score_columns=SCORE_COLUMNS,
+                    n_bootstrap=config["n_bootstrap"],
+                    rng=config["bootstrap_seed"],
+                    n_min=config["n_min"],
+                )
             metrics["model"] = model
             per_model.append(metrics)
 
@@ -52,7 +75,6 @@ rule compute_metrics:
         out["dataset"] = wildcards.dataset
         out.to_parquet(output[0], index=False)
         print(
-            f"[gpn_star_eval] {wildcards.dataset}: {len(out)} metric rows "
-            f"({len(per_model)} models × {len(SCORE_COLUMNS)} score columns × "
-            f"per-subset rows incl. _global_ / _macro_avg_)"
+            f"[gpn_star_eval] {wildcards.dataset} ({protocol}): {len(out)} metric "
+            f"rows ({len(per_model)} models × {len(SCORE_COLUMNS)} score columns)"
         )

--- a/snakemake/gpn_star_eval/workflow/rules/score.smk
+++ b/snakemake/gpn_star_eval/workflow/rules/score.smk
@@ -2,14 +2,18 @@
 combined long parquet with one row per (model, variant).
 
 Output schema:
-- REQUIRED_VARIANT_COLUMNS (chrom, pos, ref, alt, label, subset, match_group)
+- variant columns, keyed by eval protocol (`get_dataset_variant_columns`):
+  matched_pair → REQUIRED_VARIANT_COLUMNS (chrom, pos, ref, alt, label, subset,
+  match_group); sge → SGE_VARIANT_COLUMNS (chrom, pos, ref, alt, mavedb_urn,
+  gene, subset, label).
 - model: ``"GPN-Star-V" | "GPN-Star-M" | "GPN-Star-P"``
 - llr, abs_llr, llr_calibrated, abs_llr_calibrated (passthrough from
   predictions parquet)
 - minus_llr, minus_llr_calibrated (derived: ``-llr`` / ``-llr_calibrated``
   for the leaderboard convention)
 
-Total rows = ``len(MODELS) * n_variants_in_split``.
+The align (`score_variants_gpn_star`) is protocol-independent — only the carried
+variant columns differ. Total rows = ``len(MODELS) * n_variants_in_split``.
 """
 
 
@@ -25,7 +29,8 @@ rule score_variants:
             split=config["split"],
             revision=HF_REVISION[wildcards.dataset],
         ).to_pandas()
-        for col in REQUIRED_VARIANT_COLUMNS:
+        variant_cols = get_dataset_variant_columns(wildcards.dataset)
+        for col in variant_cols:
             assert col in hf.columns, f"HF dataset missing column {col!r}"
 
         per_model = []
@@ -35,7 +40,7 @@ rule score_variants:
             scores = score_variants_gpn_star(hf, preds, split=config["split"])
             combined = pd.concat(
                 [
-                    hf[list(REQUIRED_VARIANT_COLUMNS)].reset_index(drop=True),
+                    hf[list(variant_cols)].reset_index(drop=True),
                     scores.reset_index(drop=True),
                 ],
                 axis=1,

--- a/src/marin_dna/pipelines/evals/gpn_star.py
+++ b/src/marin_dna/pipelines/evals/gpn_star.py
@@ -54,24 +54,53 @@ GPN_STAR_GIST_BASE: str = (
     "02484d50d9bfd80337e313652b26f98a9362b6b1"
 )
 
+# SGE (saturation genome editing) predictions live in a **separate** gist from
+# the matched-pair upload above — same producer, same file-naming + schema, but a
+# distinct gist id/commit. Row-aligned to ``bolinas-dna/evals_sge`` split=train @
+# revision 225d3d1e (issue #145 comment
+# https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4683700490),
+# the same revision evals_v2 / conservation_eval pin for SGE.
+GPN_STAR_SGE_GIST_BASE: str = (
+    "https://gist.githubusercontent.com/gonzalobenegas/"
+    "1285ea85cd068e522b1ff6fc1c76acec/raw/"
+    "571e443dca86630bd7d22506c3edfdeea21b2ee6"
+)
+
+# Which gist hosts each dataset's prediction parquets. Adding a dataset to the
+# GPN-Star baseline = add its gist base here (and its leaderboard column below).
+_GIST_BASE_BY_DATASET: dict[str, str] = {
+    "mendelian_traits": GPN_STAR_GIST_BASE,
+    "complex_traits": GPN_STAR_GIST_BASE,
+    "sge": GPN_STAR_SGE_GIST_BASE,
+}
+
 # Per-dataset leaderboard score column. The calibrated variant is what each
 # leaderboard issue (#161 / #162) renders. The uncalibrated counterpart is
 # reported in #145 for context. (eQTL #172 retired in #194 — no current upload.)
+# SGE (#301): signed ``minus_llr_calibrated`` — abnormal = loss of function =
+# deleterious, a directional signal like Mendelian (not magnitude like complex).
 GPN_STAR_SCORE_COLUMN: dict[str, str] = {
     "mendelian_traits": "minus_llr_calibrated",
     "complex_traits": "abs_llr_calibrated",
+    "sge": "minus_llr_calibrated",
 }
 
 
 def predictions_url(dataset: str, model: str) -> str:
     """Return the gist raw URL for one GPN-Star prediction parquet.
 
-    The current-revision upload names files ``bolinas_{dataset}_GPN-Star-{model}``
-    (underscore separator); the earlier 1:1-revision upload used a ``.`` before
-    ``GPN-Star``. See ``GPN_STAR_GIST_BASE``.
+    The upload names files ``bolinas_{dataset}_GPN-Star-{model}`` (underscore
+    separator). The hosting gist differs by dataset (see
+    :data:`_GIST_BASE_BY_DATASET`): matched-pair datasets share
+    :data:`GPN_STAR_GIST_BASE`; SGE uses :data:`GPN_STAR_SGE_GIST_BASE`.
     """
     assert model in GPN_STAR_MODELS, f"unknown GPN-Star model {model!r}"
-    return f"{GPN_STAR_GIST_BASE}/bolinas_{dataset}_GPN-Star-{model}.parquet"
+    assert dataset in _GIST_BASE_BY_DATASET, (
+        f"no GPN-Star prediction gist for dataset {dataset!r}; "
+        f"known: {sorted(_GIST_BASE_BY_DATASET)}"
+    )
+    base = _GIST_BASE_BY_DATASET[dataset]
+    return f"{base}/bolinas_{dataset}_GPN-Star-{model}.parquet"
 
 
 def score_variants_gpn_star(

--- a/src/marin_dna/pipelines/evals/leaderboard.py
+++ b/src/marin_dna/pipelines/evals/leaderboard.py
@@ -413,6 +413,14 @@ def sge_normalized_rows(dataset: str = "sge") -> pl.DataFrame:
             # conservation's parquet path is split-specific (…/metrics_{SPLIT}.parquet),
             # so it only needs the per-track score_name select, no split filter.
             df = df.filter(pl.col("score_name") == method.id)
+        elif method.family == "gpn_star":
+            # All three GPN-Star variants (V/M/P) share ONE per-dataset parquet
+            # (`_parquet_path` is model-independent for this family), stacked with a
+            # `model` column. Filter to this method's model — without it each of the
+            # 3 registered methods would re-emit all 3 models' rows (9× duplication,
+            # mislabeled). Train-only parquet, so no split filter (mirrors
+            # fetch_method_metrics' gpn_star branch). `model` == `Model.id`.
+            df = df.filter(pl.col("model") == method.id)
         elif method.family == "marin_dna":
             # The per-model parquet path is NOT split-specific and carries a
             # `split` column for whichever split was scored — guard it like

--- a/tests/pipelines/evals/test_gpn_star.py
+++ b/tests/pipelines/evals/test_gpn_star.py
@@ -12,6 +12,7 @@ from marin_dna.pipelines.evals.gpn_star import (
     GPN_STAR_MODELS,
     GPN_STAR_MODEL_INFO,
     GPN_STAR_SCORE_COLUMN,
+    GPN_STAR_SGE_GIST_BASE,
     predictions_url,
     score_variants_gpn_star,
 )
@@ -288,8 +289,8 @@ def test_score_variants_missing_pred_column() -> None:
 
 def test_predictions_url_format() -> None:
     # Current-revision upload uses an underscore before ``GPN-Star`` (the earlier
-    # 1:1-revision upload used a dot). Datasets are mendelian + complex (eQTL
-    # retired, #172/#194).
+    # 1:1-revision upload used a dot). Matched-pair datasets (mendelian + complex)
+    # share GPN_STAR_GIST_BASE; eQTL retired (#172/#194).
     assert predictions_url("mendelian_traits", "V") == (
         f"{GPN_STAR_GIST_BASE}/bolinas_mendelian_traits_GPN-Star-V.parquet"
     )
@@ -298,9 +299,25 @@ def test_predictions_url_format() -> None:
     )
 
 
+def test_predictions_url_sge_uses_separate_gist() -> None:
+    # SGE predictions live in a different gist from the matched-pair upload
+    # (#145 comment 4683700490), but keep the same filename convention.
+    assert predictions_url("sge", "M") == (
+        f"{GPN_STAR_SGE_GIST_BASE}/bolinas_sge_GPN-Star-M.parquet"
+    )
+    # The two gists are distinct — a regression guard so a future edit can't
+    # collapse SGE back onto the matched-pair base.
+    assert GPN_STAR_SGE_GIST_BASE != GPN_STAR_GIST_BASE
+
+
 def test_predictions_url_unknown_model() -> None:
     with pytest.raises(AssertionError, match="unknown GPN-Star model"):
         predictions_url("mendelian_traits", "X")
+
+
+def test_predictions_url_unknown_dataset() -> None:
+    with pytest.raises(AssertionError, match="no GPN-Star prediction gist"):
+        predictions_url("caqtl", "V")
 
 
 def test_score_column_per_dataset_convention() -> None:
@@ -308,8 +325,9 @@ def test_score_column_per_dataset_convention() -> None:
     assert GPN_STAR_SCORE_COLUMN["mendelian_traits"] == "minus_llr_calibrated"
     # Complex uses magnitude (direction-agnostic).
     assert GPN_STAR_SCORE_COLUMN["complex_traits"] == "abs_llr_calibrated"
-    # No surprise datasets (eQTL #172 retired in #194).
-    assert set(GPN_STAR_SCORE_COLUMN) == {"mendelian_traits", "complex_traits"}
+    # SGE: signed (abnormal = loss of function = deleterious), like Mendelian.
+    assert GPN_STAR_SCORE_COLUMN["sge"] == "minus_llr_calibrated"
+    assert set(GPN_STAR_SCORE_COLUMN) == {"mendelian_traits", "complex_traits", "sge"}
 
 
 def test_model_info_keys_match_models_tuple() -> None:

--- a/tests/pipelines/evals/test_leaderboard.py
+++ b/tests/pipelines/evals/test_leaderboard.py
@@ -649,10 +649,11 @@ def test_storage_options_ignores_other_values(monkeypatch: pytest.MonkeyPatch):
 
 
 def _sge_metrics_parquet(
-    score_types, *, score_name=None, split="train"
+    score_types, *, score_name=None, split="train", model=None
 ) -> pl.DataFrame:
     """Tiny SGE metrics parquet: one AUPRC row per score_type at the headline
-    (across-accession × across-subset macro) cell."""
+    (across-accession × across-subset macro) cell. ``model`` stamps the gpn_star
+    `model` column (V/M/P); ``score_name`` the conservation track column."""
     rows = [
         {
             "metric": "AUPRC",
@@ -673,6 +674,8 @@ def _sge_metrics_parquet(
     df = pl.DataFrame(rows)
     if score_name is not None:
         df = df.with_columns(pl.lit(score_name).alias("score_name"))
+    if model is not None:
+        df = df.with_columns(pl.lit(model).alias("model"))
     return df
 
 
@@ -735,6 +738,42 @@ def test_sge_normalized_rows_marin_and_conservation(monkeypatch: pytest.MonkeyPa
     # SGE v3 is AUPRC-only; every metric row is AUPRC with a finite n_pos.
     assert set(df["metric"].to_list()) == {"AUPRC"}
     assert df["n_pos"].is_finite().all()
+
+
+def test_sge_normalized_rows_gpn_star_filters_by_model(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The 3 GPN-Star variants share ONE model-stacked sge parquet (the path is
+    model-independent for this family). sge_normalized_rows must filter each
+    method to its own `model` — without the filter every method would re-emit all
+    3 models' rows (9× duplication, mislabeled)."""
+    v = _mk_method(id="GPN-Star-V", family="gpn_star", datasets=("sge",))
+    m = _mk_method(id="GPN-Star-M", family="gpn_star", datasets=("sge",))
+    p = _mk_method(id="GPN-Star-P", family="gpn_star", datasets=("sge",))
+    _patch_methods(monkeypatch, (v, m, p))
+
+    # All three resolve to the same shared parquet path.
+    path = leaderboard._parquet_path(v, "sge")
+    assert leaderboard._parquet_path(m, "sge") == path
+    assert leaderboard._parquet_path(p, "sge") == path
+
+    # Model-stacked parquet: each model × 2 score_types (the cLLR + LLR columns).
+    stacked = pl.concat(
+        [
+            _sge_metrics_parquet(["minus_llr_calibrated", "minus_llr"], model=mid)
+            for mid in ("GPN-Star-V", "GPN-Star-M", "GPN-Star-P")
+        ]
+    )
+    _patch_read_parquet(monkeypatch, {path: stacked})
+
+    df = leaderboard.sge_normalized_rows("sge")
+    # Each method gets only its own 2 rows — 6 total, not 18 (no cross-model leak).
+    assert df.height == 6
+    for mid in ("GPN-Star-V", "GPN-Star-M", "GPN-Star-P"):
+        sub = df.filter(pl.col("method_id") == mid)
+        assert sub.height == 2
+        assert set(sub["score_type"].to_list()) == {"minus_llr_calibrated", "minus_llr"}
+        assert (sub["family"] == "gpn_star").all()
 
 
 def test_sge_normalized_rows_skips_missing_parquet(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
Scores the three GPN-Star variants (V = vertebrate-100way, M = mammal-447way, P = primate-243way; all 200M) on the **saturation-genome-editing** benchmark (`bolinas-dna/evals_sge` v3 @ `225d3d1e`) and surfaces them on the SGE leaderboard, directly comparable to our gLMs and the 5 conservation baselines. Tracked in #145.

## What

The producer published SGE prediction parquets in a **separate gist** from the matched-pair upload ([#145 comment 4683700490](https://github.com/Open-Athena/marin-dna/issues/145#issuecomment-4683700490)), row-aligned to the `evals_sge` train split at the revision every other SGE pipeline pins. This reuses the existing align (`score_variants_gpn_star`) + the **shared** `compute_sge_metrics` (the same per-accession × consequence-subset AUPRC path as evals_v2 / conservation) — no new metric logic.

- **`gpn_star.py`** — add `GPN_STAR_SGE_GIST_BASE`, make `predictions_url` dataset-aware (matched-pair vs SGE gist), add `GPN_STAR_SCORE_COLUMN['sge'] = minus_llr_calibrated`.
- **`gpn_star_eval` pipeline** — make the score/metrics rules **eval-protocol-aware** (mirrors `conservation_eval`): `sge` → `SGE_VARIANT_COLUMNS` + `compute_sge_metrics`; added the `sge` dataset to config. Output: `results/metrics/sge.parquet` on S3.
- **`leaderboard.sge_normalized_rows`** — filter the shared `gpn_star` parquet by `model` (V/M/P share one parquet — without the filter each method would re-emit all 3 models' rows, 9× duplicated).
- **dashboard** — register GPN-Star V/M/P for `sge` (`models.yaml`); add `gpn_star` to the SGE page's `SGE_SCORE_TYPE` (`{cLLR: minus_llr_calibrated, LLR: minus_llr}`). Everything else was already wired (`controls.js` family/protocol).
- tests (`test_gpn_star.py`, `test_leaderboard.py`) + README updated.

## Result — SGE headline macro AUPRC (default score per family)

| Rank | Model | Family | macro AUPRC |
|---|---|---|---|
| 1 | **GPN-Star (V)** | gpn_star | **0.558 ± 0.011** |
| 2 | **GPN-Star (M)** | gpn_star | **0.516 ± 0.012** |
| 3 | exp13-mixture-proportional | marin_dna | 0.450 ± 0.011 |
| 4 | scaling-v0.5 4B | marin_dna | 0.441 ± 0.011 |
| 5 | **GPN-Star (P)** | gpn_star | **0.411 ± 0.011** |
| 6 | phyloP (100v) | conservation | 0.365 ± 0.010 |
| … | … | … | … |

GPN-Star V and M (deep-MSA conservation models) top the SGE leaderboard, ahead of our best gLM; primate-only (P) lands mid-pack — consistent with SGE deleteriousness tracking cross-species conservation depth.

## Verification

- `uv run pytest tests/pipelines/evals/` → 421 passed (incl. new `predictions_url` SGE + `sge_normalized_rows` model-filter tests).
- Dry-run targets exactly `score_variants(sge)` + `compute_metrics(sge)` — no matched-pair reruns.
- Real run wrote `results/metrics/sge.parquet` (3 models × 4 score columns); reloaded via `sge_normalized_rows` — headline matches the table above, no cross-model leak.
- `npm run build` (fresh cache) renders the SGE page; the built data file embeds all 3 GPN-Star methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)