### PR TITLE
fix(evals): order-deterministic resumable DNase-LFC scorer (maintain_order)

### DIFF
--- a/src/marin_dna/pipelines/evals/alphagenome.py
+++ b/src/marin_dna/pipelines/evals/alphagenome.py
@@ -406,7 +406,10 @@ def score_dnase_lfc_resumable(
             pl.lit(None, dtype=pl.Float64).alias(_DNASE_LFC_COL)
         )
 
-    todo = work.join(cached.select(key), on=key, how="anti")
+    # maintain_order="left" keeps `todo` (and so the chunk boundaries) in `variants`
+    # order; polars' hash anti-join order is otherwise unspecified and varies with
+    # process-wide engine state, so it differed depending on what ran earlier in the run.
+    todo = work.join(cached.select(key), on=key, how="anti", maintain_order="left")
     n_missing = todo.height
     if max_new_calls is not None and n_missing > max_new_calls:
         raise RuntimeError(
@@ -428,7 +431,10 @@ def score_dnase_lfc_resumable(
         )
         cached.write_parquet(checkpoint_path)
 
-    out = work.join(cached, on=key, how="left")
+    # maintain_order="left" so the returned frame is aligned to `variants` (the documented
+    # contract) deterministically — a plain left-join's row order is unspecified in polars
+    # and varied with process-wide engine state (passed alone, scrambled in the full suite).
+    out = work.join(cached, on=key, how="left", maintain_order="left")
     # is_null catches variants the join didn't cover; is_nan catches a variant the scorer
     # returned NaN for (polars treats NaN as a non-null float, so is_null alone misses it).
     scored = out.get_column(_DNASE_LFC_COL)

--- a/tests/pipelines/evals/test_alphagenome.py
+++ b/tests/pipelines/evals/test_alphagenome.py
@@ -230,6 +230,10 @@ def test_score_dnase_lfc_resumable_scores_and_caches(tmp_path):
     )
     assert counter["rows"] == 4
     assert out.columns == ["chrom", "pos", "ref", "alt", "alphagenome_dnase_lfc"]
+    # Rows must stay aligned to `variants` order (the scorer's maintain_order joins). Scores
+    # are pos-derived, so a non-order-preserving join surfaces here as a permuted list — this
+    # was the symptom of the row-order bug that only appeared under the full-suite run.
+    assert out.select("chrom", "pos", "ref", "alt").rows() == _variants().rows()
     assert out["alphagenome_dnase_lfc"].to_list() == [1.0, 2.0, 3.0, 4.0]
 
     # Resume: the checkpoint now has all 4 → zero new API calls, same scores.


### PR DESCRIPTION
🤖 Fixes a pre-existing cross-test flake found while shipping #312 (PR #316).

`score_dnase_lfc_resumable` returned its rows in polars' **unspecified** hash-join order — the left/anti joins didn't set `maintain_order`. That order varies with process-wide engine state, so the unit test `test_score_dnase_lfc_resumable_scores_and_caches` passed in isolation but **failed inside the full evals suite** (rows permuted to `[1.0, 3.0, 2.0, 4.0]`). Confirmed on `main`, deterministic even with `-p no:randomly`.

## Fix

Pin both joins to `maintain_order="left"` — the pattern [`sge.py` already uses](https://github.com/Open-Athena/marin-dna/blob/a64ce51008d20f918bb87bb0a98c691a92d166f6/src/marin_dna/pipelines/evals/sge.py#L263) — so the returned frame is aligned to `variants` as documented and the chunk boundaries are deterministic, independent of what ran earlier in the process ([the two joins](https://github.com/Open-Athena/marin-dna/blob/a64ce51008d20f918bb87bb0a98c691a92d166f6/src/marin_dna/pipelines/evals/alphagenome.py#L412-L437)).

Added an explicit row-alignment assertion to the test (`out.select(key).rows() == _variants().rows()`) so a future `maintain_order` removal is an obvious contract break, not a suite-order-dependent flake.

## Verify

- `uv run pytest tests/pipelines/evals/ -p no:randomly` → **428 passed** (was 427 passed + 1 failed).
- The two resumable tests also pass in isolation.
- **No production behavior change**: each variant's LFC value was always correct (the scorer is per-variant); only the returned *row order* was non-deterministic. Downstream (`qtl_benchmark.py`) joins on key, so this was latent in production but broke the test's positional assertion.
