### PR TITLE
evals: model-agnostic caQTL/dsQTL official-metrics benchmark (#311)

### DIFF
--- a/scripts/correct_ag_predictions.py
+++ b/scripts/correct_ag_predictions.py
@@ -29,6 +29,7 @@ import argparse
 import polars as pl
 
 from marin_dna.pipelines.evals.qtl_scoring import (
+    QTL_HF_REVISION,
     SUPPL_TABLE4_REFERENCE,
     align_score_sign,
     compute_qtl_split_metrics,
@@ -44,12 +45,6 @@ AG_RESULTS = "s3://oa-bolinas/snakemake/alphagenome_eval/results"
 RAW_PREFIX = f"{AG_RESULTS}/dnase_lfc_raw"  # immutable #262 originals (raw convention)
 OUT_PREFIX = f"{AG_RESULTS}/dnase_lfc"  # convention-aligned (genome-native) predictions
 
-# Canonical caQTL/dsQTL datasets (#313). Pinned to the validated build for the
-# Suppl-Table-4 reproduction check and as the ChromBPNet sign anchor.
-HF_REVISION = {
-    "caqtl": "27a24296f50ed55afdc412d1612df680d13138d6",
-    "dsqtl": "4a3bf152cd7c28be290adde48a402ec40992cb62",
-}
 # Acceptance: reproduce Suppl Table 4 to ≤0.004 at the table's precision. The binding
 # case is the caQTL AlphaGenome *direction* (0.7328 vs published 0.7368, Δ0.0040) — the
 # forward-strand-only-vs-RC-averaged gap baked into the #262 predictions; every other
@@ -68,7 +63,7 @@ def _s3_exists(path: str) -> bool:
 def load_canonical(name: str) -> pl.DataFrame:
     """Canonical dataset (train ∪ test) from the pinned HF build, with a ``split_source``
     tag — carries ``label``, ``effect`` and the ChromBPNet/Enformer baseline columns."""
-    rev = HF_REVISION[name]
+    rev = QTL_HF_REVISION[name]
     parts = [
         pl.read_parquet(
             f"hf://datasets/bolinas-dna/evals_{name}@{rev}/{split}.parquet"
@@ -120,8 +115,10 @@ def verify_reproduction(
     """Assert the aligned AlphaGenome predictions reproduce Suppl Table 4 (AG-test slice)
     to ≤0.004 — causality auPRC and direction Pearson."""
     joined = dataset.join(corrected, on=KEY, how="left")
-    n_null = int(joined.get_column(LFC_COL).is_null().sum())
-    assert n_null == 0, f"{name}: {n_null} dataset variants missing a corrected score"
+    # is_null = unmatched variant; is_nan = a NaN score align_score_sign preserved.
+    score = joined.get_column(LFC_COL)
+    n_bad = int((score.is_null() | score.is_nan()).sum())
+    assert n_bad == 0, f"{name}: {n_bad} dataset variants missing/NaN corrected score"
 
     scores = to_score_interface(joined, LFC_COL, LFC_COL)
     metrics = compute_qtl_split_metrics(

--- a/scripts/correct_ag_predictions.py
+++ b/scripts/correct_ag_predictions.py
@@ -1,0 +1,165 @@
+"""One-time correction of the #262 AlphaGenome DNase-LFC predictions into the dataset's
+accessibility convention (issue #311).
+
+Root cause (validated by diagnostics): AlphaGenome's raw DNase-LFC sits in a per-dataset
+accessibility *convention* that is **uniformly** flipped on dsQTL relative to the study.
+On dsQTL the raw LFC anti-correlates with the carried ChromBPNet logFC (corr ≈ −0.91,
+*uniformly* across orientation swaps); on caQTL it agrees (≈ +0.90). So it is **not** a
+per-variant orientation/swap issue — it is a single per-dataset sign convention (a
+lift-related #262 artifact). The carried ChromBPNet logFC is the validated, study-aligned
+accessibility baseline, so we align AlphaGenome's sign to it once
+(:func:`align_score_sign`, which fails loud if the correlation is ambiguous). After this,
+AlphaGenome is a positively-oriented single-signal accessibility score like every other
+model — no per-dataset flip lives anywhere downstream.
+
+Idempotent: the immutable #262 originals are backed up to ``dnase_lfc_raw/`` on first run,
+and the correction is always applied *from* that backup → re-running never double-flips.
+Verifies the corrected predictions reproduce AlphaGenome Suppl Table 4 (causality auPRC +
+direction Pearson on the AG-test slice) to ≤0.004.
+
+Run (needs AWS creds for S3; reads the canonical datasets from HuggingFace):
+
+    uv run python scripts/correct_ag_predictions.py
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import polars as pl
+
+from marin_dna.pipelines.evals.qtl_scoring import (
+    SUPPL_TABLE4_REFERENCE,
+    align_score_sign,
+    compute_qtl_split_metrics,
+    to_score_interface,
+)
+
+KEY = ["chrom", "pos", "ref", "alt"]
+LFC_COL = "alphagenome_dnase_lfc"
+ANCHOR_COL = "chrombpnet_atac_logfc"  # study-aligned carried accessibility baseline
+DATASETS = ("caqtl", "dsqtl")
+
+AG_RESULTS = "s3://oa-bolinas/snakemake/alphagenome_eval/results"
+RAW_PREFIX = f"{AG_RESULTS}/dnase_lfc_raw"  # immutable #262 originals (raw convention)
+OUT_PREFIX = f"{AG_RESULTS}/dnase_lfc"  # convention-aligned (genome-native) predictions
+
+# Canonical caQTL/dsQTL datasets (#313). Pinned to the validated build for the
+# Suppl-Table-4 reproduction check and as the ChromBPNet sign anchor.
+HF_REVISION = {
+    "caqtl": "27a24296f50ed55afdc412d1612df680d13138d6",
+    "dsqtl": "4a3bf152cd7c28be290adde48a402ec40992cb62",
+}
+# Acceptance: reproduce Suppl Table 4 to ≤0.004 at the table's precision. The binding
+# case is the caQTL AlphaGenome *direction* (0.7328 vs published 0.7368, Δ0.0040) — the
+# forward-strand-only-vs-RC-averaged gap baked into the #262 predictions; every other
+# reproduction is ≤0.0033. 0.005 gives that one boundary case float-safe headroom.
+ABS_TOL = 0.005
+
+
+def _s3_exists(path: str) -> bool:
+    try:
+        pl.read_parquet_schema(path)
+        return True
+    except Exception:
+        return False
+
+
+def load_canonical(name: str) -> pl.DataFrame:
+    """Canonical dataset (train ∪ test) from the pinned HF build, with a ``split_source``
+    tag — carries ``label``, ``effect`` and the ChromBPNet/Enformer baseline columns."""
+    rev = HF_REVISION[name]
+    parts = [
+        pl.read_parquet(
+            f"hf://datasets/bolinas-dna/evals_{name}@{rev}/{split}.parquet"
+        ).with_columns(pl.lit(split).alias("split_source"))
+        for split in ("train", "test")
+    ]
+    return pl.concat(parts)
+
+
+def correct_dataset(name: str, dataset: pl.DataFrame) -> pl.DataFrame:
+    """Back up the #262 raw predictions (once), align their sign to the carried
+    ChromBPNet logFC, and write the convention-aligned predictions. Returns them."""
+    raw_path = f"{RAW_PREFIX}/{name}.parquet"
+    out_path = f"{OUT_PREFIX}/{name}.parquet"
+
+    # Capture the immutable #262 originals on first run (dnase_lfc/ still holds them).
+    if not _s3_exists(raw_path):
+        original = pl.read_parquet(out_path)
+        assert LFC_COL in original.columns, (
+            f"{name}: {out_path} is not the raw #262 file"
+        )
+        print(
+            f"[{name}] backing up #262 originals -> {raw_path} ({original.height} rows)"
+        )
+        original.write_parquet(raw_path)
+
+    raw = pl.read_parquet(raw_path).select([*KEY, LFC_COL])
+    joined = dataset.join(raw, on=KEY, how="inner")
+    assert joined.height == dataset.height == raw.height, (
+        f"{name}: {joined.height} aligned vs dataset {dataset.height} / raw {raw.height} "
+        "— predictions must align 1:1 with the canonical dataset"
+    )
+
+    aligned, sign = align_score_sign(
+        joined.get_column(LFC_COL).to_numpy(),
+        joined.get_column(ANCHOR_COL).to_numpy(),
+    )
+    corrected = joined.select(KEY).with_columns(pl.Series(LFC_COL, aligned))
+    corrected.write_parquet(out_path)
+    print(
+        f"[{name}] sign={sign:+.0f} (aligned to {ANCHOR_COL}) -> genome-native {out_path}"
+    )
+    return corrected
+
+
+def verify_reproduction(
+    name: str, corrected: pl.DataFrame, dataset: pl.DataFrame
+) -> None:
+    """Assert the aligned AlphaGenome predictions reproduce Suppl Table 4 (AG-test slice)
+    to ≤0.004 — causality auPRC and direction Pearson."""
+    joined = dataset.join(corrected, on=KEY, how="left")
+    n_null = int(joined.get_column(LFC_COL).is_null().sum())
+    assert n_null == 0, f"{name}: {n_null} dataset variants missing a corrected score"
+
+    scores = to_score_interface(joined, LFC_COL, LFC_COL)
+    metrics = compute_qtl_split_metrics(
+        scores,
+        dataset,
+        dataset=name,
+        model="alphagenome",
+        splits=("ag_test",),
+        n_bootstrap=100,
+    )
+    row = metrics.iloc[0]
+    ref_auprc, ref_pearson = SUPPL_TABLE4_REFERENCE[name]["AlphaGenome"]
+    d_auprc = abs(row["causality_auPRC"] - ref_auprc)
+    d_pearson = abs(row["direction_pearson"] - ref_pearson)
+    print(
+        f"[{name}] AG-test  auPRC={row['causality_auPRC']:.4f} (ref {ref_auprc}, "
+        f"Δ{d_auprc:.4f})  pearson={row['direction_pearson']:.4f} (ref {ref_pearson}, "
+        f"Δ{d_pearson:.4f})"
+    )
+    assert d_auprc <= ABS_TOL, (
+        f"{name}: causality auPRC off by {d_auprc:.4f} > {ABS_TOL}"
+    )
+    assert d_pearson <= ABS_TOL, (
+        f"{name}: direction Pearson off by {d_pearson:.4f} > {ABS_TOL}"
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--datasets", nargs="+", default=list(DATASETS), choices=DATASETS)
+    args = ap.parse_args()
+
+    for name in args.datasets:
+        dataset = load_canonical(name)
+        corrected = correct_dataset(name, dataset)
+        verify_reproduction(name, corrected, dataset)
+    print("\nAll datasets aligned and reproduce AlphaGenome Suppl Table 4 to ≤0.004.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qtl_benchmark.py
+++ b/scripts/qtl_benchmark.py
@@ -1,0 +1,171 @@
+"""Model-agnostic caQTL/dsQTL official-metrics benchmark driver (issue #311).
+
+Lightweight glue over the tested library logic in
+``marin_dna.pipelines.evals.qtl_scoring`` — no logic of its own. For each dataset it:
+
+1. loads the canonical HF dataset (``train`` + ``test``, tagged ``split_source``) and
+   joins the genome-native AlphaGenome ``dnase_lfc`` predictions (corrected once by
+   ``correct_ag_predictions.py``);
+2. writes ``scores/{model}/{dataset}.parquet`` (``[chrom,pos,ref,alt,causality_score,
+   direction_score]``) for each built-in model (AlphaGenome / ChromBPNet / Enformer) —
+   the plug-in interface a future fine-tuned gLM (#243) also writes into;
+3. computes ``metrics/{model}/{dataset}.parquet`` for **every** model whose scores
+   parquet is present at the prefix (discovered by listing — adding a model is one new
+   parquet, no code change), plus the static ``metrics_reference/{dataset}.parquet``.
+
+``--reproduce`` prints the AG-test slice vs AlphaGenome Suppl Table 4 and asserts ≤0.005.
+
+Outputs live under ``s3://oa-bolinas/qtl_benchmark/`` for the dashboard (#312). Runs
+locally (small data; the bootstrap is the only cost). Run:
+
+    uv run python scripts/qtl_benchmark.py            # build everything
+    uv run python scripts/qtl_benchmark.py --reproduce
+"""
+
+from __future__ import annotations
+
+import argparse
+from urllib.parse import urlparse
+
+import boto3
+import pandas as pd
+import polars as pl
+
+from marin_dna.pipelines.evals.qtl_scoring import (
+    MODEL_SCORE_COLUMNS,
+    SUPPL_TABLE4_REFERENCE,
+    compute_qtl_split_metrics,
+    reference_metrics,
+    to_score_interface,
+)
+
+KEY = ["chrom", "pos", "ref", "alt"]
+DATASETS = ("caqtl", "dsqtl")
+REGION = "us-east-2"
+
+BENCH = "s3://oa-bolinas/qtl_benchmark"  # scores/{model}/{ds}, metrics/{model}/{ds}, metrics_reference/{ds}
+AG_DNASE_LFC = (
+    "s3://oa-bolinas/snakemake/alphagenome_eval/results/dnase_lfc"  # genome-native AG
+)
+AG_LFC_COL = "alphagenome_dnase_lfc"
+
+HF_REVISION = {
+    "caqtl": "27a24296f50ed55afdc412d1612df680d13138d6",
+    "dsqtl": "4a3bf152cd7c28be290adde48a402ec40992cb62",
+}
+
+# Map built-in model keys to their AlphaGenome Suppl Table 4 reference name (Enformer is
+# the ChromBPNet-paper baseline, not in Suppl Table 4 → no published reference).
+REPRO_REF = {"alphagenome": "AlphaGenome", "chrombpnet": "ChromBPNet"}
+REPRO_TOL = 0.005
+
+
+def _split_s3(url: str) -> tuple[str, str]:
+    p = urlparse(url)
+    return p.netloc, p.path.lstrip("/")
+
+
+def load_dataset(name: str) -> pl.DataFrame:
+    """Canonical dataset (train ∪ test, ``split_source`` tagged) + genome-native AG LFC."""
+    rev = HF_REVISION[name]
+    parts = [
+        pl.read_parquet(
+            f"hf://datasets/bolinas-dna/evals_{name}@{rev}/{split}.parquet"
+        ).with_columns(pl.lit(split).alias("split_source"))
+        for split in ("train", "test")
+    ]
+    dataset = pl.concat(parts)
+    ag = pl.read_parquet(f"{AG_DNASE_LFC}/{name}.parquet").select([*KEY, AG_LFC_COL])
+    dataset = dataset.join(ag, on=KEY, how="left")
+    n_null = int(dataset.get_column(AG_LFC_COL).is_null().sum())
+    assert n_null == 0, f"{name}: {n_null} variants missing an AlphaGenome score"
+    return dataset
+
+
+def write_model_scores(name: str, dataset: pl.DataFrame) -> None:
+    """Materialize the plug-in score parquet for each built-in model."""
+    for model, (causality_col, direction_col) in MODEL_SCORE_COLUMNS.items():
+        scores = to_score_interface(dataset, causality_col, direction_col)
+        path = f"{BENCH}/scores/{model}/{name}.parquet"
+        scores.write_parquet(path)
+        print(f"[{name}] wrote scores/{model} ({scores.height} variants)")
+
+
+def discover_models(name: str) -> list[str]:
+    """Every model with a ``scores/{model}/{name}.parquet`` at the benchmark prefix —
+    built-ins plus any externally dropped model (e.g. a fine-tuned gLM, #243)."""
+    bucket, prefix = _split_s3(f"{BENCH}/scores/")
+    s3 = boto3.client("s3", region_name=REGION)
+    resp = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, Delimiter="/")
+    models = []
+    for cp in resp.get("CommonPrefixes", []):
+        model = cp["Prefix"].rstrip("/").split("/")[-1]
+        try:
+            s3.head_object(Bucket=bucket, Key=f"{prefix}{model}/{name}.parquet")
+            models.append(model)
+        except s3.exceptions.ClientError:
+            continue  # this model has no scores for this dataset
+    return sorted(models)
+
+
+def compute_metrics(name: str, dataset: pl.DataFrame, n_bootstrap: int) -> pl.DataFrame:
+    """Compute ``metrics/{model}/{name}`` for every discovered model + the reference."""
+    rows = []
+    for model in discover_models(name):
+        scores = pl.read_parquet(f"{BENCH}/scores/{model}/{name}.parquet")
+        metrics = compute_qtl_split_metrics(
+            scores, dataset, dataset=name, model=model, n_bootstrap=n_bootstrap
+        )
+        pl.from_pandas(metrics).write_parquet(f"{BENCH}/metrics/{model}/{name}.parquet")
+        print(f"[{name}] wrote metrics/{model}")
+        rows.append(metrics)
+    pl.from_pandas(reference_metrics(name)).write_parquet(
+        f"{BENCH}/metrics_reference/{name}.parquet"
+    )
+    return pl.from_pandas(pd.concat(rows, ignore_index=True))
+
+
+def reproduce(name: str, metrics: pl.DataFrame) -> bool:
+    """Print the AG-test slice vs Suppl Table 4 for the reference models; return pass."""
+    ag = metrics.filter(pl.col("split") == "ag_test")
+    print(f"\n=== {name}: AG-test slice vs AlphaGenome Suppl Table 4 ===")
+    ok = True
+    for row in ag.iter_rows(named=True):
+        model = row["model"]
+        ref = SUPPL_TABLE4_REFERENCE[name].get(REPRO_REF.get(model, ""))
+        line = (
+            f"  {model:12s} auPRC={row['causality_auPRC']:.4f} "
+            f"pearson={row['direction_pearson']:.4f}"
+        )
+        if ref is not None:
+            d_auprc = abs(row["causality_auPRC"] - ref[0])
+            d_pearson = abs(row["direction_pearson"] - ref[1])
+            line += f"   ref {ref}  Δ=({d_auprc:.4f}, {d_pearson:.4f})"
+            ok = ok and d_auprc <= REPRO_TOL and d_pearson <= REPRO_TOL
+        print(line)
+    return ok
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--datasets", nargs="+", default=list(DATASETS), choices=DATASETS)
+    ap.add_argument("--n-bootstrap", type=int, default=1000)
+    ap.add_argument(
+        "--reproduce", action="store_true", help="assert AG-test vs Suppl Table 4"
+    )
+    args = ap.parse_args()
+
+    all_ok = True
+    for name in args.datasets:
+        dataset = load_dataset(name)
+        write_model_scores(name, dataset)
+        metrics = compute_metrics(name, dataset, args.n_bootstrap)
+        if args.reproduce:
+            all_ok = reproduce(name, metrics) and all_ok
+    if args.reproduce:
+        assert all_ok, f"reproduction exceeded ±{REPRO_TOL} vs Suppl Table 4"
+        print("\nReproduces AlphaGenome Suppl Table 4 (reference models) to ≤0.005.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qtl_benchmark.py
+++ b/scripts/qtl_benchmark.py
@@ -33,6 +33,7 @@ import polars as pl
 
 from marin_dna.pipelines.evals.qtl_scoring import (
     MODEL_SCORE_COLUMNS,
+    QTL_HF_REVISION,
     SUPPL_TABLE4_REFERENCE,
     compute_qtl_split_metrics,
     reference_metrics,
@@ -49,11 +50,6 @@ AG_DNASE_LFC = (
 )
 AG_LFC_COL = "alphagenome_dnase_lfc"
 
-HF_REVISION = {
-    "caqtl": "27a24296f50ed55afdc412d1612df680d13138d6",
-    "dsqtl": "4a3bf152cd7c28be290adde48a402ec40992cb62",
-}
-
 # Map built-in model keys to their AlphaGenome Suppl Table 4 reference name (Enformer is
 # the ChromBPNet-paper baseline, not in Suppl Table 4 → no published reference).
 REPRO_REF = {"alphagenome": "AlphaGenome", "chrombpnet": "ChromBPNet"}
@@ -67,7 +63,7 @@ def _split_s3(url: str) -> tuple[str, str]:
 
 def load_dataset(name: str) -> pl.DataFrame:
     """Canonical dataset (train ∪ test, ``split_source`` tagged) + genome-native AG LFC."""
-    rev = HF_REVISION[name]
+    rev = QTL_HF_REVISION[name]
     parts = [
         pl.read_parquet(
             f"hf://datasets/bolinas-dna/evals_{name}@{rev}/{split}.parquet"
@@ -110,8 +106,13 @@ def discover_models(name: str) -> list[str]:
 
 def compute_metrics(name: str, dataset: pl.DataFrame, n_bootstrap: int) -> pl.DataFrame:
     """Compute ``metrics/{model}/{name}`` for every discovered model + the reference."""
+    models = discover_models(name)
+    assert models, (
+        f"no models discovered under {BENCH}/scores/ for {name} — check the S3 prefix, "
+        "region, and that write_model_scores ran"
+    )
     rows = []
-    for model in discover_models(name):
+    for model in models:
         scores = pl.read_parquet(f"{BENCH}/scores/{model}/{name}.parquet")
         metrics = compute_qtl_split_metrics(
             scores, dataset, dataset=name, model=model, n_bootstrap=n_bootstrap

--- a/snakemake/alphagenome_eval/README.md
+++ b/snakemake/alphagenome_eval/README.md
@@ -1,50 +1,50 @@
-# alphagenome_eval — AlphaGenome baseline on matched-pair eval datasets
+# alphagenome_eval — AlphaGenome predictions for the eval datasets
 
-AUPRC ± cluster-bootstrap SE (cluster = `match_group`) for
-[AlphaGenome](https://github.com/google-deepmind/alphagenome) on the
-matched-pair eval datasets `bolinas-dna/evals_mendelian_traits` and
-`bolinas-dna/evals_complex_traits` (1:k matched groups, PR #194 rebuild).
-Provides issue [#154](https://github.com/Open-Athena/marin-dna/issues/154)'s
-baseline row for the leaderboards in
-[#161](https://github.com/Open-Athena/marin-dna/issues/161) and
-[#162](https://github.com/Open-Athena/marin-dna/issues/162). The metric
-mirrors `snakemake/analysis/evals_v2/`'s post-PR-#195 schema.
+Runs the [AlphaGenome](https://github.com/google-deepmind/alphagenome) API to produce
+per-variant predictions, on a small CPU node, writing to S3. Two independent paths share
+this pipeline (and its one AlphaGenome API setup):
+
+1. **Matched-group baseline** (`mendelian_traits` / `complex_traits`) — AUPRC ±
+   cluster-bootstrap SE, the AlphaGenome baseline row for the mendelian/complex
+   leaderboards ([#161](https://github.com/Open-Athena/marin-dna/issues/161) /
+   [#162](https://github.com/Open-Athena/marin-dna/issues/162)).
+2. **DNase-LFC QTL predictions** (`caqtl` / `dsqtl`) — the single GM12878-DNase LFC
+   scorer for the supervised accessibility-QTL benchmark
+   ([#311](https://github.com/Open-Athena/marin-dna/issues/311) / #309). This pipeline
+   produces only AlphaGenome's per-variant predictions; the model-agnostic **metrics and
+   leaderboard** (ChromBPNet/Enformer baselines + the official metrics) are the
+   `scripts/qtl_benchmark.py` driver, not a rule here.
 
 ## What it does
 
+### Matched-group baseline (`mendelian_traits`, `complex_traits`)
+
 For each `dataset` in `config["datasets"]`:
 
-1. **Score** every variant via the AlphaGenome API. One forward-strand call per
-   variant returns L2_DIFF_LOG1P aggregated scores across 7 assays (ATAC,
-   DNASE, CHIP_TF, CHIP_HISTONE, CAGE, PROCAP, RNA_SEQ); each assay yields
-   many tracks (one per cell type / tissue), so the per-variant output is a
-   wide row with hundreds of track columns.
-2. **Aggregate** to a single column by taking the max across all track
-   columns: `alphagenome_max_l2`. The full per-track table is preserved on S3
-   so the aggregation protocol can change later (e.g. per-assay) without
-   re-spending the API budget.
-3. **Compute** AUPRC ± cluster-bootstrap SE per consequence subset on
-   `alphagenome_max_l2`, with `match_group` as the cluster (resamples
-   groups, not rows, so SE reflects the 1:k matched structure). Same
-   column for both datasets — L2 is direction-agnostic and fits both the
-   mendelian and complex-trait protocols. Output includes per-subset
-   rows plus `_global_` (pooled) and `_macro_avg_` (mean of qualifying
-   subsets) aggregates.
+1. **Score** every variant via the AlphaGenome API — one forward-strand call returns
+   L2_DIFF_LOG1P scores across 7 assays (ATAC, DNASE, CHIP_TF, CHIP_HISTONE, CAGE,
+   PROCAP, RNA_SEQ); each assay yields many tracks (cell types / tissues), so the
+   per-variant output is a wide row with hundreds of track columns.
+2. **Aggregate** to one column by max across all tracks: `alphagenome_max_l2`. The full
+   per-track table is preserved on S3 so the aggregation can change later (e.g.
+   per-assay) without re-spending the API budget.
+3. **Compute** AUPRC ± cluster-bootstrap SE per consequence subset on `alphagenome_max_l2`,
+   with `match_group` (the 1:k matched set) as the resampling cluster. Output includes
+   per-subset rows plus `_global_` (pooled) and `_macro_avg_` aggregates.
 
-### QTL datasets (`caqtl` / `dsqtl`, `eval_protocol: qtl_global`)
+### DNase-LFC QTL predictions (`caqtl`, `dsqtl`)
 
-The DART-Eval Task-5 chromatin-accessibility QTL benchmarks (PR #214) are
-**unmatched** (no `subset` / `match_group`), so a dataset entry with
-`eval_protocol: qtl_global` skips the per-subset path: scoring and max-across-
-tracks aggregation are unchanged, but `compute_metrics` calls
-`compute_qtl_metrics` — **global AUPRC** over all variants plus **Pearson /
-Spearman** of `alphagenome_max_l2` vs the dataset's `effect_size` over
-**positive variants only**. The metrics parquet then has a `metric` column
-(`AUPRC` / `pearson` / `spearman`) and no subset rows.
+`score_dnase_lfc` scores each variant with AlphaGenome's recommended accessibility
+scorer (Suppl Table 9): `CenterMaskScorer(DNASE, width=501, DIFF_LOG2_SUM)`,
+GM12878-matched (ontology `EFO:0002784`) — one signed log2 fold-change (alt vs ref) per
+variant. The scorer is **resumable + S3-checkpointed** (`score_dnase_lfc_resumable`): it
+seeds from `dnase_lfc.s3_prefix/{ds}.parquet` and scores only missing variants.
 
-> **API budget:** the train split alone is caQTL 41,382 + dsQTL 15,018
-> variants (~56K, ~5× mendelian_traits' ~11K) — one forward-strand call each.
-> Keep `num_workers` at 4 (rate-limit ceiling); a single 4-worker run is ~4 h.
+> **caQTL/dsQTL spend 0 API.** Their genome-native predictions already exist (the #262
+> run, corrected once into the dataset's sign convention by
+> `scripts/correct_ag_predictions.py`), so the rule seeds them and makes no API calls
+> (`max_new_calls: 0` is a fail-loud guard). Raise `max_new_calls` only to score a
+> genuinely new dataset.
 
 ## Outputs
 
@@ -52,84 +52,72 @@ S3 bucket `s3://oa-bolinas/snakemake/alphagenome_eval/`:
 
 ```
 results/
-├── per_track_l2/{dataset}.parquet    # variant cols + per-track L2 columns
-├── scores/{dataset}.parquet          # variant cols + alphagenome_max_l2
-└── metrics/{dataset}.parquet         # AUPRC ± cluster-bootstrap SE per subset
+├── per_track_l2/{dataset}.parquet   # matched-group: variant cols + per-track L2
+├── scores/{dataset}.parquet         # matched-group: variant cols + alphagenome_max_l2
+├── metrics/{dataset}.parquet         # matched-group: AUPRC ± cluster-bootstrap SE
+├── dnase_lfc/{ds}.parquet            # caqtl/dsqtl: genome-native GM12878-DNase LFC
+└── dnase_lfc_raw/{ds}.parquet        # caqtl/dsqtl: raw #262 originals (pre sign-alignment)
 ```
+
+The supervised-benchmark `scores/{model}/{ds}` and `metrics/{model}/{ds}` parquets live
+under a separate prefix, `s3://oa-bolinas/qtl_benchmark/`, written by
+`scripts/qtl_benchmark.py`.
 
 ## Conventions
 
-- **Train split only.** Test is held out for the final-eval pass.
-- **No reverse-complement averaging.** TraitGym's reference pipeline averages
-  forward + reverse strand calls. We skip the RC pass to halve the API budget;
-  the metric loss has been small in practice.
-- **No edge filtering.** The 1MB sequence context wraps near chromosome ends;
-  AlphaGenome handles this internally.
-- **Retries transient `INTERNAL` errors.** AlphaGenome's backend intermittently
-  returns `StatusCode.INTERNAL` ("bad machine" outages — a known, maintainer-
-  acknowledged server-side issue). The SDK's built-in `@retry_rpc` only retries
-  `RESOURCE_EXHAUSTED` / `UNAVAILABLE`, so `score_variants_alphagenome` re-wraps
-  `score_variant` to also retry `INTERNAL` / `DEADLINE_EXCEEDED` (10 attempts,
-  exponential backoff). Without this a single bad-machine hit aborts the whole
-  dataset; large runs (the ~41k-variant caQTL set) effectively require it.
+- **Matched-group: train split only.** Test is held out for the final-eval pass.
+- **No reverse-complement averaging.** TraitGym's reference averages forward + reverse
+  strand; we score forward only to halve the API budget (metric loss is small — it is
+  the ~0.004 gap on the caQTL AlphaGenome *direction* reproduction).
+- **DNase-LFC sign convention.** AlphaGenome's raw DNase-LFC is uniformly sign-flipped on
+  dsQTL relative to the study (a lift artifact of the #262 run). The genome-native
+  predictions are aligned once to the carried ChromBPNet baseline by
+  `scripts/correct_ag_predictions.py`; downstream there is no per-dataset flip.
+- **Retries transient `INTERNAL` errors.** AlphaGenome's backend intermittently returns
+  `StatusCode.INTERNAL` ("bad machine" outages). The SDK's `@retry_rpc` only retries
+  `RESOURCE_EXHAUSTED` / `UNAVAILABLE`, so the scorers re-wrap `score_variant` to also
+  retry `INTERNAL` / `DEADLINE_EXCEEDED` (10 attempts, exponential backoff). A single
+  un-retried bad-machine hit would otherwise abort a whole dataset.
 
 ## Setup
 
 `ALPHA_GENOME_API_KEY` env var (request one at
-[deepmind.google/alphagenome](https://deepmind.google/science/alphagenome)).
-Recommended: export it in `~/.bashrc` so every shell — including the one you
-launch SkyPilot from — has it set.
+[deepmind.google/alphagenome](https://deepmind.google/science/alphagenome)). Export it in
+`~/.bashrc` so every shell — including the one you launch SkyPilot from — has it set.
 
-```bash
-# In ~/.bashrc:
-export ALPHA_GENOME_API_KEY=...
-```
-
-The pipeline reads it from the env at the start of `compute_per_track_l2`;
-SkyPilot inherits it via the `envs:` block in `sky/run.yaml`.
-
-The official Google `alphagenome` Python client is in the optional
-`alphagenome-eval` dep group:
+The official Google `alphagenome` client is in the optional `alphagenome-eval` dep group:
 
 ```bash
 uv sync --group alphagenome-eval
 ```
 
-(SkyPilot's `setup:` does this automatically.)
+(SkyPilot's `setup:` does this automatically.) caQTL/dsQTL reuse the cached predictions,
+so a run that only refreshes `dnase_lfc` makes no API calls.
 
 ## Usage
 
 ### SkyPilot (recommended)
 
 ```bash
-# Once per session (or persisted in ~/.bashrc):
 export ALPHA_GENOME_API_KEY=...
-
 sky launch snakemake/alphagenome_eval/sky/run.yaml -c alphagenome-eval \
     --env ALPHA_GENOME_API_KEY
 ```
 
-The launch yaml provisions a small CPU EC2 node (`m6i.xlarge`-class — 16 GB
-to leave headroom for the per-variant API responses, us-east-2), runs the
-full pipeline (~2-3 h end-to-end), and writes outputs to S3. Tear down with
-`sky down alphagenome-eval`.
+Provisions a small CPU node (us-east-2), runs the full pipeline, writes to S3. Tear down
+with `sky down alphagenome-eval`.
 
-> **Re-running an existing dataset:** if the rule code or library changes,
-> Snakemake's provenance check will re-trigger `compute_per_track_l2` and
-> burn the API budget again. If the change is known to produce identical
-> outputs, skip the rerun with `snakemake --cleanup-metadata results/per_track_l2/{dataset}.parquet`.
+> **Re-running matched-group scoring:** a rule-code or library change re-triggers
+> `compute_per_track_l2` and burns the API budget again. If the change is known to
+> produce identical outputs, skip with
+> `snakemake --cleanup-metadata results/per_track_l2/{dataset}.parquet`.
 
-### Local (small subsets only)
+### Local
 
 ```bash
 cd snakemake/alphagenome_eval
-
-# Dry-run to inspect the DAG.
-uv run snakemake -n
-
-# Real run — will hit the AlphaGenome API for ~12K variants if you don't
-# subsample first; only do this if you mean to pay the wallclock.
-uv run snakemake
+uv run snakemake -n          # dry-run; confirm score_dnase_lfc is NOT scheduled to score
+uv run snakemake             # caqtl/dsqtl: 0 API; matched-group: ~11K+ API calls each
 ```
 
 ## Configuration (`config/config.yaml`)
@@ -137,27 +125,26 @@ uv run snakemake
 | Key | Purpose |
 | --- | --- |
 | `input_hf_prefix` | HF prefix for `f"{prefix}_{dataset}"`. |
-| `split` | `train` (test held out). |
-| `datasets` | List of `{name, hf_revision, [eval_protocol]}` entries. The SHA pins the HF commit consumed; bumping it forces a re-run via snakemake's `params:` hash (re-spends API budget). SHAs mirror `snakemake/analysis/evals_v2/config/config.yaml`. Optional `eval_protocol` ∈ `{matched_pair (default), qtl_global}` — `qtl_global` selects the global AUPRC + positives-only `effect_size` correlation path for caqtl/dsqtl. |
-| `num_workers` | Threads in the API ThreadPoolExecutor. Keep ≤ 4. |
-| `score_column` | Column name written by `aggregate_max` and consumed by `compute_metrics`. |
-| `n_bootstrap` | AUPRC cluster-bootstrap iterations per subset. |
-| `bootstrap_seed` | RNG seed for the bootstrap; bumping it re-triggers `compute_metrics`. |
+| `split` | Matched-group split (`train`; test held out). |
+| `datasets` | Matched-group `{name, hf_revision}` entries (mendelian/complex). The SHA pins the HF commit; bumping it re-runs scoring (re-spends API). |
+| `num_workers` | API ThreadPoolExecutor threads. Keep ≤ 4. |
+| `score_column` | Column written by `aggregate_max`, read by `compute_metrics`. |
+| `n_bootstrap` / `bootstrap_seed` | Matched-group AUPRC cluster-bootstrap. |
+| `subset_n_pairs` | Smoke knob: keep only the first N match groups (null in production). |
+| `dnase_lfc` | `{s3_prefix, datasets:[{name,hf_revision}], num_workers, chunk_size, max_new_calls}` for the caqtl/dsqtl DNase-LFC predictions. `max_new_calls: 0` ⇒ reuse-only (fail loud if the cache is incomplete). |
 
-The 7 assays, the 1MB sequence length, and `L2_DIFF_LOG1P` aggregation type
-are **code constants** in `marin_dna.evals.alphagenome`, not config.
+The 7 assays, the 1MB sequence length, and the aggregation types are **code constants**
+in `marin_dna.pipelines.evals.alphagenome`, not config.
 
 ## Library
 
-Pipeline rules are thin glue around `marin_dna.evals.alphagenome`:
+Rules are thin glue around `marin_dna.pipelines.evals.alphagenome`:
 
-- `score_variants_alphagenome(V, num_workers=4)` — main entry; threads through
-  forward-strand `model.score_variant` calls and returns a wide DataFrame.
-- `parse_score_response(tidy, scorer_repr_to_assay)` — pure helper converting
-  AlphaGenome's `tidy_scores` long-format output to a 1-row wide DataFrame
-  with `{assay}_{idx}` column names.
-- `make_scorers()` — the 7 `CenterMaskScorer(width=None, L2_DIFF_LOG1P)`
-  scorers and their reverse map.
+- `score_variants_alphagenome(V, num_workers=4)` — matched-group 7-assay L2 scorer.
+- `score_variants_dnase_lfc(V, num_workers=4)` / `make_dnase_lfc_scorer` /
+  `select_gm12878_dnase_lfc` — the single GM12878-DNase LFC scorer.
+- `score_dnase_lfc_resumable(variants, checkpoint_path, …)` — resumable, S3-checkpointed
+  DNase-LFC scoring (seed + score-missing + checkpoint, with a `max_new_calls` cap).
 
-Tests at `tests/evals/test_alphagenome.py` cover the parser without touching
-the API; the scorer-construction test is gated on `import alphagenome`.
+Tests at `tests/pipelines/evals/test_alphagenome.py` cover the parsers + the resumable
+scorer without touching the API (the scorer-construction tests are import-gated).

--- a/snakemake/alphagenome_eval/config/config.yaml
+++ b/snakemake/alphagenome_eval/config/config.yaml
@@ -1,39 +1,49 @@
 input_hf_prefix: bolinas-dna/evals
 split: train
 
+# Matched-group AlphaGenome baseline (mendelian / complex traits): per-track
+# L2_DIFF_LOG1P → max across tracks → AUPRC ± cluster-bootstrap SE (cluster =
+# `match_group`, the 1:k matched set). Provides the AlphaGenome baseline row for the
+# mendelian/complex leaderboards. SHAs mirror
+# snakemake/analysis/evals_v2 (PR #194 k=9 rebuild); bumping one re-triggers
+# `compute_per_track_l2` via snakemake's `params:` hash (re-spends API budget).
 datasets:
-  # Per-dataset `hf_revision` pins the HF dataset commit consumed by
-  # this run. Bumping the SHA triggers re-execution via snakemake's
-  # `params:` hash. SHAs mirror evals_v2's pins (PR #194 k=9 rebuild).
   - name: mendelian_traits
     hf_revision: 4aed58e50c5dea0b878a665007af2ef9e5108e9f
   - name: complex_traits
     hf_revision: 22f86a89c65cb8f3007ac3cc2739f40efefa4340
-  # DART-Eval QTL benchmarks (PR #214). `qtl_global` → no subset/match_group;
-  # global AUPRC + Pearson/Spearman of alphagenome_max_l2 vs `effect_size`
-  # over positives only.
-  - name: caqtl
-    hf_revision: 9d004a21812c067b9ba1ebfe72f51b9095a5d0f8
-    eval_protocol: qtl_global
-  - name: dsqtl
-    hf_revision: b7e02a07beb831c7047286aacd3ddfd299d6f88f
-    eval_protocol: qtl_global
 
 # AlphaGenome rate-limits — keep workers low (4 has been a safe ceiling).
 num_workers: 4
 
 # Single column written by `aggregate_max` and consumed by `compute_metrics`.
-# Direction-agnostic by construction (max over per-track L2 of delta-log1p)
-# — same column works for both mendelian (pathogenic > common) and complex
-# (magnitude) datasets, so no per-dataset score_protocol fan-out.
+# Direction-agnostic (max over per-track L2 of delta-log1p) — same column works
+# for both mendelian (pathogenic > common) and complex (magnitude) datasets.
 score_column: alphagenome_max_l2
 
-# AUPRC cluster-bootstrap params (cluster = `match_group`), mirroring
-# evals_v2. Bumping `bootstrap_seed` re-triggers `compute_metrics` via
-# snakemake's `params:` hash.
+# AUPRC cluster-bootstrap params (cluster = `match_group`). Bumping `bootstrap_seed`
+# re-triggers `compute_metrics` via snakemake's `params:` hash.
 n_bootstrap: 1000
 bootstrap_seed: 0
 
 # Smoke-test knob: keep only the first N matched groups. Override via
 # `--config subset_n_pairs=5`. Leave null in production runs.
 subset_n_pairs: null
+
+# DNase-LFC QTL predictions (caqtl/dsqtl) for the supervised official-metrics
+# benchmark (#311). This produces only AlphaGenome's per-variant predictions — the
+# model-agnostic metrics/leaderboard are the `scripts/qtl_benchmark.py` driver.
+# `score_dnase_lfc` is resumable and seeds from `s3_prefix/{ds}.parquet`; for
+# caqtl/dsqtl those genome-native predictions already exist (corrected once by
+# `scripts/correct_ag_predictions.py`) so it spends 0 API. `max_new_calls` is a
+# fail-loud cap — raise it only to score a genuinely new dataset.
+dnase_lfc:
+  s3_prefix: s3://oa-bolinas/snakemake/alphagenome_eval/results/dnase_lfc
+  datasets:
+    - name: caqtl
+      hf_revision: 27a24296f50ed55afdc412d1612df680d13138d6
+    - name: dsqtl
+      hf_revision: 4a3bf152cd7c28be290adde48a402ec40992cb62
+  num_workers: 4
+  chunk_size: 500
+  max_new_calls: 0

--- a/snakemake/alphagenome_eval/config/config.yaml
+++ b/snakemake/alphagenome_eval/config/config.yaml
@@ -39,6 +39,8 @@ subset_n_pairs: null
 # fail-loud cap — raise it only to score a genuinely new dataset.
 dnase_lfc:
   s3_prefix: s3://oa-bolinas/snakemake/alphagenome_eval/results/dnase_lfc
+  # hf_revision must match marin_dna.pipelines.evals.qtl_scoring.QTL_HF_REVISION (the
+  # benchmark scripts' single source) — snakemake reads YAML and can't import it.
   datasets:
     - name: caqtl
       hf_revision: 27a24296f50ed55afdc412d1612df680d13138d6

--- a/snakemake/alphagenome_eval/workflow/Snakefile
+++ b/snakemake/alphagenome_eval/workflow/Snakefile
@@ -1,7 +1,8 @@
-"""Snakemake workflow: AlphaGenome baseline on matched-pair eval datasets.
+"""Snakemake workflow: AlphaGenome predictions for the eval datasets.
 
-Per-track L2_DIFF_LOG1P scores via the AlphaGenome API → max across tracks
-→ PairwiseAccuracy ± SE per consequence subset. Train split only.
+Two independent paths (see rules/common.smk):
+- matched-group baseline (mendelian/complex): per-track L2 → max → AUPRC ± SE.
+- DNase-LFC QTL predictions (caqtl/dsqtl) for the #311 supervised benchmark.
 """
 
 
@@ -11,11 +12,10 @@ configfile: "config/config.yaml"
 include: "rules/common.smk"
 include: "rules/score.smk"
 include: "rules/metrics.smk"
+include: "rules/dnase_lfc.smk"
 
 
 rule all:
     input:
-        expand(
-            "results/metrics/{dataset}.parquet",
-            dataset=DATASETS,
-        ),
+        expand("results/metrics/{dataset}.parquet", dataset=DATASETS),
+        expand("results/dnase_lfc/{ds}.parquet", ds=DNASE_LFC_DATASETS),

--- a/snakemake/alphagenome_eval/workflow/rules/common.smk
+++ b/snakemake/alphagenome_eval/workflow/rules/common.smk
@@ -1,22 +1,23 @@
-"""Common imports + helpers for alphagenome_eval rules."""
+"""Common imports + helpers for alphagenome_eval rules.
 
-import os
+Two independent paths share this pipeline (and its AlphaGenome API setup):
+
+- **Matched-group baseline** (`datasets`: mendelian/complex) — per-track L2 → max →
+  AUPRC ± cluster-bootstrap SE (cluster = `match_group`, the 1:k matched set). Rules:
+  `compute_per_track_l2`, `aggregate_max`,
+  `compute_metrics` (`score.smk` / `metrics.smk`).
+- **DNase-LFC QTL predictions** (`dnase_lfc.datasets`: caqtl/dsqtl) — the single
+  GM12878-DNase LFC scorer for the supervised official-metrics benchmark (#311). Rule:
+  `score_dnase_lfc` (`dnase_lfc.smk`). The benchmark *metrics* are not here — they are
+  the model-agnostic `scripts/qtl_benchmark.py` driver.
+"""
 
 import pandas as pd
 from datasets import load_dataset
 
 from marin_dna.pipelines.evals.alphagenome import score_variants_alphagenome
-from marin_dna.pipelines.evals.conservation import (
-    QTL_VARIANT_COLUMNS,
-    REQUIRED_VARIANT_COLUMNS,
-)
-from marin_dna.pipelines.evals.metrics import compute_auprc_metrics, compute_qtl_metrics
-
-# Per-dataset eval protocol — see snakemake/analysis/evals_v2 common.smk.
-# `matched_pair` (default) → per-subset AUPRC + cluster bootstrap.
-# `qtl_global` → global AUPRC + positives-only effect_size correlation on the
-# unmatched DART-Eval QTL datasets (caqtl/dsqtl).
-EVAL_PROTOCOLS = ("matched_pair", "qtl_global")
+from marin_dna.pipelines.evals.conservation import REQUIRED_VARIANT_COLUMNS
+from marin_dna.pipelines.evals.metrics import compute_auprc_metrics
 
 
 def get_dataset_config(name):
@@ -26,26 +27,19 @@ def get_dataset_config(name):
     raise ValueError(f"dataset {name!r} not found in config")
 
 
-def get_dataset_protocol(name):
-    """Eval protocol for a dataset (default `matched_pair`)."""
-    return get_dataset_config(name).get("eval_protocol", "matched_pair")
-
-
-def get_dataset_variant_columns(name):
-    """Required variant columns for a dataset, keyed by eval protocol."""
-    return (
-        QTL_VARIANT_COLUMNS
-        if get_dataset_protocol(name) == "qtl_global"
-        else REQUIRED_VARIANT_COLUMNS
-    )
-
-
+# Matched-group datasets. Pinned in a `wildcard_constraints` on every matched-group
+# rule so its `{dataset}` wildcard can't match the DNase-LFC `{ds}` paths.
 DATASETS = [d["name"] for d in config["datasets"]]
+MATCHED_CONSTRAINT = "|".join(DATASETS)
 
-# Fail fast on an unknown eval_protocol (typo) at parse time.
-for _d in config["datasets"]:
-    _ep = _d.get("eval_protocol", "matched_pair")
-    assert _ep in EVAL_PROTOCOLS, (
-        f"dataset {_d['name']!r} `eval_protocol` must be one of "
-        f"{sorted(EVAL_PROTOCOLS)}, got {_ep!r}"
-    )
+# DNase-LFC QTL prediction datasets (#311).
+DNASE_LFC = config["dnase_lfc"]
+DNASE_LFC_DATASETS = [d["name"] for d in DNASE_LFC["datasets"]]
+DNASE_LFC_CONSTRAINT = "|".join(DNASE_LFC_DATASETS)
+
+
+def get_dnase_lfc_revision(name):
+    for d in DNASE_LFC["datasets"]:
+        if d["name"] == name:
+            return d["hf_revision"]
+    raise ValueError(f"dnase_lfc dataset {name!r} not found in config")

--- a/snakemake/alphagenome_eval/workflow/rules/dnase_lfc.smk
+++ b/snakemake/alphagenome_eval/workflow/rules/dnase_lfc.smk
@@ -1,0 +1,55 @@
+"""AlphaGenome GM12878-DNase LFC predictions for the supervised caQTL/dsQTL
+benchmark (#311).
+
+The recommended accessibility scorer (Suppl Table 9): `CenterMaskScorer(DNASE,
+width=501, DIFF_LOG2_SUM)`, GM12878-matched — one signed log2 fold-change per variant.
+Resumable + S3-checkpointed (`score_dnase_lfc_resumable`): it seeds from
+`dnase_lfc.s3_prefix/{ds}.parquet` and scores only missing variants, so for caqtl/dsqtl —
+whose genome-native predictions already exist (corrected once by
+`scripts/correct_ag_predictions.py`) — it spends **0 API** (guarded by `max_new_calls`).
+
+This rule produces only AlphaGenome's per-variant predictions. The model-agnostic
+benchmark *metrics* (ChromBPNet/Enformer carried scores + the shared official metrics +
+the leaderboard) are the `scripts/qtl_benchmark.py` driver.
+"""
+
+import polars as pl
+
+from marin_dna.pipelines.evals.alphagenome import score_dnase_lfc_resumable
+
+
+rule score_dnase_lfc:
+    output:
+        "results/dnase_lfc/{ds}.parquet",
+    wildcard_constraints:
+        ds=DNASE_LFC_CONSTRAINT,
+    threads: DNASE_LFC["num_workers"]
+    params:
+        hf_path=lambda wc: f"{config['input_hf_prefix']}_{wc.ds}",
+        hf_revision=lambda wc: get_dnase_lfc_revision(wc.ds),
+        # Resumable checkpoint == the canonical S3 artifact (seed + output location).
+        checkpoint=lambda wc: f"{DNASE_LFC['s3_prefix']}/{wc.ds}.parquet",
+    run:
+        # Canonical genome-oriented variants = train ∪ test of the pinned HF build.
+        variants = pl.concat(
+            [
+                pl.from_pandas(
+                    load_dataset(
+                        params.hf_path, split=split, revision=params.hf_revision
+                    ).to_pandas()
+                ).select(["chrom", "pos", "ref", "alt"])
+                for split in ("train", "test")
+            ]
+        )
+        out = score_dnase_lfc_resumable(
+            variants,
+            params.checkpoint,
+            num_workers=DNASE_LFC["num_workers"],
+            chunk_size=DNASE_LFC["chunk_size"],
+            max_new_calls=DNASE_LFC["max_new_calls"],
+        )
+        out.write_parquet(output[0])
+        print(
+            f"[alphagenome_eval] dnase_lfc {wildcards.ds}: {out.height} variants "
+            f"(genome-native GM12878-DNase LFC)"
+        )

--- a/snakemake/alphagenome_eval/workflow/rules/metrics.smk
+++ b/snakemake/alphagenome_eval/workflow/rules/metrics.smk
@@ -1,16 +1,10 @@
-"""AUPRC + cluster-bootstrap SE per (dataset).
+"""AUPRC + cluster-bootstrap SE per matched-group dataset.
 
-Cluster = `match_group`; resamples groups (not rows) so the SE accounts
-for the 1:k matched structure. Output schema mirrors
+Cluster = `match_group`; resamples groups (not rows) so the SE accounts for the 1:k
+matched structure. Output schema mirrors
 `marin_dna.pipelines.evals.metrics.compute_auprc_metrics`:
-`[score_type, subset, value, se, n_groups, n_rows]` plus `_global_` and
-`_macro_avg_` aggregate rows per score_type.
-
-For `eval_protocol: qtl_global` datasets (caqtl/dsqtl) the unmatched path
-runs instead via `compute_qtl_metrics`: one row per (metric × score_type),
-metric ∈ {AUPRC, pearson, spearman} — global AUPRC + Pearson/Spearman of
-`alphagenome_max_l2` vs `effect_size` over positives only (a `metric`
-column, no subset rows).
+`[score_type, subset, value, se, n_groups, n_rows]` plus `_global_` and `_macro_avg_`
+aggregate rows per score_type.
 """
 
 
@@ -20,40 +14,29 @@ rule compute_metrics:
     output:
         "results/metrics/{dataset}.parquet",
     wildcard_constraints:
-        dataset="|".join(DATASETS),
+        dataset=MATCHED_CONSTRAINT,
     params:
         n_bootstrap=config["n_bootstrap"],
         bootstrap_seed=config["bootstrap_seed"],
     run:
         score_col = config["score_column"]
         df = pd.read_parquet(input[0])
-        eval_protocol = get_dataset_protocol(wildcards.dataset)
-        for col in get_dataset_variant_columns(wildcards.dataset):
+        for col in REQUIRED_VARIANT_COLUMNS:
             assert col in df.columns, f"scores parquet missing column {col!r}"
         assert (
             score_col in df.columns
         ), f"scores parquet missing score column {score_col!r}"
 
-        if eval_protocol == "qtl_global":
-            metrics = compute_qtl_metrics(
-                dataset=df[["label", "effect_size"]],
-                scores=df[[score_col]],
-                score_columns=[score_col],
-                n_bootstrap=params.n_bootstrap,
-                rng=params.bootstrap_seed,
-            )
-        else:
-            metrics = compute_auprc_metrics(
-                dataset=df[list(REQUIRED_VARIANT_COLUMNS)],
-                scores=df[[score_col]],
-                score_columns=[score_col],
-                n_bootstrap=params.n_bootstrap,
-                rng=params.bootstrap_seed,
-            )
+        metrics = compute_auprc_metrics(
+            dataset=df[list(REQUIRED_VARIANT_COLUMNS)],
+            scores=df[[score_col]],
+            score_columns=[score_col],
+            n_bootstrap=params.n_bootstrap,
+            rng=params.bootstrap_seed,
+        )
         metrics["dataset"] = wildcards.dataset
         metrics["split"] = config["split"]
         metrics.to_parquet(output[0], index=False)
         print(
-            f"[alphagenome_eval] {wildcards.dataset} ({eval_protocol}): "
-            f"{len(metrics)} metric rows"
+            f"[alphagenome_eval] {wildcards.dataset}: {len(metrics)} metric rows"
         )

--- a/snakemake/alphagenome_eval/workflow/rules/score.smk
+++ b/snakemake/alphagenome_eval/workflow/rules/score.smk
@@ -1,8 +1,7 @@
-"""AlphaGenome scoring + per-track aggregation.
+"""AlphaGenome scoring + per-track aggregation (matched-group baseline).
 
-Two rules so the per-track parquet is preserved on S3 — a future change to
-the aggregation protocol (e.g. per-assay) won't have to re-spend the API
-budget.
+Two rules so the per-track parquet is preserved on S3 — a future change to the
+aggregation protocol (e.g. per-assay) won't have to re-spend the API budget.
 """
 
 
@@ -10,29 +9,24 @@ rule compute_per_track_l2:
     output:
         "results/per_track_l2/{dataset}.parquet",
     wildcard_constraints:
-        dataset="|".join(DATASETS),
+        dataset=MATCHED_CONSTRAINT,
     threads: config["num_workers"]
     params:
-        # Pin the HF dataset commit. Bumping it triggers rerun via the
-        # `params:` hash. `load_dataset(revision=…)` raises
-        # `RevisionNotFoundError` on an unknown SHA — no silent fallback
-        # to `main`.
+        # Pin the HF dataset commit. Bumping it triggers rerun via the `params:`
+        # hash. `load_dataset(revision=…)` raises `RevisionNotFoundError` on an
+        # unknown SHA — no silent fallback to `main`.
         hf_path=lambda wc: f"{config['input_hf_prefix']}_{wc.dataset}",
         hf_revision=lambda wc: get_dataset_config(wc.dataset)["hf_revision"],
     run:
         ds = load_dataset(
             params.hf_path, split=config["split"], revision=params.hf_revision
         ).to_pandas()
-        # qtl_global datasets (caqtl/dsqtl) carry effect_size, no
-        # subset/match_group.
-        variant_cols = get_dataset_variant_columns(wildcards.dataset)
-        for col in variant_cols:
+        for col in REQUIRED_VARIANT_COLUMNS:
             assert col in ds.columns, f"dataset missing column {col!r}"
 
-        # subset_n_pairs is a matched-pair smoke knob (slices on match_group);
-        # QTL datasets have none, so it's ignored for them (null in production).
+        # subset_n_pairs is a smoke knob: keep only the first N matched groups.
         n_pairs = config.get("subset_n_pairs")
-        if n_pairs is not None and get_dataset_protocol(wildcards.dataset) == "matched_pair":
+        if n_pairs is not None:
             keep = ds["match_group"].drop_duplicates().head(int(n_pairs))
             ds = ds[ds["match_group"].isin(keep)].reset_index(drop=True)
             print(
@@ -47,7 +41,7 @@ rule compute_per_track_l2:
 
         out = pd.concat(
             [
-                ds[list(variant_cols)].reset_index(drop=True),
+                ds[list(REQUIRED_VARIANT_COLUMNS)].reset_index(drop=True),
                 per_track.reset_index(drop=True),
             ],
             axis=1,
@@ -65,17 +59,14 @@ rule aggregate_max:
     output:
         "results/scores/{dataset}.parquet",
     wildcard_constraints:
-        dataset="|".join(DATASETS),
+        dataset=MATCHED_CONSTRAINT,
     run:
         score_col = config["score_column"]
         df = pd.read_parquet(input[0])
-        # Exclude the variant columns (which for QTL datasets include
-        # effect_size) so only the real per-track L2 columns are max-reduced.
-        variant_cols = get_dataset_variant_columns(wildcards.dataset)
-        track_cols = [c for c in df.columns if c not in variant_cols]
+        track_cols = [c for c in df.columns if c not in REQUIRED_VARIANT_COLUMNS]
         assert track_cols, "no per-track columns found in input parquet"
 
-        out = df[list(variant_cols)].copy()
+        out = df[list(REQUIRED_VARIANT_COLUMNS)].copy()
         out[score_col] = df[track_cols].max(axis=1)
         assert (
             out[score_col].notna().all()

--- a/src/marin_dna/pipelines/evals/alphagenome.py
+++ b/src/marin_dna/pipelines/evals/alphagenome.py
@@ -429,6 +429,9 @@ def score_dnase_lfc_resumable(
         cached.write_parquet(checkpoint_path)
 
     out = work.join(cached, on=key, how="left")
-    n_null = int(out.get_column(_DNASE_LFC_COL).is_null().sum())
-    assert n_null == 0, f"{n_null} variants unscored after resumable run"
+    # is_null catches variants the join didn't cover; is_nan catches a variant the scorer
+    # returned NaN for (polars treats NaN as a non-null float, so is_null alone misses it).
+    scored = out.get_column(_DNASE_LFC_COL)
+    n_bad = int((scored.is_null() | scored.is_nan()).sum())
+    assert n_bad == 0, f"{n_bad} variants unscored or NaN after resumable run"
     return out

--- a/src/marin_dna/pipelines/evals/alphagenome.py
+++ b/src/marin_dna/pipelines/evals/alphagenome.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import concurrent.futures
 import os
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
+import polars as pl
 from tqdm.auto import tqdm
 
 if TYPE_CHECKING:
@@ -213,3 +215,220 @@ def score_variants_alphagenome(
             buf[i] = arr
 
     return pd.DataFrame(buf, columns=columns)
+
+
+# --- Chromatin-accessibility QTL path (caQTL/dsQTL, issues #262/#311) ------------
+# AlphaGenome's recommended accessibility variant scorer (Suppl Table 9): a single
+# center-mask, width=501, DIFF_LOG2_SUM (= signed log2 fold-change) on the DNASE
+# output, cell-type-matched to GM12878. Deliberately separate from the 7-assay
+# L2_DIFF_LOG1P matched-pair path above — different scorer, aggregation, single track.
+
+# GM12878's Experimental Factor Ontology cell-line CURIE (AlphaGenome track metadata;
+# confirmed against the paper's SPI1-in-GM12878 = EFO:0002784).
+GM12878_ONTOLOGY_CURIE: str = "EFO:0002784"
+DNASE_LFC_MASK_WIDTH: int = 501
+
+
+def make_dnase_lfc_scorer() -> "_vs.CenterMaskScorer":
+    """The GM12878-DNase accessibility scorer for QTLs.
+
+    ``CenterMaskScorer(DNASE, width=501, DIFF_LOG2_SUM)`` — returns a signed log2
+    fold-change (alt vs ref) of summed DNase coverage in the 501 bp window centered
+    on the variant. A single API call returns this for *all* DNASE tracks (one per
+    cell type); :func:`select_gm12878_dnase_lfc` picks GM12878.
+    """
+    from alphagenome.models import dna_client, variant_scorers
+
+    return variant_scorers.CenterMaskScorer(
+        requested_output=dna_client.OutputType.DNASE,
+        width=DNASE_LFC_MASK_WIDTH,
+        aggregation_type=variant_scorers.AggregationType.DIFF_LOG2_SUM,
+    )
+
+
+def select_gm12878_dnase_lfc(tidy: pd.DataFrame) -> float:
+    """Signed GM12878-DNase LFC from a single-variant ``tidy_scores`` frame.
+
+    The DNase scorer returns every DNASE track (one per cell type); we keep the
+    GM12878 cell line (``output_type == "DNASE"`` and ``ontology_curie ==
+    "EFO:0002784"``) and return the mean ``raw_score`` over the matched track(s) —
+    there is exactly one GM12878 DNase track today, but a mean is robust if
+    AlphaGenome adds replicates. Asserts at least one match so a metadata-schema
+    change fails loud rather than silently returning NaN.
+    """
+    needed = {"output_type", "ontology_curie", "raw_score"}
+    assert needed <= set(tidy.columns), (
+        f"tidy_scores missing {needed - set(tidy.columns)}; got {tidy.columns.tolist()}"
+    )
+    sel = tidy[
+        (tidy["output_type"] == "DNASE")
+        & (tidy["ontology_curie"] == GM12878_ONTOLOGY_CURIE)
+    ]
+    assert len(sel) >= 1, (
+        f"no GM12878 DNase track (ontology {GM12878_ONTOLOGY_CURIE}) in tidy_scores; "
+        f"available DNASE ontologies e.g. "
+        f"{tidy.loc[tidy['output_type'] == 'DNASE', 'ontology_curie'].head(3).tolist()}"
+    )
+    return float(sel["raw_score"].mean())
+
+
+def score_variants_dnase_lfc(
+    V: pd.DataFrame,
+    num_workers: int = 4,
+    api_key: str | None = None,
+) -> np.ndarray:
+    """Per-variant signed GM12878-DNase log2 fold-change (alt vs ref).
+
+    Same forward-strand, per-variant, retry-wrapped threading as
+    :func:`score_variants_alphagenome`, but with the single DNase-LFC scorer and
+    GM12878-track selection. ``V`` needs ``chrom, pos, ref, alt`` (``pos`` 1-based,
+    ``chrom`` unprefixed). Returns a float array aligned to ``V``'s row order (the
+    signed LFC; correlate against the signed study effect for direction, ``|·|`` for
+    causality).
+
+    Genome-orient ``ref``/``alt`` before scoring (e.g. via the #310 dataset build):
+    AlphaGenome computes ``log2(alt/ref)`` for the alleles you pass, so passing
+    genome-oriented alleles yields a genome-frame signed LFC directly — no
+    downstream sign flip.
+    """
+    import grpc
+    from alphagenome.data import genome
+    from alphagenome.models import dna_client, variant_scorers
+
+    if api_key is None:
+        api_key = os.environ.get("ALPHA_GENOME_API_KEY")
+    assert api_key, "ALPHA_GENOME_API_KEY not set; pass api_key= or export the env var"
+    missing = {"chrom", "pos", "ref", "alt"} - set(V.columns)
+    assert not missing, f"V missing required columns: {missing}"
+
+    model = dna_client.create(api_key)
+    score_variant_with_retry = dna_client.retry_rpc(
+        model.score_variant,
+        max_attempts=SCORE_VARIANT_MAX_ATTEMPTS,
+        retry_status_codes=frozenset(
+            getattr(grpc.StatusCode, name) for name in SCORE_VARIANT_RETRY_STATUS
+        ),
+    )
+    sequence_length = dna_client.SUPPORTED_SEQUENCE_LENGTHS[
+        f"SEQUENCE_LENGTH_{SEQUENCE_LENGTH}"
+    ]
+    organism = dna_client.Organism.HOMO_SAPIENS
+    scorer = make_dnase_lfc_scorer()
+
+    def score_one(row) -> float:
+        chrom = row.chrom if str(row.chrom).startswith("chr") else f"chr{row.chrom}"
+        variant = genome.Variant(
+            chromosome=chrom,
+            position=int(row.pos),
+            reference_bases=row.ref,
+            alternate_bases=row.alt,
+        )
+        interval = variant.reference_interval.resize(sequence_length).copy()
+        interval.strand = "+"
+        scores = score_variant_with_retry(
+            interval=interval,
+            variant=variant,
+            organism=organism,
+            variant_scorers=[scorer],
+        )
+        tidy = variant_scorers.tidy_scores([scores])
+        return select_gm12878_dnase_lfc(tidy)
+
+    out = np.empty(len(V), dtype=np.float64)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as ex:
+        for i, lfc in enumerate(
+            tqdm(ex.map(score_one, V.itertuples(index=False)), total=len(V))
+        ):
+            out[i] = lfc
+    return out
+
+
+_DNASE_LFC_COL = "alphagenome_dnase_lfc"
+_DNASE_LFC_KEY = ("chrom", "pos", "ref", "alt")
+
+
+def _read_lfc_checkpoint(path: str) -> pl.DataFrame | None:
+    """Read a resumable LFC checkpoint, or ``None`` if it doesn't exist yet.
+
+    ``path`` may be local or ``s3://`` (polars reads both natively). A missing file
+    is the expected first-run state → ``None``; any other read error propagates.
+    """
+    try:
+        return pl.read_parquet(path)
+    except (FileNotFoundError, OSError, pl.exceptions.ComputeError):
+        return None
+
+
+def score_dnase_lfc_resumable(
+    variants: pl.DataFrame,
+    checkpoint_path: str,
+    *,
+    num_workers: int = 4,
+    chunk_size: int = 500,
+    max_new_calls: int | None = None,
+    score_fn: Callable[..., np.ndarray] = score_variants_dnase_lfc,
+    api_key: str | None = None,
+) -> pl.DataFrame:
+    """Resumably score variants' GM12878-DNase LFC, S3-checkpointed to ``checkpoint_path``.
+
+    Reads the checkpoint (if present) keyed by ``(chrom, pos, ref, alt)``, scores only
+    the *missing* variants in chunks of ``chunk_size``, and rewrites the checkpoint after
+    each chunk — so a crash / spot preemption resumes from the last chunk. Returns
+    ``[chrom, pos, ref, alt, alphagenome_dnase_lfc]`` aligned to ``variants`` (full
+    coverage asserted). Scoring genome-oriented ``ref``/``alt`` yields genome-frame LFC.
+
+    Args:
+        variants: ``[chrom, pos, ref, alt]`` work-list (unique; genome-oriented).
+        checkpoint_path: local or ``s3://`` parquet path used as both the seed cache
+            and the resumable checkpoint. Point it at an existing fully-scored artifact
+            to reuse without re-spending the API (the caqtl/dsqtl case → 0 calls).
+        num_workers / chunk_size: API threading + checkpoint granularity.
+        max_new_calls: fail-loud cap — raise if more than this many variants would be
+            sent to the API (guards against an accidental full re-score). ``None`` =
+            uncapped.
+        score_fn: injectable for tests (defaults to :func:`score_variants_dnase_lfc`).
+    """
+    key = list(_DNASE_LFC_KEY)
+    missing = set(key) - set(variants.columns)
+    assert not missing, f"variants missing required columns: {missing}"
+    work = variants.select(key)
+    assert work.unique().height == work.height, (
+        "duplicate (chrom,pos,ref,alt) in variants — dedupe before scoring"
+    )
+
+    prior = _read_lfc_checkpoint(checkpoint_path)
+    if prior is not None and prior.height:
+        for col in (*key, _DNASE_LFC_COL):
+            assert col in prior.columns, f"checkpoint missing column {col!r}"
+        cached = prior.select([*key, _DNASE_LFC_COL])
+    else:
+        cached = work.head(0).with_columns(
+            pl.lit(None, dtype=pl.Float64).alias(_DNASE_LFC_COL)
+        )
+
+    todo = work.join(cached.select(key), on=key, how="anti")
+    n_missing = todo.height
+    if max_new_calls is not None and n_missing > max_new_calls:
+        raise RuntimeError(
+            f"{n_missing} variants need AlphaGenome scoring but max_new_calls="
+            f"{max_new_calls}; raise the cap or point checkpoint_path at the cached "
+            "predictions (caqtl/dsqtl reuse should need 0 new calls)"
+        )
+
+    for start in range(0, n_missing, chunk_size):
+        chunk = todo.slice(start, chunk_size)
+        scores = np.asarray(
+            score_fn(chunk.to_pandas(), num_workers=num_workers, api_key=api_key),
+            dtype=np.float64,
+        )
+        assert len(scores) == chunk.height, "score_fn returned wrong length"
+        cached = pl.concat(
+            [cached, chunk.with_columns(pl.Series(_DNASE_LFC_COL, scores))],
+            how="vertical_relaxed",
+        )
+        cached.write_parquet(checkpoint_path)
+
+    out = work.join(cached, on=key, how="left")
+    n_null = int(out.get_column(_DNASE_LFC_COL).is_null().sum())
+    assert n_null == 0, f"{n_null} variants unscored after resumable run"
+    return out

--- a/src/marin_dna/pipelines/evals/qtl_scoring.py
+++ b/src/marin_dna/pipelines/evals/qtl_scoring.py
@@ -76,6 +76,15 @@ SUPPL_TABLE4_REFERENCE: dict[str, dict[str, tuple[float, float]]] = {
 # Pearson for a random scorer is 0. Anchors for the dashboard (#312).
 RANDOM_BASELINE_AUPRC: dict[str, float] = {"caqtl": 0.0852, "dsqtl": 0.0200}
 
+# Canonical caQTL/dsQTL HF dataset revisions (#313 build) — the single source for the
+# benchmark scripts (correct_ag_predictions.py / qtl_benchmark.py). Keep in sync with
+# snakemake/alphagenome_eval/config/config.yaml (snakemake reads YAML and can't import
+# this).
+QTL_HF_REVISION: dict[str, str] = {
+    "caqtl": "27a24296f50ed55afdc412d1612df680d13138d6",
+    "dsqtl": "4a3bf152cd7c28be290adde48a402ec40992cb62",
+}
+
 _KEY: tuple[str, ...] = ("chrom", "pos", "ref", "alt")
 
 
@@ -195,8 +204,10 @@ def compute_qtl_split_metrics(
         how="inner",
     )
     assert joined.height == scores_df.height, (
-        f"{joined.height}/{scores_df.height} scored variants matched the dataset — "
-        "every scored variant must be a known dataset variant (key/orientation mismatch?)"
+        f"{joined.height}/{scores_df.height} scored variants matched the dataset — every "
+        "scored variant must be a known dataset variant (genome-orientation mismatch, or "
+        f"a (chrom,pos,ref,alt) key-dtype skew between the two frames: "
+        f"{[scores_df.schema[c] for c in key]} vs {[dataset_df.schema[c] for c in key]})"
     )
     coverage = round(joined.height / dataset_df.height, 4)
     for col in ("causality_score", "direction_score"):

--- a/src/marin_dna/pipelines/evals/qtl_scoring.py
+++ b/src/marin_dna/pipelines/evals/qtl_scoring.py
@@ -1,0 +1,296 @@
+"""Model-agnostic supervised accessibility-QTL benchmark (issue #311).
+
+The **per-variant score parquet is the plug-in interface**: every scorer emits
+``[chrom, pos, ref, alt, causality_score, direction_score]`` and the shared metric
+treats them uniformly — **causality** = auPRC (+AUROC) on ``|causality_score|`` over
+all variants in a split; **direction** = signed Pearson (+Spearman) of
+``direction_score`` vs the study ``effect`` over the positives. Single-signal models
+(AlphaGenome, Enformer, a fine-tuned gLM) write the same value into both columns;
+ChromBPNet writes ATAC **IPS** for causality and **logFC** for direction (the
+ChromBPNet-paper recommended scores).
+
+Adding a model = drop one ``scores/{model}/{dataset}.parquet`` — no metric-code change
+(:func:`compute_qtl_split_metrics` takes ``model`` as an opaque label).
+
+Splits are a metrics-time slice (not a re-score): ``all`` / our ``train`` (odd chroms)
+/ ``test`` (even chroms) — the production splits — plus ``ag_test`` (AlphaGenome's test
+chromosomes), used only to **reproduce** AlphaGenome Suppl Table 4.
+
+No per-dataset sign-flip lives in the metric. AlphaGenome's raw DNase-LFC sits in a
+per-dataset accessibility *convention* that is uniformly flipped on dsQTL relative to
+the study (a lift-related #262 artifact — uniform across orientation swaps, not a
+per-variant orientation issue). It is aligned to the dataset's convention **once**
+upstream (:func:`align_score_sign` anchored on the carried ChromBPNet logFC →
+``scripts/correct_ag_predictions.py``), so by the time scores reach the metric every
+model is already a positively-oriented accessibility score, exactly like the carried
+ChromBPNet/Enformer columns.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import polars as pl
+from scipy.stats import pearsonr
+
+from marin_dna.pipelines.chrombpnet_eval.metrics import compute_supervised_qtl_metrics
+
+# Per-model protocol columns: (causality_col, direction_col). The carried column names
+# are the canonical names produced by ``chrombpnet_qtl.load_standardized_qtl``;
+# ``alphagenome_dnase_lfc`` is the column written by
+# ``alphagenome.score_dnase_lfc_resumable``. ChromBPNet uses IPS for causality and
+# logFC for direction; every other model is single-signal (same column twice).
+MODEL_SCORE_COLUMNS: dict[str, tuple[str, str]] = {
+    "alphagenome": ("alphagenome_dnase_lfc", "alphagenome_dnase_lfc"),
+    "chrombpnet": ("chrombpnet_atac_ips", "chrombpnet_atac_logfc"),
+    "enformer": ("enformer_dnase_local_logfc", "enformer_dnase_local_logfc"),
+}
+
+# AlphaGenome's test chromosomes (Suppl Table 4 is reported on this slice). Used only
+# to reproduce the published numbers — production reporting uses our train/test splits.
+AG_TEST_CHROMS: frozenset[str] = frozenset(
+    {"3", "6", "9", "12", "16", "18", "19", "21"}
+)
+
+# The named splits the benchmark reports, each a row-mask over the scored variants.
+QTL_SPLITS: tuple[str, ...] = ("all", "train", "test", "ag_test")
+
+# AlphaGenome Suppl Table 4 (published): (causality auPRC, direction Pearson) on the
+# AG-test slice. Borzoi-ensemble is the one model we have no per-variant scores for, so
+# it is a pure static reference; ChromBPNet/AlphaGenome are kept as published targets to
+# show our reproduced numbers against. Random-baseline auPRC anchors are separate.
+SUPPL_TABLE4_REFERENCE: dict[str, dict[str, tuple[float, float]]] = {
+    "caqtl": {
+        "ChromBPNet": (0.4148, 0.6737),
+        "Borzoi-ensemble": (0.4624, 0.6485),
+        "AlphaGenome": (0.5643, 0.7368),
+    },
+    "dsqtl": {
+        "ChromBPNet": (0.5432, 0.7722),
+        "Borzoi-ensemble": (0.6056, 0.7922),
+        "AlphaGenome": (0.6308, 0.8323),
+    },
+}
+
+# AlphaGenome's reported random-baseline causality auPRC (= positive rate); direction
+# Pearson for a random scorer is 0. Anchors for the dashboard (#312).
+RANDOM_BASELINE_AUPRC: dict[str, float] = {"caqtl": 0.0852, "dsqtl": 0.0200}
+
+_KEY: tuple[str, ...] = ("chrom", "pos", "ref", "alt")
+
+
+def to_score_interface(
+    df: pl.DataFrame, causality_col: str, direction_col: str
+) -> pl.DataFrame:
+    """Project a frame onto the uniform score interface.
+
+    Returns ``[chrom, pos, ref, alt, causality_score, direction_score]``. For a
+    single-signal model pass the same column name twice. ``df`` must carry the key
+    columns and both score columns.
+    """
+    for col in (*_KEY, causality_col, direction_col):
+        assert col in df.columns, f"frame missing column {col!r}"
+    return df.select(
+        [
+            *_KEY,
+            pl.col(causality_col).alias("causality_score"),
+            pl.col(direction_col).alias("direction_score"),
+        ]
+    )
+
+
+def align_score_sign(
+    scores: np.ndarray, reference: np.ndarray, *, min_abs_corr: float = 0.5
+) -> tuple[np.ndarray, float]:
+    """Flip ``scores`` to agree in sign with ``reference``; return ``(aligned, sign)``.
+
+    Used to put an externally-computed accessibility score that lives in a per-dataset
+    flipped convention (the #262 AlphaGenome DNase-LFC: uniformly anti-correlated with
+    the study on dsQTL) into the dataset's accessibility convention, anchored on a
+    carried baseline that is already study-aligned (ChromBPNet logFC). Two accessibility
+    predictors of the same allelic effect should correlate strongly; the **sign** of
+    that correlation is the convention. Asserts ``|corr| >= min_abs_corr`` so a
+    near-zero (ambiguous) correlation fails loud rather than silently guessing a sign.
+
+    ``sign`` is ``+1.0`` (kept) or ``-1.0`` (flipped). Non-finite pairs are dropped for
+    the correlation; ``aligned`` is ``scores * sign`` (NaNs preserved).
+    """
+    scores = np.asarray(scores, dtype=float)
+    reference = np.asarray(reference, dtype=float)
+    assert scores.shape == reference.shape, "scores/reference length mismatch"
+    finite = np.isfinite(scores) & np.isfinite(reference)
+    assert finite.sum() >= 2, "need >=2 finite pairs to align sign"
+    r = float(pearsonr(scores[finite], reference[finite])[0])
+    assert abs(r) >= min_abs_corr, (
+        f"|corr|={abs(r):.3f} < {min_abs_corr} — sign alignment is ambiguous; the "
+        "anchor (carried ChromBPNet logFC) should strongly track the accessibility score"
+    )
+    sign = 1.0 if r >= 0 else -1.0
+    return scores * sign, sign
+
+
+def qtl_split_masks(
+    chrom: np.ndarray, split_source: np.ndarray
+) -> dict[str, np.ndarray]:
+    """Row-masks for the named splits.
+
+    ``chrom`` = per-variant chromosome (unprefixed str); ``split_source`` = each
+    variant's home split in the dataset (``"train"`` / ``"test"``, the odd/even chrom
+    partition). ``all`` = every row; ``train``/``test`` = membership; ``ag_test`` =
+    chrom ∈ :data:`AG_TEST_CHROMS` (an independent slice that spans both).
+    """
+    chrom = np.asarray(chrom).astype(str)
+    split_source = np.asarray(split_source).astype(str)
+    extra = set(np.unique(split_source).tolist()) - {"train", "test"}
+    assert not extra, f"unexpected split_source values {sorted(extra)}"
+    return {
+        "all": np.ones(len(chrom), dtype=bool),
+        "train": split_source == "train",
+        "test": split_source == "test",
+        "ag_test": np.isin(chrom, list(AG_TEST_CHROMS)),
+    }
+
+
+def _pick(metrics: pd.DataFrame, metric: str) -> tuple[float, float]:
+    """``(value, se)`` for one metric row from ``compute_supervised_qtl_metrics``."""
+    row = metrics.loc[metrics["metric"] == metric]
+    assert len(row) == 1, f"expected exactly one {metric!r} row, got {len(row)}"
+    return float(row["value"].iloc[0]), float(row["se"].iloc[0])
+
+
+def compute_qtl_split_metrics(
+    scores_df: pl.DataFrame,
+    dataset_df: pl.DataFrame,
+    *,
+    dataset: str,
+    model: str,
+    splits: tuple[str, ...] = QTL_SPLITS,
+    n_bootstrap: int = 1000,
+    rng: int = 0,
+) -> pd.DataFrame:
+    """Official caQTL/dsQTL metrics for one model's scores, per split.
+
+    Joins ``scores_df`` (``[chrom,pos,ref,alt,causality_score,direction_score]``) to
+    ``dataset_df`` (must carry ``label``, ``effect``, ``split_source``) on the variant
+    key, then for each split reuses :func:`compute_supervised_qtl_metrics` — causality
+    metrics (AUROC/AUPRC on ``|causality_score|``) from the causality column, direction
+    metrics (Pearson/Spearman on ``direction_score`` over positives) from the direction
+    column (a single call when the two columns are identical, i.e. single-signal
+    models). ``model`` is an opaque label — **any** model flows through unchanged.
+
+    Returns a wide row per split: ``[dataset, model, split, n_rows, n_pos, coverage,
+    causality_auPRC, causality_se, causality_AUROC, causality_AUROC_se,
+    direction_pearson, direction_pearson_se, direction_spearman,
+    direction_spearman_se]``.
+    """
+    key = list(_KEY)
+    for col in ("causality_score", "direction_score"):
+        assert col in scores_df.columns, f"scores_df missing {col!r}"
+    for col in ("label", "effect", "split_source"):
+        assert col in dataset_df.columns, f"dataset_df missing {col!r}"
+
+    joined = scores_df.join(
+        dataset_df.select([*key, "label", "effect", "split_source"]),
+        on=key,
+        how="inner",
+    )
+    assert joined.height == scores_df.height, (
+        f"{joined.height}/{scores_df.height} scored variants matched the dataset — "
+        "every scored variant must be a known dataset variant (key/orientation mismatch?)"
+    )
+    coverage = round(joined.height / dataset_df.height, 4)
+    for col in ("causality_score", "direction_score"):
+        assert joined.get_column(col).is_finite().all(), (
+            f"non-finite {col!r} — fill/align upstream before scoring"
+        )
+
+    single_signal = bool(
+        (
+            joined.get_column("causality_score") == joined.get_column("direction_score")
+        ).all()
+    )
+    masks = qtl_split_masks(
+        joined.get_column("chrom").to_numpy(),
+        joined.get_column("split_source").to_numpy(),
+    )
+
+    rows: list[dict] = []
+    for split in splits:
+        assert split in masks, f"unknown split {split!r}"
+        sub = joined.filter(pl.Series(masks[split])).to_pandas()
+        causality = compute_supervised_qtl_metrics(
+            sub,
+            score_col="causality_score",
+            label_col="label",
+            effect_col="effect",
+            n_bootstrap=n_bootstrap,
+            rng=rng,
+        )
+        direction = (
+            causality
+            if single_signal
+            else compute_supervised_qtl_metrics(
+                sub,
+                score_col="direction_score",
+                label_col="label",
+                effect_col="effect",
+                n_bootstrap=n_bootstrap,
+                rng=rng,
+            )
+        )
+        auprc, auprc_se = _pick(causality, "AUPRC")
+        auroc, auroc_se = _pick(causality, "AUROC")
+        pearson, pearson_se = _pick(direction, "pearson")
+        spearman, spearman_se = _pick(direction, "spearman")
+        rows.append(
+            {
+                "dataset": dataset,
+                "model": model,
+                "split": split,
+                "n_rows": int(len(sub)),
+                "n_pos": int(sub["label"].sum()),
+                "coverage": coverage,
+                "causality_auPRC": auprc,
+                "causality_se": auprc_se,
+                "causality_AUROC": auroc,
+                "causality_AUROC_se": auroc_se,
+                "direction_pearson": pearson,
+                "direction_pearson_se": pearson_se,
+                "direction_spearman": spearman,
+                "direction_spearman_se": spearman_se,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def reference_metrics(dataset: str) -> pd.DataFrame:
+    """Static published reference rows (AlphaGenome Suppl Table 4), ``split="ag_test"``.
+
+    Borzoi-ensemble (no per-variant scores) is the essential static row; ChromBPNet and
+    AlphaGenome are kept as published targets to compare our reproduced numbers against.
+    A ``Random`` row carries the random-baseline auPRC anchor (direction Pearson 0).
+    The ``source`` column distinguishes these from our computed metrics.
+    """
+    rows: list[dict] = []
+    for model, (auprc, pearson) in SUPPL_TABLE4_REFERENCE[dataset].items():
+        rows.append(
+            {
+                "dataset": dataset,
+                "model": model,
+                "split": "ag_test",
+                "causality_auPRC": auprc,
+                "direction_pearson": pearson,
+                "source": "AlphaGenome Suppl Table 4 (published)",
+            }
+        )
+    rows.append(
+        {
+            "dataset": dataset,
+            "model": "Random",
+            "split": "ag_test",
+            "causality_auPRC": RANDOM_BASELINE_AUPRC[dataset],
+            "direction_pearson": 0.0,
+            "source": "random baseline",
+        }
+    )
+    return pd.DataFrame(rows)

--- a/tests/pipelines/evals/test_alphagenome.py
+++ b/tests/pipelines/evals/test_alphagenome.py
@@ -4,15 +4,21 @@ The ``alphagenome`` package is an optional dep — the parse-response tests run
 without it; the scorer-construction test is gated on the import.
 """
 
+import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 from marin_dna.pipelines.evals.alphagenome import (
     ALPHAGENOME_TRACKS,
+    DNASE_LFC_MASK_WIDTH,
+    GM12878_ONTOLOGY_CURIE,
     SCORE_VARIANT_MAX_ATTEMPTS,
     SCORE_VARIANT_RETRY_STATUS,
     SEQUENCE_LENGTH,
     parse_score_response,
+    score_dnase_lfc_resumable,
+    select_gm12878_dnase_lfc,
 )
 
 
@@ -119,3 +125,151 @@ def test_make_scorers_uses_l2_diff_log1p():
     assert set(repr_to_assay.values()) == set(ALPHAGENOME_TRACKS)
     for s in scorers:
         assert s.aggregation_type == variant_scorers.AggregationType.L2_DIFF_LOG1P
+
+
+# --- GM12878-DNase LFC scorer (caQTL/dsQTL, #262/#311) --------------------------
+
+
+def _dnase_tidy() -> pd.DataFrame:
+    """Mock tidy_scores from the DNase scorer: many DNASE tracks (one per cell type)
+    plus a stray non-DNASE row; GM12878 is ontology EFO:0002784."""
+    return pd.DataFrame(
+        {
+            "output_type": ["DNASE", "DNASE", "DNASE", "ATAC"],
+            "ontology_curie": [
+                "CL:0000047",
+                GM12878_ONTOLOGY_CURIE,
+                "CL:0000084",
+                GM12878_ONTOLOGY_CURIE,
+            ],
+            "biosample_name": ["neuronal stem cell", "GM12878", "T-cell", "GM12878"],
+            "raw_score": [-0.0164, -0.0059, 0.1333, 9.9],
+        }
+    )
+
+
+def test_gm12878_constants():
+    assert GM12878_ONTOLOGY_CURIE == "EFO:0002784"
+    assert DNASE_LFC_MASK_WIDTH == 501
+
+
+def test_select_gm12878_dnase_lfc_picks_the_one_track():
+    # exactly the DNASE + EFO:0002784 row (not the ATAC GM12878 row, not other cells)
+    assert select_gm12878_dnase_lfc(_dnase_tidy()) == pytest.approx(-0.0059)
+
+
+def test_select_gm12878_dnase_lfc_means_replicates():
+    tidy = pd.DataFrame(
+        {
+            "output_type": ["DNASE", "DNASE", "DNASE"],
+            "ontology_curie": [
+                GM12878_ONTOLOGY_CURIE,
+                GM12878_ONTOLOGY_CURIE,
+                "CL:0000084",
+            ],
+            "raw_score": [0.2, 0.4, 9.9],
+        }
+    )
+    assert select_gm12878_dnase_lfc(tidy) == pytest.approx(0.3)  # mean of the two
+
+
+def test_select_gm12878_dnase_lfc_no_match_fails_loud():
+    tidy = pd.DataFrame(
+        {"output_type": ["DNASE"], "ontology_curie": ["CL:0000047"], "raw_score": [0.1]}
+    )
+    with pytest.raises(AssertionError, match="no GM12878 DNase track"):
+        select_gm12878_dnase_lfc(tidy)
+
+
+def test_select_gm12878_dnase_lfc_missing_columns_fails_loud():
+    with pytest.raises(AssertionError, match="tidy_scores missing"):
+        select_gm12878_dnase_lfc(pd.DataFrame({"output_type": ["DNASE"]}))
+
+
+def test_make_dnase_lfc_scorer_is_diff_log2_sum():
+    pytest.importorskip("alphagenome")
+    from alphagenome.models import dna_client, variant_scorers
+
+    from marin_dna.pipelines.evals.alphagenome import make_dnase_lfc_scorer
+
+    scorer = make_dnase_lfc_scorer()
+    assert scorer.requested_output == dna_client.OutputType.DNASE
+    assert scorer.width == DNASE_LFC_MASK_WIDTH
+    assert scorer.aggregation_type == variant_scorers.AggregationType.DIFF_LOG2_SUM
+
+
+# --- Resumable DNase-LFC scoring (no API; injected score_fn) ---------------------
+
+
+def _variants(n: int = 4) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "chrom": ["1", "1", "2", "2"][:n],
+            "pos": [10, 20, 30, 40][:n],
+            "ref": ["A", "C", "G", "T"][:n],
+            "alt": ["G", "T", "A", "C"][:n],
+        }
+    )
+
+
+def _counting_score_fn(counter: dict):
+    """Deterministic fake scorer: lfc = pos * 0.1; records #variants it was asked."""
+
+    def fn(V, **kwargs):
+        counter["calls"] += 1
+        counter["rows"] += len(V)
+        return V["pos"].to_numpy().astype(float) * 0.1
+
+    return fn
+
+
+def test_score_dnase_lfc_resumable_scores_and_caches(tmp_path):
+    ckpt = str(tmp_path / "ckpt.parquet")
+    counter = {"calls": 0, "rows": 0}
+    out = score_dnase_lfc_resumable(
+        _variants(), ckpt, chunk_size=2, score_fn=_counting_score_fn(counter)
+    )
+    assert counter["rows"] == 4
+    assert out.columns == ["chrom", "pos", "ref", "alt", "alphagenome_dnase_lfc"]
+    assert out["alphagenome_dnase_lfc"].to_list() == [1.0, 2.0, 3.0, 4.0]
+
+    # Resume: the checkpoint now has all 4 → zero new API calls, same scores.
+    counter2 = {"calls": 0, "rows": 0}
+    out2 = score_dnase_lfc_resumable(
+        _variants(), ckpt, chunk_size=2, score_fn=_counting_score_fn(counter2)
+    )
+    assert counter2["rows"] == 0
+    assert out2["alphagenome_dnase_lfc"].to_list() == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_score_dnase_lfc_resumable_partial_resume(tmp_path):
+    ckpt = tmp_path / "ckpt.parquet"
+    # Pre-seed 2 of the 4 variants with sentinel scores that must survive untouched.
+    pl.DataFrame(
+        {
+            "chrom": ["1", "1"],
+            "pos": [10, 20],
+            "ref": ["A", "C"],
+            "alt": ["G", "T"],
+            "alphagenome_dnase_lfc": [99.0, 98.0],
+        }
+    ).write_parquet(ckpt)
+    counter = {"calls": 0, "rows": 0}
+    out = score_dnase_lfc_resumable(
+        _variants(), str(ckpt), score_fn=_counting_score_fn(counter)
+    )
+    assert counter["rows"] == 2  # only the 2 missing variants scored
+    by_pos = dict(zip(out["pos"].to_list(), out["alphagenome_dnase_lfc"].to_list()))
+    assert by_pos == {10: 99.0, 20: 98.0, 30: 3.0, 40: 4.0}
+
+
+def test_score_dnase_lfc_resumable_cap_fails_loud(tmp_path):
+    counter = {"calls": 0, "rows": 0}
+    with pytest.raises(RuntimeError, match="max_new_calls"):
+        score_dnase_lfc_resumable(
+            _variants(),
+            str(tmp_path / "ckpt.parquet"),
+            max_new_calls=0,
+            score_fn=_counting_score_fn(counter),
+        )
+    assert counter["rows"] == 0  # cap tripped before any scoring

--- a/tests/pipelines/evals/test_alphagenome.py
+++ b/tests/pipelines/evals/test_alphagenome.py
@@ -4,7 +4,6 @@ The ``alphagenome`` package is an optional dep — the parse-response tests run
 without it; the scorer-construction test is gated on the import.
 """
 
-import numpy as np
 import pandas as pd
 import polars as pl
 import pytest

--- a/tests/pipelines/evals/test_qtl_scoring.py
+++ b/tests/pipelines/evals/test_qtl_scoring.py
@@ -1,0 +1,188 @@
+"""Tests for the model-agnostic QTL benchmark logic (issue #311).
+
+Synthetic data with *known* causality (perfectly separable ``|causality_score|``) and
+direction (``direction_score`` ∝ ``effect`` over positives) pins the metric to 1.0, so
+the assertions are exact and the two-column vs single-signal paths are both exercised.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from marin_dna.pipelines.evals.qtl_scoring import (
+    AG_TEST_CHROMS,
+    MODEL_SCORE_COLUMNS,
+    RANDOM_BASELINE_AUPRC,
+    SUPPL_TABLE4_REFERENCE,
+    align_score_sign,
+    compute_qtl_split_metrics,
+    qtl_split_masks,
+    reference_metrics,
+    to_score_interface,
+)
+
+
+def _synthetic(single_signal: bool) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """20 variants (10 positive / 10 control) with every split populated.
+
+    Positives: chroms 3 (4) + 1 (6), split_source train (5) / test (5); controls the
+    same layout. ``|causality_score|`` is large for positives and 0 for controls
+    (auPRC → 1.0); ``direction_score`` ∝ ``effect`` over positives (Pearson → 1.0).
+    """
+    pos_effect = [round(0.1 * (i + 1), 2) for i in range(10)]  # 0.1 .. 1.0
+    chrom = (["3"] * 4 + ["1"] * 6) * 2  # positives then controls
+    pos = list(range(1, 21))
+    label = [True] * 10 + [False] * 10
+    effect = pos_effect + [None] * 10
+    split_source = (["train"] * 5 + ["test"] * 5) * 2
+    dataset = pl.DataFrame(
+        {
+            "chrom": chrom,
+            "pos": pos,
+            "ref": ["A"] * 20,
+            "alt": ["G"] * 20,
+            "label": label,
+            "effect": effect,
+            "split_source": split_source,
+        }
+    )
+    causality = [e * 10 for e in pos_effect] + [0.0] * 10
+    direction = causality if single_signal else (pos_effect + [0.0] * 10)
+    scores = pl.DataFrame(
+        {
+            "chrom": chrom,
+            "pos": pos,
+            "ref": ["A"] * 20,
+            "alt": ["G"] * 20,
+            "causality_score": causality,
+            "direction_score": direction,
+        }
+    )
+    return scores, dataset
+
+
+def test_to_score_interface_aliases_and_selects():
+    df = pl.DataFrame(
+        {
+            "chrom": ["1"],
+            "pos": [10],
+            "ref": ["A"],
+            "alt": ["G"],
+            "ips": [2.0],
+            "logfc": [0.5],
+            "other": [9.9],
+        }
+    )
+    out = to_score_interface(df, "ips", "logfc")
+    assert out.columns == [
+        "chrom",
+        "pos",
+        "ref",
+        "alt",
+        "causality_score",
+        "direction_score",
+    ]
+    assert out["causality_score"].to_list() == [2.0]
+    assert out["direction_score"].to_list() == [0.5]
+
+
+def test_to_score_interface_missing_column_fails_loud():
+    df = pl.DataFrame({"chrom": ["1"], "pos": [10], "ref": ["A"], "alt": ["G"]})
+    with pytest.raises(AssertionError, match="missing column 'ips'"):
+        to_score_interface(df, "ips", "ips")
+
+
+def test_align_score_sign_keeps_and_flips():
+    reference = np.array([1.0, 2.0, 3.0, -1.0, -2.0])
+    base = np.array([0.5, 1.0, 1.5, -0.5, -1.0])  # agrees with reference
+    aligned, sign = align_score_sign(base, reference)
+    assert sign == 1.0 and np.allclose(aligned, base)
+    # A flipped-convention score is flipped back to agree with the reference.
+    aligned, sign = align_score_sign(-base, reference)
+    assert sign == -1.0 and np.allclose(aligned, base)
+
+
+def test_align_score_sign_ambiguous_fails_loud():
+    a = np.array([1.0, 1.0, -1.0, -1.0])
+    b = np.array([1.0, -1.0, 1.0, -1.0])  # orthogonal → corr 0 → ambiguous
+    with pytest.raises(AssertionError, match="ambiguous"):
+        align_score_sign(a, b)
+
+
+def test_qtl_split_masks():
+    chrom = np.array(["1", "3", "2", "6"])
+    split_source = np.array(["train", "train", "test", "test"])
+    masks = qtl_split_masks(chrom, split_source)
+    assert masks["all"].tolist() == [True, True, True, True]
+    assert masks["train"].tolist() == [True, True, False, False]
+    assert masks["test"].tolist() == [False, False, True, True]
+    # ag_test is chrom membership (3 and 6 are AG-test chroms; 1 and 2 are not).
+    assert masks["ag_test"].tolist() == [False, True, False, True]
+    assert {"3", "6"} <= AG_TEST_CHROMS and "1" not in AG_TEST_CHROMS
+
+
+def test_qtl_split_masks_rejects_unknown_split_source():
+    with pytest.raises(AssertionError, match="unexpected split_source"):
+        qtl_split_masks(np.array(["1"]), np.array(["holdout"]))
+
+
+@pytest.mark.parametrize("single_signal", [True, False])
+def test_compute_qtl_split_metrics_known_values(single_signal: bool):
+    scores, dataset = _synthetic(single_signal)
+    out = compute_qtl_split_metrics(
+        scores, dataset, dataset="caqtl", model="chrombpnet", n_bootstrap=50
+    )
+    assert list(out["split"]) == ["all", "train", "test", "ag_test"]
+    # Perfectly separable causality and perfectly correlated direction → 1.0 everywhere.
+    assert np.allclose(out["causality_auPRC"], 1.0)
+    assert np.allclose(out["causality_AUROC"], 1.0)
+    assert np.allclose(out["direction_pearson"], 1.0)
+    assert np.allclose(out["direction_spearman"], 1.0)
+    by_split = {r["split"]: r for r in out.to_dict("records")}
+    assert (by_split["all"]["n_rows"], by_split["all"]["n_pos"]) == (20, 10)
+    assert (by_split["train"]["n_rows"], by_split["train"]["n_pos"]) == (10, 5)
+    assert (by_split["test"]["n_rows"], by_split["test"]["n_pos"]) == (10, 5)
+    assert (by_split["ag_test"]["n_rows"], by_split["ag_test"]["n_pos"]) == (8, 4)
+    assert (out["dataset"] == "caqtl").all() and (out["coverage"] == 1.0).all()
+
+
+def test_compute_qtl_split_metrics_is_model_agnostic():
+    """Acceptance (#311): an arbitrary, never-before-seen model name flows through the
+    shared metric with no code change."""
+    scores, dataset = _synthetic(single_signal=True)
+    out = compute_qtl_split_metrics(
+        scores, dataset, dataset="dsqtl", model="some_future_glm_v7", n_bootstrap=20
+    )
+    assert (out["model"] == "some_future_glm_v7").all()
+    assert np.allclose(out["causality_auPRC"], 1.0)
+    assert "some_future_glm_v7" not in MODEL_SCORE_COLUMNS  # truly unknown to the code
+
+
+def test_compute_qtl_split_metrics_rejects_key_mismatch():
+    scores, dataset = _synthetic(single_signal=True)
+    # A scored variant absent from the dataset must fail loud (orientation/key bug).
+    bad = scores.with_columns(
+        pl.when(pl.col("pos") == 1)
+        .then(pl.lit(999))
+        .otherwise(pl.col("pos"))
+        .alias("pos")
+    )
+    with pytest.raises(AssertionError, match="scored variants matched the dataset"):
+        compute_qtl_split_metrics(
+            bad, dataset, dataset="caqtl", model="x", splits=("all",), n_bootstrap=10
+        )
+
+
+def test_reference_metrics():
+    out = reference_metrics("dsqtl")
+    assert (out["split"] == "ag_test").all()
+    by_model = {r["model"]: r for r in out.to_dict("records")}
+    for model, (auprc, pearson) in SUPPL_TABLE4_REFERENCE["dsqtl"].items():
+        assert by_model[model]["causality_auPRC"] == pytest.approx(auprc)
+        assert by_model[model]["direction_pearson"] == pytest.approx(pearson)
+    assert by_model["Random"]["causality_auPRC"] == pytest.approx(
+        RANDOM_BASELINE_AUPRC["dsqtl"]
+    )
+    assert by_model["Random"]["direction_pearson"] == 0.0


### PR DESCRIPTION
🤖 Part of #309. Closes #311.

Productionizes the #262 one-off run into a **model-agnostic supervised caQTL/dsQTL official-metrics benchmark** — **causality** = auPRC on `|score|` over all variants; **direction** = signed Pearson of the score vs the study effect over positives. AlphaGenome, ChromBPNet, Enformer (and any future fine-tuned gLM, #243) are scored through one uniform interface.

## Architecture — three homes (no heavyweight new pipeline)

- **Metric/benchmark logic → `src/`** ([qtl_scoring.py](https://github.com/Open-Athena/marin-dna/blob/cda5c45572e783f24884d4849aa4c5aa71bfc192/src/marin_dna/pipelines/evals/qtl_scoring.py)): the two-column score interface `[chrom,pos,ref,alt,causality_score,direction_score]`, `compute_qtl_split_metrics` (reuses the existing `compute_supervised_qtl_metrics`; model-agnostic — `model` is an opaque label), split masks, static Suppl-Table-4 reference rows, and `align_score_sign`. The GM12878-DNase LFC scorer + resumable S3-checkpointed driver are in [alphagenome.py](https://github.com/Open-Athena/marin-dna/blob/cda5c45572e783f24884d4849aa4c5aa71bfc192/src/marin_dna/pipelines/evals/alphagenome.py).
- **AlphaGenome predictions → `snakemake/alphagenome_eval`**: a resumable `score_dnase_lfc` rule ([dnase_lfc.smk](https://github.com/Open-Athena/marin-dna/blob/cda5c45572e783f24884d4849aa4c5aa71bfc192/snakemake/alphagenome_eval/workflow/rules/dnase_lfc.smk)). The matched-group AlphaGenome baseline (mendelian/complex) is **kept**; only the old DART-Eval `qtl_global` caqtl/dsqtl path is removed.
- **Carried extraction + metrics + leaderboard → `scripts/`** ([qtl_benchmark.py](https://github.com/Open-Athena/marin-dna/blob/cda5c45572e783f24884d4849aa4c5aa71bfc192/scripts/qtl_benchmark.py)): a lightweight driver that writes `scores/{model}/{ds}` + `metrics/{model}/{ds}` to `s3://oa-bolinas/qtl_benchmark/` for the #312 dashboard. **Adding a model = drop one `scores/{model}/{ds}.parquet`** (discovered by listing the prefix — no metrics-code change; covered by a test).

## Reproduces AlphaGenome Suppl Table 4 (AG-test slice {3,6,9,12,16,18,19,21}, ≤0.005)

| dataset | model | causality auPRC (ref) | direction Pearson (ref) |
|---|---|---|---|
| caqtl | AlphaGenome | 0.5632 (0.5643) | 0.7328 (0.7368) |
| caqtl | ChromBPNet | 0.4148 (0.4148) | 0.6704 (0.6737) |
| caqtl | Enformer | 0.4158 | 0.6299 |
| dsqtl | AlphaGenome | 0.6319 (0.6308) | 0.8309 (0.8323) |
| dsqtl | ChromBPNet | 0.5432 (0.5432) | 0.7732 (0.7722) |
| dsqtl | Enformer | 0.5001 | 0.7306 |

Max Δ is 0.0040 (caQTL AlphaGenome direction — the forward-strand-only vs RC-averaged gap baked into the #262 predictions). **Production reporting uses our own `train`/`test` splits (odd/even chroms); `ag_test` exists only for this reproduction.**

## AlphaGenome sign correction (one-time, no API)

The cached #262 AlphaGenome DNase-LFC sits in a per-dataset accessibility convention that is **uniformly** flipped on dsQTL relative to the study — a lift artifact, validated *uniform across orientation swaps* (corr with the carried ChromBPNet logFC: `+0.90` caqtl / `−0.91` dsqtl; per-swap and per-no-swap subsets agree). [correct_ag_predictions.py](https://github.com/Open-Athena/marin-dna/blob/cda5c45572e783f24884d4849aa4c5aa71bfc192/scripts/correct_ag_predictions.py) aligns it **once** to the carried ChromBPNet baseline — sign *derived from the data* (`+1` caqtl, `−1` dsqtl; fails loud if the correlation is ambiguous) — and backs up the raw originals to `dnase_lfc_raw/`. Downstream there is no per-dataset flip: AlphaGenome is a normal positively-oriented single-signal model like the carried ChromBPNet/Enformer columns. **The #310 datasets themselves are untouched.**

## Tests / verification

- 44 unit tests pass (`tests/pipelines/evals/test_{alphagenome,qtl_scoring,chrombpnet_qtl}.py`), including the acceptance test that an arbitrary new model name flows through the metric with no code change, and the resumable scorer (fake `score_fn`, tmp checkpoint, resume ⇒ 0 calls, cap trips).
- `correct_ag_predictions.py` and `qtl_benchmark.py --reproduce` assert ≤0.005 vs Suppl Table 4.
- Pipeline `snakemake -n`: `score_dnase_lfc` is satisfied by the cached genome-native artifacts (**0 API**).

## S3 artifacts (produced; old ones superseded, not deleted)

- `…/alphagenome_eval/results/dnase_lfc/{caqtl,dsqtl}.parquet` (genome-native) + `dnase_lfc_raw/` (raw #262 backup).
- `s3://oa-bolinas/qtl_benchmark/{scores,metrics,metrics_reference}/…` (1000-bootstrap).

Out of scope: #312 dashboard wiring (consumes these metrics); the #243 gLM scorer.
